### PR TITLE
Correct Postgres url from password:password to user:password

### DIFF
--- a/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
@@ -80,7 +80,7 @@ export const ShowExternalPostgresCredentials = ({ postgresId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `postgresql://${data?.databasePassword}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
+			return `postgresql://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());


### PR DESCRIPTION
Postgres external url currently returns password:password when it should be user:password.