### PR TITLE
fix(backups): auto deletion of backups

### DIFF
--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -80,7 +80,8 @@ export const initCronJobs = async () => {
 					console.log(
 						`PG-SERVER[${new Date().toLocaleString()}] Running Backup ${backupId}`,
 					);
-					runPostgresBackup(pg, backup);
+					await runPostgresBackup(pg, backup);
+					await keepLatestNBackups(backup, pg.serverId);
 				});
 			}
 		}
@@ -112,6 +113,7 @@ export const initCronJobs = async () => {
 						`MARIADB-SERVER[${new Date().toLocaleString()}] Running Backup ${backupId}`,
 					);
 					await runMariadbBackup(maria, backup);
+					await keepLatestNBackups(backup, maria.serverId);
 				});
 			}
 		}
@@ -141,6 +143,7 @@ export const initCronJobs = async () => {
 						`MONGO-SERVER[${new Date().toLocaleString()}] Running Backup ${backupId}`,
 					);
 					await runMongoBackup(mongo, backup);
+					await keepLatestNBackups(backup, mongo.serverId);
 				});
 			}
 		}
@@ -170,6 +173,7 @@ export const initCronJobs = async () => {
 						`MYSQL-SERVER[${new Date().toLocaleString()}] Running Backup ${backupId}`,
 					);
 					await runMySqlBackup(mysql, backup);
+					await keepLatestNBackups(backup, mysql.serverId);
 				});
 			}
 		}


### PR DESCRIPTION
The auto deletion of db backups wasn't working after the server update. I investigated the issue. It seems the bullmq worker job processing is not applicable for self-hosted instances. So, we need to make this change for auto deletion to work.