### PR TITLE
chore: typo "accesed" changed to "accessed" for TS code

### DIFF
--- a/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
@@ -30,8 +30,8 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const addPermissions = z.object({
-	accesedProjects: z.array(z.string()).optional(),
-	accesedServices: z.array(z.string()).optional(),
+	accessedProjects: z.array(z.string()).optional(),
+	accessedServices: z.array(z.string()).optional(),
 	canCreateProjects: z.boolean().optional().default(false),
 	canCreateServices: z.boolean().optional().default(false),
 	canDeleteProjects: z.boolean().optional().default(false),
@@ -66,8 +66,8 @@ export const AddUserPermissions = ({ userId }: Props) => {
 
 	const form = useForm<AddPermissions>({
 		defaultValues: {
-			accesedProjects: [],
-			accesedServices: [],
+			accessedProjects: [],
+			accessedServices: [],
 		},
 		resolver: zodResolver(addPermissions),
 	});
@@ -75,8 +75,8 @@ export const AddUserPermissions = ({ userId }: Props) => {
 	useEffect(() => {
 		if (data) {
 			form.reset({
-				accesedProjects: data.accesedProjects || [],
-				accesedServices: data.accesedServices || [],
+				accessedProjects: data.accessedProjects || [],
+				accessedServices: data.accessedServices || [],
 				canCreateProjects: data.canCreateProjects,
 				canCreateServices: data.canCreateServices,
 				canDeleteProjects: data.canDeleteProjects,
@@ -98,8 +98,8 @@ export const AddUserPermissions = ({ userId }: Props) => {
 			canDeleteServices: data.canDeleteServices,
 			canDeleteProjects: data.canDeleteProjects,
 			canAccessToTraefikFiles: data.canAccessToTraefikFiles,
-			accesedProjects: data.accesedProjects || [],
-			accesedServices: data.accesedServices || [],
+			accessedProjects: data.accessedProjects || [],
+			accessedServices: data.accessedServices || [],
 			canAccessToDocker: data.canAccessToDocker,
 			canAccessToAPI: data.canAccessToAPI,
 			canAccessToSSHKeys: data.canAccessToSSHKeys,
@@ -318,7 +318,7 @@ export const AddUserPermissions = ({ userId }: Props) => {
 						/>
 						<FormField
 							control={form.control}
-							name="accesedProjects"
+							name="accessedProjects"
 							render={() => (
 								<FormItem className="md:col-span-2">
 									<div className="mb-4">
@@ -339,7 +339,7 @@ export const AddUserPermissions = ({ userId }: Props) => {
 												<FormField
 													key={`project-${index}`}
 													control={form.control}
-													name="accesedProjects"
+													name="accessedProjects"
 													render={({ field }) => {
 														return (
 															<FormItem
@@ -380,7 +380,7 @@ export const AddUserPermissions = ({ userId }: Props) => {
 																	<FormField
 																		key={`project-${index}`}
 																		control={form.control}
-																		name="accesedServices"
+																		name="accessedServices"
 																		render={({ field }) => {
 																			return (
 																				<FormItem

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -68,7 +68,7 @@ export const projectRouter = createTRPCRouter({
 		.input(apiFindOneProject)
 		.query(async ({ input, ctx }) => {
 			if (ctx.user.rol === "user") {
-				const { accesedServices } = await findUserByAuthId(ctx.user.authId);
+				const { accessedServices } = await findUserByAuthId(ctx.user.authId);
 
 				await checkProjectAccess(ctx.user.authId, "access", input.projectId);
 
@@ -79,28 +79,28 @@ export const projectRouter = createTRPCRouter({
 					),
 					with: {
 						compose: {
-							where: buildServiceFilter(compose.composeId, accesedServices),
+							where: buildServiceFilter(compose.composeId, accessedServices),
 						},
 						applications: {
 							where: buildServiceFilter(
 								applications.applicationId,
-								accesedServices,
+								accessedServices,
 							),
 						},
 						mariadb: {
-							where: buildServiceFilter(mariadb.mariadbId, accesedServices),
+							where: buildServiceFilter(mariadb.mariadbId, accessedServices),
 						},
 						mongo: {
-							where: buildServiceFilter(mongo.mongoId, accesedServices),
+							where: buildServiceFilter(mongo.mongoId, accessedServices),
 						},
 						mysql: {
-							where: buildServiceFilter(mysql.mysqlId, accesedServices),
+							where: buildServiceFilter(mysql.mysqlId, accessedServices),
 						},
 						postgres: {
-							where: buildServiceFilter(postgres.postgresId, accesedServices),
+							where: buildServiceFilter(postgres.postgresId, accessedServices),
 						},
 						redis: {
-							where: buildServiceFilter(redis.redisId, accesedServices),
+							where: buildServiceFilter(redis.redisId, accessedServices),
 						},
 					},
 				});
@@ -125,18 +125,18 @@ export const projectRouter = createTRPCRouter({
 		}),
 	all: protectedProcedure.query(async ({ ctx }) => {
 		if (ctx.user.rol === "user") {
-			const { accesedProjects, accesedServices } = await findUserByAuthId(
+			const { accessedProjects, accessedServices } = await findUserByAuthId(
 				ctx.user.authId,
 			);
 
-			if (accesedProjects.length === 0) {
+			if (accessedProjects.length === 0) {
 				return [];
 			}
 
 			const query = await db.query.projects.findMany({
 				where: and(
 					sql`${projects.projectId} IN (${sql.join(
-						accesedProjects.map((projectId) => sql`${projectId}`),
+						accessedProjects.map((projectId) => sql`${projectId}`),
 						sql`, `,
 					)})`,
 					eq(projects.adminId, ctx.user.adminId),
@@ -145,27 +145,27 @@ export const projectRouter = createTRPCRouter({
 					applications: {
 						where: buildServiceFilter(
 							applications.applicationId,
-							accesedServices,
+							accessedServices,
 						),
 						with: { domains: true },
 					},
 					mariadb: {
-						where: buildServiceFilter(mariadb.mariadbId, accesedServices),
+						where: buildServiceFilter(mariadb.mariadbId, accessedServices),
 					},
 					mongo: {
-						where: buildServiceFilter(mongo.mongoId, accesedServices),
+						where: buildServiceFilter(mongo.mongoId, accessedServices),
 					},
 					mysql: {
-						where: buildServiceFilter(mysql.mysqlId, accesedServices),
+						where: buildServiceFilter(mysql.mysqlId, accessedServices),
 					},
 					postgres: {
-						where: buildServiceFilter(postgres.postgresId, accesedServices),
+						where: buildServiceFilter(postgres.postgresId, accessedServices),
 					},
 					redis: {
-						where: buildServiceFilter(redis.redisId, accesedServices),
+						where: buildServiceFilter(redis.redisId, accessedServices),
 					},
 					compose: {
-						where: buildServiceFilter(compose.composeId, accesedServices),
+						where: buildServiceFilter(compose.composeId, accessedServices),
 						with: { domains: true },
 					},
 				},
@@ -239,10 +239,10 @@ export const projectRouter = createTRPCRouter({
 			}
 		}),
 });
-function buildServiceFilter(fieldName: AnyPgColumn, accesedServices: string[]) {
-	return accesedServices.length > 0
+function buildServiceFilter(fieldName: AnyPgColumn, accessedServices: string[]) {
+	return accessedServices.length > 0
 		? sql`${fieldName} IN (${sql.join(
-				accesedServices.map((serviceId) => sql`${serviceId}`),
+				accessedServices.map((serviceId) => sql`${serviceId}`),
 				sql`, `,
 			)})`
 		: sql`1 = 0`;

--- a/packages/server/src/db/schema/user.ts
+++ b/packages/server/src/db/schema/user.ts
@@ -40,11 +40,11 @@ export const users = pgTable("user", {
 	canAccessToTraefikFiles: boolean("canAccessToTraefikFiles")
 		.notNull()
 		.default(false),
-	accesedProjects: text("accesedProjects")
+	accessedProjects: text("accesedProjects")
 		.array()
 		.notNull()
 		.default(sql`ARRAY[]::text[]`),
-	accesedServices: text("accesedServices")
+	accessedServices: text("accesedServices")
 		.array()
 		.notNull()
 		.default(sql`ARRAY[]::text[]`),
@@ -73,8 +73,8 @@ const createSchema = createInsertSchema(users, {
 	token: z.string().min(1),
 	isRegistered: z.boolean().optional(),
 	adminId: z.string(),
-	accesedProjects: z.array(z.string()).optional(),
-	accesedServices: z.array(z.string()).optional(),
+	accessedProjects: z.array(z.string()).optional(),
+	accessedServices: z.array(z.string()).optional(),
 	canCreateProjects: z.boolean().optional(),
 	canCreateServices: z.boolean().optional(),
 	canDeleteProjects: z.boolean().optional(),
@@ -106,8 +106,8 @@ export const apiAssignPermissions = createSchema
 		canCreateServices: true,
 		canDeleteProjects: true,
 		canDeleteServices: true,
-		accesedProjects: true,
-		accesedServices: true,
+		accessedProjects: true,
+		accessedServices: true,
 		canAccessToTraefikFiles: true,
 		canAccessToDocker: true,
 		canAccessToAPI: true,

--- a/packages/server/src/services/user.ts
+++ b/packages/server/src/services/user.ts
@@ -54,7 +54,7 @@ export const addNewProject = async (authId: string, projectId: string) => {
 	await db
 		.update(users)
 		.set({
-			accesedProjects: [...user.accesedProjects, projectId],
+			accessedProjects: [...user.accessedProjects, projectId],
 		})
 		.where(eq(users.authId, authId));
 };
@@ -64,7 +64,7 @@ export const addNewService = async (authId: string, serviceId: string) => {
 	await db
 		.update(users)
 		.set({
-			accesedServices: [...user.accesedServices, serviceId],
+			accessedServices: [...user.accessedServices, serviceId],
 		})
 		.where(eq(users.authId, authId));
 };
@@ -73,8 +73,8 @@ export const canPerformCreationService = async (
 	userId: string,
 	projectId: string,
 ) => {
-	const { accesedProjects, canCreateServices } = await findUserByAuthId(userId);
-	const haveAccessToProject = accesedProjects.includes(projectId);
+	const { accessedProjects, canCreateServices } = await findUserByAuthId(userId);
+	const haveAccessToProject = accessedProjects.includes(projectId);
 
 	if (canCreateServices && haveAccessToProject) {
 		return true;
@@ -87,8 +87,8 @@ export const canPerformAccessService = async (
 	userId: string,
 	serviceId: string,
 ) => {
-	const { accesedServices } = await findUserByAuthId(userId);
-	const haveAccessToService = accesedServices.includes(serviceId);
+	const { accessedServices } = await findUserByAuthId(userId);
+	const haveAccessToService = accessedServices.includes(serviceId);
 
 	if (haveAccessToService) {
 		return true;
@@ -101,8 +101,8 @@ export const canPeformDeleteService = async (
 	authId: string,
 	serviceId: string,
 ) => {
-	const { accesedServices, canDeleteServices } = await findUserByAuthId(authId);
-	const haveAccessToService = accesedServices.includes(serviceId);
+	const { accessedServices, canDeleteServices } = await findUserByAuthId(authId);
+	const haveAccessToService = accessedServices.includes(serviceId);
 
 	if (canDeleteServices && haveAccessToService) {
 		return true;
@@ -135,9 +135,9 @@ export const canPerformAccessProject = async (
 	authId: string,
 	projectId: string,
 ) => {
-	const { accesedProjects } = await findUserByAuthId(authId);
+	const { accessedProjects } = await findUserByAuthId(authId);
 
-	const haveAccessToProject = accesedProjects.includes(projectId);
+	const haveAccessToProject = accessedProjects.includes(projectId);
 
 	if (haveAccessToProject) {
 		return true;


### PR DESCRIPTION
This PR fixes the typo "accesed" -> "accessed" in TS files - specifically:
- accessedProjects
- accessedServices

I've left the mapping to DB untouched (unsure how Dokploy handles migrations in version upgrades atm).

---

As an aside, I was discovered this while attempting to implement the "custom sort order" services for projects and services (suggested in #700). It appears that a user's access to projects and services are stored as string arrays instead of in dedicated permission tables:

https://github.com/Dokploy/dokploy/blob/332416b7e7d9ceb740dc67a22302e74deb9f1205/packages/server/src/db/schema/user.ts#L43-L50

which makes it difficult to implement a custom sort order on a per-user basis.

Would you be open to receiving a PR that normalises the schema + changes the way user permissions are handled?
E.g. replacing arrays with junction tables joining users with projects, and a users with services.
This is quite a big change so asking first before attempting.