### PR TITLE
refactor: update project name reference in compose template processing

### DIFF
--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dokploy",
-	"version": "v0.20.0",
+	"version": "v0.20.2",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -607,7 +607,7 @@ export const composeRouter = createTRPCRouter({
 
 				const processedTemplate = processTemplate(config, {
 					serverIp: serverIp,
-					projectName: compose.project.name,
+					projectName: compose.appName,
 				});
 
 				return {
@@ -676,7 +676,7 @@ export const composeRouter = createTRPCRouter({
 
 				const processedTemplate = processTemplate(config, {
 					serverIp: serverIp,
-					projectName: compose.project.name,
+					projectName: compose.appName,
 				});
 
 				// Update compose file

--- a/packages/server/src/templates/index.ts
+++ b/packages/server/src/templates/index.ts
@@ -53,14 +53,12 @@ export const generatePassword = (quantity = 16): string => {
 };
 
 /**
- * Generate a random base64 string of specified length
+ * Generate a random base64 string from N random bytes
+ * @param bytes Number of random bytes to generate before base64 encoding (default: 32)
+ * @returns base64 encoded string of the random bytes
  */
-export function generateBase64(length: number): string {
-	// To get N characters in base64, we need to generate N * 3/4 bytes
-	const bytesNeeded = Math.ceil((length * 3) / 4);
-	return Buffer.from(randomBytes(bytesNeeded))
-		.toString("base64")
-		.substring(0, length);
+export function generateBase64(bytes = 32): string {
+	return randomBytes(bytes).toString("base64");
 }
 
 export function generateJwt(length = 256): string {


### PR DESCRIPTION
Change references from `compose.project.name` to `compose.appName` when processing compose templates to ensure correct project naming