### PR TITLE
fix: expose docker stack services

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -203,9 +203,6 @@ export const addDomainToCompose = async (
 		if (!result?.services?.[serviceName]) {
 			throw new Error(`The service ${serviceName} not found in the compose`);
 		}
-		if (!result.services[serviceName].labels) {
-			result.services[serviceName].labels = [];
-		}
 
 		const httpLabels = await createDomainLabels(appName, domain, "web");
 		if (https) {
@@ -217,13 +214,35 @@ export const addDomainToCompose = async (
 			httpLabels.push(...httpsLabels);
 		}
 
-		const labels = result.services[serviceName].labels;
-
-		if (Array.isArray(labels)) {
-			if (!labels.includes("traefik.enable=true")) {
-				labels.push("traefik.enable=true");
+		if (compose.composeType === "docker-compose") {
+			if (!result.services[serviceName].labels) {
+				result.services[serviceName].labels = [];
 			}
-			labels.push(...httpLabels);
+
+			const labels = result.services[serviceName].labels;
+
+			if (Array.isArray(labels)) {
+				if (!labels.includes("traefik.enable=true")) {
+					labels.push("traefik.enable=true");
+				}
+				labels.push(...httpLabels);
+			}
+		} else {
+			if (!result.services[serviceName].deploy) {
+				result.services[serviceName].deploy = {};
+			}
+			if (!result.services[serviceName].deploy.labels) {
+				result.services[serviceName].deploy.labels = [];
+			}
+
+			const labels = result.services[serviceName].deploy.labels;
+
+			if (Array.isArray(labels)) {
+				if (!labels.includes("traefik.enable=true")) {
+					labels.push("traefik.enable=true");
+				}
+				labels.push(...httpLabels);
+			}
 		}
 
 		// Add the dokploy-network to the service

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -214,20 +214,15 @@ export const addDomainToCompose = async (
 			httpLabels.push(...httpsLabels);
 		}
 
+		let labels: DefinitionsService["labels"] = [];
 		if (compose.composeType === "docker-compose") {
 			if (!result.services[serviceName].labels) {
 				result.services[serviceName].labels = [];
 			}
 
-			const labels = result.services[serviceName].labels;
-
-			if (Array.isArray(labels)) {
-				if (!labels.includes("traefik.enable=true")) {
-					labels.push("traefik.enable=true");
-				}
-				labels.push(...httpLabels);
-			}
+			labels = result.services[serviceName].labels;
 		} else {
+			// Stack Case
 			if (!result.services[serviceName].deploy) {
 				result.services[serviceName].deploy = {};
 			}
@@ -235,14 +230,14 @@ export const addDomainToCompose = async (
 				result.services[serviceName].deploy.labels = [];
 			}
 
-			const labels = result.services[serviceName].deploy.labels;
+			labels = result.services[serviceName].deploy.labels;
+		}
 
-			if (Array.isArray(labels)) {
-				if (!labels.includes("traefik.enable=true")) {
-					labels.push("traefik.enable=true");
-				}
-				labels.push(...httpLabels);
+		if (Array.isArray(labels)) {
+			if (!labels.includes("traefik.enable=true")) {
+				labels.push("traefik.enable=true");
 			}
+			labels.push(...httpLabels);
 		}
 
 		// Add the dokploy-network to the service


### PR DESCRIPTION
Dokploy handle Traefik labels the same way for Docker Compose and Docker Stack projects but it makes Stack projects are unable to be exposed (or the user needs to manually add the labels).
![image](https://github.com/user-attachments/assets/d5ffb480-7aa5-483b-9a71-9362b3a7c454)
![image](https://github.com/user-attachments/assets/34c80c01-7847-4d8d-b86e-f780df92d41b)
