### PR TITLE
chore: update umami to v2.16.1

### DIFF
--- a/apps/dokploy/templates/templates.ts
+++ b/apps/dokploy/templates/templates.ts
@@ -426,7 +426,7 @@ export const templates: TemplateData[] = [
 	{
 		id: "umami",
 		name: "Umami",
-		version: "v2.14.0",
+		version: "v2.16.1",
 		description:
 			"Umami is a simple, fast, privacy-focused alternative to Google Analytics.",
 		logo: "umami.png",

--- a/apps/dokploy/templates/umami/docker-compose.yml
+++ b/apps/dokploy/templates/umami/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-v2.14.0
+    image: ghcr.io/umami-software/umami:postgresql-v2.16.1
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:3000/api/heartbeat"]


### PR DESCRIPTION
Works fine on my self-hosted Dokploy instance!
![image](https://github.com/user-attachments/assets/c360e845-1a02-40a0-9614-1f7ad505aea6)
