### PR TITLE
fix(templates): change mountPath of volumes to be in files folder

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/volumes/add-volumes.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/volumes/add-volumes.tsx
@@ -82,7 +82,7 @@ export const AddVolumes = ({
 		defaultValues: {
 			type: serviceType === "compose" ? "file" : "bind",
 			hostPath: "",
-			mountPath: serviceType === "compose" ? "/" : "",
+			mountPath: "",
 		},
 		resolver: zodResolver(mySchema),
 	});
@@ -330,22 +330,20 @@ export const AddVolumes = ({
 										/>
 									</>
 								)}
-								{serviceType !== "compose" && (
-									<FormField
-										control={form.control}
-										name="mountPath"
-										render={({ field }) => (
-											<FormItem>
-												<FormLabel>Mount Path (In the container)</FormLabel>
-												<FormControl>
-													<Input placeholder="Mount Path" {...field} />
-												</FormControl>
+								<FormField
+									control={form.control}
+									name="mountPath"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Mount Path (In the container)</FormLabel>
+											<FormControl>
+												<Input placeholder="Mount Path" {...field} />
+											</FormControl>
 
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-								)}
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 							</div>
 						</div>
 					</form>

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -227,6 +227,7 @@ export const composeRouter = createTRPCRouter({
 			if (mounts && mounts?.length > 0) {
 				for (const mount of mounts) {
 					await createMount({
+						filePath: mount.filePath,
 						mountPath: mount.mountPath,
 						content: mount.content,
 						serviceId: compose.composeId,

--- a/apps/dokploy/templates/listmonk/index.ts
+++ b/apps/dokploy/templates/listmonk/index.ts
@@ -21,6 +21,7 @@ export function generate(schema: Schema): Template {
 
 	const mounts: Template["mounts"] = [
 		{
+			filePath: "config.toml",
 			mountPath: "../files/config.toml",
 			content: `[app]
 address = "0.0.0.0:9000"

--- a/apps/dokploy/templates/listmonk/index.ts
+++ b/apps/dokploy/templates/listmonk/index.ts
@@ -21,7 +21,7 @@ export function generate(schema: Schema): Template {
 
 	const mounts: Template["mounts"] = [
 		{
-			mountPath: "./config.toml",
+			mountPath: "../files/config.toml",
 			content: `[app]
 address = "0.0.0.0:9000"
 

--- a/apps/dokploy/templates/plausible/index.ts
+++ b/apps/dokploy/templates/plausible/index.ts
@@ -23,6 +23,7 @@ export function generate(schema: Schema): Template {
 
 	const mounts: Template["mounts"] = [
 		{
+			filePath: "clickhouse-config.xml",
 			mountPath: "../files/clickhouse/clickhouse-config.xml",
 			content: `
             <clickhouse>
@@ -45,6 +46,7 @@ export function generate(schema: Schema): Template {
             `,
 		},
 		{
+			filePath: "clickhouse-user-config.xml",
 			mountPath: "../files/clickhouse/clickhouse-user-config.xml",
 			content: `
             <clickhouse>

--- a/apps/dokploy/templates/plausible/index.ts
+++ b/apps/dokploy/templates/plausible/index.ts
@@ -23,7 +23,7 @@ export function generate(schema: Schema): Template {
 
 	const mounts: Template["mounts"] = [
 		{
-			mountPath: "./clickhouse/clickhouse-config.xml",
+			mountPath: "../files/clickhouse/clickhouse-config.xml",
 			content: `
             <clickhouse>
             <logger>
@@ -45,7 +45,7 @@ export function generate(schema: Schema): Template {
             `,
 		},
 		{
-			mountPath: "./clickhouse/clickhouse-user-config.xml",
+			mountPath: "../files/clickhouse/clickhouse-user-config.xml",
 			content: `
             <clickhouse>
                 <profiles>

--- a/apps/dokploy/templates/utils/index.ts
+++ b/apps/dokploy/templates/utils/index.ts
@@ -13,6 +13,7 @@ export interface Schema {
 export interface Template {
 	envs: string[];
 	mounts?: {
+		filePath: string;
 		mountPath: string;
 		content?: string;
 	}[];


### PR DESCRIPTION
https://github.com/Dokploy/dokploy/pull/272 has changed path of volumes to be in files folder. There are also some mountPath that need to be changed.

The error occurred after deploying `listmonk` now:
```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/etc/dokploy/compose/test-listmonk-848fac/files/config.toml" to rootfs at "/listmonk/config.toml": stat /etc/dokploy/compose/test-listmonk-848fac/files/config.toml: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
Error ❌
```
