### PR TITLE
fix: isWSL check was not awaited

### DIFF
--- a/apps/dokploy/server/utils/docker.ts
+++ b/apps/dokploy/server/utils/docker.ts
@@ -14,7 +14,7 @@ export const isWSL = async () => {
 /** Returns the Docker host IP address. */
 export const getDockerHost = async (): Promise<string> => {
 	if (process.env.NODE_ENV === "production") {
-		if (process.platform === "linux" && !isWSL()) {
+		if (process.platform === "linux" && !(await isWSL())) {
 			try {
 				// Try to get the Docker bridge IP first
 				const { stdout } = await execAsync(


### PR DESCRIPTION
- added missing await before `isWSL()` check, which caused it to always return `true` and picking `host.docker.internal` even on linux not running on WSL