### PR TITLE
fix: removed protocol dublicates and rewrited path segment

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
@@ -94,7 +94,7 @@ export const DnsHelperModal = ({ domain, serverIp }: Props) => {
 									<li>
 										Test your domain by visiting:{" "}
 										{domain.host}
-										{typeof domain.path === 'string' && domain.path !== '/' && domain.path}
+										{typeof domain.path === 'string' && domain.path !== '/' && domain.path.substring(1)}
 									</li>
 									<li>Use a DNS lookup tool to verify your records</li>
 								</ul>

--- a/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
@@ -94,7 +94,7 @@ export const DnsHelperModal = ({ domain, serverIp }: Props) => {
 									<li>
 										Test your domain by visiting:{" "}
 										{domain.host}
-										{domain.path || "/"}
+										{typeof domain.path === 'string' && domain.path !== '/' && domain.path}
 									</li>
 									<li>Use a DNS lookup tool to verify your records</li>
 								</ul>

--- a/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
@@ -93,7 +93,6 @@ export const DnsHelperModal = ({ domain, serverIp }: Props) => {
 									<li>Wait for DNS propagation (usually 15-30 minutes)</li>
 									<li>
 										Test your domain by visiting:{" "}
-										{domain.https ? "https://" : "http://"}
 										{domain.host}
 										{domain.path || "/"}
 									</li>


### PR DESCRIPTION
Right now protocol and segment path dublicates in verify configuration block:

![before](https://github.com/user-attachments/assets/48573fce-3359-4d12-80d8-dbc8ebb6db27)

So response from API looks like this:

```json
{
  "domains": [
    {
      "domainId": "xxxxxx",
      "host": "https://xxxxxx.org/",
      "https": true,
      "port": 80,
      "path": "/",
      "serviceName": null,
      "domainType": "application",
      "uniqueConfigKey": 3,
      "createdAt": "xxxxxxxxxxxxxx",
      "composeId": null,
      "customCertResolver": null,
      "applicationId": "xxxxxxxxxxxxxxx",
      "previewDeploymentId": null,
      "certificateType": "letsencrypt"
    }
  ]
}
```

I suppose host should not contain protocol and path segment but it is what it is.

So considering that the API always returns domains in this format we can just use host and check path:

```tsx
<li>
    Test your domain by visiting:{" "}
    {domain.host}
    {typeof domain.path === "string" && domain.path !== "/" && domain.path.substring(1)}
</li>
```