### PR TITLE
feat: add --pull always flag to Docker Compose commands

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -174,7 +174,7 @@ export const createCommand = (compose: ComposeNested) => {
 	let command = "";
 
 	if (composeType === "docker-compose") {
-		command = `compose -p ${appName} -f ${path} up -d --build --remove-orphans`;
+		command = `compose -p ${appName} -f ${path} up -d --build --remove-orphans --pull always`;
 	} else if (composeType === "stack") {
 		command = `stack deploy -c ${path} ${appName} --prune`;
 	}


### PR DESCRIPTION
**Description**

This PR adds the --pull always flag to Docker Compose commands to ensure the latest image versions are always pulled when deploying, preventing outdated images from being used. This is especially useful when using tags like my-app:latest to guarantee the most recent version is deployed rather than using a cached image.

**Changes Made**

Modified the Docker Compose command builder to include the --pull always flag
This ensures that even when using the same tag (like latest), the most recent version will always be pulled from the registry

**Why This Matters**

Without this flag, Docker may continue using locally cached versions of images even when newer versions exist in the registry with the same tag. This can lead to inconsistencies between environments and prevent security updates from being applied.

![image](https://github.com/user-attachments/assets/fb37a88c-0575-4595-af53-12bfc49f5461)


**Testing**
I've tested this change by:

- Deploying an application with my-app:latest before the change
- Updating the registry with a newer my-app:latest image
- Deploying again without the flag (Docker used cached image)
- Deploying with the new --pull always flag (Docker pulled the latest image)