### PR TITLE
Add missing organization to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For detailed documentation, visit [docs.dokploy.com](https://docs.dokploy.com).
 
 <div style="display: flex; gap: 30px; flex-wrap: wrap;">
 <a href="https://steamsets.com/?ref=dokploy"><img src="https://avatars.githubusercontent.com/u/111978405?s=200&v=4" width="60px" alt="Steamsets.com"/></a>
+<a href="https://rivo.gg/?ref=dokploy"><img src="https://avatars.githubusercontent.com/u/126797452?s=200&v=4" width="60px" alt="Rivo.gg"/></a>
 </div>
 
 #### Organizations:


### PR DESCRIPTION
Adds the missing organization to the readme under the correct tier