### PR TITLE
feat(logs): use fancy-ansi for ansi colors

### DIFF
--- a/apps/dokploy/components/dashboard/docker/logs/utils.ts
+++ b/apps/dokploy/components/dashboard/docker/logs/utils.ts
@@ -12,47 +12,6 @@ interface LogStyle {
 	variant: LogVariant;
 	color: string;
 }
-interface AnsiSegment {
-	text: string;
-	className: string;
-}
-
-const ansiToTailwind: Record<number, string> = {
-	// Reset
-	0: "",
-	// Regular colors
-	30: "text-black dark:text-gray-900",
-	31: "text-red-600 dark:text-red-500",
-	32: "text-green-600 dark:text-green-500",
-	33: "text-yellow-600 dark:text-yellow-500",
-	34: "text-blue-600 dark:text-blue-500",
-	35: "text-purple-600 dark:text-purple-500",
-	36: "text-cyan-600 dark:text-cyan-500",
-	37: "text-gray-600 dark:text-gray-400",
-	// Bright colors
-	90: "text-gray-500 dark:text-gray-600",
-	91: "text-red-500 dark:text-red-600",
-	92: "text-green-500 dark:text-green-600",
-	93: "text-yellow-500 dark:text-yellow-600",
-	94: "text-blue-500 dark:text-blue-600",
-	95: "text-purple-500 dark:text-purple-600",
-	96: "text-cyan-500 dark:text-cyan-600",
-	97: "text-white dark:text-gray-300",
-	// Background colors
-	40: "bg-black",
-	41: "bg-red-600",
-	42: "bg-green-600",
-	43: "bg-yellow-600",
-	44: "bg-blue-600",
-	45: "bg-purple-600",
-	46: "bg-cyan-600",
-	47: "bg-white",
-	// Formatting
-	1: "font-bold",
-	2: "opacity-75",
-	3: "italic",
-	4: "underline",
-};
 
 const LOG_STYLES: Record<LogType, LogStyle> = {
 	error: {
@@ -191,56 +150,3 @@ export const getLogType = (message: string): LogStyle => {
 
 	return LOG_STYLES.info;
 };
-
-export function parseAnsi(text: string) {
-	const segments: { text: string; className: string }[] = [];
-	let currentIndex = 0;
-	let currentClasses: string[] = [];
-
-	while (currentIndex < text.length) {
-		const escStart = text.indexOf("\x1b[", currentIndex);
-
-		// No more escape sequences found
-		if (escStart === -1) {
-			if (currentIndex < text.length) {
-				segments.push({
-					text: text.slice(currentIndex),
-					className: currentClasses.join(" "),
-				});
-			}
-			break;
-		}
-
-		// Add text before escape sequence
-		if (escStart > currentIndex) {
-			segments.push({
-				text: text.slice(currentIndex, escStart),
-				className: currentClasses.join(" "),
-			});
-		}
-
-		const escEnd = text.indexOf("m", escStart);
-		if (escEnd === -1) break;
-
-		// Handle multiple codes in one sequence (e.g., \x1b[1;31m)
-		const codesStr = text.slice(escStart + 2, escEnd);
-		const codes = codesStr.split(";").map((c) => Number.parseInt(c, 10));
-
-		if (codes.includes(0)) {
-			// Reset all formatting
-			currentClasses = [];
-		} else {
-			// Add new classes for each code
-			for (const code of codes) {
-				const className = ansiToTailwind[code];
-				if (className && !currentClasses.includes(className)) {
-					currentClasses.push(className);
-				}
-			}
-		}
-
-		currentIndex = escEnd + 1;
-	}
-
-	return segments;
-}

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -35,8 +35,6 @@
 		"test": "vitest --config __test__/vitest.config.ts"
 	},
 	"dependencies": {
-		"react-confetti-explosion":"2.1.2",
-		"@stepperize/react": "4.0.1",
 		"@codemirror/lang-json": "^6.0.1",
 		"@codemirror/lang-yaml": "^6.1.1",
 		"@codemirror/language": "^6.10.1",
@@ -64,6 +62,7 @@
 		"@radix-ui/react-tabs": "^1.0.4",
 		"@radix-ui/react-toggle": "^1.0.3",
 		"@radix-ui/react-tooltip": "^1.0.7",
+		"@stepperize/react": "4.0.1",
 		"@stripe/stripe-js": "4.8.0",
 		"@tanstack/react-query": "^4.36.1",
 		"@tanstack/react-table": "^8.16.0",
@@ -87,6 +86,7 @@
 		"dotenv": "16.4.5",
 		"drizzle-orm": "^0.30.8",
 		"drizzle-zod": "0.5.1",
+		"fancy-ansi": "^0.1.3",
 		"i18next": "^23.16.4",
 		"input-otp": "^1.2.4",
 		"js-cookie": "^3.0.5",
@@ -104,6 +104,7 @@
 		"postgres": "3.4.4",
 		"public-ip": "6.0.2",
 		"react": "18.2.0",
+		"react-confetti-explosion": "2.1.2",
 		"react-dom": "18.2.0",
 		"react-hook-form": "^7.49.3",
 		"react-i18next": "^15.1.0",

--- a/apps/dokploy/tailwind.config.ts
+++ b/apps/dokploy/tailwind.config.ts
@@ -87,7 +87,7 @@ const config = {
 			},
 		},
 	},
-	plugins: [require("tailwindcss-animate")],
+	plugins: [require("tailwindcss-animate"), require("fancy-ansi/plugin")],
 } satisfies Config;
 
 export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,6 +250,9 @@ importers:
       drizzle-zod:
         specifier: 0.5.1
         version: 0.5.1(drizzle-orm@0.30.10(@types/react@18.3.5)(postgres@3.4.4)(react@18.2.0))(zod@3.23.8)
+      fancy-ansi:
+        specifier: ^0.1.3
+        version: 0.1.3
       i18next:
         specifier: ^23.16.4
         version: 23.16.5
@@ -874,9 +877,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -4401,6 +4406,9 @@ packages:
     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -4459,6 +4467,9 @@ packages:
 
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
+
+  fancy-ansi@0.1.3:
+    resolution: {integrity: sha512-tRQVTo5jjdSIiydqgzIIEZpKddzSsfGLsSVt6vWdjVm7fbvDTiQkyoPu6Z3dIPlAM4OZk0jP5jmTCX4G8WGgBw==}
 
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
@@ -10735,6 +10746,8 @@ snapshots:
 
   escalade@3.1.2: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@5.0.0: {}
@@ -10794,6 +10807,10 @@ snapshots:
   ext@1.7.0:
     dependencies:
       type: 2.7.3
+
+  fancy-ansi@0.1.3:
+    dependencies:
+      escape-html: 1.0.3
 
   fast-copy@3.0.2: {}
 


### PR DESCRIPTION
This pull request focuses on enhancing the log parsing and highlighting functionality by integrating the `fancy-ansi` library and removing redundant code. Additionally, it updates the dependencies and configuration files accordingly.

![image](https://github.com/user-attachments/assets/520b1668-287e-4f3f-ad65-aff751be2d8e)

![image](https://github.com/user-attachments/assets/7040fa8d-955b-4fa4-a5d5-d3a4f7e11ee0)

![image](https://github.com/user-attachments/assets/33f1a156-f521-4be4-9fd6-6a5cb5f3587d)

### Enhancements to log parsing and highlighting:

* [`apps/dokploy/components/dashboard/docker/logs/terminal-line.tsx`](diffhunk://#diff-219a675bf21dd72a836467a41488fb5c123d565c76981e5397529b1730eca434R10-R22): Integrated `fancy-ansi` to replace the custom ANSI parsing logic, simplifying the code and improving performance. [[1]](diffhunk://#diff-219a675bf21dd72a836467a41488fb5c123d565c76981e5397529b1730eca434R10-R22) [[2]](diffhunk://#diff-219a675bf21dd72a836467a41488fb5c123d565c76981e5397529b1730eca434L37-L67)
* [`apps/dokploy/components/dashboard/docker/logs/utils.ts`](diffhunk://#diff-fa0f53f954dd05e0ea1a499ef920295ad575c8bddc6a67a813f05ee5ea9d19b2L15-L55): Removed the custom `parseAnsi` function and related ANSI-to-Tailwind mappings, as they are now handled by `fancy-ansi`. [[1]](diffhunk://#diff-fa0f53f954dd05e0ea1a499ef920295ad575c8bddc6a67a813f05ee5ea9d19b2L15-L55) [[2]](diffhunk://#diff-fa0f53f954dd05e0ea1a499ef920295ad575c8bddc6a67a813f05ee5ea9d19b2L194-L246)

### Dependency updates:

* [`apps/dokploy/package.json`](diffhunk://#diff-54d8a657aa0f29e34c3be2673b3df63e8770b13be87cda237ae83a4a29519d73L38-L39): Added `fancy-ansi` and updated the placement of `@stepperize/react` and `react-confetti-explosion` dependencies. [[1]](diffhunk://#diff-54d8a657aa0f29e34c3be2673b3df63e8770b13be87cda237ae83a4a29519d73L38-L39) [[2]](diffhunk://#diff-54d8a657aa0f29e34c3be2673b3df63e8770b13be87cda237ae83a4a29519d73R65) [[3]](diffhunk://#diff-54d8a657aa0f29e34c3be2673b3df63e8770b13be87cda237ae83a4a29519d73R89) [[4]](diffhunk://#diff-54d8a657aa0f29e34c3be2673b3df63e8770b13be87cda237ae83a4a29519d73R107)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR253-R255): Updated to include `fancy-ansi` and its dependency `escape-html`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR253-R255) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR880-R884) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4409-R4411) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4471-R4473) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10749-R10750) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10811-R10814)

### Configuration updates:

* [`apps/dokploy/tailwind.config.ts`](diffhunk://#diff-083b21c7c8ed0c0b4b8f66ba0673a8f1301acb04f2887a61e8f3dcfb461d6928L90-R90): Added `fancy-ansi/plugin` to the Tailwind CSS configuration to support the new ANSI styling.