### PR TITLE
feat: (#107) webhook listener filter docker events based on image tag.

### DIFF
--- a/pages/api/deploy/[refreshToken].ts
+++ b/pages/api/deploy/[refreshToken].ts
@@ -35,7 +35,20 @@ export default async function handler(
 		const deploymentTitle = extractCommitMessage(req.headers, req.body);
 
 		const sourceType = application.sourceType;
-		if (sourceType === "github") {
+
+		if (sourceType === "docker") {
+			const applicationDockerTag = extractImageTagFromApplication(application.dockerImage);
+			if (applicationDockerTag) {
+				const webhookDockerTag = extractImageTagFromRequestEventPayload(req.headers, req.body);
+				if (webhookDockerTag && (webhookDockerTag !== applicationDockerTag)) {
+					res.status(301).json({
+						message: `Application Image Tag(${applicationDockerTag}) doesn't match request event payload Image Tag(${webhookDockerTag}).`
+					});
+					return;
+				}
+			}
+		}
+		else if (sourceType === "github") {
 			const branchName = extractBranchName(req.headers, req.body);
 			if (!branchName || branchName !== application.branch) {
 				res.status(301).json({ message: "Branch Not Match" });
@@ -79,6 +92,40 @@ export default async function handler(
 		res.status(400).json({ message: "Error To Deploy Application", error });
 	}
 }
+
+/**
+ * Return the last part of the image name, which is the tag
+ * Example: "my-image" => null
+ * Example: "my-image:latest" => "latest"
+ * Example: "my-image:1.0.0" => "1.0.0"
+ * Example: "myregistryhost:5000/fedora/httpd:version1.0" => "version1.0"
+ * @link https://docs.docker.com/reference/cli/docker/image/tag/
+ */
+function extractImageTagFromApplication(dockerImage: string | null) {
+	if (!dockerImage || typeof dockerImage !== "string") {
+		return null;
+	}
+
+	const partsOfDockerImageName = dockerImage.split(':')
+	if (partsOfDockerImageName.length === 1) {
+		return null;
+	}
+
+	return partsOfDockerImageName[partsOfDockerImageName.length - 1];
+}
+
+/**
+ * @link https://docs.docker.com/docker-hub/webhooks/#example-webhook-payload
+ */
+function extractImageTagFromRequestEventPayload(headers: any, body: any) {
+	if (headers["user-agent"]?.includes("Go-http-client")) {
+		if (body.push_data && body.repository) {
+			return body.push_data.tag;
+		}
+	}
+	return null;
+}
+
 function extractCommitMessage(headers: any, body: any) {
 	// GitHub
 	if (headers["x-github-event"]) {

--- a/pages/api/deploy/[refreshToken].ts
+++ b/pages/api/deploy/[refreshToken].ts
@@ -47,9 +47,10 @@ export default async function handler(
 				webhookDockerTag &&
 				webhookDockerTag !== applicationDockerTag
 			) {
-				return res.status(301).json({
+				 res.status(301).json({
 					message: `Application Image Tag (${applicationDockerTag}) doesn't match request event payload Image Tag (${webhookDockerTag}).`,
 				});
+				return;
 			}
 		}
 		else if (sourceType === "github") {


### PR DESCRIPTION
Tracking issue #107 

## Summary
Added an filter when `application.sourceType` is equal `docker`. 

## Scenarios: 
- User setup docker image **WITHOUT** including tag, then
  -> nothing changes, application still listening to dockerhub events from webhook and adding deploy action to queue.

- User setup docker image **INCLUDING** tag, then
  - Extract tag from provided image
  - Extract tag from webhook payload
     -> If not equals 
       - ends with 301, do not add it on queue








#### Autolink
Fixes #107 
Resolves #107 