### PR TITLE
fix: Application create endpoint returns value

### DIFF
--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -72,6 +72,7 @@ export const applicationRouter = createTRPCRouter({
 				if (ctx.user.rol === "user") {
 					await addNewService(ctx.user.authId, newApplication.applicationId);
 				}
+				return newApplication;
 			} catch (error: unknown) {
 				if (error instanceof TRPCError) {
 					throw error;


### PR DESCRIPTION
The endpoint to create an application/service executes successfully but it doesn't return any values.
https://docs.dokploy.com/en/docs/api/reference-api/reference-application#application-create

This makes it hard to develop as we don't know the ID of the application we just created and looks weird as all the other endpoints return values.

Adding that return statement makes the return of create the same as get one application
https://docs.dokploy.com/en/docs/api/reference-api/reference-application#application-one

Example without fix:
![image](https://github.com/user-attachments/assets/de14a0b4-6346-4b61-a6f0-ef1c104d2566)

Example with fix:
![image](https://github.com/user-attachments/assets/db00b9cc-24fc-4b29-b243-d71d601fca9a)

Making sure the output marches get one:
![image](https://github.com/user-attachments/assets/67984835-c037-44df-8090-ad5ff34af01f)

