### PR TITLE
docs: add explanation how to use multiline env variables

### DIFF
--- a/apps/docs/content/docs/core/application/overview.mdx
+++ b/apps/docs/content/docs/core/application/overview.mdx
@@ -15,6 +15,8 @@ Configure the source of your code, the way your application is built, and also m
 
 If you need to assign environment variables to your application, you can do so here.
 
+In case you need to use a multiline variable, you can wrap it in double quotes just like this `'"here_is_my_private_key"'`.
+
 ## Monitoring
 
 Four graphs will be displayed for the use of memory, CPU, disk, and network. Note that the information is only updated if you are viewing the current page, otherwise it will not be updated.

--- a/apps/docs/content/docs/core/databases/overview.mdx
+++ b/apps/docs/content/docs/core/databases/overview.mdx
@@ -26,6 +26,8 @@ Actions like deploying, updating, and deleting your database, and stopping it.
 
 If you need to assign environment variables to your application, you can do so here.
 
+In case you need to use a multiline variable, you can wrap it in double quotes just like this `'"here_is_my_private_key"'`.
+
 ## Monitoring
 
 Four graphs will be displayed for the use of memory, CPU, disk, and network. Note that the information is only updated if you are viewing the current page, otherwise it will not be updated.


### PR DESCRIPTION
Small update to the documentation on how to manage multiline env variables. For better clarity. 