### PR TITLE
Add Redis management actions to server settings

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/actions/show-dokploy-actions.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/actions/show-dokploy-actions.tsx
@@ -22,6 +22,9 @@ export const ShowDokployActions = () => {
 	const { mutateAsync: reloadServer, isLoading } =
 		api.settings.reloadServer.useMutation();
 
+	const { mutateAsync: cleanRedis } = api.settings.cleanRedis.useMutation();
+	const { mutateAsync: reloadRedis } = api.settings.reloadRedis.useMutation();
+
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild disabled={isLoading}>
@@ -69,6 +72,36 @@ export const ShowDokployActions = () => {
 							{t("settings.server.webServer.updateServerIp")}
 						</DropdownMenuItem>
 					</UpdateServerIp>
+
+					<DropdownMenuItem
+						className="cursor-pointer"
+						onClick={async () => {
+							await cleanRedis()
+								.then(async () => {
+									toast.success("Redis cleaned");
+								})
+								.catch(() => {
+									toast.error("Error cleaning Redis");
+								});
+						}}
+					>
+						Clean Redis
+					</DropdownMenuItem>
+
+					<DropdownMenuItem
+						className="cursor-pointer"
+						onClick={async () => {
+							await reloadRedis()
+								.then(async () => {
+									toast.success("Redis reloaded");
+								})
+								.catch(() => {
+									toast.error("Error reloading Redis");
+								});
+						}}
+					>
+						Reload Redis
+					</DropdownMenuItem>
 				</DropdownMenuGroup>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -79,6 +79,33 @@ export const settingsRouter = createTRPCRouter({
 		await execAsync(`docker service update --force ${stdout.trim()}`);
 		return true;
 	}),
+	cleanRedis: adminProcedure.mutation(async () => {
+		if (IS_CLOUD) {
+			return true;
+		}
+
+		const { stdout: containerId } = await execAsync(
+			`docker ps --filter "name=dokploy-redis" --filter "status=running" -q | head -n 1`,
+		);
+
+		if (!containerId) {
+			throw new Error("Redis container not found");
+		}
+
+		const redisContainerId = containerId.trim();
+
+		await execAsync(`docker exec -i ${redisContainerId} redis-cli flushall`);
+		return true;
+	}),
+	reloadRedis: adminProcedure.mutation(async () => {
+		if (IS_CLOUD) {
+			return true;
+		}
+
+		await execAsync("docker service scale dokploy-redis=0");
+		await execAsync("docker service scale dokploy-redis=1");
+		return true;
+	}),
 	reloadTraefik: adminProcedure
 		.input(apiServerSchema)
 		.mutation(async ({ input }) => {


### PR DESCRIPTION
Implement 'Clean Redis' and 'Reload Redis' actions in the dashboard settings. These actions allow users to flush all data in Redis and restart the Redis service, respectively. Update the API to handle these new mutations with appropriate error handling and success notifications.