### PR TITLE
fix: docker registry URL if provided

### DIFF
--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -44,7 +44,11 @@ export const pullImage = async (
 				onData,
 			);
 		}
-		await spawnAsync("docker", ["pull", dockerImage], onData);
+		const imageUrl = authConfig?.registryUrl
+				? `${authConfig.registryUrl}/${dockerImage}`
+				: dockerImage;
+
+		await spawnAsync("docker", ["pull", imageUrl], onData);
 	} catch (error) {
 		throw error;
 	}


### PR DESCRIPTION
- Updated logic to include registry URL if provided

👋 Hi, This PR solved a problem for me and another brother @Hundred-Killer, in some countries or network situation, we can only use similar self-hosted Docker image service, I used Github Action to implement the packaging and push to my own private image, when I use register url to implement docker deployment, I always get some errors.

This issue has been discussed on Discord and Issue as follows:

Issues: [custom image registry dont work #902](https://github.com/Dokploy/dokploy/issues/902)
Discord Help Post:  [Deployment Docker Register Url is not expected](https://discord.com/channels/1234073262418563112/1318099944762245171)