### PR TITLE
feat: upgrade listmonk version

### DIFF
--- a/apps/dokploy/templates/listmonk/docker-compose.yml
+++ b/apps/dokploy/templates/listmonk/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:13
+    image: postgres:17-alpine
     ports:
       - 5432
     networks:
@@ -19,7 +19,7 @@ services:
       - listmonk-data:/var/lib/postgresql/data
 
   setup:
-    image: listmonk/listmonk:v3.0.0
+    image: listmonk/listmonk:v4.1.0
     networks:
       - dokploy-network
     volumes:
@@ -35,7 +35,7 @@ services:
 
   app:
     restart: unless-stopped
-    image: listmonk/listmonk:v3.0.0
+    image: listmonk/listmonk:v4.1.0
     environment:
       - TZ=Etc/UTC
     depends_on:

--- a/apps/dokploy/templates/listmonk/index.ts
+++ b/apps/dokploy/templates/listmonk/index.ts
@@ -2,13 +2,11 @@ import {
 	type DomainSchema,
 	type Schema,
 	type Template,
-	generatePassword,
 	generateRandomDomain,
 } from "../utils";
 
 export function generate(schema: Schema): Template {
 	const randomDomain = generateRandomDomain(schema);
-	const adminPassword = generatePassword(32);
 
 	const domains: DomainSchema[] = [
 		{
@@ -19,7 +17,7 @@ export function generate(schema: Schema): Template {
 	];
 
 	const envs = [
-		`# login with admin:${adminPassword}`,
+		`# visit the page to setup your super admin user`,
 		"# check config.toml in Advanced / Volumes for more options",
 	];
 
@@ -28,9 +26,6 @@ export function generate(schema: Schema): Template {
 			filePath: "config.toml",
 			content: `[app]
 address = "0.0.0.0:9000"
-
-admin_username = "admin"
-admin_password = "${adminPassword}"
 
 [db]
 host = "db"


### PR DESCRIPTION
- Upgrade listmonk version to v4.
- Upgrade postgres version to 17-alpine (according to [listmonks docker-compose](https://github.com/knadh/listmonk/blob/master/docker-compose.yml) file)
- Remove automatic admin credentials generation (because in version 4 there's an initial setup page)