### PR TITLE
fix: directus healthchecks (fix race condition starting up), volumes for uploads & extensions, add secret/db password generation, bump version to 11.0.2

### DIFF
--- a/apps/dokploy/templates/directus/docker-compose.yml
+++ b/apps/dokploy/templates/directus/docker-compose.yml
@@ -64,6 +64,3 @@ volumes:
   directus_uploads:
   directus_extensions:
   directus_database:
-networks:
-  dokploy-network:
-    external: true

--- a/apps/dokploy/templates/directus/docker-compose.yml
+++ b/apps/dokploy/templates/directus/docker-compose.yml
@@ -1,47 +1,69 @@
-version: "3.8"
 services:
   database:
     image: postgis/postgis:13-master
     volumes:
-      - directus:/var/lib/postgresql/data
+      - directus_database:/var/lib/postgresql/data
     networks:
       - dokploy-network
     environment:
       POSTGRES_USER: "directus"
-      POSTGRES_PASSWORD: "directus"
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
       POSTGRES_DB: "directus"
+    healthcheck:
+      test: ["CMD", "pg_isready", "--host=localhost", "--username=directus"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_interval: 5s
+      start_period: 30s
 
   cache:
     image: redis:6
+    healthcheck:
+      test: ["CMD-SHELL", "[ $$(redis-cli ping) = 'PONG' ]"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_interval: 5s
+      start_period: 30s
     networks:
       - dokploy-network
 
   directus:
-    image: directus/directus:10.12.1
+    image: directus/directus:11.0.2
     ports:
       - 8055
     volumes:
-      - ../files/uploads:/directus/uploads
-      - ../files/extensions:/directus/extensions
+      - directus_uploads:/directus/uploads
+      - directus_extensions:/directus/extensions
     depends_on:
-      - cache
-      - database
+      database:
+        condition: service_healthy
+      cache:
+        condition: service_healthy
     environment:
-      SECRET: "replace-with-secure-random-value"
+      SECRET: ${DIRECTUS_SECRET}
 
       DB_CLIENT: "pg"
       DB_HOST: "database"
       DB_PORT: "5432"
       DB_DATABASE: "directus"
       DB_USER: "directus"
-      DB_PASSWORD: "directus"
+      DB_PASSWORD: ${DATABASE_PASSWORD}
 
       CACHE_ENABLED: "true"
       CACHE_AUTO_PURGE: "true"
       CACHE_STORE: "redis"
       REDIS: "redis://cache:6379"
 
+      # After first successful login, remove the admin email/password env. variables below
+      # as these will now be stored in the database.
       ADMIN_EMAIL: "admin@example.com"
       ADMIN_PASSWORD: "d1r3ctu5"
 volumes:
-  directus:
+  directus_uploads:
+  directus_extensions:
+  directus_database:
+networks:
+  dokploy-network:
+    external: true

--- a/apps/dokploy/templates/directus/index.ts
+++ b/apps/dokploy/templates/directus/index.ts
@@ -3,9 +3,14 @@ import {
 	type Schema,
 	type Template,
 	generateRandomDomain,
+	generateBase64,
+	generatePassword,
 } from "../utils";
 
 export function generate(schema: Schema): Template {
+	const directusSecret = generateBase64(64);
+	const databasePassword = generatePassword();
+
 	const domains: DomainSchema[] = [
 		{
 			host: generateRandomDomain(schema),
@@ -14,7 +19,13 @@ export function generate(schema: Schema): Template {
 		},
 	];
 
+	const envs = [
+		`DATABASE_PASSWORD=${databasePassword}`,
+		`DIRECTUS_SECRET=${directusSecret}`,
+	];
+
 	return {
 		domains,
+		envs,
 	};
 }

--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -80,7 +80,7 @@ export const templates: TemplateData[] = [
 	{
 		id: "directus",
 		name: "Directus",
-		version: "10.12.1",
+		version: "11.0.2",
 		description:
 			"Directus is an open source headless CMS that provides an API-first solution for building custom backends.",
 		logo: "directus.jpg",


### PR DESCRIPTION
**Directus template:**

* Adding healthchecks (as per [official documentation](https://docs.directus.io/self-hosted/docker-guide.html#example-docker-compose)) as there seems to be a race-issue when starting.
* Adding volumes for uploads & extensions folders as these seem to be read-only on start-up and you can't upload.
* Adding documentation comments to recommend deleting ADMIN_* env variables on first run as these get stored in the database and would introduce security issues.
* Generate secret for application & database password.
* Bump version to 11.0.2 (as per official docs above)