### PR TITLE
fix(notifications): discord decoration tiny adjustment

### DIFF
--- a/packages/server/src/utils/notifications/build-success.ts
+++ b/packages/server/src/utils/notifications/build-success.ts
@@ -61,7 +61,7 @@ export const sendBuildSuccessNotifications = async ({
 				`${discord.decoration ? decoration : ""} ${text}`.trim();
 
 			await sendDiscordNotification(discord, {
-				title: "> `✅` Build Success",
+				title: decorate(">", "`✅` Build Success"),
 				color: 0x57f287,
 				fields: [
 					{


### PR DESCRIPTION
Remove "> " when decoration is turned off.
<img width="256" alt="example" src="https://github.com/user-attachments/assets/c775b4b4-901c-4ad9-ab63-3cffec1a1935" />
