### PR TITLE
fix(security): remove sensitive files on static build

### DIFF
--- a/packages/server/src/utils/builders/static.ts
+++ b/packages/server/src/utils/builders/static.ts
@@ -25,6 +25,12 @@ export const buildStatic = async (
 			].join("\n"),
 		);
 
+		createFile(
+			buildAppDirectory,
+			".dockerignore",
+			[".git", ".env", "Dockerfile", ".dockerignore"].join("\n"),
+		);
+
 		await buildCustomDocker(
 			{
 				...application,


### PR DESCRIPTION
Sensitive files were exposed from Nginx. I added a .dockerignore file to exclude them during the `COPY . .` command.