### PR TITLE
chore: remove duplicated sentence in projects dialog

### DIFF
--- a/apps/dokploy/components/dashboard/projects/project-environment.tsx
+++ b/apps/dokploy/components/dashboard/projects/project-environment.tsx
@@ -99,8 +99,7 @@ export const ProjectEnvironment = ({ projectId, children }: Props) => {
 					<DialogTitle>Project Environment</DialogTitle>
 					<DialogDescription>
 						Update the env Environment variables that are accessible to all
-						services of this project. Use this syntax to reference project-level
-						variables in your service environments:
+						services of this project.
 					</DialogDescription>
 				</DialogHeader>
 				{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}


### PR DESCRIPTION
The sentence "Use this syntax to reference project-level variables in your service environments" is duplicated in the dialog description and the callout. This removes the one in the description.

![Untitled](https://github.com/user-attachments/assets/e8f52b5f-350e-45a0-8278-c6b61f6bb93b)
