### PR TITLE
fix(setup): use traefik port/version from env

### DIFF
--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -7,6 +7,9 @@ import {
 } from "@dokploy/server/services/deployment";
 import { findServerById } from "@dokploy/server/services/server";
 import {
+	TRAEFIK_PORT,
+	TRAEFIK_SSL_PORT,
+	TRAEFIK_VERSION,
 	getDefaultMiddlewares,
 	getDefaultServerTraefikConfig,
 } from "@dokploy/server/setup/traefik-setup";
@@ -510,7 +513,7 @@ export const createTraefikInstance = () => {
 			echo "Traefik already exists ✅"
 		else
 			# Create the dokploy-traefik service
-			TRAEFIK_VERSION=3.1.2
+			TRAEFIK_VERSION=${TRAEFIK_VERSION}
 			docker service create \
 				--name dokploy-traefik \
 				--replicas 1 \
@@ -520,8 +523,8 @@ export const createTraefikInstance = () => {
 				--mount type=bind,src=/etc/dokploy/traefik/dynamic,dst=/etc/dokploy/traefik/dynamic \
 				--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
 				--label traefik.enable=true \
-				--publish mode=host,target=443,published=443 \
-				--publish mode=host,target=80,published=80 \
+				--publish mode=host,target=${TRAEFIK_SSL_PORT},published=${TRAEFIK_SSL_PORT} \
+				--publish mode=host,target=${TRAEFIK_PORT},published=${TRAEFIK_PORT} \
 				traefik:v$TRAEFIK_VERSION
 			echo "Traefik version $TRAEFIK_VERSION installed ✅"
 		fi

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -8,9 +8,11 @@ import { getRemoteDocker } from "../utils/servers/remote-docker";
 import type { FileConfig } from "../utils/traefik/file-types";
 import type { MainTraefikConfig } from "../utils/traefik/types";
 
-const TRAEFIK_SSL_PORT =
+export const TRAEFIK_SSL_PORT =
 	Number.parseInt(process.env.TRAEFIK_SSL_PORT!, 10) || 443;
-const TRAEFIK_PORT = Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
+export const TRAEFIK_PORT =
+	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.1.2";
 
 interface TraefikOptions {
 	enableDashboard?: boolean;
@@ -30,7 +32,7 @@ export const initializeTraefik = async ({
 	additionalPorts = [],
 }: TraefikOptions = {}) => {
 	const { MAIN_TRAEFIK_PATH, DYNAMIC_TRAEFIK_PATH } = paths(!!serverId);
-	const imageName = "traefik:v3.1.2";
+	const imageName = `traefik:v${TRAEFIK_VERSION}`;
 	const containerName = "dokploy-traefik";
 	const settings: CreateServiceOptions = {
 		Name: containerName,


### PR DESCRIPTION
This pull request includes updates to the `server-setup.ts` and `traefik-setup.ts` files to make the Traefik configuration more dynamic by utilizing environment variables for version and port numbers.

### Updates to Traefik configuration:

* [`packages/server/src/setup/server-setup.ts`](diffhunk://#diff-6c5bd715fb2bd5b9e487e44796de9dbdc6baecaf657016b1331d5000d5813d0dR12-R14): Added `TRAEFIK_SSL_PORT`, `TRAEFIK_PORT`, and `TRAEFIK_VERSION` imports from `traefik-setup` to dynamically set these values.
* [`packages/server/src/setup/server-setup.ts`](diffhunk://#diff-6c5bd715fb2bd5b9e487e44796de9dbdc6baecaf657016b1331d5000d5813d0dL513-R516): Modified the `createTraefikInstance` function to use the `TRAEFIK_VERSION` environment variable instead of a hardcoded version.
* [`packages/server/src/setup/server-setup.ts`](diffhunk://#diff-6c5bd715fb2bd5b9e487e44796de9dbdc6baecaf657016b1331d5000d5813d0dL523-R527): Updated the `createTraefikInstance` function to use `TRAEFIK_SSL_PORT` and `TRAEFIK_PORT` environment variables for publishing ports.

### Exporting constants for Traefik configuration:

* [`packages/server/src/setup/traefik-setup.ts`](diffhunk://#diff-c7ba7f17cb123f305f679bcd93556195954a10cfa0953ea18780adc7e4967e39L11-R14): Exported `TRAEFIK_SSL_PORT`, `TRAEFIK_PORT`, and `TRAEFIK_VERSION` constants to be used across different modules.
* [`packages/server/src/setup/traefik-setup.ts`](diffhunk://#diff-c7ba7f17cb123f305f679bcd93556195954a10cfa0953ea18780adc7e4967e39L33-R34): Updated the `initializeTraefik` function to use the `TRAEFIK_VERSION` environment variable for the image name.