### PR TITLE
feat(ui): move profile to top of account dropdown

### DIFF
--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -75,6 +75,14 @@ export const UserNav = () => {
 					<DropdownMenuItem
 						className="cursor-pointer"
 						onClick={() => {
+							router.push("/dashboard/settings/profile");
+						}}
+					>
+						Profile
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						className="cursor-pointer"
+						onClick={() => {
 							router.push("/dashboard/projects");
 						}}
 					>
@@ -126,14 +134,6 @@ export const UserNav = () => {
 						</>
 					) : (
 						<>
-							<DropdownMenuItem
-								className="cursor-pointer"
-								onClick={() => {
-									router.push("/dashboard/settings/profile");
-								}}
-							>
-								Profile
-							</DropdownMenuItem>
 							{data?.role === "owner" && (
 								<DropdownMenuItem
 									className="cursor-pointer"


### PR DESCRIPTION
When clicking the user account button at the bottom of the left sidebar
- `Profile` is **missing** from the self-host version
- `Profile` is the second-from-top item in the cloud version

Given that everything is already accessible from the left sidebar with Dokploy's new UI, the most intuitive item that people would look for when clicking the user photo is `Profile`, and hence it should be first, i.e:

![profile-dropdown](https://github.com/user-attachments/assets/f4a57b0a-5b25-48b0-9b2f-820e604180a0)

For comparison, here is GitHub:

![image](https://github.com/user-attachments/assets/e2ae80d2-9407-4b3f-95d8-adc609b3078e)

This is, however, quite subjective, although I think at the least, `Profile` should be available in the self-host version's dropdown menu.