### PR TITLE
fix: breadcrumbs UX

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -383,9 +383,8 @@ export const AddTemplate = ({ projectId }: Props) => {
 																		side="top"
 																	>
 																		<span>
-																			If ot server is selected, the application
-																			will be deployed on the server where the
-																			user is logged in.
+																			If no server is selected, the application will be
+                                      deployed on the server where the user is logged in.
 																		</span>
 																	</TooltipContent>
 																</Tooltip>

--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -384,7 +384,7 @@ export const AddTemplate = ({ projectId }: Props) => {
 																	>
 																		<span>
 																			If no server is selected, the application will be
-                                      deployed on the server where the user is logged in.
+																			deployed on the server where the user is logged in.
 																		</span>
 																	</TooltipContent>
 																</Tooltip>

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -1055,10 +1055,6 @@ export default function Page({ children }: Props) {
 												</Link>
 											</BreadcrumbLink>
 										</BreadcrumbItem>
-										<BreadcrumbSeparator className="block" />
-										<BreadcrumbItem>
-											<BreadcrumbPage>{activeItem?.title}</BreadcrumbPage>
-										</BreadcrumbItem>
 									</BreadcrumbList>
 								</Breadcrumb>
 							</div>

--- a/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
+++ b/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
@@ -37,7 +37,7 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 											)}
 										</BreadcrumbLink>
 									</BreadcrumbItem>
-									<BreadcrumbSeparator className="block" />
+                  {_index + 1 < list.length && <BreadcrumbSeparator className="block" />}
 								</Fragment>
 							))}
 						</BreadcrumbList>

--- a/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
+++ b/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
@@ -37,7 +37,7 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 											)}
 										</BreadcrumbLink>
 									</BreadcrumbItem>
-                  {_index + 1 < list.length && <BreadcrumbSeparator className="block" />}
+									{_index + 1 < list.length && <BreadcrumbSeparator className="block" />}
 								</Fragment>
 							))}
 						</BreadcrumbList>


### PR DESCRIPTION
Better breadcrumbs UX:

- Removed duplicate for single pages;
- Removed ending separator;

Before / After
![image](https://github.com/user-attachments/assets/2b02def4-47a3-4159-8f45-c9af0738e213)
![image](https://github.com/user-attachments/assets/09db25d0-95da-4fe5-84ff-f46108704103)

![image](https://github.com/user-attachments/assets/aab33415-5122-44be-a4f2-efd8580edbda)
![image](https://github.com/user-attachments/assets/33e95e9e-f81f-4c6a-990d-251ef9085c0b)

Fixed text in template > server hint:
![image](https://github.com/user-attachments/assets/3b3a2687-9ea7-4c0e-ba72-1ce45b4bf176)

