### PR TITLE
fix: added unzip to server setup

### DIFF
--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -360,7 +360,7 @@ const installUtilities = () => `
 		;;
 	ubuntu | debian | raspbian)
 		DEBIAN_FRONTEND=noninteractive apt-get update -y >/dev/null
-		DEBIAN_FRONTEND=noninteractive apt-get install -y curl wget git jq openssl >/dev/null
+		DEBIAN_FRONTEND=noninteractive apt-get install -y unzip curl wget git jq openssl >/dev/null
 		;;
 	centos | fedora | rhel | ol | rocky | almalinux | amzn)
 		if [ "$OS_TYPE" = "amzn" ]; then


### PR DESCRIPTION
The installation script for rclone requires unzip to be present in order to install. This adds this dep to the deps installed as it's not present on Debian.