### PR TITLE
feat(dokploy): add env for ADVERTISE_ADDR to installation #593

### DIFF
--- a/apps/docs/content/docs/core/get-started/manual-installation.cn.mdx
+++ b/apps/docs/content/docs/core/get-started/manual-installation.cn.mdx
@@ -15,13 +15,13 @@ description: '学习如何在服务器上手动安装 Dokploy。'
 
 ```bash
 #!/bin/bash
-# 确保以根用户身份运行脚本
+# Ensure the script is run as root
 if [ "$(id -u)" != "0" ]; then
     echo "This script must be run as root" >&2
     exit 1
 fi
 
-# 检查 Linux 操作系统（非 macOS 或 Docker 容器内的操作系统）
+# Check for Linux OS (not macOS or inside a Docker container)
 if [ "$(uname)" = "Darwin" ]; then
     echo "This script must be run on Linux" >&2
     exit 1
@@ -32,7 +32,7 @@ if [ -f /.dockerenv ]; then
     exit 1
 fi
 
-# 检查端口是否被占用
+# Check for occupied ports
 if ss -tulnp | grep ':80 ' >/dev/null; then
     echo "Error: Port 80 is already in use" >&2
     exit 1
@@ -43,32 +43,53 @@ if ss -tulnp | grep ':443 ' >/dev/null; then
     exit 1
 fi
 
-# 检查命令是否存在
+# Function to check if a command exists
 command_exists() {
   command -v "$@" > /dev/null 2>&1
 }
 
-# 如果未安装 Docker 则安装
+# Install Docker if it is not installed
 if command_exists docker; then
   echo "Docker already installed"
 else
   curl -sSL https://get.docker.com | sh
 fi
 
-# 初始化 Docker Swarm
+# Initialize Docker Swarm
 docker swarm leave --force 2>/dev/null
-advertise_addr=$(curl -s ifconfig.me)
-docker swarm init --advertise-addr $advertise_addr
-echo "Swarm initialized"
 
-#  创建网络
-docker network rm -f dokploy-network 2>/dev/null
-docker network create --driver overlay --attachable dokploy-network
-echo "Network created"
+    get_ip() {
+        # Try to get IPv4
+        local ipv4=$(curl -4s https://ifconfig.io 2>/dev/null)
 
-# 准备配置目录
-mkdir -p /etc/dokploy
-chmod -R 777 /etc/dokploy
+        if [ -n "$ipv4" ]; then
+            echo "$ipv4"
+        else
+            # Try to get IPv6
+            local ipv6=$(curl -6s https://ifconfig.io 2>/dev/null)
+            if [ -n "$ipv6" ]; then
+                echo "$ipv6"
+            fi
+        fi
+    }
+
+ advertise_addr="${ADVERTISE_ADDR:-$(get_ip)}"
+
+  docker swarm init --advertise-addr $advertise_addr
+
+  if [ $? -ne 0 ]; then
+      echo "Error: Failed to initialize Docker Swarm" >&2
+      exit 1
+  fi
+
+  docker network rm -f dokploy-network 2>/dev/null
+  docker network create --driver overlay --attachable dokploy-network
+
+  echo "Network created"
+
+  mkdir -p /etc/dokploy
+
+  chmod 777 /etc/dokploy
 
 # Pull and deploy Dokploy
 docker pull dokploy/dokploy:latest
@@ -84,9 +105,10 @@ docker service create \
   -e PORT=<Value For PORT eg(3000)> \
   -e TRAEFIK_SSL_PORT=<Value For SSL PORT eg(444)> \
   -e TRAEFIK_PORT=<VALUE FOR TRAEFIK HTTP PORT eg(81)> \
+  -e ADVERTISE_ADDR=$advertise_addr \
   dokploy/dokploy:latest
 
-# 输出成功消息
+# Output success message
 GREEN="\033[0;32m"
 YELLOW="\033[1;33m"
 BLUE="\033[0;34m"

--- a/apps/docs/content/docs/core/get-started/manual-installation.mdx
+++ b/apps/docs/content/docs/core/get-started/manual-installation.mdx
@@ -57,18 +57,39 @@ fi
 
 # Initialize Docker Swarm
 docker swarm leave --force 2>/dev/null
-advertise_addr=$(curl -s ifconfig.me)
-docker swarm init --advertise-addr $advertise_addr
-echo "Swarm initialized"
 
-# Create network
-docker network rm -f dokploy-network 2>/dev/null
-docker network create --driver overlay --attachable dokploy-network
-echo "Network created"
+    get_ip() {
+        # Try to get IPv4
+        local ipv4=$(curl -4s https://ifconfig.io 2>/dev/null)
 
-# Prepare configuration directory
-mkdir -p /etc/dokploy
-chmod -R 777 /etc/dokploy
+        if [ -n "$ipv4" ]; then
+            echo "$ipv4"
+        else
+            # Try to get IPv6
+            local ipv6=$(curl -6s https://ifconfig.io 2>/dev/null)
+            if [ -n "$ipv6" ]; then
+                echo "$ipv6"
+            fi
+        fi
+    }
+
+ advertise_addr="${ADVERTISE_ADDR:-$(get_ip)}"
+
+  docker swarm init --advertise-addr $advertise_addr
+
+  if [ $? -ne 0 ]; then
+      echo "Error: Failed to initialize Docker Swarm" >&2
+      exit 1
+  fi
+
+  docker network rm -f dokploy-network 2>/dev/null
+  docker network create --driver overlay --attachable dokploy-network
+
+  echo "Network created"
+
+  mkdir -p /etc/dokploy
+
+  chmod 777 /etc/dokploy
 
 # Pull and deploy Dokploy
 docker pull dokploy/dokploy:latest
@@ -84,6 +105,7 @@ docker service create \
   -e PORT=<Value For PORT eg(3000)> \
   -e TRAEFIK_SSL_PORT=<Value For SSL PORT eg(444)> \
   -e TRAEFIK_PORT=<VALUE FOR TRAEFIK HTTP PORT eg(81)> \
+  -e ADVERTISE_ADDR=$advertise_addr \
   dokploy/dokploy:latest
 
 # Output success message

--- a/apps/website/public/canary.sh
+++ b/apps/website/public/canary.sh
@@ -57,7 +57,7 @@ install_dokploy() {
         fi
     }
 
-    advertise_addr=$(get_ip)
+    advertise_addr="${ADVERTISE_ADDR:-$(get_ip)}"
 
     docker swarm init --advertise-addr $advertise_addr
 
@@ -92,6 +92,7 @@ install_dokploy() {
     --update-order stop-first \
     --constraint 'node.role == manager' \
     -e RELEASE_TAG=canary \
+    -e ADVERTISE_ADDR=$advertise_addr \
     dokploy/dokploy:canary
 
     GREEN="\033[0;32m"

--- a/apps/website/public/install.sh
+++ b/apps/website/public/install.sh
@@ -56,7 +56,7 @@ install_dokploy() {
         fi
     }
 
-    advertise_addr=$(get_ip)
+    advertise_addr="${ADVERTISE_ADDR:-$(get_ip)}"
 
     docker swarm init --advertise-addr $advertise_addr
     
@@ -90,6 +90,7 @@ install_dokploy() {
       --update-parallelism 1 \
       --update-order stop-first \
       --constraint 'node.role == manager' \
+      -e ADVERTISE_ADDR=$advertise_addr \
       dokploy/dokploy:latest
 
     GREEN="\033[0;32m"

--- a/packages/server/src/services/auth.ts
+++ b/packages/server/src/services/auth.ts
@@ -43,7 +43,8 @@ export const createAdmin = async (input: typeof apiCreateAdmin._type) => {
 			.values({
 				authId: newAuth.id,
 				...(!IS_CLOUD && {
-					serverIp: await getPublicIpWithFallback(),
+					serverIp:
+						process.env.ADVERTISE_ADDR || (await getPublicIpWithFallback()),
 				}),
 			})
 			.returning();


### PR DESCRIPTION
Adds support for custom ENV to the installation for `ADVERTISE_ADDR` which allows to set any IP and this will be injected to the installation to initialize the docker swarm on that IP, if no value is provided, the Public IP will be used.