### PR TITLE
feat: add user role editing functionality and update user role mutation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ yarn-error.log*
 .DS_Store
 *.pem
 
-
 .db
+
+.tool-versions

--- a/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
@@ -139,6 +139,7 @@ export const AddInvitation = () => {
 											</FormControl>
 											<SelectContent>
 												<SelectItem value="member">Member</SelectItem>
+												<SelectItem value="admin">Admin</SelectItem>
 											</SelectContent>
 										</Select>
 										<FormDescription>

--- a/apps/dokploy/components/dashboard/settings/users/edit-role.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/edit-role.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { api } from "@/utils/api";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Edit3Icon } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const editUserRole = z.object({
+	role: z.enum(["member", "admin"]),
+});
+
+type EditUserRole = z.infer<typeof editUserRole>;
+
+interface EditUserRoleProps {
+	userId: string;
+	currentRole: string;
+	userEmail: string;
+}
+
+export const EditUserRole = ({ userId, currentRole, userEmail }: EditUserRoleProps) => {
+	const [open, setOpen] = useState(false);
+	const utils = api.useUtils();
+
+	const { mutateAsync: updateRoleMember, isLoading } = api.user.updateRoleMember.useMutation();
+
+	const form = useForm<EditUserRole>({
+		defaultValues: {
+			role: currentRole,
+		} as EditUserRole,
+		resolver: zodResolver(editUserRole),
+	});
+
+	const onSubmit = async (data: EditUserRole) => {
+		if (data.role === currentRole) {
+			toast.info("No changes made");
+			setOpen(false);
+			return;
+		}
+
+		try {
+			await updateRoleMember({
+				userId: userId,
+				role: data.role,
+			});
+
+			toast.success(`User role updated to ${data.role}`);
+			setOpen(false);
+			
+			utils.user.all.invalidate();
+		} catch (error: any) {
+			toast.error(error?.message || "Error updating user role");
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<DropdownMenuItem
+					className="w-full cursor-pointer"
+					onSelect={(e) => e.preventDefault()}
+				>
+					<Edit3Icon className="h-4 w-4 mr-2" />
+					Edit Role
+				</DropdownMenuItem>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Edit User Role</DialogTitle>
+					<DialogDescription>
+						Change the role for {userEmail}
+					</DialogDescription>
+				</DialogHeader>
+
+				<Form {...form}>
+					<form
+						id="edit-user-role-form"
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="space-y-4"
+					>
+						<FormField
+							control={form.control}
+							name="role"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Role</FormLabel>
+									<Select
+										onValueChange={field.onChange}
+										defaultValue={field.value}
+									>
+										<FormControl>
+											<SelectTrigger>
+												<SelectValue placeholder="Select a role" />
+											</SelectTrigger>
+										</FormControl>
+										<SelectContent>
+											<SelectItem value="member">Member</SelectItem>
+											<SelectItem value="admin">Admin</SelectItem>
+										</SelectContent>
+									</Select>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+					</form>
+				</Form>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={isLoading}
+					>
+						Cancel
+					</Button>
+					<Button
+						form="edit-user-role-form"
+						type="submit"
+						isLoading={isLoading}
+					>
+						Update Role
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -31,6 +31,7 @@ import { MoreHorizontal, Users } from "lucide-react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { AddUserPermissions } from "./add-permissions";
+import { EditUserRole } from "./edit-role";
 
 export const ShowUsers = () => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
@@ -126,6 +127,14 @@ export const ShowUsers = () => {
 																		<DropdownMenuLabel>
 																			Actions
 																		</DropdownMenuLabel>
+
+																		{member.role !== "owner" && (
+																			<EditUserRole
+																				userId={member.user.id}
+																				currentRole={member.role}
+																				userEmail={member.user.email}
+																			/>
+																		)}
 
 																		{member.role !== "owner" && (
 																			<AddUserPermissions


### PR DESCRIPTION
# Add ability to edit user roles

## Description
This PR adds the ability for organization owners to edit user roles (member, admin) through the UI.

## Changes Made

### Backend
- Added `updateRoleMember` mutation to `userRouter`
- Validates that only owners can update roles
- Prevents users from changing their own role
- Returns updated member data

### Frontend
- Fixed admin role option in `AddInvitation` component (was missing from SelectContent)
- Added `EditUserRole` component with role selection dialog
- Integrated edit role functionality in user management table
- Added proper permission checks (owners can edit others, but not themselves)

## Files Changed
- `packages/server/src/routers/user.ts` - Added updateRoleMember mutation
- `apps/dokploy/components/dashboard/settings/users/add-invitation.tsx` - Fixed admin role option
- `apps/dokploy/components/dashboard/settings/users/edit-user-role.tsx` - New component
- `apps/dokploy/components/dashboard/settings/users/show-users.tsx` - Integrated edit functionality

## Security
- Only organization owners can update member roles
- Users cannot update their own role (prevents accidental lockout)
- Validates member exists in organization before updating

## Screenshots
![imagem](https://github.com/user-attachments/assets/c670f70e-737e-4afa-aa61-7098c61c2dd1)
![imagem](https://github.com/user-attachments/assets/a8e04a90-95b7-4aa1-b7a3-1d31c87068fd)
