### PR TITLE
fix: docker compose monitoring

### DIFF
--- a/components/dashboard/compose/monitoring/show.tsx
+++ b/components/dashboard/compose/monitoring/show.tsx
@@ -31,6 +31,7 @@ export const ShowMonitoringCompose = ({
 	const { data } = api.docker.getContainersByAppNameMatch.useQuery(
 		{
 			appName: appName,
+			appType,
 		},
 		{
 			enabled: !!appName,


### PR DESCRIPTION
It is the same as https://github.com/Dokploy/dokploy/pull/257 but for monitoring:

Current: 
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/de53b474-e0a1-4ea4-bafe-2242da7cac06">

Update:
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/180b3a8f-e4ef-47f3-aa2f-2f7847728d56">
