### PR TITLE
Docker stack include the `--with-registry-auth` flag

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -176,7 +176,7 @@ export const createCommand = (compose: ComposeNested) => {
 	if (composeType === "docker-compose") {
 		command = `compose -p ${appName} -f ${path} up -d --build --remove-orphans`;
 	} else if (composeType === "stack") {
-		command = `stack deploy -c ${path} ${appName} --prune`;
+		command = `stack deploy -c ${path} ${appName} --prune --with-registry-auth`;
 	}
 
 	return command;


### PR DESCRIPTION
This pull request addresses an issue where Docker Swarm deployments managed by Dokploy were unable to fully access images from the private registry, specifically failing to record image digests during `docker stack deploy`.