### PR TITLE
fix(dokploy): Wrong input for `target port` when updating ports.

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/ports/update-port.tsx
@@ -140,7 +140,7 @@ export const UpdatePort = ({ portId }: Props) => {
 									<FormItem>
 										<FormLabel>Target Port</FormLabel>
 										<FormControl>
-											<Input placeholder="1-65535" {...field} />
+											<NumberInput placeholder="1-65535" {...field} />
 										</FormControl>
 
 										<FormMessage />


### PR DESCRIPTION
This PR fix an issue where the target port field was accepting a string instead of a number.

![Screenshot 2024-11-05 at 17 49 00](https://github.com/user-attachments/assets/07705a55-ef20-4d58-aa93-9df0526307ab)