### PR TITLE
fix(signin-page): fix a broken link to password reset docs

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -199,7 +199,7 @@ export default function Home({ IS_CLOUD }: Props) {
 								) : (
 									<Link
 										className="hover:underline text-muted-foreground"
-										href="https://docs.dokploy.com/docs/core/get-started/reset-password"
+										href="https://docs.dokploy.com/docs/core/reset-password"
 										target="_blank"
 									>
 										Lost your password?


### PR DESCRIPTION
Fixed a broken link to password reset documentation.
I changed the link of *Lost your password?* from: https://docs.dokploy.com/docs/core/get-started/reset-password
to https://docs.dokploy.com/docs/core/reset-password.