### PR TITLE
Allow traefik labels customization in docker-composes

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -238,9 +238,9 @@ export const addDomainToCompose = async (
 
 		if (Array.isArray(labels)) {
 			if (!labels.includes("traefik.enable=true")) {
-				labels.push("traefik.enable=true");
+				labels.unshift("traefik.enable=true");
 			}
-			labels.push(...httpLabels);
+			labels.unshift(...httpLabels);
 		}
 
 		if (!compose.isolatedDeployment) {


### PR DESCRIPTION
From my understanding traefik labels are evaluated in order, the latest ones having the priority to override the first ones

I was personally unable to add CORS using traefik middlewares to some of my services since dokploys traefik middleware settings were overriding mine.

By prepending labels instead of adding them at the end this should allow the customization of traefik labels while still retaining the same functionality for whoever doesnt need it

I really hope I haven't missed something trivial :D