### PR TITLE
fix(templates): change path of volumes to be in files folder to prevent the volumes delete in each deploy

### DIFF
--- a/templates/appsmith/docker-compose.yml
+++ b/templates/appsmith/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "3.8"
 services:
-   appsmith:
-     image: index.docker.io/appsmith/appsmith-ee:v1.29
-     networks:
-        - dokploy-network
-     ports:
-         - ${APP_SMITH_PORT}
-     labels:
-        - "traefik.enable=true"
-        - "traefik.http.routers.${HASH}.rule=Host(`${APP_SMITH_HOST}`)"
-        - "traefik.http.services.${HASH}.loadbalancer.server.port=${APP_SMITH_PORT}"
-     volumes:
-         - ./stacks:/appsmith-stacks
+  appsmith:
+    image: index.docker.io/appsmith/appsmith-ee:v1.29
+    networks:
+      - dokploy-network
+    ports:
+      - ${APP_SMITH_PORT}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${HASH}.rule=Host(`${APP_SMITH_HOST}`)"
+      - "traefik.http.services.${HASH}.loadbalancer.server.port=${APP_SMITH_PORT}"
+    volumes:
+      - ../files/stacks:/appsmith-stacks
 
 networks:
   dokploy-network:

--- a/templates/directus/docker-compose.yml
+++ b/templates/directus/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     ports:
       - 8055
     volumes:
-      - ./uploads:/directus/uploads
-      - ./extensions:/directus/extensions
+      - ../files/uploads:/directus/uploads
+      - ../files/extensions:/directus/extensions
     depends_on:
       - cache
       - database
@@ -53,4 +53,4 @@ networks:
   dokploy-network:
     external: true
 volumes:
-  directus: 
+  directus:

--- a/templates/listmonk/docker-compose.yml
+++ b/templates/listmonk/docker-compose.yml
@@ -23,10 +23,15 @@ services:
     networks:
       - dokploy-network
     volumes:
-      - ./config.toml:/listmonk/config.toml
+      - ../files/config.toml:/listmonk/config.toml
     depends_on:
       - db
-    command: [sh, -c, "sleep 3 && ./listmonk --install --idempotent --yes --config config.toml"]
+    command:
+      [
+        sh,
+        -c,
+        "sleep 3 && ./listmonk --install --idempotent --yes --config config.toml",
+      ]
 
   app:
     restart: unless-stopped
@@ -41,7 +46,7 @@ services:
       - db
       - setup
     volumes:
-      - ./config.toml:/listmonk/config.toml
+      - ../files/config.toml:/listmonk/config.toml
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.${HASH}.rule=Host(`${LISTMONK_HOST}`)"
@@ -50,7 +55,7 @@ services:
 volumes:
   listmonk-data:
     driver: local
-    
+
 networks:
   dokploy-network:
     external: true

--- a/templates/odoo/docker-compose.yml
+++ b/templates/odoo/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 services:
   web:
     image: odoo:16.0
@@ -18,8 +18,8 @@ services:
       - "traefik.http.services.${HASH}.loadbalancer.server.port=${ODOO_PORT}"
     volumes:
       - odoo-web-data:/var/lib/odoo
-      - ./config:/etc/odoo
-      - ./addons:/mnt/extra-addons
+      - ../files/config:/etc/odoo
+      - ../files/addons:/mnt/extra-addons
 
   db:
     image: postgres:13
@@ -35,7 +35,6 @@ services:
 volumes:
   odoo-web-data:
   odoo-db-data:
-
 
 networks:
   dokploy-network:

--- a/templates/plausible/docker-compose.yml
+++ b/templates/plausible/docker-compose.yml
@@ -18,8 +18,8 @@ services:
     volumes:
       - event-data:/var/lib/clickhouse
       - event-logs:/var/log/clickhouse-server
-      - ./clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
-      - ./clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/logging.xml:ro
+      - ../files/clickhouse/clickhouse-config.xml:/etc/clickhouse-server/config.d/logging.xml:ro
+      - ../files/clickhouse/clickhouse-user-config.xml:/etc/clickhouse-server/users.d/logging.xml:ro
     ulimits:
       nofile:
         soft: 262144
@@ -50,7 +50,7 @@ volumes:
     driver: local
   event-logs:
     driver: local
-    
+
 networks:
   dokploy-network:
     external: true


### PR DESCRIPTION
This PR updates the path of certain template which use the filesystem of dokploy to define volumes, which was causing in each deploy the volumes and everything delete so we move to `/files` folder