### PR TITLE
fix(ui): volume file mount content, line clamp and preserve whitespace

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/volumes/show-volumes.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/volumes/show-volumes.tsx
@@ -100,7 +100,7 @@ export const ShowVolumes = ({ id, type }: Props) => {
 											{mount.type === "file" && (
 												<div className="flex flex-col gap-1">
 													<span className="font-medium">Content</span>
-													<span className="text-sm text-muted-foreground">
+													<span className="text-sm text-muted-foreground line-clamp-[10] whitespace-break-spaces">
 														{mount.content}
 													</span>
 												</div>


### PR DESCRIPTION
As suggested by @190km in this [comment](https://github.com/Dokploy/dokploy/pull/1160#issuecomment-2604783414), this PR
- limits the volume file mount content to **max 10 lines**
- preserve white spaces

---

Before:

![before](https://github.com/user-attachments/assets/13b8466f-cca0-4a59-bd30-371e6f5c5cef)

After:

![after](https://github.com/user-attachments/assets/51b6a84d-388b-4efd-8bcc-73175429102e)
