### PR TITLE
Enhance compose removal process by adding network disconnection command

### DIFF
--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -478,7 +478,9 @@ export const removeCompose = async (
 		const projectPath = join(COMPOSE_PATH, compose.appName);
 
 		if (compose.composeType === "stack") {
-			const command = `cd ${projectPath} && docker stack rm ${compose.appName} && rm -rf ${projectPath}`;
+			const command = `
+			docker network disconnect ${compose.appName} dokploy-traefik;
+			cd ${projectPath} && docker stack rm ${compose.appName} && rm -rf ${projectPath}`;
 
 			if (compose.serverId) {
 				await execAsyncRemote(compose.serverId, command);
@@ -489,12 +491,11 @@ export const removeCompose = async (
 				cwd: projectPath,
 			});
 		} else {
-			let command: string;
-			if (deleteVolumes) {
-				command = `cd ${projectPath} && docker compose -p ${compose.appName} down --volumes && rm -rf ${projectPath}`;
-			} else {
-				command = `cd ${projectPath} && docker compose -p ${compose.appName} down && rm -rf ${projectPath}`;
-			}
+			const command = `
+			 docker network disconnect ${compose.appName} dokploy-traefik;
+			cd ${projectPath} && docker compose -p ${compose.appName} down ${
+				deleteVolumes ? "--volumes" : ""
+			} && rm -rf ${projectPath}`;
 
 			if (compose.serverId) {
 				await execAsyncRemote(compose.serverId, command);

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -40,8 +40,6 @@ export const getServiceImageDigest = async () => {
 		"docker service inspect dokploy --format '{{.Spec.TaskTemplate.ContainerSpec.Image}}'",
 	);
 
-	console.log("stdout", stdout);
-
 	const currentDigest = stdout.trim().split("@")[1];
 
 	if (!currentDigest) {


### PR DESCRIPTION
- Updated the `removeCompose` function to include a command for disconnecting the Docker network before removing the stack or compose application, improving cleanup reliability.
- Removed unnecessary console logging in the `getServiceImageDigest` function to streamline output and enhance code clarity.