### PR TITLE
fix: invalid glitchtip git link

### DIFF
--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -326,7 +326,7 @@ export const templates: TemplateData[] = [
 		description: "Glitchtip is simple, open source error tracking",
 		logo: "glitchtip.png",
 		links: {
-			github: "https://github.com/glitchtip/glitchtip",
+			github: "https://gitlab.com/glitchtip/",
 			website: "https://glitchtip.com/",
 			docs: "https://glitchtip.com/documentation",
 		},


### PR DESCRIPTION
The git of this self-hosted service is officially hosted at https://gitlab.com/glitchtip/, it does not have a mirror on github. The link in the pull request has been corrected.

It is worth noting that the icon https://lucide.dev/icons/github is used as a link to the service repository in the templates. I think in the future there will be more services that do not use github as a version control hosting. I think you can replace the icon with GitIcon (apps/dokploy/components/icons/data-tools-icons.tsx) or use different ones depending on the host.