### PR TITLE
fix: randomize-compose missing await

### DIFF
--- a/apps/dokploy/components/dashboard/compose/general/randomize-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/randomize-compose.tsx
@@ -77,8 +77,8 @@ export const RandomizeCompose = ({ composeId }: Props) => {
 			randomize: formData?.randomize || false,
 		})
 			.then(async (_data) => {
-				randomizeCompose();
-				refetch();
+				await randomizeCompose();
+				await refetch();
 				toast.success("Compose updated");
 			})
 			.catch(() => {


### PR DESCRIPTION
I added this change in the isolated deployment PR #1917, but forgot to make the same changes in the randomize compose.

Basically awaiting the randomize update & refetch before printing the success message. This way, errors will also be caught and handled properly.