### PR TITLE
fix(backups): suppress output during backup and restore processes

### DIFF
--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -29,7 +29,7 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 			await execAsync(`cp -r ${BASE_PATH}/* ${tempDir}/filesystem/`);
 
 			await execAsync(
-				`cd ${tempDir} && zip -r ${backupFileName} database.sql filesystem/`,
+				`cd ${tempDir} && zip -r ${backupFileName} database.sql filesystem/ > /dev/null 2>&1`,
 			);
 
 			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${tempDir}/${backupFileName}" "${s3Path}"`;

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -45,7 +45,7 @@ export const restoreWebServerBackup = async (
 
 			// Extract backup
 			emit("Extracting backup...");
-			await execAsync(`cd ${tempDir} && unzip ${backupFile}`);
+			await execAsync(`cd ${tempDir} && unzip ${backupFile} > /dev/null 2>&1`);
 
 			// Restore filesystem first
 			emit("Restoring filesystem...");


### PR DESCRIPTION
- Updated the backup command in runWebServerBackup to suppress output by redirecting it to /dev/null.
- Modified the restore command in restoreWebServerBackup to also suppress output during the extraction of backups.