### PR TITLE
fix: removed duplicate percentage label

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -218,7 +218,7 @@ export const ContainerFreeMonitoring = ({
 					<CardContent>
 						<div className="flex flex-col gap-2 w-full">
 							<span className="text-sm text-muted-foreground">
-								Used: {currentData.cpu.value}%
+								Used: {currentData.cpu.value}
 							</span>
 							<Progress value={currentData.cpu.value} className="w-[100%]" />
 							<DockerCpuChart acummulativeData={acummulativeData.cpu} />


### PR DESCRIPTION
There is a duplicate "%" unit label on the CPU Usage monitoring graph:
![CleanShot 2025-03-14 at 19 35 57@2x](https://github.com/user-attachments/assets/415f1dda-282e-42d4-829d-1a9624eaaa5d)

Removes the duplicate label