### PR TITLE
Database empty backups fix

### DIFF
--- a/packages/server/src/utils/databases/mariadb.ts
+++ b/packages/server/src/utils/databases/mariadb.ts
@@ -31,7 +31,7 @@ export const buildMariadb = async (mariadb: MariadbNested) => {
 		mounts,
 	} = mariadb;
 
-	const defaultMariadbEnv = `MARIADB_DATABASE=${databaseName}\nMARIADB_USER=${databaseUser}\nMARIADB_PASSWORD=${databasePassword}\nMARIADB_ROOT_PASSWORD=${databaseRootPassword}${
+	const defaultMariadbEnv = `MARIADB_DATABASE="${databaseName}"\nMARIADB_USER="${databaseUser}"\nMARIADB_PASSWORD="${databasePassword}"\nMARIADB_ROOT_PASSWORD="${databaseRootPassword}"${
 		env ? `\n${env}` : ""
 	}`;
 	const resources = calculateResources({

--- a/packages/server/src/utils/databases/mongo.ts
+++ b/packages/server/src/utils/databases/mongo.ts
@@ -77,7 +77,7 @@ fi
 
 ${command ?? "wait $MONGOD_PID"}`;
 
-	const defaultMongoEnv = `MONGO_INITDB_ROOT_USERNAME=${databaseUser}\nMONGO_INITDB_ROOT_PASSWORD=${databasePassword}${replicaSets ? "\nMONGO_INITDB_DATABASE=admin" : ""}${
+	const defaultMongoEnv = `MONGO_INITDB_ROOT_USERNAME="${databaseUser}"\nMONGO_INITDB_ROOT_PASSWORD="${databasePassword}"${replicaSets ? "\nMONGO_INITDB_DATABASE=admin" : ""}${
 		env ? `\n${env}` : ""
 	}`;
 

--- a/packages/server/src/utils/databases/mysql.ts
+++ b/packages/server/src/utils/databases/mysql.ts
@@ -34,10 +34,10 @@ export const buildMysql = async (mysql: MysqlNested) => {
 
 	const defaultMysqlEnv =
 		databaseUser !== "root"
-			? `MYSQL_USER=${databaseUser}\nMYSQL_DATABASE=${databaseName}\nMYSQL_PASSWORD=${databasePassword}\nMYSQL_ROOT_PASSWORD=${databaseRootPassword}${
+			? `MYSQL_USER="${databaseUser}"\nMYSQL_DATABASE="${databaseName}"\nMYSQL_PASSWORD="${databasePassword}"\nMYSQL_ROOT_PASSWORD="${databaseRootPassword}"${
 					env ? `\n${env}` : ""
 				}`
-			: `MYSQL_DATABASE=${databaseName}\nMYSQL_ROOT_PASSWORD=${databaseRootPassword}${
+			: `MYSQL_DATABASE="${databaseName}"\nMYSQL_ROOT_PASSWORD="${databaseRootPassword}"${
 					env ? `\n${env}` : ""
 				}`;
 	const resources = calculateResources({

--- a/packages/server/src/utils/databases/postgres.ts
+++ b/packages/server/src/utils/databases/postgres.ts
@@ -30,7 +30,7 @@ export const buildPostgres = async (postgres: PostgresNested) => {
 		mounts,
 	} = postgres;
 
-	const defaultPostgresEnv = `POSTGRES_DB=${databaseName}\nPOSTGRES_USER=${databaseUser}\nPOSTGRES_PASSWORD=${databasePassword}${
+	const defaultPostgresEnv = `POSTGRES_DB="${databaseName}"\nPOSTGRES_USER="${databaseUser}"\nPOSTGRES_PASSWORD="${databasePassword}"${
 		env ? `\n${env}` : ""
 	}`;
 	const resources = calculateResources({

--- a/packages/server/src/utils/databases/redis.ts
+++ b/packages/server/src/utils/databases/redis.ts
@@ -28,7 +28,7 @@ export const buildRedis = async (redis: RedisNested) => {
 		mounts,
 	} = redis;
 
-	const defaultRedisEnv = `REDIS_PASSWORD=${databasePassword}${
+	const defaultRedisEnv = `REDIS_PASSWORD="${databasePassword}"${
 		env ? `\n${env}` : ""
 	}`;
 	const resources = calculateResources({


### PR DESCRIPTION
All started when I tried to setup a mysql database backup to a S3 destination. I ran the manual backup and what I found on S3 was an empty sql file even though Dokploy said that it was a succesful dump. 

So, I decided to write my own script to do it. While doing it i discovered something quite interesting. When trying to do a mysqldump with wrong credentials it sitll creates the dump file but empty! Aha so something had to be wrong with my mysql credentials on my dokploy service.

I remembered that my root password ended in a whitespace. Could this mess with the dump command? Well, since the password it's written within quotes in the code then it works perfectly:

`"mysqldump --default-character-set=utf8mb4 -u 'root' --password='${databaseRootPassword}' --single-transaction --no-tablespaces --quick '${database}' | gzip"`

Then I tried to connect to mysql using the Dokploy console (mysql -u root -p) and copied and paste my root password and it failed the login! But i could connect if i removed the final whitespace of the password. So my understanding was that dokploy has stored my root password with a final whitespace but the mysql is actually configured without it and therefore when Dokploy tries to do the mysqldump is using the wrong password and failing to dump the database (Well doesn't fail but the dump is empty).

Long story short, I submerged into the code in order to find where is the mysql service actually creating and found the issue:

Here are the Env Variables:
![image](https://github.com/user-attachments/assets/fb131d9d-a971-4748-855b-1354921cfc7d)

And later they are treated in here before using them:
![image](https://github.com/user-attachments/assets/95931fa9-80fb-4f37-aabf-89b5240b3490)

The issue is with **dotenv.parse** function:
![image](https://github.com/user-attachments/assets/ad455c04-4e42-4853-8f2a-a5c62d2d53a3)

I checked the documentation and ran some tests myself and  **dotenv.parse**  it's trimming the values among other things. So effectively is creating the mysql service without that final whitespace in the root password that i personally created.

So in the end the backup problem is that Dokploy thinks that my password has the whitespace but in reality the service is created without it hence creating a discrepancy.

The solution I thought was to wrap the values of the env variables in quotes so everything inside it is treated as a string by dotenv.parse() respecting leading and trailing whitespace and also quotes within the password (Another case for the bug).

This is my first ever PR of anything so I hope I at least helped identifying the bug and someone more knowledgeable can find the optimum solution.
