### PR TITLE
fix: Missing `/compose` in auto-deploy URL

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -86,7 +86,7 @@ export const ShowDeployments = ({
 							<span>Webhook URL: </span>
 							<div className="flex flex-row items-center gap-2">
 								<span className="break-all text-muted-foreground">
-									{`${url}/api/deploy/${refreshToken}`}
+									{`${url}/api/deploy${type === 'compose' ? '/compose' : ''}/${refreshToken}`}
 								</span>
 								{(type === "application" || type === "compose") && (
 									<RefreshToken id={id} type={type} />


### PR DESCRIPTION
This fixes an issue where `Compose` auto-deploy URLs were displayed without the `/compose` in the URL path.

For type `Application`:
![Screenshot 2025-05-16 at 4 14 39 PM](https://github.com/user-attachments/assets/f5b651ec-efaa-41f8-af01-3a48a4af8a62)

For type `Compose`:
![Screenshot 2025-05-16 at 4 13 55 PM](https://github.com/user-attachments/assets/78968504-de81-4ad3-bbd4-7ab7ce7fa511)

fixes: #1831 