### PR TITLE
fix: make databases be only available in manager

### DIFF
--- a/server/utils/databases/mariadb.ts
+++ b/server/utils/databases/mariadb.ts
@@ -63,6 +63,9 @@ export const buildMariadb = async (mariadb: MariadbWithMounts) => {
 			Resources: {
 				...resources,
 			},
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
 		Mode: {
 			Replicated: {

--- a/server/utils/databases/mongo.ts
+++ b/server/utils/databases/mongo.ts
@@ -63,6 +63,9 @@ export const buildMongo = async (mongo: MongoWithMounts) => {
 			Resources: {
 				...resources,
 			},
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
 		Mode: {
 			Replicated: {

--- a/server/utils/databases/mysql.ts
+++ b/server/utils/databases/mysql.ts
@@ -69,6 +69,9 @@ export const buildMysql = async (mysql: MysqlWithMounts) => {
 			Resources: {
 				...resources,
 			},
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
 		Mode: {
 			Replicated: {

--- a/server/utils/databases/postgres.ts
+++ b/server/utils/databases/postgres.ts
@@ -63,6 +63,9 @@ export const buildPostgres = async (postgres: PostgresWithMounts) => {
 			Resources: {
 				...resources,
 			},
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
 		Mode: {
 			Replicated: {

--- a/server/utils/databases/redis.ts
+++ b/server/utils/databases/redis.ts
@@ -61,6 +61,9 @@ export const buildRedis = async (redis: RedisWithMounts) => {
 			Resources: {
 				...resources,
 			},
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
 		Mode: {
 			Replicated: {


### PR DESCRIPTION
When using multi node feature, it could be sometimes that databases being deployed on another node, so now all the databases will be only on the manager node(DOKPLOY SERVER)