### PR TITLE
feat: add roundcube template

### DIFF
--- a/apps/docs/content/docs/core/templates/overview.mdx
+++ b/apps/docs/content/docs/core/templates/overview.mdx
@@ -31,8 +31,7 @@ The following templates are available:
 - **Wordpress**: Open Source Content Management System
 - **Open WebUI**: Free and Open Source ChatGPT Alternative
 - **Teable**: Open Source Airtable Alternative, Developer Friendly, No-code Database Built on Postgres
-
-
+- **Roundcube**: Free and open source webmail software for the masses, written in PHP, uses SMTP[^1].
 
 ## Create your own template
 
@@ -41,3 +40,5 @@ We accept contributions to upload new templates to the dokploy repository.
 Make sure to follow the guidelines for creating a template:
 
 [Steps to create your own template](https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#templates)
+
+[^1]: Please note that if you're self-hosting a mail server you need port 25 to be open for SMTP (Mail Transmission Protocol that allows you to send and receive) to work properly. Some VPS providers like [Hetzner](https://docs.hetzner.com/cloud/servers/faq/#why-can-i-not-send-any-mails-from-my-server) block this port by default for new clients.

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -3,17 +3,17 @@ import defaultComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
-  return {
-    ...defaultComponents,
-    ...components,
-    ImageZoom,
-    p: ({ children }) => (
-      <p className="text-[#3E4342] dark:text-muted-foreground">{children}</p>
-    ),
-    li: ({ children, id }) => (
-      <li {...{ id }} className="text-[#3E4342] dark:text-muted-foreground">
-        {children}
-      </li>
-    ),
-  };
+	return {
+		...defaultComponents,
+		...components,
+		ImageZoom,
+		p: ({ children }) => (
+			<p className="text-[#3E4342] dark:text-muted-foreground">{children}</p>
+		),
+		li: ({ children, id }) => (
+			<li {...{ id }} className="text-[#3E4342] dark:text-muted-foreground">
+				{children}
+			</li>
+		),
+	};
 }

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -3,15 +3,17 @@ import defaultComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
-	return {
-		...defaultComponents,
-		...components,
-		ImageZoom,
-		p: ({ children }) => (
-			<p className="text-[#3E4342] dark:text-muted-foreground">{children}</p>
-		),
-		li: ({ children }) => (
-			<li className="text-[#3E4342] dark:text-muted-foreground">{children}</li>
-		),
-	};
+  return {
+    ...defaultComponents,
+    ...components,
+    ImageZoom,
+    p: ({ children }) => (
+      <p className="text-[#3E4342] dark:text-muted-foreground">{children}</p>
+    ),
+    li: ({ children, id }) => (
+      <li {...{ id }} className="text-[#3E4342] dark:text-muted-foreground">
+        {children}
+      </li>
+    ),
+  };
 }

--- a/apps/dokploy/public/templates/roundcube.svg
+++ b/apps/dokploy/public/templates/roundcube.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="9.14 141.8 573.65 573.65">
+<style type="text/css">
+.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#404F54;}
+.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#E5E5E5;}
+.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#CCCCCC;}
+.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#37BEFF;}
+</style>
+<polygon class="st3" points="582.79,549.77 295.96,384.1 295.96,207.27 582.79,372.95 "/>
+<polygon class="st0" points="9.14,549.77 295.96,384.1 295.96,207.27 9.14,372.95 "/>
+<path class="st2" d="M295.96,141.8c109.56,0,198.41,88.85,198.41,198.41c0,109.56-88.85,198.41-198.41,198.41 c-109.56,0-198.41-88.85-198.41-198.41C97.55,230.65,186.4,141.8,295.96,141.8"/>
+<path class="st1" d="M295.96,141.8c109.6,0,198.48,88.85,198.48,198.41c0,109.56-88.88,198.41-198.48,198.41 c-62.91-42.34-88.94-127.64-88.94-198.3S233.05,184.22,295.96,141.8"/>
+<polygon class="st3" points="582.79,372.95 295.96,538.62 295.96,715.45 582.79,549.77 "/>
+<polygon class="st0" points="9.14,372.95 295.96,538.62 295.96,715.45 9.14,549.77 "/>
+</svg>

--- a/apps/dokploy/templates/roundcube/docker-compose.yml
+++ b/apps/dokploy/templates/roundcube/docker-compose.yml
@@ -1,13 +1,9 @@
-version: '2'
 services:
   roundcubemail:
     image: roundcube/roundcubemail:latest
-    container_name: roundcubemail
     volumes:
       - ./www:/var/www/html
       - ./db/sqlite:/var/roundcube/db
-    ports:
-      - '9002:80'
     environment:
       - ROUNDCUBEMAIL_DB_TYPE=sqlite
       - ROUNDCUBEMAIL_SKIN=elastic
@@ -15,6 +11,7 @@ services:
       - ROUNDCUBEMAIL_SMTP_SERVER=${SMTP_SERVER}
     networks:
       - dokploy-network
+
 networks:
   dokploy-network:
-    external: true
+    external: true```

--- a/apps/dokploy/templates/roundcube/docker-compose.yml
+++ b/apps/dokploy/templates/roundcube/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   roundcubemail:
-    image: roundcube/roundcubemail:latest
+    image: roundcube/roundcubemail:1.6.9-apache
     volumes:
       - ./www:/var/www/html
       - ./db/sqlite:/var/roundcube/db

--- a/apps/dokploy/templates/roundcube/docker-compose.yml
+++ b/apps/dokploy/templates/roundcube/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  roundcubemail:
+    image: roundcube/roundcubemail:latest
+    container_name: roundcubemail
+    volumes:
+      - ./www:/var/www/html
+      - ./db/sqlite:/var/roundcube/db
+    ports:
+      - '9002:80'
+    environment:
+      - ROUNDCUBEMAIL_DB_TYPE=sqlite
+      - ROUNDCUBEMAIL_SKIN=elastic
+      - ROUNDCUBEMAIL_DEFAULT_HOST=${DEFAULT_HOST}
+      - ROUNDCUBEMAIL_SMTP_SERVER=${SMTP_SERVER}
+    networks:
+      - dokploy-network
+networks:
+  dokploy-network:
+    external: true

--- a/apps/dokploy/templates/roundcube/docker-compose.yml
+++ b/apps/dokploy/templates/roundcube/docker-compose.yml
@@ -14,4 +14,4 @@ services:
 
 networks:
   dokploy-network:
-    external: true```
+    external: true

--- a/apps/dokploy/templates/roundcube/index.ts
+++ b/apps/dokploy/templates/roundcube/index.ts
@@ -1,0 +1,11 @@
+import type { Schema, Template } from "../utils";
+
+export function generate(schema: Schema): Template {
+	const envs = [
+		"DEFAULT_HOST=tls://mail.example.com",
+		"SMTP_SERVER=tls://mail.example.com",
+
+	];
+
+	return { envs };
+}

--- a/apps/dokploy/templates/roundcube/index.ts
+++ b/apps/dokploy/templates/roundcube/index.ts
@@ -1,11 +1,24 @@
-import type { Schema, Template } from "../utils";
+import {
+	type DomainSchema,
+	type Schema,
+	type Template,
+	generateRandomDomain,
+} from "../utils";
 
 export function generate(schema: Schema): Template {
+	const randomDomain = generateRandomDomain(schema);
 	const envs = [
 		"DEFAULT_HOST=tls://mail.example.com",
 		"SMTP_SERVER=tls://mail.example.com",
-
 	];
 
-	return { envs };
+	const domains: DomainSchema[] = [
+		{
+			host: randomDomain,
+			port: 80,
+			serviceName: "roundcubemail",
+		},
+	];
+
+	return { envs, domains };
 }

--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -501,15 +501,15 @@ export const templates: TemplateData[] = [
 		id: "roundcube",
 		name: "Roundcube",
 		version: "1.6.9",
-		description:"Free and open source webmail software for the masses, written in PHP.",
-		logo:"roundcube.svg",
-		links:{
-			github:"",
-			website:"",
-			docs:"",
+		description:
+			"Free and open source webmail software for the masses, written in PHP.",
+		logo: "roundcube.svg",
+		links: {
+			github: "https://github.com/roundcube/roundcubemail",
+			website: "https://roundcube.net/",
+			docs: "https://roundcube.net/about/",
 		},
-		tags:["self-hosted","mail","webmail"],
+		tags: ["self-hosted", "mail", "webmail"],
 		load: () => import("./roundcube/index").then((m) => m.generate),
-
-	}
+	},
 ];

--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -509,7 +509,7 @@ export const templates: TemplateData[] = [
 			website: "https://roundcube.net/",
 			docs: "https://roundcube.net/about/",
 		},
-		tags: ["self-hosted", "mail", "webmail"],
+		tags: ["self-hosted", "email", "webmail"],
 		load: () => import("./roundcube/index").then((m) => m.generate),
 	},
 ];

--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -497,4 +497,19 @@ export const templates: TemplateData[] = [
 		tags: ["self-hosted", "storage"],
 		load: () => import("./gitea/index").then((m) => m.generate),
 	},
+	{
+		id: "roundcube",
+		name: "Roundcube",
+		version: "1.6.9",
+		description:"Free and open source webmail software for the masses, written in PHP.",
+		logo:"roundcube.svg",
+		links:{
+			github:"",
+			website:"",
+			docs:"",
+		},
+		tags:["self-hosted","mail","webmail"],
+		load: () => import("./roundcube/index").then((m) => m.generate),
+
+	}
 ];


### PR DESCRIPTION
Based off https://github.com/Dokploy/dokploy/pull/458 I'd like to also add a template for roundcube so it's easier to get a self-hosted email solution up and running.
Please keep in mind some VPS/ISP block port 25.