### PR TITLE
fix: Update link text and destination for db backup settings

### DIFF
--- a/apps/dokploy/components/dashboard/database/backups/show-backups.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/show-backups.tsx
@@ -79,10 +79,10 @@ export const ShowBackups = ({ id, type }: Props) => {
 							To create a backup it is required to set at least 1 provider.
 							Please, go to{" "}
 							<Link
-								href="/dashboard/settings/server"
+								href="/dashboard/settings/destinations"
 								className="text-foreground"
 							>
-								Settings
+								S3 Destinations
 							</Link>{" "}
 							to do so.
 						</span>


### PR DESCRIPTION
## Summary

This pull request updates the link text and destination in the database backup settings prompt to align with recent frontend UI changes introduced by the `Dokploy` redesign. The change ensures that users are directed to the correct page for configuring backup providers.

## Detailed Description

### What has been modified:
- The link in the prompt advising users to set up a backup provider has been updated:
  - **Old destination and text (pre-Dokploy redesign):**
    - Link Text: `Settings`
    - Link Destination: `/dashboard/settings/server`
  - **New destination and text (aligned with the `Dokploy` redesign):**
    - Link Text: `S3 Destinations`
    - Link Destination: `/dashboard/settings/destinations`

### Why this change was made:
- Recent **frontend UI changes by Dokploy** restructured the settings page, which made the old link (`/dashboard/settings/server`) outdated and irrelevant for backup provider configuration.
- The updated link now correctly reflects the new structure and directs users to the specific "S3 Destinations" page where backup providers are managed.
- The change ensures a smooth user experience by preventing navigation to an incorrect or unrelated page.

### Code context:
The change is localized to the user-facing message displayed when no backup provider is configured, prompting users to take corrective action.

### Impact on the codebase:
- **UI Consistency**: The update aligns the link text and destination with the new frontend structure.
- **No Breaking Changes**: This is a purely text and routing update with no impact on functionality or backend logic.
