### PR TITLE
docs(contribution): fix template index.ts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,8 +201,8 @@ export function generate(schema: Schema): Template {
 
   const mounts: Template["mounts"] = [
     {
-      mountPath: "./clickhouse/clickhouse-config.xml",
-      content: `some content......`,
+      filePath: "./clickhouse/clickhouse-config.xml",
+      content: "some content......",
     },
   ];
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,7 @@ Let's take the example of `plausible` template.
 ```typescript
 // EXAMPLE
 import {
+  generateBase64,
   generateHash,
   generateRandomDomain,
   type Template,


### PR DESCRIPTION
1. See:

https://github.com/Dokploy/dokploy/blob/332416b7e7d9ceb740dc67a22302e74deb9f1205/CONTRIBUTING.md?plain=1#L171-L185

`generateBase64` is being used at line 183 without being imported from `"../utils"`

2. `mountPath` no longer exists - it is now `filePath` I presume:

https://github.com/Dokploy/dokploy/blob/332416b7e7d9ceb740dc67a22302e74deb9f1205/apps/dokploy/templates/utils/index.ts#L20-L21