### PR TITLE
fix(website): improve sponsor logo alignment

### DIFF
--- a/apps/website/components/Hero.tsx
+++ b/apps/website/components/Hero.tsx
@@ -202,6 +202,7 @@ export const ShowSponsors = () => {
 				<div className="flex flex-wrap items-center gap-4">
 					<a
 						href="https://www.hostinger.com/vps-hosting?ref=dokploy"
+						target="_blank"
 						className="flex-shrink-0"
 					>
 						<img
@@ -210,7 +211,7 @@ export const ShowSponsors = () => {
 							className="rounded-xl w-[190px] h-auto"
 						/>
 					</a>
-					<a href="https://www.lxaer.com?ref=dokploy" className="flex-shrink-0">
+					<a href="https://www.lxaer.com?ref=dokploy" target="_blank" className="flex-shrink-0">
 						<img
 							src="https://raw.githubusercontent.com/Dokploy/dokploy/canary/.github/sponsors/lxaer.png"
 							alt="lxaer.com"
@@ -224,7 +225,7 @@ export const ShowSponsors = () => {
 					Premium Supporters 🥇
 				</h2>
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					<a href="https://supafort.com/?ref=dokploy">
+					<a href="https://supafort.com/?ref=dokploy" target="_blank">
 						<img
 							src="https://supafort.com/build/q-4Ht4rBZR.webp"
 							alt="Supafort.com"
@@ -239,7 +240,7 @@ export const ShowSponsors = () => {
 					Supporting Members 🥉
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://lightspeed.run/?ref=dokploy">
+					<a href="https://lightspeed.run/?ref=dokploy" target="_blank">
 						<img
 							src="https://github.com/lightspeedrun.png"
 							className="rounded-xl"
@@ -247,7 +248,7 @@ export const ShowSponsors = () => {
 							alt="Lightspeed.run"
 						/>
 					</a>
-					<a href="https://cloudblast.io/?ref=dokploy">
+					<a href="https://cloudblast.io/?ref=dokploy" target="_blank">
 						<img
 							src="https://cloudblast.io/img/logo-icon.193cf13e.svg"
 							className="rounded-xl"
@@ -262,7 +263,7 @@ export const ShowSponsors = () => {
 					Community Backers 🤝
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://steamsets.com/?ref=dokploy">
+					<a href="https://steamsets.com/?ref=dokploy" target="_blank">
 						<img
 							src="https://avatars.githubusercontent.com/u/111978405?s=200&v=4"
 							className="rounded-xl"
@@ -270,7 +271,7 @@ export const ShowSponsors = () => {
 							alt="Steamsets.com"
 						/>
 					</a>
-					<a href="https://rivo.gg/?ref=dokploy">
+					<a href="https://rivo.gg/?ref=dokploy" target="_blank">
 						<img
 							src="https://avatars.githubusercontent.com/u/126797452?s=200&v=4"
 							className="rounded-xl"
@@ -285,7 +286,7 @@ export const ShowSponsors = () => {
 					Organizations:
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://opencollective.com/dokploy">
+					<a href="https://opencollective.com/dokploy" target="_blank">
 						<img
 							src="https://opencollective.com/dokploy/organizations.svg?width=890"
 							alt="Organization Sponsors"
@@ -298,7 +299,7 @@ export const ShowSponsors = () => {
 					Individuals:
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://opencollective.com/dokploy">
+					<a href="https://opencollective.com/dokploy" target="_blank">
 						<img
 							src="https://opencollective.com/dokploy/individuals.svg?width=890"
 							alt="Individual Sponsors"

--- a/apps/website/components/Hero.tsx
+++ b/apps/website/components/Hero.tsx
@@ -199,22 +199,22 @@ export const ShowSponsors = () => {
 				<h2 className="font-display text-2xl font-medium tracking-tight  text-primary  sm:text-2xl text-left">
 					Hero Sponsors 🎖
 				</h2>
-				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					<a href="https://www.hostinger.com/vps-hosting?ref=dokploy">
+				<div className="flex flex-wrap items-center gap-4">
+					<a
+						href="https://www.hostinger.com/vps-hosting?ref=dokploy"
+						className="flex-shrink-0"
+					>
 						<img
 							src="https://raw.githubusercontent.com/Dokploy/dokploy/canary/.github/sponsors/hostinger.jpg"
 							alt="hostinger.com"
-							className="rounded-xl"
-							width="200"
+							className="rounded-xl w-[190px] h-auto"
 						/>
 					</a>
-
-					<a href="https://www.lxaer.com?ref=dokploy">
+					<a href="https://www.lxaer.com?ref=dokploy" className="flex-shrink-0">
 						<img
 							src="https://raw.githubusercontent.com/Dokploy/dokploy/canary/.github/sponsors/lxaer.png"
 							alt="lxaer.com"
-							className="rounded-xl"
-							width="200"
+							className="rounded-xl w-[70px] h-auto"
 						/>
 					</a>
 				</div>

--- a/apps/website/components/Hero.tsx
+++ b/apps/website/components/Hero.tsx
@@ -204,6 +204,7 @@ export const ShowSponsors = () => {
 						href="https://www.hostinger.com/vps-hosting?ref=dokploy"
 						target="_blank"
 						className="flex-shrink-0"
+						rel="noreferrer"
 					>
 						<img
 							src="https://raw.githubusercontent.com/Dokploy/dokploy/canary/.github/sponsors/hostinger.jpg"
@@ -211,7 +212,12 @@ export const ShowSponsors = () => {
 							className="rounded-xl w-[190px] h-auto"
 						/>
 					</a>
-					<a href="https://www.lxaer.com?ref=dokploy" target="_blank" className="flex-shrink-0">
+					<a
+						href="https://www.lxaer.com?ref=dokploy"
+						target="_blank"
+						className="flex-shrink-0"
+						rel="noreferrer"
+					>
 						<img
 							src="https://raw.githubusercontent.com/Dokploy/dokploy/canary/.github/sponsors/lxaer.png"
 							alt="lxaer.com"
@@ -225,7 +231,11 @@ export const ShowSponsors = () => {
 					Premium Supporters 🥇
 				</h2>
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					<a href="https://supafort.com/?ref=dokploy" target="_blank">
+					<a
+						href="https://supafort.com/?ref=dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://supafort.com/build/q-4Ht4rBZR.webp"
 							alt="Supafort.com"
@@ -240,7 +250,11 @@ export const ShowSponsors = () => {
 					Supporting Members 🥉
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://lightspeed.run/?ref=dokploy" target="_blank">
+					<a
+						href="https://lightspeed.run/?ref=dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://github.com/lightspeedrun.png"
 							className="rounded-xl"
@@ -248,7 +262,11 @@ export const ShowSponsors = () => {
 							alt="Lightspeed.run"
 						/>
 					</a>
-					<a href="https://cloudblast.io/?ref=dokploy" target="_blank">
+					<a
+						href="https://cloudblast.io/?ref=dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://cloudblast.io/img/logo-icon.193cf13e.svg"
 							className="rounded-xl"
@@ -263,7 +281,11 @@ export const ShowSponsors = () => {
 					Community Backers 🤝
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://steamsets.com/?ref=dokploy" target="_blank">
+					<a
+						href="https://steamsets.com/?ref=dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://avatars.githubusercontent.com/u/111978405?s=200&v=4"
 							className="rounded-xl"
@@ -271,7 +293,11 @@ export const ShowSponsors = () => {
 							alt="Steamsets.com"
 						/>
 					</a>
-					<a href="https://rivo.gg/?ref=dokploy" target="_blank">
+					<a
+						href="https://rivo.gg/?ref=dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://avatars.githubusercontent.com/u/126797452?s=200&v=4"
 							className="rounded-xl"
@@ -286,7 +312,11 @@ export const ShowSponsors = () => {
 					Organizations:
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://opencollective.com/dokploy" target="_blank">
+					<a
+						href="https://opencollective.com/dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://opencollective.com/dokploy/organizations.svg?width=890"
 							alt="Organization Sponsors"
@@ -299,7 +329,11 @@ export const ShowSponsors = () => {
 					Individuals:
 				</h2>
 				<div className="flex flex-row gap-10">
-					<a href="https://opencollective.com/dokploy" target="_blank">
+					<a
+						href="https://opencollective.com/dokploy"
+						target="_blank"
+						rel="noreferrer"
+					>
 						<img
 							src="https://opencollective.com/dokploy/individuals.svg?width=890"
 							alt="Individual Sponsors"


### PR DESCRIPTION
Fixes the logo alignment on the website to go from this:

![image](https://github.com/user-attachments/assets/63983cf7-7211-42b9-b73c-71e493800521)

to this:

![image](https://github.com/user-attachments/assets/1fec8760-f018-48c2-a86d-584d5a86e28d)
