### PR TITLE
fix: invalid template source path

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -234,7 +234,7 @@ export const AddTemplate = ({ projectId }: Props) => {
 																</Link>
 															)}
 															<Link
-																href={`https://github.com/dokploy/dokploy/tree/canary/templates/${template.id}`}
+																href={`https://github.com/Dokploy/dokploy/tree/canary/apps/dokploy/templates/${template.id}`}
 																target="_blank"
 																className={
 																	"text-sm text-muted-foreground p-3 rounded-full hover:bg-border items-center flex transition-colors"


### PR DESCRIPTION
After refactoring the project directory in v0.5.1 the wrong path to the template source code was used, this change fixes the path