### PR TITLE
feat: automatic check for updates

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-server/toggle-auto-check-updates.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/toggle-auto-check-updates.tsx
@@ -1,0 +1,27 @@
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useState } from "react";
+
+export const ToggleAutoCheckUpdates = () => {
+	const [enabled, setEnabled] = useState<boolean>(
+		localStorage.getItem("enableAutoCheckUpdates") === "true",
+	);
+
+	const handleToggle = async (checked: boolean) => {
+		setEnabled(checked);
+		localStorage.setItem("enableAutoCheckUpdates", String(checked));
+	};
+
+	return (
+		<div className="flex items-center gap-4">
+			<Switch
+				checked={enabled}
+				onCheckedChange={handleToggle}
+				id="autoCheckUpdatesToggle"
+			/>
+			<Label className="text-primary" htmlFor="autoCheckUpdatesToggle">
+				Automatically check for new updates
+			</Label>
+		</div>
+	);
+};

--- a/apps/dokploy/components/dashboard/settings/web-server/toggle-auto-check-updates.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/toggle-auto-check-updates.tsx
@@ -7,7 +7,7 @@ export const ToggleAutoCheckUpdates = () => {
 		localStorage.getItem("enableAutoCheckUpdates") === "true",
 	);
 
-	const handleToggle = async (checked: boolean) => {
+	const handleToggle = (checked: boolean) => {
 		setEnabled(checked);
 		localStorage.setItem("enableAutoCheckUpdates", String(checked));
 	};

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -78,11 +78,17 @@ export const UpdateServer = () => {
 									await checkAndUpdateImage()
 										.then(async (updateAvailable) => {
 											setIsUpdateAvailable(updateAvailable);
-											toast.info(updateAvailable ? "Update is available" : "No updates available");
+											toast.info(
+												updateAvailable
+													? "Update is available"
+													: "No updates available",
+											);
 										})
 										.catch(() => {
 											setIsUpdateAvailable(false);
-											toast.error("An error occurred while checking for updates, please try again.");
+											toast.error(
+												"An error occurred while checking for updates, please try again.",
+											);
 										});
 								}}
 								isLoading={isLoading}

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -20,9 +20,27 @@ export const UpdateServer = () => {
 	const [isUpdateAvailable, setIsUpdateAvailable] = useState<null | boolean>(
 		null,
 	);
-	const { mutateAsync: checkServerUpdates, isLoading } =
-		api.settings.checkServerUpdates.useMutation();
+	const { mutateAsync: checkForUpdate, isLoading } =
+		api.settings.checkForUpdate.useMutation();
 	const [isOpen, setIsOpen] = useState(false);
+
+	const handleCheckUpdates = async () => {
+		try {
+			const updateAvailable = await checkForUpdate();
+			setIsUpdateAvailable(updateAvailable);
+			if (updateAvailable) {
+				toast.success("Update is available!");
+			} else {
+				toast.info("No updates available");
+			}
+		} catch (error) {
+			console.error("Error checking for updates:", error);
+			setIsUpdateAvailable(false);
+			toast.error(
+				"An error occurred while checking for updates, please try again.",
+			);
+		}
+	};
 
 	return (
 		<Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -76,24 +94,7 @@ export const UpdateServer = () => {
 						) : (
 							<Button
 								className="w-full"
-								onClick={async () => {
-									await checkServerUpdates()
-										.then(async (updateAvailable) => {
-											setIsUpdateAvailable(updateAvailable);
-											toast.info(
-												updateAvailable
-													? "Update is available"
-													: "No updates available",
-											);
-										})
-										.catch((error) => {
-											console.error("Error checking for updates:", error);
-											setIsUpdateAvailable(false);
-											toast.error(
-												"An error occurred while checking for updates, please try again.",
-											);
-										});
-								}}
+								onClick={handleCheckUpdates}
 								isLoading={isLoading}
 							>
 								{isLoading ? "Checking for updates..." : "Check for updates"}

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -14,13 +14,14 @@ import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
 import { UpdateWebServer } from "./update-webserver";
+import { ToggleAutoCheckUpdates } from "./toggle-auto-check-updates";
 
 export const UpdateServer = () => {
 	const [isUpdateAvailable, setIsUpdateAvailable] = useState<null | boolean>(
 		null,
 	);
-	const { mutateAsync: checkAndUpdateImage, isLoading } =
-		api.settings.checkAndUpdateImage.useMutation();
+	const { mutateAsync: checkServerUpdates, isLoading } =
+		api.settings.checkServerUpdates.useMutation();
 	const [isOpen, setIsOpen] = useState(false);
 
 	return (
@@ -61,6 +62,7 @@ export const UpdateServer = () => {
 					</AlertBlock>
 
 					<div className="w-full flex flex-col gap-4">
+						<ToggleAutoCheckUpdates />
 						{isUpdateAvailable === false && (
 							<div className="flex flex-col items-center gap-3">
 								<RefreshCcw className="size-6 self-center text-muted-foreground" />
@@ -75,7 +77,7 @@ export const UpdateServer = () => {
 							<Button
 								className="w-full"
 								onClick={async () => {
-									await checkAndUpdateImage()
+									await checkServerUpdates()
 										.then(async (updateAvailable) => {
 											setIsUpdateAvailable(updateAvailable);
 											toast.info(
@@ -84,7 +86,8 @@ export const UpdateServer = () => {
 													: "No updates available",
 											);
 										})
-										.catch(() => {
+										.catch((error) => {
+											console.error("Error checking for updates:", error);
 											setIsUpdateAvailable(false);
 											toast.error(
 												"An error occurred while checking for updates, please try again.",

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -20,16 +20,16 @@ export const UpdateServer = () => {
 	const [isUpdateAvailable, setIsUpdateAvailable] = useState<null | boolean>(
 		null,
 	);
-	const { mutateAsync: checkForUpdate, isLoading } =
-		api.settings.checkForUpdate.useMutation();
+	const { mutateAsync: getUpdateData, isLoading } =
+		api.settings.getUpdateData.useMutation();
 	const [isOpen, setIsOpen] = useState(false);
 
 	const handleCheckUpdates = async () => {
 		try {
-			const updateAvailable = await checkForUpdate();
+			const { updateAvailable, latestVersion } = await getUpdateData();
 			setIsUpdateAvailable(updateAvailable);
 			if (updateAvailable) {
-				toast.success("Update is available!");
+				toast.success(`${latestVersion} update is available!`);
 			} else {
 				toast.info("No updates available");
 			}

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -76,18 +76,18 @@ export const UpdateServer = () => {
 								className="w-full"
 								onClick={async () => {
 									await checkAndUpdateImage()
-										.then(async (e) => {
-											setIsUpdateAvailable(e);
+										.then(async (updateAvailable) => {
+											setIsUpdateAvailable(updateAvailable);
+											toast.info(updateAvailable ? "Update is available" : "No updates available");
 										})
 										.catch(() => {
 											setIsUpdateAvailable(false);
-											toast.error("Error to check updates");
+											toast.error("An error occurred while checking for updates, please try again.");
 										});
-									toast.success("Check updates");
 								}}
 								isLoading={isLoading}
 							>
-								Check Updates
+								{isLoading ? "Checking for updates..." : "Check for updates"}
 							</Button>
 						)}
 					</div>

--- a/apps/dokploy/components/dashboard/settings/web-server/update-webserver.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-webserver.tsx
@@ -13,22 +13,49 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/utils/api";
 import { toast } from "sonner";
 
-export const UpdateWebServer = () => {
+interface Props {
+	isNavbar?: boolean;
+}
+
+export const UpdateWebServer = ({ isNavbar }: Props) => {
 	const { mutateAsync: updateServer, isLoading } =
 		api.settings.updateServer.useMutation();
+
+	const buttonLabel = isNavbar ? "Update available" : "Update server";
+
+	const handleConfirm = async () => {
+		try {
+			await updateServer();
+			toast.success(
+				"The server has been updated. The page will be reloaded to reflect the changes...",
+			);
+			setTimeout(() => {
+				// Allow seeing the toast before reloading
+				window.location.reload();
+			}, 2000);
+		} catch (error) {
+			console.error("Error updating server:", error);
+			toast.error(
+				"An error occurred while updating the server, please try again.",
+			);
+		}
+	};
+
 	return (
 		<AlertDialog>
 			<AlertDialogTrigger asChild>
 				<Button
 					className="relative w-full"
-					variant="secondary"
+					variant={isNavbar ? "outline" : "secondary"}
 					isLoading={isLoading}
 				>
-					<span className="absolute -right-1 -top-2 flex h-3 w-3">
-						<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
-						<span className="relative inline-flex rounded-full h-3 w-3 bg-green-500" />
-					</span>
-					Update Server
+					{!isLoading && (
+						<span className="absolute -right-1 -top-2 flex h-3 w-3">
+							<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+							<span className="relative inline-flex rounded-full h-3 w-3 bg-green-500" />
+						</span>
+					)}
+					{isLoading ? "Updating..." : buttonLabel}
 				</Button>
 			</AlertDialogTrigger>
 			<AlertDialogContent>
@@ -36,19 +63,12 @@ export const UpdateWebServer = () => {
 					<AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
 					<AlertDialogDescription>
 						This action cannot be undone. This will update the web server to the
-						new version.
+						new version. The page will be reloaded once the update is finished.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
 					<AlertDialogCancel>Cancel</AlertDialogCancel>
-					<AlertDialogAction
-						onClick={async () => {
-							await updateServer();
-							toast.success("Please reload the browser to see the changes");
-						}}
-					>
-						Confirm
-					</AlertDialogAction>
+					<AlertDialogAction onClick={handleConfirm}>Confirm</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>
 		</AlertDialog>

--- a/apps/dokploy/components/layouts/navbar.tsx
+++ b/apps/dokploy/components/layouts/navbar.tsx
@@ -18,7 +18,7 @@ import { buttonVariants } from "../ui/button";
 import { useEffect, useRef, useState } from "react";
 import { UpdateWebServer } from "../dashboard/settings/web-server/update-webserver";
 
-const AUTO_CHECK_UPDATES_INTERVAL_MINUTES = 15;
+const AUTO_CHECK_UPDATES_INTERVAL_MINUTES = 5;
 
 export const Navbar = () => {
 	const [isUpdateAvailable, setIsUpdateAvailable] = useState<boolean>(false);

--- a/apps/dokploy/components/layouts/navbar.tsx
+++ b/apps/dokploy/components/layouts/navbar.tsx
@@ -34,8 +34,8 @@ export const Navbar = () => {
 		},
 	);
 	const { mutateAsync } = api.auth.logout.useMutation();
-	const { mutateAsync: checkForUpdate } =
-		api.settings.checkForUpdate.useMutation();
+	const { mutateAsync: getUpdateData } =
+		api.settings.getUpdateData.useMutation();
 
 	const checkUpdatesIntervalRef = useRef<null | NodeJS.Timeout>(null);
 
@@ -58,7 +58,7 @@ export const Navbar = () => {
 					return;
 				}
 
-				const updateAvailable = await checkForUpdate();
+				const { updateAvailable } = await getUpdateData();
 
 				if (updateAvailable) {
 					// Stop interval when update is available

--- a/apps/dokploy/components/layouts/navbar.tsx
+++ b/apps/dokploy/components/layouts/navbar.tsx
@@ -41,6 +41,10 @@ export const Navbar = () => {
 
 	useEffect(() => {
 		// Handling of automatic check for server updates
+		if (isCloud) {
+			return;
+		}
+
 		if (!localStorage.getItem("enableAutoCheckUpdates")) {
 			// Enable auto update checking by default if user didn't change it
 			localStorage.setItem("enableAutoCheckUpdates", "true");

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -45,7 +45,7 @@ import {
 	stopService,
 	stopServiceRemote,
 	updateAdmin,
-	checkIsUpdateAvailable,
+	getUpdateData,
 	updateLetsEncryptEmail,
 	updateServerById,
 	updateServerTraefik,
@@ -343,12 +343,12 @@ export const settingsRouter = createTRPCRouter({
 			writeConfig("middlewares", input.traefikConfig);
 			return true;
 		}),
-	checkForUpdate: adminProcedure.mutation(async () => {
+	getUpdateData: adminProcedure.mutation(async () => {
 		if (IS_CLOUD) {
-			return true;
+			return { latestVersion: null, updateAvailable: false };
 		}
 
-		return await checkIsUpdateAvailable();
+		return await getUpdateData();
 	}),
 	updateServer: adminProcedure.mutation(async () => {
 		if (IS_CLOUD) {

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -45,6 +45,7 @@ import {
 	stopService,
 	stopServiceRemote,
 	updateAdmin,
+	checkIsUpdateAvailable,
 	updateLetsEncryptEmail,
 	updateServerById,
 	updateServerTraefik,
@@ -342,17 +343,20 @@ export const settingsRouter = createTRPCRouter({
 			writeConfig("middlewares", input.traefikConfig);
 			return true;
 		}),
-
-	checkAndUpdateImage: adminProcedure.mutation(async () => {
+	checkForUpdate: adminProcedure.mutation(async () => {
 		if (IS_CLOUD) {
 			return true;
 		}
-		return await pullLatestRelease();
+
+		return await checkIsUpdateAvailable();
 	}),
 	updateServer: adminProcedure.mutation(async () => {
 		if (IS_CLOUD) {
 			return true;
 		}
+
+		await pullLatestRelease();
+
 		await spawnAsync("docker", [
 			"service",
 			"update",
@@ -361,6 +365,7 @@ export const settingsRouter = createTRPCRouter({
 			getDokployImage(),
 			"dokploy",
 		]);
+
 		return true;
 	}),
 

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -52,6 +52,7 @@ import {
 	writeConfig,
 	writeMainConfig,
 	writeTraefikConfigInPath,
+	DEFAULT_UPDATE_DATA,
 } from "@dokploy/server";
 import { checkGPUStatus, setupGPUSupport } from "@dokploy/server";
 import { generateOpenApiDocument } from "@dokploy/trpc-openapi";
@@ -345,7 +346,7 @@ export const settingsRouter = createTRPCRouter({
 		}),
 	getUpdateData: adminProcedure.mutation(async () => {
 		if (IS_CLOUD) {
-			return { latestVersion: null, updateAvailable: false };
+			return DEFAULT_UPDATE_DATA;
 		}
 
 		return await getUpdateData();

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -72,7 +72,9 @@ export const getUpdateData = async (): Promise<IUpdateData> => {
 		results: [{ digest: string; name: string }];
 	};
 	const { results } = data;
-	const latestTagDigest = results.find((t) => t.name === "latest")?.digest;
+	const latestTagDigest = results.find(
+		(t) => t.name === getDokployImageTag(),
+	)?.digest;
 
 	if (!latestTagDigest) {
 		return DEFAULT_UPDATE_DATA;


### PR DESCRIPTION
- added toggle in Settings->Server->Updates dialog for automatic server update checking (enabled by default, saved in local storage)
- use interval (15min) to periodically check for new updates (if enabled via toggle)
- check for new updates on page load (if enabled via toggle)
- show "Update available" button in header when new server update is available
- improved logic for checking available updates to use Docker hub API instead of pulling image, which makes checking update a lot faster
- moved pulling latest release to `updateServer` action
- removed green dot pinging while server is updating
- added button loading text while server is updating
- added automatic page reload on successful server update
- added information about page reload in confirmation modal and success toast
- added `getDokployImageTag` helper
- improved toasts messages related with updating to be clearer (separate for error, available, unavailable)

Screenshots:
![image](https://github.com/user-attachments/assets/8d6fff95-49da-4d4f-b863-df5a2a1a9041)
![image](https://github.com/user-attachments/assets/1e0056e2-f49c-4b2d-a025-9250566f933f)
![image](https://github.com/user-attachments/assets/da57de34-ed02-4ee5-830d-59cdd4f27128)
![image](https://github.com/user-attachments/assets/3c178697-2a30-4c00-a190-ea6b08039001)
![image](https://github.com/user-attachments/assets/7837b7a6-a2e4-4a8b-90ca-5d61508333d1)
