### PR TITLE
Fix metabase app template's compose file (networking setup)

### DIFF
--- a/apps/dokploy/templates/metabase/docker-compose.yml
+++ b/apps/dokploy/templates/metabase/docker-compose.yml
@@ -16,11 +16,11 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
+    networks:
+      - dokploy-network
   postgres:
     image: postgres:14
     environment:
       POSTGRES_USER: metabase
       POSTGRES_DB: metabaseappdb
       POSTGRES_PASSWORD: mysecretpassword
-    networks:
-      - dokploy-network


### PR DESCRIPTION
`metabase` service (not `postgres`) should be on `dokploy-network`