### PR TITLE
fix: tsx watch flag unwanted reload

### DIFF
--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -11,7 +11,7 @@
 		"build-next": "next build",
 		"setup": "tsx -r dotenv/config setup.ts && sleep 5 && pnpm run migration:run",
 		"reset-password": "node dist/reset-password.mjs",
-		"dev": "tsx watch -r dotenv/config ./server/server.ts  --project tsconfig.server.json ",
+		"dev": "tsx -r dotenv/config ./server/server.ts  --project tsconfig.server.json ",
 		"studio": "drizzle-kit studio --config ./server/db/drizzle.config.ts",
 		"migration:generate": "drizzle-kit generate --config ./server/db/drizzle.config.ts",
 		"migration:run": "tsx -r dotenv/config migration.ts",


### PR DESCRIPTION
It sounds like we’re running into an issue with` tsx --watch` flag causing unnecessary reloads, particularly when working with the _apps/dokploy/server_ folder.

The `tsx --watch` flag is commonly used to watch TypeScript files and automatically recompile/restart the application when files are changed. However, in our case, since Next.js is already handling the auto-reload for the server, it might be redundant and leading to performance issues.

For other cases, a manual restart is enough.