### PR TITLE
feat: add wildcard domain support

### DIFF
--- a/apps/dokploy/__test__/traefik/server/update-server-config.test.ts
+++ b/apps/dokploy/__test__/traefik/server/update-server-config.test.ts
@@ -20,6 +20,7 @@ const baseAdmin: Admin = {
 	serverIp: null,
 	certificateType: "none",
 	host: null,
+	wildcardDomain: null,
 	letsEncryptEmail: null,
 	sshPrivateKey: null,
 	enableDockerCleanup: false,

--- a/apps/dokploy/components/dashboard/settings/web-domain.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-domain.tsx
@@ -35,6 +35,7 @@ const addServerDomain = z
 		domain: z.string().min(1, { message: "URL is required" }),
 		letsEncryptEmail: z.string(),
 		certificateType: z.enum(["letsencrypt", "none"]),
+		wildcardDomain: z.string().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.certificateType === "letsencrypt" && !data.letsEncryptEmail) {
@@ -60,6 +61,7 @@ export const WebDomain = () => {
 			domain: "",
 			certificateType: "none",
 			letsEncryptEmail: "",
+			wildcardDomain: "",
 		},
 		resolver: zodResolver(addServerDomain),
 	});
@@ -69,6 +71,7 @@ export const WebDomain = () => {
 				domain: user?.host || "",
 				certificateType: user?.certificateType,
 				letsEncryptEmail: user?.letsEncryptEmail || "",
+				wildcardDomain: user?.wildcardDomain || "",
 			});
 		}
 	}, [form, form.reset, user]);
@@ -78,6 +81,7 @@ export const WebDomain = () => {
 			host: data.domain,
 			letsEncryptEmail: data.letsEncryptEmail,
 			certificateType: data.certificateType,
+			wildcardDomain: data.wildcardDomain,
 		})
 			.then(async () => {
 				await refetch();
@@ -117,6 +121,30 @@ export const WebDomain = () => {
 												<Input
 													className="w-full"
 													placeholder={"dokploy.com"}
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									);
+								}}
+							/>
+
+							<FormField
+								control={form.control}
+								name="wildcardDomain"
+								render={({ field }) => {
+									return (
+										<FormItem>
+											<FormLabel>
+												{t("settings.server.domain.form.wildcardDomain")}
+											</FormLabel>
+											<FormControl>
+												<Input
+													className="w-full"
+													placeholder={t(
+														"settings.server.domain.form.wildcardDomain.placeholder",
+													)}
 													{...field}
 												/>
 											</FormControl>

--- a/apps/dokploy/drizzle/0045_add_custom_domain.sql
+++ b/apps/dokploy/drizzle/0045_add_custom_domain.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "admin" ADD COLUMN "wildcardDomain" text;

--- a/apps/dokploy/public/locales/en/settings.json
+++ b/apps/dokploy/public/locales/en/settings.json
@@ -8,6 +8,8 @@
 	"settings.server.domain.form.certificate.placeholder": "Select a certificate",
 	"settings.server.domain.form.certificateOptions.none": "None",
 	"settings.server.domain.form.certificateOptions.letsencrypt": "Let's Encrypt (Default)",
+	"settings.server.domain.form.wildcardDomain": "Wildcard Domain",
+	"settings.server.domain.form.wildcardDomain.placeholder": "traefik.me",
 
 	"settings.server.webServer.title": "Web Server",
 	"settings.server.webServer.description": "Reload or clean the web server.",

--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -881,8 +881,8 @@ export const templates: TemplateData[] = [
 		},
 		tags: ["forum", "community", "discussion"],
 		load: () => import("./discourse/index").then((m) => m.generate),
-  },
-    {
+	},
+	{
 		id: "immich",
 		name: "Immich",
 		version: "v1.121.0",
@@ -896,8 +896,8 @@ export const templates: TemplateData[] = [
 		},
 		tags: ["photos", "videos", "backup", "media"],
 		load: () => import("./immich/index").then((m) => m.generate),
-  },
-    {
+	},
+	{
 		id: "twenty",
 		name: "Twenty CRM",
 		version: "latest",
@@ -911,8 +911,8 @@ export const templates: TemplateData[] = [
 		},
 		tags: ["crm", "sales", "business"],
 		load: () => import("./twenty/index").then((m) => m.generate),
-  },
-    {
+	},
+	{
 		id: "yourls",
 		name: "YOURLS",
 		version: "1.9.2",
@@ -926,8 +926,8 @@ export const templates: TemplateData[] = [
 		},
 		tags: ["url-shortener", "php"],
 		load: () => import("./yourls/index").then((m) => m.generate),
-  },
-    {
+	},
+	{
 		id: "ryot",
 		name: "Ryot",
 		version: "v7.10",

--- a/apps/dokploy/templates/utils/index.ts
+++ b/apps/dokploy/templates/utils/index.ts
@@ -10,6 +10,7 @@ import type { TemplatesKeys } from "../types/templates-data.type";
 export interface Schema {
 	serverIp: string;
 	projectName: string;
+	wildcardDomain?: string | null;
 }
 
 export type DomainSchema = Pick<Domain, "host" | "port" | "serviceName">;
@@ -26,9 +27,14 @@ export interface Template {
 export const generateRandomDomain = ({
 	serverIp,
 	projectName,
+	wildcardDomain,
 }: Schema): string => {
 	const hash = randomBytes(3).toString("hex");
 	const slugIp = serverIp.replaceAll(".", "-");
+
+	if (wildcardDomain) {
+		return `${projectName}.${wildcardDomain}`;
+	}
 
 	return `${projectName}-${hash}${slugIp === "" ? "" : `-${slugIp}`}.traefik.me`;
 };

--- a/packages/server/src/db/schema/admin.ts
+++ b/packages/server/src/db/schema/admin.ts
@@ -18,6 +18,7 @@ export const admins = pgTable("admin", {
 	serverIp: text("serverIp"),
 	certificateType: certificateType("certificateType").notNull().default("none"),
 	host: text("host"),
+	wildcardDomain: text("wildcardDomain"),
 	letsEncryptEmail: text("letsEncryptEmail"),
 	sshPrivateKey: text("sshPrivateKey"),
 	enableDockerCleanup: boolean("enableDockerCleanup").notNull().default(false),
@@ -51,6 +52,7 @@ const createSchema = createInsertSchema(admins, {
 	certificateType: z.enum(["letsencrypt", "none"]).default("none"),
 	serverIp: z.string().optional(),
 	letsEncryptEmail: z.string().optional(),
+	wildcardDomain: z.string().optional(),
 });
 
 export const apiUpdateAdmin = createSchema.partial();
@@ -66,10 +68,12 @@ export const apiAssignDomain = createSchema
 		host: true,
 		certificateType: true,
 		letsEncryptEmail: true,
+		wildcardDomain: true,
 	})
 	.required()
 	.partial({
 		letsEncryptEmail: true,
+		wildcardDomain: true,
 	});
 
 export const apiUpdateDockerCleanup = createSchema

--- a/packages/server/src/services/domain.ts
+++ b/packages/server/src/services/domain.ts
@@ -45,22 +45,27 @@ export const generateTraefikMeDomain = async (
 ) => {
 	if (serverId) {
 		const server = await findServerById(serverId);
+		const admin = await findAdminById(adminId);
 		return generateRandomDomain({
 			serverIp: server.ipAddress,
 			projectName: appName,
+			wildcardDomain: admin?.wildcardDomain,
 		});
 	}
 
 	if (process.env.NODE_ENV === "development") {
+		const admin = await findAdminById(adminId);
 		return generateRandomDomain({
 			serverIp: "",
 			projectName: appName,
+			wildcardDomain: admin?.wildcardDomain,
 		});
 	}
 	const admin = await findAdminById(adminId);
 	return generateRandomDomain({
 		serverIp: admin?.serverIp || "",
 		projectName: appName,
+		wildcardDomain: admin?.wildcardDomain,
 	});
 };
 

--- a/packages/server/src/templates/utils/index.ts
+++ b/packages/server/src/templates/utils/index.ts
@@ -6,6 +6,7 @@ import type { Domain } from "@dokploy/server/services/domain";
 export interface Schema {
 	serverIp: string;
 	projectName: string;
+	wildcardDomain?: string | null;
 }
 
 export type DomainSchema = Pick<Domain, "host" | "port" | "serviceName">;
@@ -22,9 +23,14 @@ export interface Template {
 export const generateRandomDomain = ({
 	serverIp,
 	projectName,
+	wildcardDomain,
 }: Schema): string => {
 	const hash = randomBytes(3).toString("hex");
 	const slugIp = serverIp.replaceAll(".", "-");
+
+	if (wildcardDomain) {
+		return `${projectName}.${wildcardDomain}`;
+	}
 
 	return `${projectName}-${hash}${slugIp === "" ? "" : `-${slugIp}`}.traefik.me`;
 };


### PR DESCRIPTION
Adding an option for a custom wildcardDomain domain, just point *.example.com as an A record to your servers IP for your own wildcard domain.
When wildcard domain are entered we simplify the domain aswell.

Inspired from Vercel (example.vercel.app)

If I have forgot anything please let me know!