### PR TITLE
refactor: remove unnecessary extra shadow from monitoring page

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -200,7 +200,7 @@ export const ContainerFreeMonitoring = ({
 	}, [appName]);
 
 	return (
-		<div className="rounded-xl bg-background shadow-md flex flex-col gap-4">
+		<div className="rounded-xl bg-background flex flex-col gap-4">
 			<header className="flex items-center justify-between">
 				<div className="space-y-1">
 					<h1 className="text-2xl font-semibold tracking-tight">Monitoring</h1>


### PR DESCRIPTION
Removes the third shadow around the "monitoring" page content.

**Before:**
![image](https://github.com/user-attachments/assets/0feff53c-8e92-43e1-a522-3afc895e177c)

**After:**
![image](https://github.com/user-attachments/assets/02c0d1d4-6ce1-4b63-bfda-01d986bdf67b)
