### PR TITLE
Fix port input value becoming NaN

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
@@ -17,7 +17,7 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { Input, NumberInput } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -125,7 +125,7 @@ export const UpdatePort = ({ portId }: Props) => {
 									<FormItem>
 										<FormLabel>Published Port</FormLabel>
 										<FormControl>
-											<Input
+											<NumberInput
 												placeholder="1-65535"
 												{...field}
 												value={field.value?.toString() || ""}
@@ -134,10 +134,7 @@ export const UpdatePort = ({ portId }: Props) => {
 													if (value === "") {
 														field.onChange(0);
 													} else {
-														const number = Number.parseInt(value, 10);
-														if (!Number.isNaN(number)) {
-															field.onChange(number);
-														}
+														field.onChange(parseInt(value, 10));
 													}
 												}}
 											/>
@@ -158,17 +155,6 @@ export const UpdatePort = ({ portId }: Props) => {
 												placeholder="1-65535"
 												{...field}
 												value={field.value?.toString() || ""}
-												onChange={(e) => {
-													const value = e.target.value;
-													if (value === "") {
-														field.onChange(0);
-													} else {
-														const number = Number.parseInt(value, 10);
-														if (!Number.isNaN(number)) {
-															field.onChange(number);
-														}
-													}
-												}}
 											/>
 										</FormControl>
 

--- a/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
@@ -125,25 +125,14 @@ export const UpdatePort = ({ portId }: Props) => {
 									<FormItem>
 										<FormLabel>Published Port</FormLabel>
 										<FormControl>
-											<NumberInput
-												placeholder="1-65535"
-												{...field}
-												value={field.value?.toString() || ""}
-												onChange={(e) => {
-													const value = e.target.value;
-													if (value === "") {
-														field.onChange(0);
-													} else {
-														field.onChange(Number.parseInt(value, 10));
-													}
-												}}
-											/>
+											<NumberInput placeholder="1-65535" {...field} />
 										</FormControl>
 
 										<FormMessage />
 									</FormItem>
 								)}
 							/>
+
 							<FormField
 								control={form.control}
 								name="targetPort"
@@ -151,11 +140,7 @@ export const UpdatePort = ({ portId }: Props) => {
 									<FormItem>
 										<FormLabel>Target Port</FormLabel>
 										<FormControl>
-											<Input
-												placeholder="1-65535"
-												{...field}
-												value={field.value?.toString() || ""}
-											/>
+											<Input placeholder="1-65535" {...field} />
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
@@ -134,7 +134,7 @@ export const UpdatePort = ({ portId }: Props) => {
 													if (value === "") {
 														field.onChange(0);
 													} else {
-														field.onChange(parseInt(value, 10));
+														field.onChange(Number.parseInt(value, 10));
 													}
 												}}
 											/>

--- a/apps/dokploy/components/dashboard/application/domains/add-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/add-domain.tsx
@@ -18,7 +18,7 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { Input, NumberInput } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -228,12 +228,9 @@ export const AddDomain = ({
 											<FormItem>
 												<FormLabel>Container Port</FormLabel>
 												<FormControl>
-													<Input
+													<NumberInput
 														placeholder={"3000"}
 														{...field}
-														onChange={(e) => {
-															field.onChange(Number.parseInt(e.target.value));
-														}}
 													/>
 												</FormControl>
 												<FormMessage />

--- a/apps/dokploy/components/dashboard/application/domains/add-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/add-domain.tsx
@@ -228,10 +228,7 @@ export const AddDomain = ({
 											<FormItem>
 												<FormLabel>Container Port</FormLabel>
 												<FormControl>
-													<NumberInput
-														placeholder={"3000"}
-														{...field}
-													/>
+													<NumberInput placeholder={"3000"} {...field} />
 												</FormControl>
 												<FormMessage />
 											</FormItem>

--- a/apps/dokploy/components/dashboard/compose/domains/add-domain.tsx
+++ b/apps/dokploy/components/dashboard/compose/domains/add-domain.tsx
@@ -364,10 +364,7 @@ export const AddDomainCompose = ({
 											<FormItem>
 												<FormLabel>Container Port</FormLabel>
 												<FormControl>
-													<NumberInput
-														placeholder={"3000"}
-														{...field}
-													/>
+													<NumberInput placeholder={"3000"} {...field} />
 												</FormControl>
 												<FormMessage />
 											</FormItem>

--- a/apps/dokploy/components/dashboard/compose/domains/add-domain.tsx
+++ b/apps/dokploy/components/dashboard/compose/domains/add-domain.tsx
@@ -18,7 +18,7 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { Input, NumberInput } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -364,12 +364,9 @@ export const AddDomainCompose = ({
 											<FormItem>
 												<FormLabel>Container Port</FormLabel>
 												<FormControl>
-													<Input
+													<NumberInput
 														placeholder={"3000"}
 														{...field}
-														onChange={(e) => {
-															field.onChange(Number.parseInt(e.target.value));
-														}}
 													/>
 												</FormControl>
 												<FormMessage />

--- a/apps/dokploy/components/ui/input.tsx
+++ b/apps/dokploy/components/ui/input.tsx
@@ -31,4 +31,37 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = "Input";
 
-export { Input };
+const NumberInput = React.forwardRef<HTMLInputElement, InputProps>(
+	({ className, errorMessage, ...props }, ref) => {
+		return (
+			<Input
+				type="text"
+				className={cn("text-left", className)}
+				ref={ref}
+				{...props}
+				onChange={(e) => {
+					const value = e.target.value;
+					if (value === "") {
+						props.onChange?.(e);
+					} else {
+						const number = Number.parseInt(value, 10);
+						if (!Number.isNaN(number)) {
+							const syntheticEvent = {
+								...e,
+								target: {
+									...e.target,
+									value: number.toString(),
+								},
+							};
+							props.onChange?.(syntheticEvent as React.ChangeEvent<HTMLInputElement>);
+						}
+					}
+				}}
+			/>
+		);
+	}
+);
+NumberInput.displayName = "NumberInput";
+
+
+export { Input, NumberInput };

--- a/apps/dokploy/components/ui/input.tsx
+++ b/apps/dokploy/components/ui/input.tsx
@@ -39,24 +39,27 @@ const NumberInput = React.forwardRef<HTMLInputElement, InputProps>(
 				className={cn("text-left", className)}
 				ref={ref}
 				{...props}
-				onChange={(e) => {
-					const value = e.target.value;
-					if (value === "") {
-						props.onChange?.(e);
-					} else {
-						const number = Number.parseInt(value, 10);
-						if (!Number.isNaN(number)) {
-							const syntheticEvent = {
-								...e,
-								target: {
-									...e.target,
-									value: number.toString(),
-								},
-							};
-							props.onChange?.(syntheticEvent as React.ChangeEvent<HTMLInputElement>);
-						}
-					}
-				}}
+				value={props.value === undefined ? undefined : String(props.value)}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (value === "") {
+            props.onChange?.(e);
+          } else {
+            const number = Number.parseInt(value, 10);
+            if (!Number.isNaN(number)) {
+              const syntheticEvent = {
+                ...e,
+                target: {
+                  ...e.target,
+                  value: number,
+                },
+              };
+              props.onChange?.(
+                syntheticEvent as unknown as React.ChangeEvent<HTMLInputElement>
+              );
+            }
+          }
+        }}
 			/>
 		);
 	}

--- a/apps/dokploy/components/ui/input.tsx
+++ b/apps/dokploy/components/ui/input.tsx
@@ -40,31 +40,30 @@ const NumberInput = React.forwardRef<HTMLInputElement, InputProps>(
 				ref={ref}
 				{...props}
 				value={props.value === undefined ? undefined : String(props.value)}
-        onChange={(e) => {
-          const value = e.target.value;
-          if (value === "") {
-            props.onChange?.(e);
-          } else {
-            const number = Number.parseInt(value, 10);
-            if (!Number.isNaN(number)) {
-              const syntheticEvent = {
-                ...e,
-                target: {
-                  ...e.target,
-                  value: number,
-                },
-              };
-              props.onChange?.(
-                syntheticEvent as unknown as React.ChangeEvent<HTMLInputElement>
-              );
-            }
-          }
-        }}
+				onChange={(e) => {
+					const value = e.target.value;
+					if (value === "") {
+						props.onChange?.(e);
+					} else {
+						const number = Number.parseInt(value, 10);
+						if (!Number.isNaN(number)) {
+							const syntheticEvent = {
+								...e,
+								target: {
+									...e.target,
+									value: number,
+								},
+							};
+							props.onChange?.(
+								syntheticEvent as unknown as React.ChangeEvent<HTMLInputElement>,
+							);
+						}
+					}
+				}}
 			/>
 		);
-	}
+	},
 );
 NumberInput.displayName = "NumberInput";
-
 
 export { Input, NumberInput };


### PR DESCRIPTION
I have encapsulated a `NumberInput` component to handle string inputs with simple processing of number type fields(eg `port`).

If needed, I can implement the `NumberInput` component in a two-stage approach: during input and upon input completion. This is typically used for handling situations with floats.

## Demo
| Before                                                                 | After                                                                  |
|------------------------------------------------------------------------|------------------------------------------------------------------------|
| ![Kapture 2024-09-30 at 16 05 42](https://github.com/user-attachments/assets/3739f5c3-db55-486e-9071-64886d88c5f5) | ![Kapture 2024-09-30 at 16 32 41](https://github.com/user-attachments/assets/45aa41b8-e4b3-4aa2-9c9b-777872bef7c3) |

