### PR TITLE
Update Pocketbase Docker image version to latest

### DIFF
--- a/apps/dokploy/templates/pocketbase/docker-compose.yml
+++ b/apps/dokploy/templates/pocketbase/docker-compose.yml
@@ -1,7 +1,6 @@
-version: "3.8"
 services:
   pocketbase:
-    image: spectado/pocketbase:0.25.0
+    image: spectado/pocketbase:latest
     restart: unless-stopped
     volumes:
       - /etc/dokploy/templates/${HASH}/data:/pb_data


### PR DESCRIPTION
Change the Pocketbase Docker image version to 'latest' and remove the 'version' attribute from the template.