### PR TITLE
fix: show error message when compose builder throws

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -68,7 +68,7 @@ Compose Type: ${composeType} ✅`;
 
 		writeStream.write("Docker Compose Deployed: ✅");
 	} catch (error) {
-		writeStream.write("Error ❌");
+		writeStream.write(`Error ❌ ${(error as Error).message}`);
 		throw error;
 	} finally {
 		writeStream.end();


### PR DESCRIPTION
This pull request includes a change to improve error logging in the `compose.ts` utility file. The change ensures that error messages are more descriptive by including the error message in the log output. Resolves #975.

* [`packages/server/src/utils/builders/compose.ts`](diffhunk://#diff-f9cc68879adf21866cfd9c3f794ccc2c914313263081bab55b29c6156f6faf05L71-R71): Modified the error logging to include the error message in the log output.

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/2097db59-886e-4735-ac55-2b563b54ea9e" />
