### PR TITLE
Update backup command execution to use bash shell in multiple backup …

### DIFF
--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -38,7 +38,9 @@ export const runComposeBackup = async (
 		if (compose.serverId) {
 			await execAsyncRemote(compose.serverId, backupCommand);
 		} else {
-			await execAsync(backupCommand);
+			await execAsync(backupCommand, {
+				shell: "/bin/bash",
+			});
 		}
 
 		await sendDatabaseBackupNotifications({

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -37,7 +37,9 @@ export const runMariadbBackup = async (
 		if (mariadb.serverId) {
 			await execAsyncRemote(mariadb.serverId, backupCommand);
 		} else {
-			await execAsync(backupCommand);
+			await execAsync(backupCommand, {
+				shell: "/bin/bash",
+			});
 		}
 
 		await sendDatabaseBackupNotifications({

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -35,7 +35,9 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		if (mongo.serverId) {
 			await execAsyncRemote(mongo.serverId, backupCommand);
 		} else {
-			await execAsync(backupCommand);
+			await execAsync(backupCommand, {
+				shell: "/bin/bash",
+			});
 		}
 
 		await sendDatabaseBackupNotifications({

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -37,7 +37,9 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 		if (mysql.serverId) {
 			await execAsyncRemote(mysql.serverId, backupCommand);
 		} else {
-			await execAsync(backupCommand);
+			await execAsync(backupCommand, {
+				shell: "/bin/bash",
+			});
 		}
 		await sendDatabaseBackupNotifications({
 			applicationName: name,


### PR DESCRIPTION
…utilities

- Modified the `execAsync` calls in `compose.ts`, `mariadb.ts`, `mongo.ts`, and `mysql.ts` to specify the bash shell for executing backup commands, ensuring compatibility with bash-specific features across all backup utilities.