### PR TITLE
fix(ui): add condition to show update server button to admin only

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -783,7 +783,7 @@ export default function Page({ children }: Props) {
 									</SidebarMenuButton>
 								</SidebarMenuItem>
 							))}
-							{!isCloud && (
+							{!isCloud && auth?.rol === "admin" && (
 								<SidebarMenuItem>
 									<SidebarMenuButton asChild>
 										<UpdateServerButton />


### PR DESCRIPTION
Hi, @Siumauricio . 

Thank you for the approval of my PR earlier (#1165 and #1166). However, it turns out that I missed one more handling, that is for the `UpdateServerButton` component which is still visible for normal user when an update is available.

![image](https://github.com/user-attachments/assets/5a267a13-f2e7-427d-9374-e79b6ab674e7)

My assumption is that this button should be visible for admin only. So if that's currect, in this mini follow up PR, I'd like to add a small improvement to handle this as a follow up.

Thank you for your great works! Been enjoying using Dokploy so far and I'm happy that I can contribute to the project :)