### PR TITLE
fix: truncate domain overflow for external links

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -186,7 +186,7 @@ export const ShowProjects = () => {
 																										target="_blank"
 																										href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
 																									>
-																										<span>{domain.host}</span>
+																										<span className="truncate">{domain.host}</span>
 																										<ExternalLinkIcon className="size-4 shrink-0" />
 																									</Link>
 																								</DropdownMenuItem>
@@ -222,7 +222,7 @@ export const ShowProjects = () => {
 																										target="_blank"
 																										href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
 																									>
-																										<span>{domain.host}</span>
+																										<span className="truncate">{domain.host}</span>
 																										<ExternalLinkIcon className="size-4 shrink-0" />
 																									</Link>
 																								</DropdownMenuItem>


### PR DESCRIPTION
Currently, long domains result in weird overflows:

![overflow](https://github.com/user-attachments/assets/f3ecb4a1-ea10-451f-9b41-c729a6cfeeaf)

This PR will truncate the values as shown below:

![fixed-overflow](https://github.com/user-attachments/assets/19f968a7-52b2-4f52-9fc7-4e9924e7a26e)

Users can always hover their mouse over each item to see the full URL displayed by their browser (e.g. bottom-left corner for FF).