### PR TITLE
fix: throw error if traefik container creation fails for a reason other than port taken

### DIFF
--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -139,6 +139,8 @@ export const initializeTraefik = async ({
 				const newContainer = docker.getContainer(containerName);
 				await newContainer.start();
 				console.log("Traefik container started successfully after retry");
+			} else {
+				throw error;
 			}
 		}
 	} catch (error) {


### PR DESCRIPTION
Should not be failing silently.