### PR TITLE
fix: query for ssh keys to show servers, rather than default empty

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
@@ -48,9 +48,7 @@ export const ShowServers = () => {
 	const query = router.query;
 	const { data, refetch, isLoading } = api.server.all.useQuery();
 	const { mutateAsync } = api.server.remove.useMutation();
-	const { data: sshKeys } = {
-		data: [],
-	};
+	const { data: sshKeys } = api.sshKey.all.useQuery();
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data: canCreateMoreServers } =
 		api.stripe.canCreateMoreServers.useQuery();


### PR DESCRIPTION
Fixes #1097

Reverts this: https://github.com/Dokploy/dokploy/pull/1084#discussion_r1912683332