### PR TITLE
refactor(cleanUpUnusedVolumes): Remove all unused volumes, not just anonymous ones

### DIFF
--- a/apps/dokploy/server/utils/docker/utils.ts
+++ b/apps/dokploy/server/utils/docker/utils.ts
@@ -109,7 +109,7 @@ export const cleanStoppedContainers = async () => {
 
 export const cleanUpUnusedVolumes = async () => {
 	try {
-		await execAsync("docker volume prune --force");
+		await execAsync("docker volume prune --all --force");
 	} catch (error) {
 		console.error(error);
 		throw error;


### PR DESCRIPTION
When trying to clear unused volumes from the settings page it only removes "anonymous volumes" not all unused volumes.

We need to run "docker volume prune --all" to remove all unused volumes.

Ref: https://docs.docker.com/reference/cli/docker/volume/prune/#:~:text=-a%2C%20--all,just%20anonymous%20ones