### PR TITLE
revert "feat<templates>: Updated PocketBase version to 0.25.0" #1259

### DIFF
--- a/apps/dokploy/templates/pocketbase/docker-compose.yml
+++ b/apps/dokploy/templates/pocketbase/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   pocketbase:
-    image: spectado/pocketbase:0.25.0
+    image: spectado/pocketbase:0.23.3
     restart: unless-stopped
     volumes:
       - /etc/dokploy/templates/${HASH}/data:/pb_data


### PR DESCRIPTION
Reverts Dokploy/dokploy#1259

As [kucherenko](https://github.com/kucherenko) said, [0.25.0](https://hub.docker.com/r/spectado/pocketbase/tags) version does not exist.
