### PR TITLE
fix: listmonk docker network

### DIFF
--- a/apps/dokploy/templates/listmonk/docker-compose.yml
+++ b/apps/dokploy/templates/listmonk/docker-compose.yml
@@ -36,6 +36,8 @@ services:
   app:
     restart: unless-stopped
     image: listmonk/listmonk:v4.1.0
+    networks:
+      - dokploy-network
     environment:
       - TZ=Etc/UTC
     depends_on:


### PR DESCRIPTION
`app` was missing the `dokploy-network` network and so the db wasn't accessible to it.