### PR TITLE
Various Improvements

### DIFF
--- a/apps/dokploy/components/dashboard/application/update-application.tsx
+++ b/apps/dokploy/components/dashboard/application/update-application.tsx
@@ -121,7 +121,7 @@ export const UpdateApplication = ({ applicationId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/compose/update-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/update-compose.tsx
@@ -121,7 +121,7 @@ export const UpdateCompose = ({ composeId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/mariadb/update-mariadb.tsx
+++ b/apps/dokploy/components/dashboard/mariadb/update-mariadb.tsx
@@ -119,7 +119,7 @@ export const UpdateMariadb = ({ mariadbId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/mongo/update-mongo.tsx
+++ b/apps/dokploy/components/dashboard/mongo/update-mongo.tsx
@@ -121,7 +121,7 @@ export const UpdateMongo = ({ mongoId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -218,7 +218,7 @@ export const ContainerFreeMonitoring = ({
 					<CardContent>
 						<div className="flex flex-col gap-2 w-full">
 							<span className="text-sm text-muted-foreground">
-								Used: {currentData.cpu.value}%
+								Used: {currentData.cpu.value}
 							</span>
 							<Progress value={currentData.cpu.value} className="w-[100%]" />
 							<DockerCpuChart acummulativeData={acummulativeData.cpu} />

--- a/apps/dokploy/components/dashboard/mysql/update-mysql.tsx
+++ b/apps/dokploy/components/dashboard/mysql/update-mysql.tsx
@@ -119,7 +119,7 @@ export const UpdateMysql = ({ mysqlId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/postgres/update-postgres.tsx
+++ b/apps/dokploy/components/dashboard/postgres/update-postgres.tsx
@@ -121,7 +121,7 @@ export const UpdatePostgres = ({ postgresId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/projects/handle-project.tsx
+++ b/apps/dokploy/components/dashboard/projects/handle-project.tsx
@@ -148,7 +148,7 @@ export const HandleProject = ({ projectId }: Props) => {
 									<FormItem>
 										<FormLabel>Name</FormLabel>
 										<FormControl>
-											<Input placeholder="Tesla" {...field} />
+											<Input placeholder="Vandelay Industries" {...field} />
 										</FormControl>
 
 										<FormMessage />

--- a/apps/dokploy/components/dashboard/redis/update-redis.tsx
+++ b/apps/dokploy/components/dashboard/redis/update-redis.tsx
@@ -119,7 +119,7 @@ export const UpdateRedis = ({ redisId }: Props) => {
 										<FormItem>
 											<FormLabel>Name</FormLabel>
 											<FormControl>
-												<Input placeholder="Tesla" {...field} />
+												<Input placeholder="Vandelay Industries" {...field} />
 											</FormControl>
 
 											<FormMessage />

--- a/apps/dokploy/components/dashboard/settings/web-server/docker-terminal-modal.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/docker-terminal-modal.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -23,6 +24,7 @@ import { Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import type React from "react";
 import { useEffect, useState } from "react";
+import { badgeStateColor } from "../../application/logs/show";
 
 const Terminal = dynamic(
 	() =>
@@ -109,7 +111,10 @@ export const DockerTerminalModal = ({ children, appName, serverId }: Props) => {
 									key={container.containerId}
 									value={container.containerId}
 								>
-									{container.name} ({container.containerId}) {container.state}
+									{container.name} ({container.containerId}){" "}
+									<Badge variant={badgeStateColor(container.state)}>
+										{container.state}
+									</Badge>
 								</SelectItem>
 							))}
 							<SelectLabel>Containers ({data?.length})</SelectLabel>

--- a/apps/dokploy/components/dashboard/settings/web-server/show-modal-logs.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/show-modal-logs.tsx
@@ -21,6 +21,8 @@ import { Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import type React from "react";
 import { useEffect, useState } from "react";
+import { badgeStateColor } from "../../application/logs/show";
+import { Badge } from "@/components/ui/badge";
 
 export const DockerLogsId = dynamic(
 	() =>
@@ -90,7 +92,10 @@ export const ShowModalLogs = ({
 										key={container.containerId}
 										value={container.containerId}
 									>
-										{container.name} ({container.containerId}) {container.state}
+										{container.name} ({container.containerId}){" "}
+										<Badge variant={badgeStateColor(container.state)}>
+											{container.state}
+										</Badge>
 									</SelectItem>
 								))}
 								<SelectLabel>Containers ({data?.length})</SelectLabel>

--- a/apps/dokploy/public/locales/en/settings.json
+++ b/apps/dokploy/public/locales/en/settings.json
@@ -1,6 +1,6 @@
 {
 	"settings.common.save": "Save",
-	"settings.common.enterTerminal": "Enter the terminal",
+	"settings.common.enterTerminal": "Terminal",
 	"settings.server.domain.title": "Server Domain",
 	"settings.server.domain.description": "Add a domain to your server application.",
 	"settings.server.domain.form.domain": "Domain",
@@ -14,7 +14,7 @@
 	"settings.server.webServer.description": "Reload or clean the web server.",
 	"settings.server.webServer.actions": "Actions",
 	"settings.server.webServer.reload": "Reload",
-	"settings.server.webServer.watchLogs": "Watch logs",
+	"settings.server.webServer.watchLogs": "View Logs",
 	"settings.server.webServer.updateServerIp": "Update Server IP",
 	"settings.server.webServer.server.label": "Server",
 	"settings.server.webServer.traefik.label": "Traefik",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -437,12 +437,11 @@ export const composeRouter = createTRPCRouter({
 				serverIp = "127.0.0.1";
 			}
 
+			const projectName = slugify(`${project.name} ${input.id}`);
 			const generate = processTemplate(template.config, {
 				serverIp: serverIp,
-				projectName: project.name,
+				projectName: projectName,
 			});
-
-			const projectName = slugify(`${project.name} ${input.id}`);
 
 			const compose = await createComposeByTemplate({
 				...input,


### PR DESCRIPTION
This pull request includes several improvements:

### Bugfix
* Moved the `projectName` assignment to before the `generate` call in `compose.ts` to ensure project name is properly slugified.

### UI Component Enhancements:
* Updated placeholder text from "Tesla" to "Vandelay Industries" in multiple form components including `UpdateApplication`, `UpdateCompose`, `UpdateMariadb`, `UpdateMongo`, `UpdateMysql`, `UpdatePostgres`, `HandleProject`, and `UpdateRedis`. [[1]](diffhunk://#diff-b014793f5d52bb74d37c521e5b6cfe5831e032c64872c7481001ffd077c56fb4L124-R124) [[2]](diffhunk://#diff-046793df509de5c61ad827f0fdcf917ad8bc96d20031def0e021ebc0967d907cL124-R124) [[3]](diffhunk://#diff-ddf4043fb244e858e23d668aafcb7c5292557374515ad2101bc3aa26bc5f16fbL122-R122) [[4]](diffhunk://#diff-34bb0d7ab785de0f5a6ed847a8786d3ca63253246038677e667cda5fa2daa2bdL124-R124) [[5]](diffhunk://#diff-1596434f4b9ac789aff33759e22e7954dfd15dc97f46083fa3af357d59018137L122-R122) [[6]](diffhunk://#diff-9fd19e47adfa3cf339961747dd8da9921d98a09ecd41f1056791fb408e66e6f1L124-R124) [[7]](diffhunk://#diff-917aa91a1a90010243e6f3cb21f4e0d9256349de27c1cf12a547add0c56f64cbL151-R151) [[8]](diffhunk://#diff-5d83ce6d4e201a455a494770709575e5900e20daad8d07d8a0e3c11b2fa95d4cL122-R122)
* Added `Badge` component to display container state in `DockerTerminalModal` and `ShowModalLogs`. [[1]](diffhunk://#diff-643ebed009463bae951d31c5bc88b74bc50d58ca18686217aca69e25906dee83R1) [[2]](diffhunk://#diff-643ebed009463bae951d31c5bc88b74bc50d58ca18686217aca69e25906dee83R27) [[3]](diffhunk://#diff-643ebed009463bae951d31c5bc88b74bc50d58ca18686217aca69e25906dee83L112-R117) [[4]](diffhunk://#diff-c6924accc4abd85a7c2a3dbd91e31da0c0d6550d61a2b4b7f02f31333dd73098R24-R25) [[5]](diffhunk://#diff-c6924accc4abd85a7c2a3dbd91e31da0c0d6550d61a2b4b7f02f31333dd73098L93-R98)
* Removed the percentage sign from the CPU usage display in `ContainerFreeMonitoring`.
* Changed "Enter the terminal" to "Terminal" and "Watch logs" to "View Logs" in `settings.json` localization file. [[1]](diffhunk://#diff-b2d23062842c4b343c92b1ec1cb2483af3d67d7a8b08f6e854a3213decedd729L3-R3) [[2]](diffhunk://#diff-b2d23062842c4b343c92b1ec1cb2483af3d67d7a8b08f6e854a3213decedd729L17-R17)