### PR TITLE
Fix domain responsiveness

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -186,7 +186,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 								return (
 									<Card
 										key={item.domainId}
-										className="relative overflow-hidden w-full border bg-card transition-all hover:shadow-md bg-transparent h-fit"
+										className="relative overflow-hidden w-full border transition-all hover:shadow-md bg-transparent h-fit"
 									>
 										<CardContent className="p-6">
 											<div className="flex flex-col gap-4">

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -191,25 +191,14 @@ export const ShowDomains = ({ id, type }: Props) => {
 										<CardContent className="p-6">
 											<div className="flex flex-col gap-4">
 												{/* Service & Domain Info */}
-												<div className="flex items-start justify-between">
-													<div className="flex flex-col gap-2">
-														{item.serviceName && (
-															<Badge variant="outline" className="w-fit">
-																<Server className="size-3 mr-1" />
-																{item.serviceName}
-															</Badge>
-														)}
-
-														<Link
-															className="flex items-center gap-2 text-base font-medium hover:underline"
-															target="_blank"
-															href={`${item.https ? "https" : "http"}://${item.host}${item.path}`}
-														>
-															{item.host}
-															<ExternalLink className="size-4" />
-														</Link>
-													</div>
-													<div className="flex gap-2">
+												<div className="flex items-center justify-between flex-wrap gap-y-2">
+													{item.serviceName && (
+														<Badge variant="outline" className="w-fit">
+															<Server className="size-3 mr-1" />
+															{item.serviceName}
+														</Badge>
+													)}
+													<div className="flex gap-2 flex-wrap">
 														{!item.host.includes("traefik.me") && (
 															<DnsHelperModal
 																domain={{
@@ -265,6 +254,16 @@ export const ShowDomains = ({ id, type }: Props) => {
 															</Button>
 														</DialogAction>
 													</div>
+												</div>
+												<div className="w-full break-all">
+													<Link
+														className="flex items-center gap-2 text-base font-medium hover:underline"
+														target="_blank"
+														href={`${item.https ? "https" : "http"}://${item.host}${item.path}`}
+													>
+														{item.host}
+														<ExternalLink className="size-4 min-w-4" />
+													</Link>
 												</div>
 
 												{/* Domain Details */}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -217,12 +217,12 @@ const Service = (
 									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-scroll">
 										<TabsList
 											className={cn(
-												"lg:grid lg:w-fit max-md:overflow-y-scroll justify-start",
+												"xl:grid xl:w-fit max-md:overflow-y-scroll justify-start",
 												isCloud && data?.serverId
-													? "lg:grid-cols-9"
+													? "xl:grid-cols-9"
 													: data?.serverId
-														? "lg:grid-cols-8"
-														: "lg:grid-cols-9",
+														? "xl:grid-cols-8"
+														: "xl:grid-cols-9",
 											)}
 										>
 											<TabsTrigger value="general">General</TabsTrigger>


### PR DESCRIPTION
Domain buttons are not usuable for smaller desktop screenwidths, e.g. when
- using Zen Browser with Sidebar
- using Tablet/Ipad
- using a window manager with two applications side by side

This PR addresses the responsiveness design across all screen widths

## Before:

[before.webm](https://github.com/user-attachments/assets/2555debc-5d69-4e9f-a558-5e4236ecd622)


## After:

[after.webm](https://github.com/user-attachments/assets/b716dfe0-41d4-4362-9e8a-f45b62dfee63)

**Edit:** have also fixed the toolbar responsiveness in [136570b](https://github.com/Dokploy/dokploy/pull/1891/commits/136570b36cd3cf5f4dbefe823fa57eb972b7607a)
