### PR TITLE
refactor: WordPress template - update WordPress version, use MariaDB vs MySQL, password generation

### DIFF
--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -155,7 +155,7 @@ export const templates: TemplateData[] = [
 	{
 		id: "wordpress",
 		name: "Wordpress",
-		version: "5.8.3",
+		version: "6.6.1",
 		description:
 			"Wordpress is a free and open source content management system (CMS) for publishing and managing websites.",
 		logo: "wordpress.png",

--- a/apps/dokploy/templates/wordpress/docker-compose.yml
+++ b/apps/dokploy/templates/wordpress/docker-compose.yml
@@ -1,24 +1,29 @@
-version: "3.8"
 services:
   wordpress:
-    image: wordpress:5.8.3
+    image: wordpress:6.6.1
+    restart: always
+    depends_on:
+      - db
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: exampleuser
-      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_PASSWORD: ${MYSQL_PASSWORD}
       WORDPRESS_DB_NAME: exampledb
     volumes:
       - wordpress_data:/var/www/html
 
   db:
-    image: mysql:5.7.34
+    image: mariadb:11.5.2
+    restart: always
+    depends_on:
+      - db
     networks:
       - dokploy-network
     environment:
       MYSQL_DATABASE: exampledb
       MYSQL_USER: exampleuser
-      MYSQL_PASSWORD: examplepass
-      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - db_data:/var/lib/mysql
 

--- a/apps/dokploy/templates/wordpress/index.ts
+++ b/apps/dokploy/templates/wordpress/index.ts
@@ -2,11 +2,14 @@ import {
 	type DomainSchema,
 	type Schema,
 	type Template,
+	generatePassword,
 	generateRandomDomain,
 } from "../utils";
 
 export function generate(schema: Schema): Template {
 	const randomDomain = generateRandomDomain(schema);
+	const mysqlPassword = generatePassword(32);
+	const mysqlRootPassword = generatePassword(32);
 
 	const domains: DomainSchema[] = [
 		{
@@ -16,7 +19,13 @@ export function generate(schema: Schema): Template {
 		},
 	];
 
+	const envs = [
+		`MYSQL_PASSWORD=${mysqlPassword}`,
+		`MYSQL_ROOT_PASSWORD=${mysqlRootPassword}`,
+	];
+
 	return {
 		domains,
+		envs,
 	};
 }


### PR DESCRIPTION
- Updated WordPress to latest version in template
- Use MariaDB over MySQL
- Generate root/database passwords
- Add restart always entries
- Add dependency on DB