### PR TITLE
fix(ui): Autocomplete

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -115,7 +115,7 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 								<FormItem>
 									<FormLabel>Username</FormLabel>
 									<FormControl>
-										<Input placeholder="username" {...field} />
+										<Input placeholder="username" autoComplete="username" {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -130,7 +130,7 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 								<FormItem>
 									<FormLabel>Password</FormLabel>
 									<FormControl>
-										<Input placeholder="Password" {...field} type="password" />
+										<Input placeholder="Password" autoComplete="one-time-code" {...field} type="password" />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -115,7 +115,7 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 								<FormItem>
 									<FormLabel>Username</FormLabel>
 									<FormControl>
-										<Input placeholder="username" autoComplete="username" {...field} />
+										<Input placeholder="Username" autoComplete="username" {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -494,7 +494,7 @@ export const AddDatabase = ({ projectId, projectName }: Props) => {
 												<Input
 													type="password"
 													placeholder="******************"
-													autoComplete="off"
+													autoComplete="one-time-code"
 													{...field}
 												/>
 											</FormControl>

--- a/apps/dokploy/components/dashboard/settings/cluster/registry/handle-registry.tsx
+++ b/apps/dokploy/components/dashboard/settings/cluster/registry/handle-registry.tsx
@@ -207,7 +207,7 @@ export const HandleRegistry = ({ registryId }: Props) => {
 										<FormControl>
 											<Input
 												placeholder="Username"
-												autoComplete="off"
+												autoComplete="username"
 												{...field}
 											/>
 										</FormControl>
@@ -227,7 +227,7 @@ export const HandleRegistry = ({ registryId }: Props) => {
 										<FormControl>
 											<Input
 												placeholder="Password"
-												autoComplete="off"
+												autoComplete="one-time-code"
 												{...field}
 												type="password"
 											/>


### PR DESCRIPTION
Better autocomplete work. Prevents browsers from automatically filling in Username and Password fields.
Use one-time-code instead of off value. [reference](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion#managing_autofill_for_login_fields)
Tested for Chrome and Chromium based browsers.

Before / After
![image](https://github.com/user-attachments/assets/2cc4734a-902e-42c3-b199-698ada1d5155)
![image](https://github.com/user-attachments/assets/2060e6e8-1f81-4b2d-bf0d-6f5787bd7117)
