### PR TITLE
feat(cluster): use code editor for node config

### DIFF
--- a/apps/dokploy/components/dashboard/settings/cluster/nodes/show-node-data.tsx
+++ b/apps/dokploy/components/dashboard/settings/cluster/nodes/show-node-data.tsx
@@ -1,3 +1,4 @@
+import { CodeEditor } from "@/components/shared/code-editor";
 import {
 	Dialog,
 	DialogContent,
@@ -33,7 +34,13 @@ export const ShowNodeData = ({ data }: Props) => {
 				<div className="text-wrap rounded-lg border p-4 text-sm sm:max-w-[59rem] bg-card">
 					<code>
 						<pre className="whitespace-pre-wrap break-words">
-							{JSON.stringify(data, null, 2)}
+							<CodeEditor
+								language="json"
+								lineWrapping
+								lineNumbers={false}
+								readOnly
+								value={JSON.stringify(data, null, 2)}
+							/>
 						</pre>
 					</code>
 				</div>


### PR DESCRIPTION
This PR uses the Code Editor to display the Node Config similar to #865 

![image](https://github.com/user-attachments/assets/0fdeab27-8eb6-4f69-856d-7e00054bbc2b)
