### PR TITLE
fix: make spacing between sidebar elements consistent

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -676,7 +676,7 @@ export default function Page({ children }: Props) {
 					</SidebarGroup>
 					<SidebarGroup>
 						<SidebarGroupLabel>Settings</SidebarGroupLabel>
-						<SidebarMenu className="gap-2">
+						<SidebarMenu>
 							{filteredSettings.map((item) => {
 								const isSingle = item.isSingle !== false;
 								const isActive = isSingle
@@ -793,7 +793,7 @@ export default function Page({ children }: Props) {
 						</SidebarMenu>
 					</SidebarGroup>
 				</SidebarContent>
-				<SidebarFooter>
+				<SidebarFooter className="gap-1">
 					<SidebarMenu>
 						<SidebarMenuItem>
 							<UserNav />


### PR DESCRIPTION
Before this PR, the spacing between sidebar items was inconsistent across sections:
![image](https://github.com/user-attachments/assets/d10a4b5b-1fbe-4e93-a66f-81c30a8442bf)

This PR fixes that!