### PR TITLE
feat: Bitbucket branch length

### DIFF
--- a/packages/server/src/utils/providers/bitbucket.ts
+++ b/packages/server/src/utils/providers/bitbucket.ts
@@ -275,7 +275,7 @@ export const getBitbucketBranches = async (
 	}
 	const bitbucketProvider = await findBitbucketById(input.bitbucketId);
 	const { owner, repo } = input;
-	const url = `https://api.bitbucket.org/2.0/repositories/${owner}/${repo}/refs/branches`;
+	const url = `https://api.bitbucket.org/2.0/repositories/${owner}/${repo}/refs/branches?pagelen=100`;
 
 	try {
 		const response = await fetch(url, {


### PR DESCRIPTION
Fixes: https://github.com/Dokploy/dokploy/issues/1397

This change fetches 100 branches instead of the default 10 from Bitbucket.

**Before**
<img width="788" alt="Screenshot 2025-03-04 at 10 55 48" src="https://github.com/user-attachments/assets/9930ad42-09c3-414d-ac28-8eac8adf28c5" />

**After**
<img width="781" alt="Screenshot 2025-03-04 at 10 55 13" src="https://github.com/user-attachments/assets/823366b3-ea6b-482f-b0d2-2c813b170ac9" />
<img width="676" alt="Screenshot 2025-03-04 at 10 55 03" src="https://github.com/user-attachments/assets/ab83e097-f16e-419c-a93e-07d8aeb3e262" />
