### PR TITLE
feat: improve projects grid

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -115,7 +115,7 @@ export const ShowProjects = () => {
 											</span>
 										</div>
 									)}
-									<div className="w-full grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 3xl:grid-cols-5 flex-wrap gap-5">
+									<div className="w-full grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 flex-wrap gap-5">
 										{filteredProjects?.map((project) => {
 											const emptyServices =
 												project?.mariadb.length === 0 &&


### PR DESCRIPTION
Enhance the project grid for 2XL resolution by increasing the width of the thumbnails.

Before:
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/a6cf9e60-6c32-4e02-808c-c810ce2090ec" />
After:
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/3025451c-f2c4-43fe-a18f-fe651895c160" />
