### PR TITLE
fix(ui): volume mountPath undefined for file mount - meant to display filePath instead?

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/volumes/show-volumes.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/volumes/show-volumes.tsx
@@ -98,12 +98,20 @@ export const ShowVolumes = ({ id, type }: Props) => {
 											)}
 
 											{mount.type === "file" && (
-												<div className="flex flex-col gap-1">
-													<span className="font-medium">Content</span>
-													<span className="text-sm text-muted-foreground">
-														{mount.content}
-													</span>
-												</div>
+												<>
+													<div className="flex flex-col gap-1">
+														<span className="font-medium">Content</span>
+														<span className="text-sm text-muted-foreground">
+															{mount.content}
+														</span>
+													</div>
+													<div className="flex flex-col gap-1">
+														<span className="font-medium">File Path</span>
+														<span className="text-sm text-muted-foreground">
+															{mount.filePath}
+														</span>
+													</div>
+												</>
 											)}
 											{mount.type === "bind" && (
 												<div className="flex flex-col gap-1">
@@ -113,12 +121,14 @@ export const ShowVolumes = ({ id, type }: Props) => {
 													</span>
 												</div>
 											)}
-											<div className="flex flex-col gap-1">
-												<span className="font-medium">Mount Path</span>
-												<span className="text-sm text-muted-foreground">
-													{mount.mountPath}
-												</span>
-											</div>
+											{mount.type !== "file" && (
+												<div className="flex flex-col gap-1">
+													<span className="font-medium">Mount Path</span>
+													<span className="text-sm text-muted-foreground">
+														{mount.mountPath}
+													</span>
+												</div>
+											)}
 										</div>
 										<div className="flex flex-row gap-1">
 											<UpdateVolume

--- a/apps/dokploy/components/dashboard/application/advanced/volumes/show-volumes.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/volumes/show-volumes.tsx
@@ -98,20 +98,12 @@ export const ShowVolumes = ({ id, type }: Props) => {
 											)}
 
 											{mount.type === "file" && (
-												<>
-													<div className="flex flex-col gap-1">
-														<span className="font-medium">Content</span>
-														<span className="text-sm text-muted-foreground">
-															{mount.content}
-														</span>
-													</div>
-													<div className="flex flex-col gap-1">
-														<span className="font-medium">File Path</span>
-														<span className="text-sm text-muted-foreground">
-															{mount.filePath}
-														</span>
-													</div>
-												</>
+												<div className="flex flex-col gap-1">
+													<span className="font-medium">Content</span>
+													<span className="text-sm text-muted-foreground">
+														{mount.content}
+													</span>
+												</div>
 											)}
 											{mount.type === "bind" && (
 												<div className="flex flex-col gap-1">
@@ -121,7 +113,14 @@ export const ShowVolumes = ({ id, type }: Props) => {
 													</span>
 												</div>
 											)}
-											{mount.type !== "file" && (
+											{mount.type === "file" ? (
+												<div className="flex flex-col gap-1">
+													<span className="font-medium">File Path</span>
+													<span className="text-sm text-muted-foreground">
+														{mount.filePath}
+													</span>
+												</div>
+											) : (
 												<div className="flex flex-col gap-1">
 													<span className="font-medium">Mount Path</span>
 													<span className="text-sm text-muted-foreground">


### PR DESCRIPTION
Shows `filePath` instead of `mountPath` for file mounts (mount path appears to be empty?)

---

Before (mount path is undefined):

![before](https://github.com/user-attachments/assets/88aac9b1-6b17-465b-b6bc-27344b1381b9)


After (mount path is visible):

![after](https://github.com/user-attachments/assets/0ba11257-166c-464e-acc9-78706f13f039)
