### PR TITLE
Clarify error message for naming validation in `AppName`

### DIFF
--- a/components/dashboard/project/add-application.tsx
+++ b/components/dashboard/project/add-application.tsx
@@ -40,7 +40,7 @@ const AddTemplateSchema = z.object({
 		})
 		.regex(/^[a-z](?!.*--)([a-z0-9-]*[a-z])?$/, {
 			message:
-				"App name supports letters, numbers, '-' and can only start and end letters, and does not support continuous '-'",
+				"App name supports lowercase letters, numbers, '-' and can only start and end letters, and does not support continuous '-'",
 		}),
 	description: z.string().optional(),
 });

--- a/components/dashboard/project/add-compose.tsx
+++ b/components/dashboard/project/add-compose.tsx
@@ -48,7 +48,7 @@ const AddComposeSchema = z.object({
 		})
 		.regex(/^[a-z](?!.*--)([a-z0-9-]*[a-z])?$/, {
 			message:
-				"App name supports letters, numbers, '-' and can only start and end letters, and does not support continuous '-'",
+				"App name supports lowercase letters, numbers, '-' and can only start and end letters, and does not support continuous '-'",
 		}),
 	description: z.string().optional(),
 });

--- a/components/dashboard/project/add-database.tsx
+++ b/components/dashboard/project/add-database.tsx
@@ -66,7 +66,7 @@ const baseDatabaseSchema = z.object({
 		})
 		.regex(/^[a-z](?!.*--)([a-z0-9-]*[a-z])?$/, {
 			message:
-				"App name supports letters, numbers, '-' and can only start and end letters, and does not support continuous '-'",
+				"App name supports lowercase letters, numbers, '-' and can only start and end letters, and does not support continuous '-'",
 		}),
 	databasePassword: z.string(),
 	dockerImage: z.string(),


### PR DESCRIPTION
The current error message for naming validation in AppName should be updated to explicitly state that only lowercase letters are supported. The new error message should be clear and concise, applying to naming **applications**, **databases**, and **compose items**.