### PR TITLE
fix(template): prepend superset_ to postgres/redis

### DIFF
--- a/apps/dokploy/templates/superset/docker-compose.yml
+++ b/apps/dokploy/templates/superset/docker-compose.yml
@@ -13,8 +13,11 @@ services:
     image: amancevice/superset
     restart: always
     depends_on:
-      - db
-      - redis
+      - superset_postgres
+      - superset_redis
+    volumes:
+      # This superset_config.py can be edited in Dokploy's UI Advanced -> Volume Mount
+      - ../files/superset/superset_config.py:/etc/superset/superset_config.py
     environment:
       SECRET_KEY: ${SECRET_KEY}
       MAPBOX_API_KEY: ${MAPBOX_API_KEY}
@@ -22,11 +25,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
       REDIS_PASSWORD: ${REDIS_PASSWORD}
-    volumes:
-      # Note: superset_config.py can be edited in Dokploy's UI Volume Mount
-      - ../files/superset/superset_config.py:/etc/superset/superset_config.py
+      # Ensure the hosts matches your service names below.
+      POSTGRES_HOST: superset_postgres
+      REDIS_HOST: superset_redis
 
-  db:
+  superset_postgres:
     image: postgres
     restart: always
     environment:
@@ -34,7 +37,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - postgres:/var/lib/postgresql/data
+      - superset_postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 30s
@@ -43,11 +46,11 @@ services:
     networks:
       - dokploy-network
 
-  redis:
+  superset_redis:
     image: redis
     restart: always
     volumes:
-      - redis:/data
+      - superset_redis_data:/data
     command: redis-server --requirepass ${REDIS_PASSWORD}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
@@ -58,5 +61,5 @@ services:
       - dokploy-network
 
 volumes:
-  postgres:
-  redis:
+  superset_postgres_data:
+  superset_redis_data:

--- a/apps/dokploy/templates/superset/index.ts
+++ b/apps/dokploy/templates/superset/index.ts
@@ -47,13 +47,13 @@ CACHE_CONFIG = {
   "CACHE_REDIS_HOST": "redis",
   "CACHE_REDIS_PORT": 6379,
   "CACHE_REDIS_DB": 1,
-  "CACHE_REDIS_URL": f"redis://:{os.getenv('REDIS_PASSWORD')}@redis:6379/1",
+  "CACHE_REDIS_URL": f"redis://:{os.getenv('REDIS_PASSWORD')}@{os.getenv('REDIS_HOST')}:6379/1",
 }
 
 FILTER_STATE_CACHE_CONFIG = {**CACHE_CONFIG, "CACHE_KEY_PREFIX": "superset_filter_"}
 EXPLORE_FORM_DATA_CACHE_CONFIG = {**CACHE_CONFIG, "CACHE_KEY_PREFIX": "superset_explore_form_"}
 
-SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}@db:5432/{os.getenv('POSTGRES_DB')}"
+SQLALCHEMY_DATABASE_URI = f"postgresql+psycopg2://{os.getenv('POSTGRES_USER')}:{os.getenv('POSTGRES_PASSWORD')}@{os.getenv('POSTGRES_HOST')}:5432/{os.getenv('POSTGRES_DB')}"
 SQLALCHEMY_TRACK_MODIFICATIONS = True
 			`.trim(),
 		},


### PR DESCRIPTION
Renamed `db` to `superset_postgres` and `redis` to `superset_redis`.

This is to avoid potential hostname conflicts with other compose/applications that may use the name `redis` or `db` hostname on `dokploy-network`.