### PR TITLE
fix: http to https

### DIFF
--- a/__test__/traefik/traefik.test.ts
+++ b/__test__/traefik/traefik.test.ts
@@ -18,7 +18,7 @@ const baseApp: ApplicationNested = {
 	cpuReservation: null,
 	createdAt: "",
 	customGitBranch: "",
-	customGitBuildPath: "/",
+	customGitBuildPath: "",
 	customGitSSHKey: "",
 	customGitUrl: "",
 	description: "",

--- a/__test__/traefik/traefik.test.ts
+++ b/__test__/traefik/traefik.test.ts
@@ -1,0 +1,187 @@
+import type { Domain } from "@/server/api/services/domain";
+import type { Redirect } from "@/server/api/services/redirect";
+import type { ApplicationNested } from "@/server/utils/builders";
+import { createRouterConfig } from "@/server/utils/traefik/domain";
+import { expect, test } from "vitest";
+
+const baseApp: ApplicationNested = {
+	applicationId: "",
+	applicationStatus: "done",
+	appName: "",
+	autoDeploy: true,
+	branch: null,
+	buildArgs: null,
+	buildPath: "/",
+	buildType: "nixpacks",
+	command: null,
+	cpuLimit: null,
+	cpuReservation: null,
+	createdAt: "",
+	customGitBranch: "",
+	customGitBuildPath: "/",
+	customGitSSHKey: "",
+	customGitUrl: "",
+	description: "",
+	dockerfile: null,
+	dockerImage: null,
+	dropBuildPath: null,
+	enabled: null,
+	env: null,
+	healthCheckSwarm: null,
+	labelsSwarm: null,
+	memoryLimit: null,
+	memoryReservation: null,
+	modeSwarm: null,
+	mounts: [],
+	name: "",
+	networkSwarm: null,
+	owner: null,
+	password: null,
+	placementSwarm: null,
+	ports: [],
+	projectId: "",
+	redirects: [],
+	refreshToken: "",
+	registry: null,
+	registryId: null,
+	replicas: 1,
+	repository: null,
+	restartPolicySwarm: null,
+	rollbackConfigSwarm: null,
+	security: [],
+	sourceType: "git",
+	subtitle: null,
+	title: null,
+	updateConfigSwarm: null,
+	username: null,
+};
+
+const baseDomain: Domain = {
+	applicationId: "",
+	certificateType: "none",
+	createdAt: "",
+	domainId: "",
+	host: "",
+	https: false,
+	path: null,
+	port: null,
+	uniqueConfigKey: 1,
+};
+
+const baseRedirect: Redirect = {
+	redirectId: "",
+	regex: "",
+	replacement: "",
+	permanent: false,
+	uniqueConfigKey: 1,
+	createdAt: "",
+	applicationId: "",
+};
+
+/** Middlewares */
+
+test("Web entrypoint on http domain", async () => {
+	const router = await createRouterConfig(
+		baseApp,
+		{ ...baseDomain, https: false },
+		"web",
+	);
+
+	expect(router.middlewares).not.toContain("redirect-to-https");
+});
+
+test("Web entrypoint on http domain with redirect", async () => {
+	const router = await createRouterConfig(
+		{
+			...baseApp,
+			appName: "test",
+			redirects: [{ ...baseRedirect, uniqueConfigKey: 1 }],
+		},
+		{ ...baseDomain, https: false },
+		"web",
+	);
+
+	expect(router.middlewares).not.toContain("redirect-to-https");
+	expect(router.middlewares).toContain("redirect-test-1");
+});
+
+test("Web entrypoint on http domain with multiple redirect", async () => {
+	const router = await createRouterConfig(
+		{
+			...baseApp,
+			appName: "test",
+			redirects: [
+				{ ...baseRedirect, uniqueConfigKey: 1 },
+				{ ...baseRedirect, uniqueConfigKey: 2 },
+			],
+		},
+		{ ...baseDomain, https: false },
+		"web",
+	);
+
+	expect(router.middlewares).not.toContain("redirect-to-https");
+	expect(router.middlewares).toContain("redirect-test-1");
+	expect(router.middlewares).toContain("redirect-test-2");
+});
+
+test("Web entrypoint on https domain", async () => {
+	const router = await createRouterConfig(
+		baseApp,
+		{ ...baseDomain, https: true },
+		"web",
+	);
+
+	expect(router.middlewares).toContain("redirect-to-https");
+});
+
+test("Web entrypoint on https domain with redirect", async () => {
+	const router = await createRouterConfig(
+		{
+			...baseApp,
+			appName: "test",
+			redirects: [{ ...baseRedirect, uniqueConfigKey: 1 }],
+		},
+		{ ...baseDomain, https: true },
+		"web",
+	);
+
+	expect(router.middlewares).toContain("redirect-to-https");
+	expect(router.middlewares).not.toContain("redirect-test-1");
+});
+
+test("Websecure entrypoint on https domain", async () => {
+	const router = await createRouterConfig(
+		baseApp,
+		{ ...baseDomain, https: true },
+		"websecure",
+	);
+
+	expect(router.middlewares).not.toContain("redirect-to-https");
+});
+
+test("Websecure entrypoint on https domain with redirect", async () => {
+	const router = await createRouterConfig(
+		{
+			...baseApp,
+			appName: "test",
+			redirects: [{ ...baseRedirect, uniqueConfigKey: 1 }],
+		},
+		{ ...baseDomain, https: true },
+		"websecure",
+	);
+
+	expect(router.middlewares).not.toContain("redirect-to-https");
+	expect(router.middlewares).toContain("redirect-test-1");
+});
+
+/** Certificates */
+
+test("CertificateType on websecure entrypoint", async () => {
+	const router = await createRouterConfig(
+		baseApp,
+		{ ...baseDomain, certificateType: "letsencrypt" },
+		"websecure",
+	);
+
+	expect(router.tls?.certResolver).toBe("letsencrypt");
+});

--- a/server/utils/traefik/domain.ts
+++ b/server/utils/traefik/domain.ts
@@ -25,7 +25,6 @@ export const manageDomain = async (app: ApplicationNested, domain: Domain) => {
 		"web",
 	);
 
-	// if (domain.https && process.env.NODE_ENV === "production") {
 	if (domain.https) {
 		config.http.routers[routerNameSecure] = await createRouterConfig(
 			app,


### PR DESCRIPTION
Fix: https://github.com/Dokploy/dokploy/issues/253

When a domain is HTTPS, we need to generate two routers, one for the **web** and one for the **webscure** entrypoint.
The **redirect-to-https** middleware needs to stay on the **web** router, otherwise it is not catched.

There's a bit of conditioning to manage, I summarise here all the cases:
- when the domain is HTTPS, the **web** router middlewares must contain only the **redirect-to-https** middleware
- when the domain is HTTP, the **web** router middlewares must contain only the custom redirects
- when the domain is HTTPS, the **websecure** router must contain only the custom redirects

I wrote a unit test file to test these conditions. More tests can be added to cover other features, like domain deletion and domain update, but it's a stable starting point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a suite of automated unit tests for router configuration, validating HTTP and HTTPS behavior.
	- Enhanced domain management to support separate router configurations for secure and non-secure traffic.

- **Bug Fixes**
	- Improved middleware handling to ensure proper application of redirects and security settings based on router configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->