### PR TITLE
fix api: return compose informations when created from template

### DIFF
--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -496,7 +496,7 @@ export const composeRouter = createTRPCRouter({
 				}
 			}
 
-			return null;
+			return compose;
 		}),
 
 	templates: publicProcedure


### PR DESCRIPTION
Changing the return value from ```null``` to ```compose```, the variable that contain newly created compose informations, fixing the issue #2006 

Here an example with the swagger and the creation of a compose with wordpress template
![image](https://github.com/user-attachments/assets/3da8d2b8-35b2-4a01-863d-91f857da60ca)
