### PR TITLE
fix(ui): Prevent Zero from Persisting in Numeric Input

### DIFF
--- a/apps/dokploy/components/ui/input.tsx
+++ b/apps/dokploy/components/ui/input.tsx
@@ -39,7 +39,7 @@ const NumberInput = React.forwardRef<HTMLInputElement, InputProps>(
 				className={cn("text-left", className)}
 				ref={ref}
 				{...props}
-				value={props.value === undefined ? undefined : String(props.value)}
+				value={props.value === undefined || props.value === "" ? "" : String(props.value)}
 				onChange={(e) => {
 					const value = e.target.value;
 					if (value === "") {
@@ -58,6 +58,21 @@ const NumberInput = React.forwardRef<HTMLInputElement, InputProps>(
 								syntheticEvent as unknown as React.ChangeEvent<HTMLInputElement>,
 							);
 						}
+					}
+				}}
+				onBlur={(e) => {
+					// If input is empty, make 0 when focus is lost
+					if (e.target.value === "") {
+						const syntheticEvent = {
+							...e,
+							target: {
+								...e.target,
+								value: "0",
+							},
+						};
+						props.onChange?.(
+							syntheticEvent as unknown as React.ChangeEvent<HTMLInputElement>,
+						);
 					}
 				}}
 			/>


### PR DESCRIPTION
This PR resolves the issue where the numeric input field would always retain the value `0`, making it difficult to delete or update the input properly. Previously, when a user entered a new value, it would either start with `0` (e.g., `05`) or require manually deleting the `0`.

To fix this issue, the **Focus Lost (Blur)** event has been implemented with the following improvements:

- When the input loses focus and is empty, its value **automatically** resets to `0`.
- This allows users to clear the field entirely and enter new values without restrictions.
- The input behavior is now more intuitive and user-friendly.

This enhancement ensures a smoother and more natural numeric input experience, improving usability and preventing unintended formatting issues.