### PR TITLE
style: fix incosistent spacing in Card-Footer

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -308,7 +308,7 @@ export const AddTemplate = ({ projectId }: Props) => {
 										{/* Create Button */}
 										<div
 											className={cn(
-												"flex-none px-6 pb-6 pt-3 mt-auto",
+												"flex-none px-6 py-3 mt-auto",
 												viewMode === "detailed"
 													? "flex items-center justify-between bg-muted/30 border-t"
 													: "flex justify-center",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a0b8b745-adb2-4c02-b43d-97273eebd152)

I've noticed that the spacing in the "add Template"  Card-Footer is incosistent, so I fixed it.
The card on the right is the new appearance :)