### PR TITLE
fix(traefik): add udp port mapping to port 443

### DIFF
--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -22,6 +22,7 @@ interface TraefikOptions {
 		targetPort: number;
 		publishedPort: number;
 		publishMode?: "ingress" | "host";
+		Protocol?: "tcp" | "udp";
 	}[];
 }
 
@@ -74,6 +75,13 @@ export const initializeTraefik = async ({
 					TargetPort: 443,
 					PublishedPort: TRAEFIK_SSL_PORT,
 					PublishMode: "host",
+					Protocol: "udp",
+				},
+				{
+					TargetPort: 443,
+					PublishedPort: TRAEFIK_SSL_PORT,
+					PublishMode: "host",
+					Protocol: "tcp",
 				},
 				{
 					TargetPort: 80,


### PR DESCRIPTION
This PR adds udp port mapping to Traefik for port 443.

This will allow for http3 connections to Traefik.

**NB**: I have not tested tested this code, but I know adding udp to port 443 allows for http3 connection which I have verified using:

`docker service update --publish-add published=443,target=443,mode=host,protocol=udp <traefik service id>`

Closes: #1363 

**NB 2**: This does not enable http3 out of the box. There is a small change that has to be made to `traefik.yml`, but that should maybe be the user's responsibility?