### PR TITLE
fix: add try_files directive to nginx config for SPA routing

### DIFF
--- a/packages/server/src/utils/builders/static.ts
+++ b/packages/server/src/utils/builders/static.ts
@@ -58,6 +58,9 @@ export const getStaticCommand = (
 		"Dockerfile",
 		[
 			"FROM nginx:alpine",
+			"RUN cp /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.orig && \
+    		sed -i '/location \/ {/{n;s|root   /usr/share/nginx/html;|root   /usr/share/nginx/html;\n        try_files \$uri \$uri/ /index.html;|}' /etc/nginx/conf.d/default.conf",
+			"CMD [\"nginx\", \"-s\", \"reload\"]",
 			"WORKDIR /usr/share/nginx/html/",
 			`COPY ${publishDirectory || "."} .`,
 		].join("\n"),


### PR DESCRIPTION
- Add try_files $uri $uri/ /index.html to nginx configuration
- Fix 404 errors on page refresh for Vite SPA applications
- Resolves #1650