### PR TITLE
feat(gitlab): support nested group filtering using namespace.full_pat…

### DIFF
--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -255,7 +255,9 @@ export const getGitlabRepositories = async (gitlabId?: string) => {
 		if (groupName) {
 			const isIncluded = groupName
 				.split(",")
-				.some((name) => full_path === name);
+				.some((name) =>
+					full_path.toLowerCase().startsWith(name.trim().toLowerCase())
+				);
 
 			return isIncluded && kind === "group";
 		}
@@ -422,7 +424,12 @@ export const testGitlabConnection = async (
 		const { full_path, kind } = repo.namespace;
 
 		if (groupName) {
-			return groupName.split(",").some((name) => full_path === name);
+			return groupName
+			.split(",")
+			.some((name) =>
+				full_path.toLowerCase().startsWith(name.trim().toLowerCase())
+			);
+
 		}
 		return kind === "user";
 	});


### PR DESCRIPTION
### Feature: Support Nested Group Filtering for GitLab

This PR updates the filtering logic for GitLab repositories to support subgroups by matching `namespace.full_path` using `.startsWith()`.

---

### Changes

- Updated `getGitlabRepositories` and `testGitlabConnection` to allow filtering by parent group paths (e.g., `org1`) and automatically include all nested repositories.
- Applied normalization using `toLowerCase()` and `trim()` to avoid case or whitespace mismatches.

---

### Result

Now, setting `groupName = "org1"` will correctly include projects like:
- `org1/projects/...`
- `org1/infra/...`

---

Closes #1959 
