### PR TITLE
convert email to lower case when loging in

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -81,7 +81,7 @@ export default function Home({ IS_CLOUD }: Props) {
 
 	const onSubmit = async (values: Login) => {
 		await mutateAsync({
-			email: values.email,
+			email: values.email.toLowerCase(),
 			password: values.password,
 		})
 			.then((data) => {


### PR DESCRIPTION
I had an issue signing in to my dashboard only to find out it was because the first letter of my email was in caps.