### PR TITLE
feat(databases): add database rebuild functionality

### DIFF
--- a/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
+++ b/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
@@ -1,0 +1,116 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { api } from "@/utils/api";
+import { DatabaseIcon, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+interface Props {
+	id: string;
+	type: "postgres" | "mysql" | "mariadb" | "mongo" | "redis";
+}
+
+export const RebuildDatabase = ({ id, type }: Props) => {
+	const utils = api.useUtils();
+
+	const mutationMap = {
+		postgres: () => api.postgres.rebuild.useMutation(),
+		mysql: () => api.mysql.rebuild.useMutation(),
+		mariadb: () => api.mariadb.rebuild.useMutation(),
+		mongo: () => api.mongo.rebuild.useMutation(),
+		redis: () => api.redis.rebuild.useMutation(),
+	};
+
+	const { mutateAsync, isLoading } = mutationMap[type]();
+
+	const handleRebuild = async () => {
+		try {
+			await mutateAsync({
+				postgresId: type === "postgres" ? id : "",
+				mysqlId: type === "mysql" ? id : "",
+				mariadbId: type === "mariadb" ? id : "",
+				mongoId: type === "mongo" ? id : "",
+				redisId: type === "redis" ? id : "",
+			});
+			toast.success("Database rebuilt successfully");
+			await utils.invalidate();
+		} catch (error) {
+			toast.error("Error rebuilding database", {
+				description: error instanceof Error ? error.message : "Unknown error",
+			});
+		}
+	};
+
+	return (
+		<Card className="bg-background border-destructive/50">
+			<CardHeader>
+				<CardTitle className="text-xl flex items-center gap-2">
+					<AlertTriangle className="h-5 w-5 text-destructive" />
+					Danger Zone
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="flex flex-col gap-4">
+					<div className="flex flex-col gap-2">
+						<h3 className="text-base font-semibold">Rebuild Database</h3>
+						<p className="text-sm text-muted-foreground">
+							This action will completely reset your database to its initial
+							state. All data, tables, and configurations will be removed.
+						</p>
+					</div>
+					<AlertDialog>
+						<AlertDialogTrigger asChild>
+							<Button
+								variant="outline"
+								className="w-full border-destructive/50 hover:bg-destructive/10 hover:text-destructive text-destructive"
+							>
+								<DatabaseIcon className="mr-2 h-4 w-4" />
+								Rebuild Database
+							</Button>
+						</AlertDialogTrigger>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle className="flex items-center gap-2">
+									<AlertTriangle className="h-5 w-5 text-destructive" />
+									Are you absolutely sure?
+								</AlertDialogTitle>
+								<AlertDialogDescription className="space-y-2">
+									<p>This action will:</p>
+									<ul className="list-disc list-inside space-y-1">
+										<li>Stop the current database service</li>
+										<li>Delete all existing data and volumes</li>
+										<li>Reset to the default configuration</li>
+										<li>Restart the service with a clean state</li>
+									</ul>
+									<p className="font-medium text-destructive mt-4">
+										This action cannot be undone.
+									</p>
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel>Cancel</AlertDialogCancel>
+								<AlertDialogAction
+									onClick={handleRebuild}
+									className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+									disabled={isLoading}
+								>
+									{isLoading ? "Rebuilding..." : "Yes, rebuild database"}
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+				</div>
+			</CardContent>
+		</Card>
+	);
+};

--- a/apps/dokploy/components/dashboard/shared/show-database-advanced-settings.tsx
+++ b/apps/dokploy/components/dashboard/shared/show-database-advanced-settings.tsx
@@ -1,0 +1,20 @@
+import { ShowCustomCommand } from "@/components/dashboard/postgres/advanced/show-custom-command";
+import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
+import { ShowVolumes } from "@/components/dashboard/application/advanced/volumes/show-volumes";
+import { RebuildDatabase } from "./rebuild-database";
+
+interface Props {
+	id: string;
+	type: "postgres" | "mysql" | "mariadb" | "mongo" | "redis";
+}
+
+export const ShowDatabaseAdvancedSettings = ({ id, type }: Props) => {
+	return (
+		<div className="flex w-full flex-col gap-5">
+			<ShowCustomCommand id={id} type={type} />
+			<ShowVolumes id={id} type={type} />
+			<ShowResources id={id} type={type} />
+			<RebuildDatabase id={id} type={type} />
+		</div>
+	);
+};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mariadb/[mariadbId].tsx
@@ -1,5 +1,3 @@
-import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
-import { ShowVolumes } from "@/components/dashboard/application/advanced/volumes/show-volumes";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-enviroment";
 import { ShowDockerLogs } from "@/components/dashboard/application/logs/show";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
@@ -10,7 +8,7 @@ import { ShowInternalMariadbCredentials } from "@/components/dashboard/mariadb/g
 import { UpdateMariadb } from "@/components/dashboard/mariadb/update-mariadb";
 import { ContainerFreeMonitoring } from "@/components/dashboard/monitoring/free/container/show-free-container-monitoring";
 import { ContainerPaidMonitoring } from "@/components/dashboard/monitoring/paid/container/show-paid-container-monitoring";
-import { ShowCustomCommand } from "@/components/dashboard/postgres/advanced/show-custom-command";
+import { ShowDatabaseAdvancedSettings } from "@/components/dashboard/shared/show-database-advanced-settings";
 import { MariadbIcon } from "@/components/icons/data-tools-icons";
 import { ProjectLayout } from "@/components/layouts/project-layout";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
@@ -278,11 +276,10 @@ const Mariadb = (
 									</TabsContent>
 									<TabsContent value="advanced">
 										<div className="flex flex-col gap-4 pt-2.5">
-											<div className="flex w-full flex-col gap-5">
-												<ShowCustomCommand id={mariadbId} type="mariadb" />
-												<ShowVolumes id={mariadbId} type="mariadb" />
-												<ShowResources id={mariadbId} type="mariadb" />
-											</div>
+											<ShowDatabaseAdvancedSettings
+												id={mariadbId}
+												type="mariadb"
+											/>
 										</div>
 									</TabsContent>
 								</Tabs>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mongo/[mongoId].tsx
@@ -1,5 +1,3 @@
-import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
-import { ShowVolumes } from "@/components/dashboard/application/advanced/volumes/show-volumes";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-enviroment";
 import { ShowDockerLogs } from "@/components/dashboard/application/logs/show";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
@@ -10,7 +8,7 @@ import { ShowInternalMongoCredentials } from "@/components/dashboard/mongo/gener
 import { UpdateMongo } from "@/components/dashboard/mongo/update-mongo";
 import { ContainerFreeMonitoring } from "@/components/dashboard/monitoring/free/container/show-free-container-monitoring";
 import { ContainerPaidMonitoring } from "@/components/dashboard/monitoring/paid/container/show-paid-container-monitoring";
-import { ShowCustomCommand } from "@/components/dashboard/postgres/advanced/show-custom-command";
+import { ShowDatabaseAdvancedSettings } from "@/components/dashboard/shared/show-database-advanced-settings";
 import { MongodbIcon } from "@/components/icons/data-tools-icons";
 import { ProjectLayout } from "@/components/layouts/project-layout";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
@@ -279,11 +277,7 @@ const Mongo = (
 									</TabsContent>
 									<TabsContent value="advanced">
 										<div className="flex flex-col gap-4 pt-2.5">
-											<div className="flex w-full flex-col gap-5 ">
-												<ShowCustomCommand id={mongoId} type="mongo" />
-												<ShowVolumes id={mongoId} type="mongo" />
-												<ShowResources id={mongoId} type="mongo" />
-											</div>
+											<ShowDatabaseAdvancedSettings id={mongoId} type="mongo" />
 										</div>
 									</TabsContent>
 								</Tabs>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mysql/[mysqlId].tsx
@@ -1,5 +1,3 @@
-import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
-import { ShowVolumes } from "@/components/dashboard/application/advanced/volumes/show-volumes";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-enviroment";
 import { ShowDockerLogs } from "@/components/dashboard/application/logs/show";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
@@ -10,7 +8,7 @@ import { ShowExternalMysqlCredentials } from "@/components/dashboard/mysql/gener
 import { ShowGeneralMysql } from "@/components/dashboard/mysql/general/show-general-mysql";
 import { ShowInternalMysqlCredentials } from "@/components/dashboard/mysql/general/show-internal-mysql-credentials";
 import { UpdateMysql } from "@/components/dashboard/mysql/update-mysql";
-import { ShowCustomCommand } from "@/components/dashboard/postgres/advanced/show-custom-command";
+import { ShowDatabaseAdvancedSettings } from "@/components/dashboard/shared/show-database-advanced-settings";
 import { MysqlIcon } from "@/components/icons/data-tools-icons";
 import { ProjectLayout } from "@/components/layouts/project-layout";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
@@ -236,33 +234,9 @@ const MySql = (
 														/>
 													) : (
 														<>
-															{/* {monitoring?.enabledFeatures && (
-															<div className="flex flex-row border w-fit p-4 rounded-lg items-center gap-2">
-																<Label className="text-muted-foreground">
-																	Change Monitoring
-																</Label>
-																<Switch
-																	checked={toggleMonitoring}
-																	onCheckedChange={setToggleMonitoring}
-																/>
-															</div>
-														)}
-
-														{toggleMonitoring ? (
-															<ContainerPaidMonitoring
-																appName={data?.appName || ""}
-																baseUrl={`http://${monitoring?.serverIp}:${monitoring?.metricsConfig?.server?.port}`}
-																token={
-																	monitoring?.metricsConfig?.server?.token || ""
-																}
-															/>
-														) : (
-															<div> */}
 															<ContainerFreeMonitoring
 																appName={data?.appName || ""}
 															/>
-															{/* </div> */}
-															{/* )} */}
 														</>
 													)}
 												</div>
@@ -283,11 +257,10 @@ const MySql = (
 										</TabsContent>
 										<TabsContent value="advanced">
 											<div className="flex flex-col gap-4 pt-2.5">
-												<div className="flex w-full flex-col gap-5">
-													<ShowCustomCommand id={mysqlId} type="mysql" />
-													<ShowVolumes id={mysqlId} type="mysql" />
-													<ShowResources id={mysqlId} type="mysql" />
-												</div>
+												<ShowDatabaseAdvancedSettings
+													id={mysqlId}
+													type="mysql"
+												/>
 											</div>
 										</TabsContent>
 									</Tabs>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/postgres/[postgresId].tsx
@@ -1,12 +1,9 @@
-import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
-import { ShowVolumes } from "@/components/dashboard/application/advanced/volumes/show-volumes";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-enviroment";
 import { ShowDockerLogs } from "@/components/dashboard/application/logs/show";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
 import { ShowBackups } from "@/components/dashboard/database/backups/show-backups";
 import { ContainerFreeMonitoring } from "@/components/dashboard/monitoring/free/container/show-free-container-monitoring";
 import { ContainerPaidMonitoring } from "@/components/dashboard/monitoring/paid/container/show-paid-container-monitoring";
-import { ShowCustomCommand } from "@/components/dashboard/postgres/advanced/show-custom-command";
 import { ShowExternalPostgresCredentials } from "@/components/dashboard/postgres/general/show-external-postgres-credentials";
 import { ShowGeneralPostgres } from "@/components/dashboard/postgres/general/show-general-postgres";
 import { ShowInternalPostgresCredentials } from "@/components/dashboard/postgres/general/show-internal-postgres-credentials";
@@ -15,6 +12,7 @@ import { PostgresqlIcon } from "@/components/icons/data-tools-icons";
 import { ProjectLayout } from "@/components/layouts/project-layout";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ShowDatabaseAdvancedSettings } from "@/components/dashboard/shared/show-database-advanced-settings";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -235,33 +233,9 @@ const Postgresql = (
 													/>
 												) : (
 													<>
-														{/* {monitoring?.enabledFeatures && (
-															<div className="flex flex-row border w-fit p-4 rounded-lg items-center gap-2">
-																<Label className="text-muted-foreground">
-																	Change Monitoring
-																</Label>
-																<Switch
-																	checked={toggleMonitoring}
-																	onCheckedChange={setToggleMonitoring}
-																/>
-															</div>
-														)}
-
-														{toggleMonitoring ? (
-															<ContainerPaidMonitoring
-																appName={data?.appName || ""}
-																baseUrl={`http://${monitoring?.serverIp}:${monitoring?.metricsConfig?.server?.port}`}
-																token={
-																	monitoring?.metricsConfig?.server?.token || ""
-																}
-															/>
-														) : (
-															<div> */}
 														<ContainerFreeMonitoring
 															appName={data?.appName || ""}
 														/>
-														{/* </div> */}
-														{/* )} */}
 													</>
 												)}
 											</div>
@@ -282,11 +256,10 @@ const Postgresql = (
 									</TabsContent>
 									<TabsContent value="advanced">
 										<div className="flex flex-col gap-4 pt-2.5">
-											<div className="flex w-full flex-col gap-5 ">
-												<ShowCustomCommand id={postgresId} type="postgres" />
-												<ShowVolumes id={postgresId} type="postgres" />
-												<ShowResources id={postgresId} type="postgres" />
-											</div>
+											<ShowDatabaseAdvancedSettings
+												id={postgresId}
+												type="postgres"
+											/>
 										</div>
 									</TabsContent>
 								</Tabs>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/redis/[redisId].tsx
@@ -1,15 +1,13 @@
-import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
-import { ShowVolumes } from "@/components/dashboard/application/advanced/volumes/show-volumes";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-enviroment";
 import { ShowDockerLogs } from "@/components/dashboard/application/logs/show";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
 import { ContainerFreeMonitoring } from "@/components/dashboard/monitoring/free/container/show-free-container-monitoring";
 import { ContainerPaidMonitoring } from "@/components/dashboard/monitoring/paid/container/show-paid-container-monitoring";
-import { ShowCustomCommand } from "@/components/dashboard/postgres/advanced/show-custom-command";
 import { ShowExternalRedisCredentials } from "@/components/dashboard/redis/general/show-external-redis-credentials";
 import { ShowGeneralRedis } from "@/components/dashboard/redis/general/show-general-redis";
 import { ShowInternalRedisCredentials } from "@/components/dashboard/redis/general/show-internal-redis-credentials";
 import { UpdateRedis } from "@/components/dashboard/redis/update-redis";
+import { ShowDatabaseAdvancedSettings } from "@/components/dashboard/shared/show-database-advanced-settings";
 import { RedisIcon } from "@/components/icons/data-tools-icons";
 import { ProjectLayout } from "@/components/layouts/project-layout";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
@@ -272,11 +270,7 @@ const Redis = (
 									</TabsContent>
 									<TabsContent value="advanced">
 										<div className="flex flex-col gap-4 pt-2.5">
-											<div className="flex w-full flex-col gap-5 ">
-												<ShowCustomCommand id={redisId} type="redis" />
-												<ShowVolumes id={redisId} type="redis" />
-												<ShowResources id={redisId} type="redis" />
-											</div>
+											<ShowDatabaseAdvancedSettings id={redisId} type="redis" />
 										</div>
 									</TabsContent>
 								</Tabs>

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -4,6 +4,7 @@ import {
 	apiCreateMySql,
 	apiDeployMySql,
 	apiFindOneMySql,
+	apiRebuildMysql,
 	apiResetMysql,
 	apiSaveEnvironmentVariablesMySql,
 	apiSaveExternalPortMySql,
@@ -24,6 +25,7 @@ import {
 	findBackupsByDbId,
 	findMySqlById,
 	findProjectById,
+	rebuildDatabase,
 	removeMySqlById,
 	removeService,
 	startService,
@@ -378,5 +380,20 @@ export const mysqlRouter = createTRPCRouter({
 			}
 
 			return updatedMysql;
+		}),
+	rebuild: protectedProcedure
+		.input(apiRebuildMysql)
+		.mutation(async ({ input, ctx }) => {
+			const mysql = await findMySqlById(input.mysqlId);
+			if (mysql.project.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not authorized to rebuild this MySQL database",
+				});
+			}
+
+			await rebuildDatabase(mysql.mysqlId, "mysql");
+
+			return true;
 		}),
 });

--- a/packages/server/src/db/schema/mariadb.ts
+++ b/packages/server/src/db/schema/mariadb.ts
@@ -146,3 +146,9 @@ export const apiUpdateMariaDB = createSchema
 		mariadbId: z.string().min(1),
 	})
 	.omit({ serverId: true });
+
+export const apiRebuildMariadb = createSchema
+	.pick({
+		mariadbId: true,
+	})
+	.required();

--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -141,3 +141,9 @@ export const apiResetMongo = createSchema
 		appName: true,
 	})
 	.required();
+
+export const apiRebuildMongo = createSchema
+	.pick({
+		mongoId: true,
+	})
+	.required();

--- a/packages/server/src/db/schema/mysql.ts
+++ b/packages/server/src/db/schema/mysql.ts
@@ -144,3 +144,9 @@ export const apiUpdateMySql = createSchema
 		mysqlId: z.string().min(1),
 	})
 	.omit({ serverId: true });
+
+export const apiRebuildMysql = createSchema
+	.pick({
+		mysqlId: true,
+	})
+	.required();

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -140,3 +140,9 @@ export const apiUpdatePostgres = createSchema
 		postgresId: z.string().min(1),
 	})
 	.omit({ serverId: true });
+
+export const apiRebuildPostgres = createSchema
+	.pick({
+		postgresId: true,
+	})
+	.required();

--- a/packages/server/src/db/schema/redis.ts
+++ b/packages/server/src/db/schema/redis.ts
@@ -133,3 +133,9 @@ export const apiUpdateRedis = createSchema
 		redisId: z.string().min(1),
 	})
 	.omit({ serverId: true });
+
+export const apiRebuildRedis = createSchema
+	.pick({
+		redisId: true,
+	})
+	.required();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -30,7 +30,7 @@ export * from "./services/github";
 export * from "./services/gitlab";
 export * from "./services/server";
 export * from "./services/application";
-
+export * from "./utils/databases/rebuild";
 export * from "./setup/config-paths";
 export * from "./setup/postgres-setup";
 export * from "./setup/redis-setup";

--- a/packages/server/src/utils/databases/rebuild.ts
+++ b/packages/server/src/utils/databases/rebuild.ts
@@ -1,0 +1,99 @@
+import { deployPostgres } from "@dokploy/server/services/postgres";
+import { execAsyncRemote } from "../process/execAsync";
+import { execAsync } from "../process/execAsync";
+import { deployMySql } from "@dokploy/server/services/mysql";
+import { deployMariadb } from "@dokploy/server/services/mariadb";
+import { deployMongo } from "@dokploy/server/services/mongo";
+import { deployRedis } from "@dokploy/server/services/redis";
+import { removeService } from "../docker/utils";
+import { db } from "@dokploy/server/db";
+import {
+	postgres,
+	mysql,
+	mariadb,
+	mongo,
+	redis,
+} from "@dokploy/server/db/schema";
+import { eq } from "drizzle-orm";
+
+type DatabaseType = "postgres" | "mysql" | "mariadb" | "mongo" | "redis";
+
+export const rebuildDatabase = async (
+	databaseId: string,
+	type: DatabaseType,
+) => {
+	const database = await findDatabaseById(databaseId, type);
+
+	if (!database) {
+		throw new Error("Database not found");
+	}
+
+	await removeService(database.appName, database.serverId);
+	await new Promise((resolve) => setTimeout(resolve, 6000));
+
+	for (const mount of database.mounts) {
+		if (mount.type === "volume") {
+			const command = `docker volume rm ${mount?.volumeName} --force`;
+			if (database.serverId) {
+				await execAsyncRemote(database.serverId, command);
+			} else {
+				await execAsync(command);
+			}
+		}
+	}
+
+	if (type === "postgres") {
+		await deployPostgres(databaseId);
+	} else if (type === "mysql") {
+		await deployMySql(databaseId);
+	} else if (type === "mariadb") {
+		await deployMariadb(databaseId);
+	} else if (type === "mongo") {
+		await deployMongo(databaseId);
+	} else if (type === "redis") {
+		await deployRedis(databaseId);
+	}
+};
+
+const findDatabaseById = async (databaseId: string, type: DatabaseType) => {
+	if (type === "postgres") {
+		return await db.query.postgres.findFirst({
+			where: eq(postgres.postgresId, databaseId),
+			with: {
+				mounts: true,
+			},
+		});
+	}
+	if (type === "mysql") {
+		return await db.query.mysql.findFirst({
+			where: eq(mysql.mysqlId, databaseId),
+			with: {
+				mounts: true,
+			},
+		});
+	}
+	if (type === "mariadb") {
+		return await db.query.mariadb.findFirst({
+			where: eq(mariadb.mariadbId, databaseId),
+			with: {
+				mounts: true,
+			},
+		});
+	}
+	if (type === "mongo") {
+		return await db.query.mongo.findFirst({
+			where: eq(mongo.mongoId, databaseId),
+			with: {
+				mounts: true,
+			},
+		});
+	}
+	if (type === "redis") {
+		return await db.query.redis.findFirst({
+			where: eq(redis.redisId, databaseId),
+			with: {
+				mounts: true,
+			},
+		});
+	}
+};


### PR DESCRIPTION
- Implement RebuildDatabase component for all database types
- Create ShowDatabaseAdvancedSettings component to consolidate advanced settings
- Add rebuild API endpoints for Postgres, MySQL, MariaDB, MongoDB, and Redis
- Implement server-side database rebuild utility with volume and service removal
- Enhance database management with a dangerous zone for complete database reset