### PR TITLE
fix: installed git-lfs in docker image

### DIFF
--- a/apps/dokploy/Dockerfile
+++ b/apps/dokploy/Dockerfile
@@ -8,7 +8,7 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 
 
-RUN apt-get update && apt-get install -y python3 make g++ git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y python3 make g++ git git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile

--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -356,20 +356,20 @@ const installUtilities = () => `
 
 	case "$OS_TYPE" in
 	arch)
-		pacman -Sy --noconfirm --needed curl wget git jq openssl >/dev/null || true
+		pacman -Sy --noconfirm --needed curl wget git git-lfs jq openssl >/dev/null || true
 		;;
 	alpine)
 		sed -i '/^#.*\/community/s/^#//' /etc/apk/repositories
 		apk update >/dev/null
-		apk add curl wget git jq openssl sudo unzip tar >/dev/null
+		apk add curl wget git git-lfs jq openssl sudo unzip tar >/dev/null
 		;;
 	ubuntu | debian | raspbian)
 		DEBIAN_FRONTEND=noninteractive apt-get update -y >/dev/null
-		DEBIAN_FRONTEND=noninteractive apt-get install -y unzip curl wget git jq openssl >/dev/null
+		DEBIAN_FRONTEND=noninteractive apt-get install -y unzip curl wget git git-lfs jq openssl >/dev/null
 		;;
 	centos | fedora | rhel | ol | rocky | almalinux | amzn)
 		if [ "$OS_TYPE" = "amzn" ]; then
-			dnf install -y wget git jq openssl >/dev/null
+			dnf install -y wget git git-lfs jq openssl >/dev/null
 		else
 			if ! command -v dnf >/dev/null; then
 				yum install -y dnf >/dev/null
@@ -377,12 +377,12 @@ const installUtilities = () => `
 			if ! command -v curl >/dev/null; then
 				dnf install -y curl >/dev/null
 			fi
-			dnf install -y wget git jq openssl unzip >/dev/null
+			dnf install -y wget git git-lfs jq openssl unzip >/dev/null
 		fi
 		;;
 	sles | opensuse-leap | opensuse-tumbleweed)
 		zypper refresh >/dev/null
-		zypper install -y curl wget git jq openssl >/dev/null
+		zypper install -y curl wget git git-lfs jq openssl >/dev/null
 		;;
 	*)
 		echo "This script only supports Debian, Redhat, Arch Linux, or SLES based operating systems for now."


### PR DESCRIPTION
problem: when cloning repositories with LFS files, these files was not properly cloned resulting in faulty deployments.

cause: Git LFS was not supported in the dokploy image

fix: installed git-lfs and hooked it up to Git inside the Dokploy image (Modified `app/Dockerfile`)

test: i haven't built the Dokploy image to test it, but executing the added commands into the Dokploy container `sh` fixes the issue.