### PR TITLE
fix: stirling docker compose

### DIFF
--- a/apps/dokploy/templates/stirling/docker-compose.yml
+++ b/apps/dokploy/templates/stirling/docker-compose.yml
@@ -1,12 +1,22 @@
-version: "3"
-
 services:
-  soketi:
-    image: quay.io/soketi/soketi:1.4-16-debian
-    container_name: soketi
+  stirling-pdf:
+    image: frooodle/s-pdf:latest
+    ports:
+      - 8080
+    volumes:
+      - stirling_pdf_trainingdata:/usr/share/tessdata
+      - stirling_pdf_extraconfigs:/configs
+      - stirling_pdf_customfiles:/customFiles/
+      - stirling_pdf_logs:/logs/
+      - stirling_pdf_pipeline:/pipeline/
     environment:
-      SOKETI_DEBUG: "1"
-      SOKETI_HOST: "0.0.0.0"
-      SOKETI_PORT: "6001"
-      SOKETI_METRICS_SERVER_PORT: "9601"
-    restart: unless-stopped
+      - DOCKER_ENABLE_SECURITY=false
+      - INSTALL_BOOK_AND_ADVANCED_HTML_OPS=false
+      - LANGS=en_GB
+
+volumes:
+  stirling_pdf_trainingdata:
+  stirling_pdf_extraconfigs:
+  stirling_pdf_customfiles:
+  stirling_pdf_logs:
+  stirling_pdf_pipeline:


### PR DESCRIPTION
Fixing the issue with stirling when trying to deploy.
In this merge request I am just transposing the docker compose example from [Stirling documentation](https://docs.stirlingpdf.com/Getting%20started/Installation/Docker/Docker%20Install).
#742 

Before : :-1: 
![image](https://github.com/user-attachments/assets/53dfa71a-2809-4d21-a6cd-1378b5eb43d8)
![image](https://github.com/user-attachments/assets/23a00df4-f36d-4ecc-8ecd-b137bc10a789)

After : :+1:  
![image](https://github.com/user-attachments/assets/4fd7d418-a74d-480f-923b-8eb41d28c04e)