### PR TITLE
fix: Ensure Proper Permissions for acme.json in Traefik Configuration

### DIFF
--- a/server/setup/traefik-setup.ts
+++ b/server/setup/traefik-setup.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { CreateServiceOptions } from "dockerode";
 import { dump } from "js-yaml";
@@ -86,17 +86,10 @@ export const initializeTraefik = async () => {
 
 export const createDefaultServerTraefikConfig = () => {
 	const configFilePath = path.join(DYNAMIC_TRAEFIK_PATH, "dokploy.yml");
-	const acmeJsonPath = path.join(DYNAMIC_TRAEFIK_PATH, "acme.json");
-	
-	if (existsSync(acmeJsonPath)) {
-	    chmodSync(acmeJsonPath, '600');
-	} else {
-	    console.error(`File not found: ${acmeJsonPath}`);
-	}
-	
+
 	if (existsSync(configFilePath)) {
-	    console.log("Default traefik config already exists");
-	    return;
+		console.log("Default traefik config already exists");
+		return;
 	}
 
 	const appName = "dokploy";
@@ -133,6 +126,11 @@ export const createDefaultServerTraefikConfig = () => {
 
 export const createDefaultTraefikConfig = () => {
 	const mainConfig = path.join(MAIN_TRAEFIK_PATH, "traefik.yml");
+	const acmeJsonPath = path.join(DYNAMIC_TRAEFIK_PATH, "acme.json");
+
+	if (existsSync(acmeJsonPath)) {
+		chmodSync(acmeJsonPath, "600");
+	}
 	if (existsSync(mainConfig)) {
 		console.log("Main config already exists");
 		return;
@@ -192,12 +190,6 @@ export const createDefaultTraefikConfig = () => {
 	const yamlStr = dump(configObject);
 	mkdirSync(MAIN_TRAEFIK_PATH, { recursive: true });
 	writeFileSync(mainConfig, yamlStr, "utf8");
-	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
-	if (existsSync(acmeJsonPath)) {
-	    chmodSync(acmeJsonPath, '600');
-	} else {
-	    console.error(`File not found: ${acmeJsonPath}, func createDefaultTraefikConfig`);
-	}
 };
 
 export const createDefaultMiddlewares = () => {

--- a/server/setup/traefik-setup.ts
+++ b/server/setup/traefik-setup.ts
@@ -86,16 +86,17 @@ export const initializeTraefik = async () => {
 
 export const createDefaultServerTraefikConfig = () => {
 	const configFilePath = path.join(DYNAMIC_TRAEFIK_PATH, "dokploy.yml");
-	if (existsSync(configFilePath)) {
-		console.log("Default traefik config already exists");
-		return;
-	}
+	const acmeJsonPath = path.join(DYNAMIC_TRAEFIK_PATH, "acme.json");
 	
-	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
 	if (existsSync(acmeJsonPath)) {
 	    chmodSync(acmeJsonPath, '600');
 	} else {
 	    console.error(`File not found: ${acmeJsonPath}`);
+	}
+	
+	if (existsSync(configFilePath)) {
+	    console.log("Default traefik config already exists");
+	    return;
 	}
 
 	const appName = "dokploy";
@@ -191,6 +192,12 @@ export const createDefaultTraefikConfig = () => {
 	const yamlStr = dump(configObject);
 	mkdirSync(MAIN_TRAEFIK_PATH, { recursive: true });
 	writeFileSync(mainConfig, yamlStr, "utf8");
+	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
+	if (existsSync(acmeJsonPath)) {
+	    chmodSync(acmeJsonPath, '600');
+	} else {
+	    console.error(`File not found: ${acmeJsonPath}, func createDefaultTraefikConfig`);
+	}
 };
 
 export const createDefaultMiddlewares = () => {

--- a/server/setup/traefik-setup.ts
+++ b/server/setup/traefik-setup.ts
@@ -186,7 +186,11 @@ export const createDefaultTraefikConfig = () => {
 	writeFileSync(mainConfig, yamlStr, "utf8");
 	
 	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
-	chmodSync(acmeJsonPath, '600');
+	if (existsSync(acmeJsonPath)) {
+	    chmodSync(acmeJsonPath, '600');
+	} else {
+	    console.error(`File not found: ${acmeJsonPath}`);
+	}
 };
 
 export const createDefaultMiddlewares = () => {

--- a/server/setup/traefik-setup.ts
+++ b/server/setup/traefik-setup.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, chmodSync } from "node:fs";
 import path from "node:path";
 import type { CreateServiceOptions } from "dockerode";
 import { dump } from "js-yaml";
@@ -184,6 +184,9 @@ export const createDefaultTraefikConfig = () => {
 	const yamlStr = dump(configObject);
 	mkdirSync(MAIN_TRAEFIK_PATH, { recursive: true });
 	writeFileSync(mainConfig, yamlStr, "utf8");
+	
+	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
+	chmodSync(acmeJsonPath, '600');
 };
 
 export const createDefaultMiddlewares = () => {

--- a/server/setup/traefik-setup.ts
+++ b/server/setup/traefik-setup.ts
@@ -90,6 +90,13 @@ export const createDefaultServerTraefikConfig = () => {
 		console.log("Default traefik config already exists");
 		return;
 	}
+	
+	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
+	if (existsSync(acmeJsonPath)) {
+	    chmodSync(acmeJsonPath, '600');
+	} else {
+	    console.error(`File not found: ${acmeJsonPath}`);
+	}
 
 	const appName = "dokploy";
 	const serviceURLDefault = `http://${appName}:${process.env.PORT || 3000}`;
@@ -184,13 +191,6 @@ export const createDefaultTraefikConfig = () => {
 	const yamlStr = dump(configObject);
 	mkdirSync(MAIN_TRAEFIK_PATH, { recursive: true });
 	writeFileSync(mainConfig, yamlStr, "utf8");
-	
-	const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
-	if (existsSync(acmeJsonPath)) {
-	    chmodSync(acmeJsonPath, '600');
-	} else {
-	    console.error(`File not found: ${acmeJsonPath}`);
-	}
 };
 
 export const createDefaultMiddlewares = () => {


### PR DESCRIPTION
This is a potential solution of issue #259 

Description:
This pull request introduces a change to the createDefaultTraefikConfig function to ensure that the acme.json file, used by Traefik for certificate management, is created with the correct file permissions. Specifically, the permissions are set to 600 to enhance security by allowing only the file owner to read and write to the file.

Changes Made:

Added chmodSync(acmeJsonPath, '600') after the creation of acme.json to set file permissions.
Ensured the correct path /etc/dokploy/traefik/dynamic/acme.json is used for acme.json.
Code Example:

```javascript
// Creating acme.json file and setting permissions to 600
const acmeJsonPath = "/etc/dokploy/traefik/dynamic/acme.json";
chmodSync(acmeJsonPath, '600');
```

Reason for Change:
Setting the permissions of acme.json to 600 ensures that only the file owner has read and write access. This is crucial for maintaining the security of the certificate data stored in acme.json.

Testing and Validation:
Tested the creation and permission setting of acme.json to confirm that the file is created with the appropriate permissions and that Traefik can read and write to it as expected.

Impact:
This change enhances the security of the Traefik setup by ensuring the acme.json file is not accessible to unauthorized users.

Warning:
The code has only been tested on a ubuntu22 server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced security by restricting access to the `acme.json` file, ensuring only the owner can read and write to it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->