### PR TITLE
Updated the database view to hide the password in the connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ yarn-error.log*
 
 *.lockb
 *.rdb
+.idea

--- a/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
@@ -22,7 +22,7 @@ import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-import ToggleVisiblityInput from "@/components/shared/toggle-visibility-input"
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 const DockerProviderSchema = z.object({
 	externalPort: z.preprocess((a) => {
@@ -137,7 +137,7 @@ export const ShowExternalMariadbCredentials = ({ mariadbId }: Props) => {
 										<div className="flex flex-col gap-3">
 											{/* jdbc:mariadb://5.161.59.207:3306/pixel-calculate?user=mariadb&password=HdVXfq6hM7W7F1 */}
 											<Label>External Host</Label>
-											<ToggleVisiblityInput value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} disabled />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
@@ -22,6 +22,7 @@ import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import ToggleVisiblityInput from "@/components/shared/toggle-visibility-input"
 
 const DockerProviderSchema = z.object({
 	externalPort: z.preprocess((a) => {
@@ -78,7 +79,7 @@ export const ShowExternalMariadbCredentials = ({ mariadbId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}/${data?.databaseName}`;
+			return `mariadb://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());
@@ -136,7 +137,7 @@ export const ShowExternalMariadbCredentials = ({ mariadbId }: Props) => {
 										<div className="flex flex-col gap-3">
 											{/* jdbc:mariadb://5.161.59.207:3306/pixel-calculate?user=mariadb&password=HdVXfq6hM7W7F1 */}
 											<Label>External Host</Label>
-											<Input disabled value={connectionUrl} />
+											<ToggleVisiblityInput value={connectionUrl} />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
@@ -78,7 +78,7 @@ export const ShowExternalMariadbCredentials = ({ mariadbId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}/${data?.databaseName}`;
+			return `mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-external-mariadb-credentials.tsx
@@ -78,7 +78,7 @@ export const ShowExternalMariadbCredentials = ({ mariadbId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mariadb://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
+			return `mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	mariadbId: string;
@@ -31,6 +31,7 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
+										disabled
 										value={data?.databasePassword}
 									/>
 								</div>
@@ -39,6 +40,7 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 								<Label>Root Password</Label>
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
+										disabled
 										value={data?.databaseRootPassword}
 									/>
 								</div>
@@ -56,6 +58,7 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
+									disabled
 									value={`mariadb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>

--- a/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
@@ -60,7 +60,7 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`mariadb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:3306/${data?.databaseName}`}
+									value={`mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
@@ -60,7 +60,7 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:3306/${data?.databaseName}`}
+									value={`mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
+++ b/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	mariadbId: string;
@@ -29,20 +30,16 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databasePassword}
-										type="password"
 									/>
 								</div>
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Root Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databaseRootPassword}
-										type="password"
 									/>
 								</div>
 							</div>
@@ -58,9 +55,8 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
-								<Input
-									disabled
-									value={`mariadb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:3306/${data?.databaseName}`}
+								<ToggleVisibilityInput
+									value={`mariadb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
@@ -1,4 +1,4 @@
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -137,7 +137,7 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<ToggleVisibilityInput value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} disabled />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
@@ -79,7 +79,7 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mongodb://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}`;
+			return `mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
@@ -79,7 +79,7 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}`;
+			return `mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
@@ -1,3 +1,4 @@
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -79,7 +80,7 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}`;
+			return `mongodb://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());
@@ -136,7 +137,7 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<Input disabled value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	mongoId: string;
@@ -26,10 +27,8 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databasePassword}
-										type="password"
 									/>
 								</div>
 							</div>
@@ -46,9 +45,8 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
-								<Input
-									disabled
-									value={`mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:27017`}
+								<ToggleVisibilityInput
+									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -48,7 +48,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017`}
+									value={`mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:27017`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -48,7 +48,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:27017`}
+									value={`mongodb://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:27017`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	mongoId: string;
@@ -28,6 +28,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
+										disabled
 										value={data?.databasePassword}
 									/>
 								</div>
@@ -46,6 +47,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
+									disabled
 									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017`}
 								/>
 							</div>

--- a/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
@@ -79,7 +79,7 @@ export const ShowExternalMysqlCredentials = ({ mysqlId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mysql://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
+			return `mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
@@ -79,7 +79,7 @@ export const ShowExternalMysqlCredentials = ({ mysqlId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}/${data?.databaseName}`;
+			return `mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
@@ -1,3 +1,4 @@
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -79,7 +80,7 @@ export const ShowExternalMysqlCredentials = ({ mysqlId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}/${data?.databaseName}`;
+			return `mysql://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());
@@ -136,7 +137,7 @@ export const ShowExternalMysqlCredentials = ({ mysqlId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<Input disabled value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-external-mysql-credentials.tsx
@@ -1,4 +1,4 @@
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -137,7 +137,7 @@ export const ShowExternalMysqlCredentials = ({ mysqlId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<ToggleVisibilityInput value={connectionUrl} />
+											<ToggleVisibilityInput disabled value={connectionUrl} />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	mysqlId: string;
@@ -29,20 +30,16 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databasePassword}
-										type="password"
 									/>
 								</div>
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Root Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databaseRootPassword}
-										type="password"
 									/>
 								</div>
 							</div>
@@ -58,9 +55,8 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
-								<Input
-									disabled
-									value={`mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:3306/${data?.databaseName}`}
+								<ToggleVisibilityInput
+									value={`mysql://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	mysqlId: string;
@@ -31,6 +31,7 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
+										disabled
 										value={data?.databasePassword}
 									/>
 								</div>
@@ -39,6 +40,7 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 								<Label>Root Password</Label>
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
+										disabled
 										value={data?.databaseRootPassword}
 									/>
 								</div>
@@ -56,6 +58,7 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
+									disabled
 									value={`mysql://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>

--- a/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
@@ -60,7 +60,7 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:3306/${data?.databaseName}`}
+									value={`mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
+++ b/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
@@ -60,7 +60,7 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`mysql://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:3306/${data?.databaseName}`}
+									value={`mysql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:3306/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
@@ -80,7 +80,7 @@ export const ShowExternalPostgresCredentials = ({ postgresId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `postgresql://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
+			return `postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
@@ -80,7 +80,7 @@ export const ShowExternalPostgresCredentials = ({ postgresId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}/${data?.databaseName}`;
+			return `postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
@@ -1,4 +1,4 @@
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -138,7 +138,7 @@ export const ShowExternalPostgresCredentials = ({ postgresId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<ToggleVisibilityInput value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} disabled />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-external-postgres-credentials.tsx
@@ -1,3 +1,4 @@
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -80,7 +81,7 @@ export const ShowExternalPostgresCredentials = ({ postgresId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}/${data?.databaseName}`;
+			return `postgresql://${data?.databaseUser}:${data?.databasePassword}@${hostname}:${port}/${data?.databaseName}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());
@@ -137,7 +138,7 @@ export const ShowExternalPostgresCredentials = ({ postgresId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<Input disabled value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	postgresId: string;
@@ -32,6 +32,7 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
 										value={data?.databasePassword}
+										disabled
 									/>
 								</div>
 							</div>
@@ -48,6 +49,7 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 							<div className="flex flex-col gap-2">
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
+									disabled
 									value={`postgresql://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:5432/${data?.databaseName}`}
 								/>
 							</div>

--- a/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -50,7 +50,7 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:5432/${data?.databaseName}`}
+									value={`postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:5432/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -50,7 +50,7 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`postgresql://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:5432/${data?.databaseName}`}
+									value={`postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:5432/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	postgresId: string;
@@ -29,10 +30,8 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databasePassword}
-										type="password"
 									/>
 								</div>
 							</div>
@@ -48,9 +47,8 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 
 							<div className="flex flex-col gap-2">
 								<Label>Internal Connection URL </Label>
-								<Input
-									disabled
-									value={`postgresql://${data?.databaseUser}:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:5432/${data?.databaseName}`}
+								<ToggleVisibilityInput
+									value={`postgresql://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:5432/${data?.databaseName}`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/redis/general/show-external-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-external-redis-credentials.tsx
@@ -79,7 +79,7 @@ export const ShowExternalRedisCredentials = ({ redisId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `redis://default:${data?.databasePassword}@${hostname}:${port}`;
+			return `redis://default:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/redis/general/show-external-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-external-redis-credentials.tsx
@@ -1,3 +1,4 @@
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -79,7 +80,7 @@ export const ShowExternalRedisCredentials = ({ redisId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `redis://default:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}`;
+			return `redis://default:${data?.databasePassword}@${hostname}:${port}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());
@@ -129,7 +130,7 @@ export const ShowExternalRedisCredentials = ({ redisId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<Input disabled value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/redis/general/show-external-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-external-redis-credentials.tsx
@@ -79,7 +79,7 @@ export const ShowExternalRedisCredentials = ({ redisId }: Props) => {
 			const hostname = window.location.hostname;
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `redis://default:${'*'.repeat(data?.databasePassword.length)}@${hostname}:${port}`;
+			return `redis://default:${'*'.repeat(data?.databasePassword.length || 8)}@${hostname}:${port}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/components/dashboard/redis/general/show-external-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-external-redis-credentials.tsx
@@ -1,4 +1,4 @@
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -130,7 +130,7 @@ export const ShowExternalRedisCredentials = ({ redisId }: Props) => {
 									<div className="grid w-full gap-8">
 										<div className="flex flex-col gap-3">
 											<Label>External Host</Label>
-											<ToggleVisibilityInput value={connectionUrl} />
+											<ToggleVisibilityInput value={connectionUrl} disabled />
 										</div>
 									</div>
 								)}

--- a/components/dashboard/redis/general/show-internal-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-internal-redis-credentials.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	redisId: string;
@@ -25,10 +26,8 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
 								<div className="flex flex-row gap-4">
-									<Input
-										disabled
+									<ToggleVisibilityInput
 										value={data?.databasePassword}
-										type="password"
 									/>
 								</div>
 							</div>
@@ -44,9 +43,8 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
-								<Input
-									disabled
-									value={`redis://default:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:6379`}
+								<ToggleVisibilityInput
+									value={`redis://default:${data?.databasePassword}@${data?.appName}:6379`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/redis/general/show-internal-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-internal-redis-credentials.tsx
@@ -46,7 +46,7 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`redis://default:${data?.databasePassword}@${data?.appName}:6379`}
+									value={`redis://default:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:6379`}
 								/>
 							</div>
 						</div>

--- a/components/dashboard/redis/general/show-internal-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-internal-redis-credentials.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
-import ToggleVisibilityInput from "@/components/shared/toggle-visibility-input";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 
 interface Props {
 	redisId: string;
@@ -28,6 +28,7 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 								<div className="flex flex-row gap-4">
 									<ToggleVisibilityInput
 										value={data?.databasePassword}
+										disabled
 									/>
 								</div>
 							</div>
@@ -44,6 +45,7 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 							<div className="flex flex-col gap-2 md:col-span-2">
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
+									disabled
 									value={`redis://default:${data?.databasePassword}@${data?.appName}:6379`}
 								/>
 							</div>

--- a/components/dashboard/redis/general/show-internal-redis-credentials.tsx
+++ b/components/dashboard/redis/general/show-internal-redis-credentials.tsx
@@ -46,7 +46,7 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<Input
 									disabled
-									value={`redis://default:${'*'.repeat(data?.databasePassword.length)}@${data?.appName}:6379`}
+									value={`redis://default:${'*'.repeat(data?.databasePassword.length || 8)}@${data?.appName}:6379`}
 								/>
 							</div>
 						</div>

--- a/components/shared/toggle-visibility-input.tsx
+++ b/components/shared/toggle-visibility-input.tsx
@@ -1,22 +1,33 @@
 import { useState } from "react";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
-import { Input } from "../ui/input";
+import { Input, type InputProps } from "../ui/input";
 import { Button } from "../ui/button";
 
-interface ToggleVisibilityInputProps {
-    value: string | undefined
+interface ToggleVisibilityInputProps extends InputProps {
+	value: string | undefined;
 }
 
-export default function ToggleVisibilityInput({ value }: ToggleVisibilityInputProps) {
-    const [inputType, setInputType] = useState<'password' | 'text'>('password');
+export const ToggleVisibilityInput = ({
+	value,
+	...props
+}: ToggleVisibilityInputProps) => {
+	const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
-    const togglePasswordVisibility = () => {
-        setInputType(prevType => (prevType === 'password' ? 'text' : 'password'));
-    };
-    return (
-        <div className="flex w-full items-center space-x-2">
-            <Input value={value} type={inputType} />
-            <Button onClick={togglePasswordVisibility}>{inputType === "password" ? <EyeIcon /> : <EyeOffIcon />}</Button>
-        </div>
-    )
-}
+	const togglePasswordVisibility = () => {
+		setIsPasswordVisible((prevVisibility) => !prevVisibility);
+	};
+
+	const inputType = isPasswordVisible ? "text" : "password";
+	return (
+		<div className="flex w-full items-center space-x-2">
+			<Input value={value} type={inputType} {...props} />
+			<Button onClick={togglePasswordVisibility} variant={"secondary"}>
+				{inputType === "password" ? (
+					<EyeIcon className="size-4 text-muted-foreground" />
+				) : (
+					<EyeOffIcon className="size-4 text-muted-foreground" />
+				)}
+			</Button>
+		</div>
+	);
+};

--- a/components/shared/toggle-visibility-input.tsx
+++ b/components/shared/toggle-visibility-input.tsx
@@ -3,14 +3,7 @@ import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { Input, type InputProps } from "../ui/input";
 import { Button } from "../ui/button";
 
-interface ToggleVisibilityInputProps extends InputProps {
-	value: string | undefined;
-}
-
-export const ToggleVisibilityInput = ({
-	value,
-	...props
-}: ToggleVisibilityInputProps) => {
+export const ToggleVisibilityInput = ({ ...props }: InputProps) => {
 	const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
 	const togglePasswordVisibility = () => {
@@ -20,7 +13,7 @@ export const ToggleVisibilityInput = ({
 	const inputType = isPasswordVisible ? "text" : "password";
 	return (
 		<div className="flex w-full items-center space-x-2">
-			<Input value={value} type={inputType} {...props} />
+			<Input type={inputType} {...props} />
 			<Button onClick={togglePasswordVisibility} variant={"secondary"}>
 				{inputType === "password" ? (
 					<EyeIcon className="size-4 text-muted-foreground" />

--- a/components/shared/toggle-visibility-input.tsx
+++ b/components/shared/toggle-visibility-input.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+
+interface ToggleVisibilityInputProps {
+    value: string | undefined
+}
+
+export default function ToggleVisibilityInput({ value }: ToggleVisibilityInputProps) {
+    const [inputType, setInputType] = useState<'password' | 'text'>('password');
+
+    const togglePasswordVisibility = () => {
+        setInputType(prevType => (prevType === 'password' ? 'text' : 'password'));
+    };
+    return (
+        <div className="flex w-full items-center space-x-2">
+            <Input value={value} type={inputType} />
+            <Button onClick={togglePasswordVisibility}>{inputType === "password" ? <EyeIcon /> : <EyeOffIcon />}</Button>
+        </div>
+    )
+}


### PR DESCRIPTION
In the current Version inside the Database Detail Views, the Password is exposed inside the internal connectionstrings.
![image](https://github.com/Dokploy/dokploy/assets/89946878/e1b1d9ab-4c22-4118-a37e-a73fdb8ec84c)
I have updated the Detailviews to replace the passwords inside the connectionstrings with '*' so the password doesn't get accidentally leaked :)
![image](https://github.com/Dokploy/dokploy/assets/89946878/f03c4adf-1c2d-4273-9afc-54521bfaedcf)

I have also updated this for the external connectionstring, when exposing the database to the internet where this is even more critical

