### PR TITLE
fix(server-setup): resolve Alpine Linux compatibility issues 

### DIFF
--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -361,7 +361,7 @@ const installUtilities = () => `
 	alpine)
 		sed -i '/^#.*\/community/s/^#//' /etc/apk/repositories
 		apk update >/dev/null
-		apk add curl wget git jq openssl >/dev/null
+		apk add curl wget git jq openssl sudo unzip tar >/dev/null
 		;;
 	ubuntu | debian | raspbian)
 		DEBIAN_FRONTEND=noninteractive apt-get update -y >/dev/null


### PR DESCRIPTION
In this PR, in addition to installing unzip and tar mentioned in #1482, sudo is also installed. This is because sudo is not installed by default after installing Alpine Linux, to prevent users from not having it installed. 
