### PR TITLE
style: remove inconsistent gap between header and content

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -1068,7 +1068,7 @@ export default function Page({ children }: Props) {
 					</header>
 				)}
 
-				<div className="flex flex-col w-full gap-4 p-4 pt-0">{children}</div>
+				<div className="flex flex-col w-full p-4 pt-0">{children}</div>
 			</SidebarInset>
 		</SidebarProvider>
 	);


### PR DESCRIPTION
Minor styling fix. Currently, the space between the navbar and actual content has a gap on the Projects page. Because the Projects page has a different structure than the other pages, it causes an inconsistency in the spacing.

![Screencast-2025-03-11-13_15_41-_online-video-cutter com_](https://github.com/user-attachments/assets/ef51a76e-dbd0-4a23-829f-775a81e80537)

I've tested with the pages I could find using this layout, but you may want to double-check that it doesn't break anything.

