### PR TITLE
feat: prevent layout shifting from scrollbar

### DIFF
--- a/apps/dokploy/styles/globals.css
+++ b/apps/dokploy/styles/globals.css
@@ -90,6 +90,10 @@
 	}
 }
 
+html {
+	scrollbar-gutter: stable both-edges;
+}
+
 .xterm-viewport {
 	border-radius: 0.75rem /* 12px */ !important;
 }


### PR DESCRIPTION
Fixed the horizontal layout shifting that occurs when you navigate between a page with and a page without scrollbar.