### PR TITLE
feat(templates): support array-based environment variable configuration

### DIFF
--- a/apps/dokploy/__test__/templates/config.template.test.ts
+++ b/apps/dokploy/__test__/templates/config.template.test.ts
@@ -166,7 +166,12 @@ describe("processTemplate", () => {
 			if (!baseUrl || !secretKey) return;
 
 			expect(baseUrl).toContain(mockSchema.projectName);
-			expect(secretKey.split("=")[1]).toHaveLength(64);
+			const base64Value = secretKey.split("=")[1];
+			expect(base64Value).toBeDefined();
+			if (!base64Value) return;
+			expect(base64Value).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+			expect(base64Value.length).toBeGreaterThanOrEqual(86);
+			expect(base64Value.length).toBeLessThanOrEqual(88);
 		});
 
 		it("should process env vars when provided as an array", () => {
@@ -221,7 +226,12 @@ describe("processTemplate", () => {
 			if (!randomDomainEnv || !secretKeyEnv) return;
 
 			expect(randomDomainEnv).toContain(mockSchema.projectName);
-			expect(secretKeyEnv.split("=")[1]).toHaveLength(32);
+			const base64Value = secretKeyEnv.split("=")[1];
+			expect(base64Value).toBeDefined();
+			if (!base64Value) return;
+			expect(base64Value).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+			expect(base64Value.length).toBeGreaterThanOrEqual(42);
+			expect(base64Value.length).toBeLessThanOrEqual(44);
 		});
 	});
 
@@ -351,8 +361,22 @@ describe("processTemplate", () => {
 			if (!baseUrl || !secretKey || !totpKey) return;
 
 			expect(baseUrl).toContain(mockSchema.projectName);
-			expect(secretKey.split("=")[1]).toHaveLength(64);
-			expect(totpKey.split("=")[1]).toHaveLength(32);
+
+			// Check base64 lengths and format
+			const secretKeyValue = secretKey.split("=")[1];
+			const totpKeyValue = totpKey.split("=")[1];
+
+			expect(secretKeyValue).toBeDefined();
+			expect(totpKeyValue).toBeDefined();
+			if (!secretKeyValue || !totpKeyValue) return;
+
+			expect(secretKeyValue).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+			expect(secretKeyValue.length).toBeGreaterThanOrEqual(86);
+			expect(secretKeyValue.length).toBeLessThanOrEqual(88);
+
+			expect(totpKeyValue).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+			expect(totpKeyValue.length).toBeGreaterThanOrEqual(42);
+			expect(totpKeyValue.length).toBeLessThanOrEqual(44);
 
 			// Check mounts
 			expect(result.mounts).toHaveLength(1);
@@ -360,8 +384,8 @@ describe("processTemplate", () => {
 			expect(mount).toBeDefined();
 			if (!mount) return;
 			expect(mount.content).toContain(mockSchema.projectName);
-			expect(mount.content).toMatch(/secret=[A-Za-z0-9+/]{64}/);
-			expect(mount.content).toMatch(/totp=[A-Za-z0-9+/]{32}/);
+			expect(mount.content).toMatch(/secret=[A-Za-z0-9+/]{86,88}/);
+			expect(mount.content).toMatch(/totp=[A-Za-z0-9+/]{42,44}/);
 		});
 	});
 

--- a/apps/dokploy/__test__/templates/config.template.test.ts
+++ b/apps/dokploy/__test__/templates/config.template.test.ts
@@ -169,6 +169,32 @@ describe("processTemplate", () => {
 			expect(secretKey.split("=")[1]).toHaveLength(64);
 		});
 
+		it("should process env vars when provided as an array", () => {
+			const template: CompleteTemplate = {
+				metadata: {} as any,
+				variables: {},
+				config: {
+					domains: [],
+					env: [
+						'CLOUDFLARE_TUNNEL_TOKEN="<INSERT TOKEN>"',
+						'ANOTHER_VAR="some value"',
+						"DOMAIN=${domain}",
+					],
+					mounts: [],
+				},
+			};
+
+			const result = processTemplate(template, mockSchema);
+			expect(result.envs).toHaveLength(3);
+
+			// Should preserve exact format for static values
+			expect(result.envs[0]).toBe('CLOUDFLARE_TUNNEL_TOKEN="<INSERT TOKEN>"');
+			expect(result.envs[1]).toBe('ANOTHER_VAR="some value"');
+
+			// Should process variables in array items
+			expect(result.envs[2]).toContain(mockSchema.projectName);
+		});
+
 		it("should allow using utility functions directly in env vars", () => {
 			const template: CompleteTemplate = {
 				metadata: {} as any,

--- a/packages/server/src/templates/processors.ts
+++ b/packages/server/src/templates/processors.ts
@@ -45,7 +45,7 @@ export interface CompleteTemplate {
 	variables: Record<string, string>;
 	config: {
 		domains: DomainConfig[];
-		env: Record<string, string>;
+		env: Record<string, string> | string[];
 		mounts?: MountConfig[];
 	};
 }
@@ -175,7 +175,8 @@ export function processDomains(
 	variables: Record<string, string>,
 	schema: Schema,
 ): Template["domains"] {
-	return template.config.domains.map((domain: DomainConfig) => ({
+	if (!template?.config?.domains) return [];
+	return template?.config?.domains?.map((domain: DomainConfig) => ({
 		...domain,
 		host: domain.host
 			? processValue(domain.host, variables, schema)
@@ -191,6 +192,19 @@ export function processEnvVars(
 	variables: Record<string, string>,
 	schema: Schema,
 ): Template["envs"] {
+	if (!template?.config?.env) return [];
+
+	// Handle array of env vars
+	if (Array.isArray(template.config.env)) {
+		return template.config.env.map((env) => {
+			if (typeof env === "string") {
+				return processValue(env, variables, schema);
+			}
+			return env;
+		});
+	}
+
+	// Handle object of env vars
 	return Object.entries(template.config.env).map(
 		([key, value]: [string, string]) => {
 			const processedValue = processValue(value, variables, schema);
@@ -207,7 +221,7 @@ export function processMounts(
 	variables: Record<string, string>,
 	schema: Schema,
 ): Template["mounts"] {
-	if (!template.config.mounts) return [];
+	if (!template?.config?.mounts) return [];
 
 	return template.config.mounts.map((mount: MountConfig) => ({
 		filePath: processValue(mount.filePath, variables, schema),


### PR DESCRIPTION
Add support for processing environment variables defined as an array in template configurations, allowing more flexible env var definitions with direct string values and variable interpolation