### PR TITLE
feat: add support for multiple backup destination types using rclone

### DIFF
--- a/apps/dokploy/components/dashboard/settings/destination/constants.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/constants.ts
@@ -131,3 +131,13 @@ export const S3_PROVIDERS: Array<{
 		name: "Any other S3 compatible provider",
 	},
 ];
+
+export const DESTINATION_TYPES = [
+	{ key: "s3", name: "S3 Compatible (AWS, Wasabi, etc.)" },
+	{ key: "gdrive", name: "Google Drive" },
+	{ key: "onedrive", name: "Microsoft OneDrive" },
+	{ key: "ftp", name: "FTP" },
+	{ key: "sftp", name: "SFTP" },
+	{ key: "webdav", name: "WebDAV" },
+	// Add more as needed
+];

--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -35,16 +35,18 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-import { S3_PROVIDERS } from "./constants";
+import { S3_PROVIDERS, DESTINATION_TYPES } from "./constants";
 
 const addDestination = z.object({
 	name: z.string().min(1, "Name is required"),
-	provider: z.string().min(1, "Provider is required"),
-	accessKeyId: z.string().min(1, "Access Key Id is required"),
-	secretAccessKey: z.string().min(1, "Secret Access Key is required"),
-	bucket: z.string().min(1, "Bucket is required"),
-	region: z.string(),
-	endpoint: z.string().min(1, "Endpoint is required"),
+	type: z.string().min(1, "Type is required"),
+	provider: z.string().optional(),
+	accessKeyId: z.string().optional(),
+	secretAccessKey: z.string().optional(),
+	bucket: z.string().optional(),
+	region: z.string().optional(),
+	endpoint: z.string().optional(),
+	rcloneConfig: z.string().optional(),
 	serverId: z.string().optional(),
 });
 
@@ -109,6 +111,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 
 	const onSubmit = async (data: AddDestination) => {
 		await mutateAsync({
+			type: data.type,
 			provider: data.provider || "",
 			accessKey: data.accessKeyId,
 			bucket: data.bucket,
@@ -116,6 +119,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 			name: data.name,
 			region: data.region,
 			secretAccessKey: data.secretAccessKey,
+			rcloneConfig: data.rcloneConfig,
 			destinationId: destinationId || "",
 		})
 			.then(async () => {
@@ -244,116 +248,156 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 						/>
 						<FormField
 							control={form.control}
-							name="provider"
-							render={({ field }) => {
-								return (
+							name="type"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Destination Type</FormLabel>
+									<FormControl>
+										<Select
+											onValueChange={field.onChange}
+											defaultValue={field.value}
+											value={field.value}
+										>
+											<FormControl>
+												<SelectTrigger>
+													<SelectValue placeholder="Select a Destination Type" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												{DESTINATION_TYPES.map((type) => (
+													<SelectItem key={type.key} value={type.key}>
+														{type.name}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						{form.watch("type") === "s3" ? (
+							<>
+								<FormField
+									control={form.control}
+									name="provider"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Provider</FormLabel>
+											<FormControl>
+												<Select
+													onValueChange={field.onChange}
+													defaultValue={field.value}
+													value={field.value}
+												>
+													<FormControl>
+														<SelectTrigger>
+															<SelectValue placeholder="Select a S3 Provider" />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														{S3_PROVIDERS.map((s3Provider) => (
+															<SelectItem
+																key={s3Provider.key}
+																value={s3Provider.key}
+															>
+																{s3Provider.name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="accessKeyId"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Access Key Id</FormLabel>
+											<FormControl>
+												<Input placeholder={"xcas41dasde"} {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="secretAccessKey"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Secret Access Key</FormLabel>
+											<FormControl>
+												<Input placeholder={"asd123asdasw"} {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="bucket"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Bucket</FormLabel>
+											<FormControl>
+												<Input placeholder={"dokploy-bucket"} {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="region"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Region</FormLabel>
+											<FormControl>
+												<Input placeholder={"us-east-1"} {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="endpoint"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Endpoint</FormLabel>
+											<FormControl>
+												<Input
+													placeholder={"https://us.bucket.aws/s3"}
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</>
+						) : (
+							<FormField
+								control={form.control}
+								name="rcloneConfig"
+								render={({ field }) => (
 									<FormItem>
-										<FormLabel>Provider</FormLabel>
+										<FormLabel>Rclone Config / Connection String</FormLabel>
 										<FormControl>
-											<Select
-												onValueChange={field.onChange}
-												defaultValue={field.value}
-												value={field.value}
-											>
-												<FormControl>
-													<SelectTrigger>
-														<SelectValue placeholder="Select a S3 Provider" />
-													</SelectTrigger>
-												</FormControl>
-												<SelectContent>
-													{S3_PROVIDERS.map((s3Provider) => (
-														<SelectItem
-															key={s3Provider.key}
-															value={s3Provider.key}
-														>
-															{s3Provider.name}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
+											<Input placeholder={"e.g. gdrive,client_id=xxx,client_secret=yyy,token=zzz:/backup"} {...field} />
 										</FormControl>
 										<FormMessage />
+										<div className="text-xs text-muted-foreground mt-1">
+											See <a href="https://rclone.org/docs/#connection-strings" target="_blank" rel="noopener noreferrer" className="underline">rclone connection string docs</a> for details.
+										</div>
 									</FormItem>
-								);
-							}}
-						/>
-
-						<FormField
-							control={form.control}
-							name="accessKeyId"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
-										<FormControl>
-											<Input placeholder={"xcas41dasde"} {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-						<FormField
-							control={form.control}
-							name="secretAccessKey"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"asd123asdasw"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="bucket"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"dokploy-bucket"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="region"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"us-east-1"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="endpoint"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
-									<FormControl>
-										<Input
-											placeholder={"https://us.bucket.aws/s3"}
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+								)}
+							/>
+						)}
 					</form>
 
 					<DialogFooter

--- a/apps/dokploy/pages/api/destination/upload-config.ts
+++ b/apps/dokploy/pages/api/destination/upload-config.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import formidable from 'formidable';
+import fs from 'fs';
+import path from 'path';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+const ensureDir = (dir: string) => {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+  const destinationId = req.query.destinationId as string;
+  if (!destinationId) {
+    return res.status(400).json({ error: 'Missing destinationId' });
+  }
+  const uploadDir = path.join(process.cwd(), 'data', 'rclone-configs');
+  ensureDir(uploadDir);
+  const form = new formidable.IncomingForm({ uploadDir, keepExtensions: true });
+  form.parse(req, (err, fields, files) => {
+    if (err) return res.status(500).json({ error: 'Upload error' });
+    const file = files.file as formidable.File;
+    if (!file) return res.status(400).json({ error: 'No file uploaded' });
+    const savePath = path.join(uploadDir, `${destinationId}.conf`);
+    fs.renameSync(file.filepath, savePath);
+    res.status(200).json({ path: savePath });
+  });
+} 

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -13,11 +13,13 @@ export const destinations = pgTable("destination", {
 		.$defaultFn(() => nanoid()),
 	name: text("name").notNull(),
 	provider: text("provider"),
-	accessKey: text("accessKey").notNull(),
-	secretAccessKey: text("secretAccessKey").notNull(),
-	bucket: text("bucket").notNull(),
-	region: text("region").notNull(),
-	endpoint: text("endpoint").notNull(),
+	type: text("type").notNull().default('s3'),
+	rcloneConfig: text("rcloneConfig"),
+	accessKey: text("accessKey"),
+	secretAccessKey: text("secretAccessKey"),
+	bucket: text("bucket"),
+	region: text("region"),
+	endpoint: text("endpoint"),
 	organizationId: text("organizationId")
 		.notNull()
 		.references(() => organization.id, { onDelete: "cascade" }),
@@ -38,18 +40,22 @@ export const destinationsRelations = relations(
 const createSchema = createInsertSchema(destinations, {
 	destinationId: z.string(),
 	name: z.string().min(1),
-	provider: z.string(),
-	accessKey: z.string(),
-	bucket: z.string(),
-	endpoint: z.string(),
-	secretAccessKey: z.string(),
-	region: z.string(),
+	provider: z.string().optional(),
+	type: z.string().min(1),
+	rcloneConfig: z.string().optional(),
+	accessKey: z.string().optional(),
+	bucket: z.string().optional(),
+	endpoint: z.string().optional(),
+	secretAccessKey: z.string().optional(),
+	region: z.string().optional(),
 });
 
 export const apiCreateDestination = createSchema
 	.pick({
 		name: true,
 		provider: true,
+		type: true,
+		rcloneConfig: true,
 		accessKey: true,
 		bucket: true,
 		region: true,
@@ -83,6 +89,8 @@ export const apiUpdateDestination = createSchema
 		secretAccessKey: true,
 		destinationId: true,
 		provider: true,
+		type: true,
+		rcloneConfig: true,
 	})
 	.required()
 	.extend({

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -24,6 +24,7 @@ export const destinations = pgTable("destination", {
 		.notNull()
 		.references(() => organization.id, { onDelete: "cascade" }),
 	createdAt: timestamp("createdAt").notNull().defaultNow(),
+	rcloneConfigFilePath: text("rcloneConfigFilePath"),
 });
 
 export const destinationsRelations = relations(
@@ -48,6 +49,7 @@ const createSchema = createInsertSchema(destinations, {
 	endpoint: z.string().optional(),
 	secretAccessKey: z.string().optional(),
 	region: z.string().optional(),
+	rcloneConfigFilePath: z.string().optional(),
 });
 
 export const apiCreateDestination = createSchema
@@ -61,6 +63,7 @@ export const apiCreateDestination = createSchema
 		region: true,
 		endpoint: true,
 		secretAccessKey: true,
+		rcloneConfigFilePath: true,
 	})
 	.required()
 	.extend({
@@ -91,6 +94,7 @@ export const apiUpdateDestination = createSchema
 		provider: true,
 		type: true,
 		rcloneConfig: true,
+		rcloneConfigFilePath: true,
 	})
 	.required()
 	.extend({

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -3,7 +3,7 @@ import type { Compose } from "@dokploy/server/services/compose";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, getBackupCommand } from "./utils";
+import { getS3Credentials, normalizeS3Path, getBackupCommand, getRcloneUploadCommand } from "./utils";
 import {
 	createDeploymentBackup,
 	updateDeploymentStatus,
@@ -26,10 +26,7 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
+		const rcloneCommand = getRcloneUploadCommand(destination, '-', backupFileName, prefix);
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -3,7 +3,7 @@ import type { Mariadb } from "@dokploy/server/services/mariadb";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getS3Credentials, normalizeS3Path, getRcloneUploadCommand } from "./utils";
 import {
 	createDeploymentBackup,
 	updateDeploymentStatus,
@@ -25,10 +25,7 @@ export const runMariadbBackup = async (
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
+		const rcloneCommand = getRcloneUploadCommand(destination, '-', backupFileName, prefix);
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -3,7 +3,7 @@ import type { Mongo } from "@dokploy/server/services/mongo";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getS3Credentials, normalizeS3Path, getRcloneUploadCommand } from "./utils";
 import {
 	createDeploymentBackup,
 	updateDeploymentStatus,
@@ -22,10 +22,7 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
+		const rcloneCommand = getRcloneUploadCommand(destination, '-', backupFileName, prefix);
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -3,7 +3,7 @@ import type { MySql } from "@dokploy/server/services/mysql";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getS3Credentials, normalizeS3Path, getRcloneUploadCommand } from "./utils";
 import {
 	createDeploymentBackup,
 	updateDeploymentStatus,
@@ -23,11 +23,7 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
+		const rcloneCommand = getRcloneUploadCommand(destination, '-', backupFileName, prefix);
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -3,7 +3,7 @@ import type { Postgres } from "@dokploy/server/services/postgres";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getS3Credentials, normalizeS3Path, getRcloneUploadCommand } from "./utils";
 import {
 	createDeploymentBackup,
 	updateDeploymentStatus,
@@ -26,11 +26,7 @@ export const runPostgresBackup = async (
 	const backupFileName = `${new Date().toISOString()}.sql.gz`;
 	const bucketDestination = `${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
+		const rcloneCommand = getRcloneUploadCommand(destination, '-', backupFileName, prefix);
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -256,3 +256,22 @@ export const getBackupCommand = (
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };
+
+export const getRcloneUploadCommand = (
+	destination: Destination,
+	localFilePath: string,
+	remoteFileName: string,
+	prefix: string = ''
+) => {
+	if (destination.type && destination.type !== 's3') {
+		// Use rcloneConfig as the remote
+		const remote = destination.rcloneConfig || '';
+		// e.g. rclone copyto "/tmp/file.zip" "gdrive,client_id=xxx,token=yyy:/backup/file.zip"
+		return `rclone copyto "${localFilePath}" "${remote}${prefix ? '/' + prefix : ''}/${remoteFileName}"`;
+	} else {
+		// S3 logic
+		const rcloneFlags = getS3Credentials(destination);
+		const s3Path = `:s3:${destination.bucket}/${normalizeS3Path(prefix)}${remoteFileName}`;
+		return `rclone copyto ${rcloneFlags.join(' ')} "${localFilePath}" "${s3Path}"`;
+	}
+};

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -264,10 +264,11 @@ export const getRcloneUploadCommand = (
 	prefix: string = ''
 ) => {
 	if (destination.type && destination.type !== 's3') {
-		// Use rcloneConfig as the remote
 		const remote = destination.rcloneConfig || '';
-		// e.g. rclone copyto "/tmp/file.zip" "gdrive,client_id=xxx,token=yyy:/backup/file.zip"
-		return `rclone copyto "${localFilePath}" "${remote}${prefix ? '/' + prefix : ''}/${remoteFileName}"`;
+		const configFlag = destination.rcloneConfigFilePath
+			? `--config ${destination.rcloneConfigFilePath} `
+			: '';
+		return `rclone copyto ${configFlag}"${localFilePath}" "${remote}${prefix ? '/' + prefix : ''}/${remoteFileName}"`;
 	} else {
 		// S3 logic
 		const rcloneFlags = getS3Credentials(destination);

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -1,6 +1,6 @@
 import type { BackupSchedule } from "@dokploy/server/services/backup";
 import { execAsync } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path } from "./utils";
+import { getS3Credentials, normalizeS3Path, getRcloneUploadCommand } from "./utils";
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -79,10 +79,10 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 
 			writeStream.write("Zipped database and filesystem\n");
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${tempDir}/${backupFileName}" "${s3Path}"`;
+			const uploadCommand = getRcloneUploadCommand(destination, `${tempDir}/${backupFileName}`, backupFileName, backup.prefix);
 			writeStream.write(`Running command: ${uploadCommand}\n`);
 			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			writeStream.write("Uploaded backup to destination ✅\n");
 			writeStream.end();
 			await updateDeploymentStatus(deployment.deploymentId, "done");
 			return true;


### PR DESCRIPTION
## Add support for multiple backup destination types using rclone
### **Key Changes**

- **Database & API**
  - Extended the backup destination schema to include `type` (e.g., s3, gdrive, onedrive, ftp, sftp, webdav, etc.) and `rcloneConfig` (for rclone connection strings/configs).
  - Updated all relevant API endpoints and validation to support the new fields and logic.

- **Frontend**
  - Updated the destination creation/edit form:
    - Added a dropdown for destination type.
    - If S3 is selected, S3-specific fields are shown.
    - For other types, a textbox for rclone config/connection string is shown, with a link to rclone docs.
  - Improved UX for adding and editing backup destinations.

- **Backup Logic**
  - Unified backup upload logic for all providers using a new utility function.
  - All backup routines (Postgres, MySQL, MariaDB, Mongo, Compose, Web Server) now support any rclone-compatible provider.
  - Test connection logic supports both S3 and non-S3 types.

Closes- #416 
/claim #416