### PR TITLE
fix(gitlab): update repository filtering and connection testing

### DIFF
--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -266,7 +266,7 @@ export const getGitlabRepositories = async (gitlabId?: string) => {
 		if (groupName) {
 			return full_path.toLowerCase().includes(groupName) && kind === "group";
 		}
-		return kind === "member";
+		return kind === "user";
 	});
 	const mappedRepositories = filteredRepos.map((repo: any) => {
 		return {
@@ -409,6 +409,8 @@ export const testGitlabConnection = async (
 
 	const gitlabProvider = await findGitlabById(gitlabId);
 
+	console.log(gitlabProvider);
+
 	const response = await fetch(
 		`${gitlabProvider.gitlabUrl}/api/v4/projects?membership=true&owned=true&page=${0}&per_page=${100}`,
 		{
@@ -427,13 +429,15 @@ export const testGitlabConnection = async (
 
 	const repositories = await response.json();
 
+	console.log(repositories);
+
 	const filteredRepos = repositories.filter((repo: any) => {
 		const { full_path, kind } = repo.namespace;
 
 		if (groupName) {
 			return full_path.toLowerCase().includes(groupName) && kind === "group";
 		}
-		return kind === "member";
+		return kind === "user";
 	});
 
 	return filteredRepos.length;


### PR DESCRIPTION
- Change repository filtering to use 'user' kind instead of 'member'
- Add console logging for debugging GitLab provider and repository connection
- Ensure consistent filtering logic in both getGitlabRepositories and testGitlabConnection