### PR TITLE
fix: align entry point names in configs

### DIFF
--- a/apps/dokploy/__test__/traefik/server/update-server-config.test.ts
+++ b/apps/dokploy/__test__/traefik/server/update-server-config.test.ts
@@ -78,7 +78,7 @@ test("Should not touch config without host", () => {
 	expect(originalConfig).toEqual(config);
 });
 
-test("Should remove web-secure if https rollback to http", () => {
+test("Should remove websecure if https rollback to http", () => {
 	const originalConfig: FileConfig = loadOrCreateConfig("dokploy");
 
 	updateServerTraefik(

--- a/apps/dokploy/server/utils/traefik/web-server.ts
+++ b/apps/dokploy/server/utils/traefik/web-server.ts
@@ -25,7 +25,7 @@ export const updateServerTraefik = (
 		if (admin?.certificateType === "letsencrypt") {
 			config.http.routers[`${appName}-router-app-secure`] = {
 				...currentRouterConfig,
-				entryPoints: ["web-secure"],
+				entryPoints: ["websecure"],
 				tls: { certResolver: "letsencrypt" },
 			};
 


### PR DESCRIPTION
Fix entry point name mismatch in configs

- config (/etc/dokploy/traefik/traefik.yml) uses 'websecure'
- config (/etc/dokploy/traefik/dynamic/dokploy.yml) was using 'web-secure'

Updated app config to use 'websecure', fixing Web Domain Setup for Dokploy panel.