### PR TITLE
chore: update wordpress version to v6.7.1

### DIFF
--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -170,7 +170,7 @@ export const templates: TemplateData[] = [
 	{
 		id: "wordpress",
 		name: "Wordpress",
-		version: "5.8.3",
+		version: "6.7.1",
 		description:
 			"Wordpress is a free and open source content management system (CMS) for publishing and managing websites.",
 		logo: "wordpress.png",


### PR DESCRIPTION
Version mismatch: The WordPress template version was updated to v6.7.1 but not reflected in the templates.ts file.