### PR TITLE
fix: update reset password link URL

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -178,7 +178,7 @@ export default function Home() {
 							<div className="mt-4 text-sm flex flex-row justify-center gap-2">
 								<Link
 									className="hover:underline text-muted-foreground"
-									href="https://docs.dokploy.com/en/docs/core/get-started/reset-password"
+									href="https://docs.dokploy.com/docs/core/get-started/reset-password"
 									target="_blank"
 								>
 									Lost your password?

--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -178,7 +178,7 @@ export default function Home() {
 							<div className="mt-4 text-sm flex flex-row justify-center gap-2">
 								<Link
 									className="hover:underline text-muted-foreground"
-									href="https://docs.dokploy.com/get-started/reset-password"
+									href="https://docs.dokploy.com/en/docs/core/get-started/reset-password"
 									target="_blank"
 								>
 									Lost your password?


### PR DESCRIPTION
This commit updates the URL for the "Lost your password?" link in the user interface. The change replaces the previous URL with the correct link to the password reset documentation.

Changes made:
- Updated the `href` attribute of the Link component
- Ensured the link points to the correct documentation page for resetting passwords

This fix improves user experience by directing users to the proper resource for password recovery.