### PR TITLE
feat(gitlab): add support for multiple group names with a single provider

### DIFF
--- a/apps/dokploy/components/dashboard/settings/git/gitlab/add-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/gitlab/add-gitlab-provider.tsx
@@ -248,7 +248,9 @@ export const AddGitlabProvider = () => {
 									name="groupName"
 									render={({ field }) => (
 										<FormItem>
-											<FormLabel>Group Name (Optional)</FormLabel>
+											<FormLabel>
+												Group Name (Optional, Comma-Separated List)
+											</FormLabel>
 											<FormControl>
 												<Input
 													placeholder="For organization/group access use the slugish name of the group eg: my-org"

--- a/apps/dokploy/components/dashboard/settings/git/gitlab/edit-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/gitlab/edit-gitlab-provider.tsx
@@ -156,7 +156,9 @@ export const EditGitlabProvider = ({ gitlabId }: Props) => {
 									name="groupName"
 									render={({ field }) => (
 										<FormItem>
-											<FormLabel>Group Name (Optional)</FormLabel>
+											<FormLabel>
+												Group Name (Optional, Comma-Separated List)
+											</FormLabel>
 											<FormControl>
 												<Input
 													placeholder="For organization/group access use the slugish name of the group eg: my-org"

--- a/apps/dokploy/pages/dashboard/project/[projectId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId].tsx
@@ -365,7 +365,9 @@ const Project = (
 
 				switch (service.type) {
 					case "application":
-						await applicationActions.start.mutateAsync({ applicationId: serviceId });
+						await applicationActions.start.mutateAsync({
+							applicationId: serviceId,
+						});
 						break;
 					case "compose":
 						await composeActions.start.mutateAsync({ composeId: serviceId });
@@ -410,7 +412,9 @@ const Project = (
 
 				switch (service.type) {
 					case "application":
-						await applicationActions.stop.mutateAsync({ applicationId: serviceId });
+						await applicationActions.stop.mutateAsync({
+							applicationId: serviceId,
+						});
 						break;
 					case "compose":
 						await composeActions.stop.mutateAsync({ composeId: serviceId });

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -264,7 +264,11 @@ export const getGitlabRepositories = async (gitlabId?: string) => {
 		const groupName = gitlabProvider.groupName?.toLowerCase();
 
 		if (groupName) {
-			return full_path.toLowerCase().includes(groupName) && kind === "group";
+			const isIncluded = groupName
+				.split(",")
+				.some((name) => full_path.toLowerCase().includes(name));
+
+			return isIncluded && kind === "group";
 		}
 		return kind === "user";
 	});

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -435,7 +435,9 @@ export const testGitlabConnection = async (
 		const { full_path, kind } = repo.namespace;
 
 		if (groupName) {
-			return full_path.toLowerCase().includes(groupName) && kind === "group";
+			return groupName
+				.split(",")
+				.some((name) => full_path.toLowerCase().includes(name));
 		}
 		return kind === "user";
 	});


### PR DESCRIPTION
Since it's common having multiple groups in a single GitLab instance, we need to support comma separated group names. This PR add support for handling multiple GitLab group names with a single GitLab provider.
