### PR TITLE
docs(contributing): tips added for nvm use and biome ide addon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ feat: add new feature
 
 Before you start, please make the clone based on the `canary` branch, since the `main` branch is the source of truth and should always reflect the latest stable release, also the PRs will be merged to the `canary` branch.
 
-We use Node v20.9.0
+We use Node v20.9.0 and recommend this specific version. If you have nvm installed, you can run `nvm install 20.9.0 && nvm use` in the root directory. 
 
 ```bash
 git clone https://github.com/dokploy/dokploy.git
@@ -86,6 +86,8 @@ pnpm run dokploy:dev
 ```
 
 Go to http://localhost:3000 to see the development server
+
+Note: this project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.
 
 ## Build
 


### PR DESCRIPTION
Just a couple of small updates to contributing.md I think might be helpful:

```We use Node v20.9.0 and recommend this specific version. If you have nvm installed, you can run `nvm install 20.9.0 && nvm use` in the root directory.```

When I tried to run it with v22, I had errors in the console.

and

`Note: this project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.`

If your editor is configured to use prettier and eslint have any type of ADD (I don't usually, but it's not too late to start...), installing and setting up the Biome addon will stop the editor from reformatting needlessly.


