### PR TITLE
fix: umami version

### DIFF
--- a/apps/dokploy/templates/umami/docker-compose.yml
+++ b/apps/dokploy/templates/umami/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-v2.12.1
+    image: ghcr.io/umami-software/umami:postgresql-v2.13.2
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:3000/api/heartbeat"]


### PR DESCRIPTION
There is a bug in the old version that crashes on the web. 

I would propose the version to be set as postgresql-latest, but I understand why a certain version is set in apps.