### PR TITLE
feat: use `ss -tulnp | grep ':PORT '` instead of `lsof -i :PORT`

### DIFF
--- a/docker/prod.sh
+++ b/docker/prod.sh
@@ -19,13 +19,13 @@ if [ -f /.dockerenv ]; then
 fi
 
 # check if something is running on port 80
-if lsof -i :80 >/dev/null; then
+if ss -tulnp | grep ':80 ' >/dev/null; then
     echo "Error: something is already running on port 80" >&2
     exit 1
 fi
 
 # check if something is running on port 443
-if lsof -i :443 >/dev/null; then
+if ss -tulnp | grep ':443 ' >/dev/null; then
     echo "Error: something is already running on port 443" >&2
     exit 1
 fi


### PR DESCRIPTION
On GCP instances lsof -i gives false positive about port usage. Using ss -tulnp fixes this.

Before installation:
```bash
root@vm-instance-7ed850b:/home/ewert# curl -sSL https://dokploy.com/install.sh | sh
Error: something is already running on port 80
root@vm-instance-7ed850b:/home/ewert# curl localhost
curl: (7) Failed to connect to localhost port 80 after 0 ms: Connection refused
root@vm-instance-7ed850b:/home/ewert# curl 127.0.0.1
curl: (7) Failed to connect to 127.0.0.1 port 80 after 0 ms: Connection refused
root@vm-instance-7ed850b:/home/ewert# lsof -i :80
COMMAND   PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
google_os 514 root    3u  IPv4  17711      0t0  TCP vm-instance-7ed850b.europe-west3-b.c.hres-sandbox.internal:36796->metadata.google.internal:http (ESTABLISHED)
google_gu 675 root    3u  IPv4  17358      0t0  TCP vm-instance-7ed850b.europe-west3-b.c.hres-sandbox.internal:43652->metadata.google.internal:http (ESTABLISHED)
root@vm-instance-7ed850b:/home/ewert# netstat -tulnp | grep :80
Command 'netstat' not found, but can be installed with:
apt install net-tools
root@vm-instance-7ed850b:/home/ewert# apt install net-tools
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  net-tools
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 204 kB of archives.
After this operation, 819 kB of additional disk space will be used.
Get:1 http://europe-west3.gce.archive.ubuntu.com/ubuntu jammy/main amd64 net-tools amd64 1.60+git20181103.0eebece-1ubuntu5 [204 kB]
Fetched 204 kB in 0s (3673 kB/s)
Selecting previously unselected package net-tools.
(Reading database ... 66054 files and directories currently installed.)
Preparing to unpack .../net-tools_1.60+git20181103.0eebece-1ubuntu5_amd64.deb ...
Unpacking net-tools (1.60+git20181103.0eebece-1ubuntu5) ...
Setting up net-tools (1.60+git20181103.0eebece-1ubuntu5) ...
Processing triggers for man-db (2.10.2-1) ...
Scanning processes...
Scanning linux images...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
root@vm-instance-7ed850b:/home/ewert# netstat -tulnp | grep :80
root@vm-instance-7ed850b:/home/ewert# ss -tulnp | grep :80
root@vm-instance-7ed850b:/home/ewert# sudo lsof -iTCP -sTCP:LISTEN -P
COMMAND   PID            USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
systemd-r 385 systemd-resolve   14u  IPv4  17146      0t0  TCP localhost:53 (LISTEN)
sshd      819            root    3u  IPv4  18029      0t0  TCP *:22 (LISTEN)
sshd      819            root    4u  IPv6  18031      0t0  TCP *:22 (LISTEN)
```

After installation:
```bash
root@vm-instance-7ed850b:/home/ewert# sudo lsof -iTCP -sTCP:LISTEN -P
COMMAND    PID            USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
systemd-r  385 systemd-resolve   14u  IPv4  17146      0t0  TCP localhost:53 (LISTEN)
sshd       819            root    3u  IPv4  18029      0t0  TCP *:22 (LISTEN)
sshd       819            root    4u  IPv6  18031      0t0  TCP *:22 (LISTEN)
dockerd   3846            root   25u  IPv6  31497      0t0  TCP *:2377 (LISTEN)
dockerd   3846            root   30u  IPv6  31503      0t0  TCP *:7946 (LISTEN)
dockerd   3846            root   46u  IPv6  37775      0t0  TCP *:6379 (LISTEN)
dockerd   3846            root   70u  IPv6  38455      0t0  TCP *:30000 (LISTEN)
docker-pr 4415            root    4u  IPv4  34265      0t0  TCP *:3000 (LISTEN)
docker-pr 4422            root    4u  IPv6  35025      0t0  TCP *:3000 (LISTEN)
docker-pr 4599            root    4u  IPv4  36311      0t0  TCP *:8080 (LISTEN)
docker-pr 4605            root    4u  IPv6  35261      0t0  TCP *:8080 (LISTEN)
docker-pr 4622            root    4u  IPv4  37317      0t0  TCP *:443 (LISTEN)
docker-pr 4629            root    4u  IPv6  35282      0t0  TCP *:443 (LISTEN)
docker-pr 4645            root    4u  IPv4  37339      0t0  TCP *:80 (LISTEN)
docker-pr 4653            root    4u  IPv6  36324      0t0  TCP *:80 (LISTEN)
root@vm-instance-7ed850b:/home/ewert# ss -tulnp | grep :80
tcp   LISTEN 0      4096           0.0.0.0:80         0.0.0.0:*    users:(("docker-proxy",pid=4645,fd=4))
tcp   LISTEN 0      4096           0.0.0.0:8080       0.0.0.0:*    users:(("docker-proxy",pid=4599,fd=4))
tcp   LISTEN 0      4096              [::]:80            [::]:*    users:(("docker-proxy",pid=4653,fd=4))
tcp   LISTEN 0      4096              [::]:8080          [::]:*    users:(("docker-proxy",pid=4605,fd=4))
root@vm-instance-7ed850b:/home/ewert# netstat -tulnp | grep :80
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      4645/docker-proxy
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      4599/docker-proxy
tcp6       0      0 :::80                   :::*                    LISTEN      4653/docker-proxy
tcp6       0      0 :::8080                 :::*                    LISTEN      4605/docker-proxy
```

