### PR TITLE
Add no owner options to pg_restore

### DIFF
--- a/packages/server/src/utils/restore/utils.ts
+++ b/packages/server/src/utils/restore/utils.ts
@@ -7,7 +7,7 @@ export const getPostgresRestoreCommand = (
 	database: string,
 	databaseUser: string,
 ) => {
-	return `docker exec -i $CONTAINER_ID sh -c "pg_restore -U ${databaseUser} -d ${database} --clean --if-exists"`;
+	return `docker exec -i $CONTAINER_ID sh -c "pg_restore -U ${databaseUser} -d ${database} -O --clean --if-exists"`;
 };
 
 export const getMariadbRestoreCommand = (


### PR DESCRIPTION
Avoid errors during restoration when the original owning roles do not exist on the target PostgreSQL server.