### PR TITLE
fix: terminal monospace font

### DIFF
--- a/components/dashboard/docker/logs/docker-logs-id.tsx
+++ b/components/dashboard/docker/logs/docker-logs-id.tsx
@@ -23,8 +23,11 @@ export const DockerLogsId: React.FC<Props> = ({ id, containerId }) => {
 			cursorBlink: true,
 			cols: 80,
 			rows: 30,
-			lineHeight: 1.4,
+			lineHeight: 1.25,
 			fontWeight: 400,
+			fontSize: 14,
+			fontFamily:
+				'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
 
 			convertEol: true,
 			theme: {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -102,12 +102,6 @@
   }
 }
 
-#terminal span {
-  font-family: "Inter", sans-serif;
-  font-weight: 500;
-  letter-spacing: 0px !important;
-}
-
 /* Codemirror */
 .cm-editor {
   @apply w-full h-full rounded-md overflow-hidden border border-solid border-border outline-none;


### PR DESCRIPTION
I'm matching the tailwind `pre` styles. Terminal text is now selectable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Changes**
  - Improved text display in the Docker logs with adjusted line height, font size, and font family for better readability.
  - Updated terminal text styles by removing specific font settings, leading to a potential default styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->