### PR TITLE
Fix(Traefik) Move `passHostHeader` to correct indentation

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId].tsx
@@ -365,7 +365,9 @@ const Project = (
 
 				switch (service.type) {
 					case "application":
-						await applicationActions.start.mutateAsync({ applicationId: serviceId });
+						await applicationActions.start.mutateAsync({
+							applicationId: serviceId,
+						});
 						break;
 					case "compose":
 						await composeActions.start.mutateAsync({ composeId: serviceId });
@@ -410,7 +412,9 @@ const Project = (
 
 				switch (service.type) {
 					case "application":
-						await applicationActions.stop.mutateAsync({ applicationId: serviceId });
+						await applicationActions.stop.mutateAsync({
+							applicationId: serviceId,
+						});
 						break;
 					case "compose":
 						await composeActions.stop.mutateAsync({ composeId: serviceId });

--- a/packages/server/src/utils/traefik/web-server.ts
+++ b/packages/server/src/utils/traefik/web-server.ts
@@ -37,9 +37,9 @@ export const updateServerTraefik = (
 				servers: [
 					{
 						url: `http://dokploy:${process.env.PORT || 3000}`,
-						passHostHeader: true,
 					},
 				],
+				passHostHeader: true,
 			},
 		},
 	};


### PR DESCRIPTION
`passHostHeader` was moved to  the `servers` field, but should be inside the `loadBalancer` field. i.e. the same level as `servers`