### PR TITLE
fix(traefik-setup): now pulling the traefik image to make it sure it's present locally

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -12,6 +12,7 @@ import {
 	initializeNetwork,
 	initializeSwarm,
 } from "@dokploy/server/setup/setup";
+import { execAsync } from "@dokploy/server";
 (async () => {
 	try {
 		setupDirectories();
@@ -20,6 +21,7 @@ import {
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
+		await execAsync("docker pull traefik:v3.1.2");
 		await initializeTraefik();
 		await initializeRedis();
 		await initializePostgres();

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -124,16 +124,25 @@ export const initializeTraefik = async ({
 			console.log("No existing container to remove");
 		}
 
-		console.log(`Pulling image ${imageName}...`);
-		const stream = await docker.pull(imageName);
-		await new Promise((resolve, reject) => {
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			docker.modem.followProgress(stream, (err: Error, res: any) =>
-				err ? reject(err) : resolve(res),
-			);
-		});
-		console.log(`Image ${imageName} pulled successfully.`);
+		try {
+			await docker.getImage(imageName).inspect();
+			console.log(`Image ${imageName} already exists locally.`);
+		} catch (error: any) {
+			if (error?.statusCode === 404) {
+				console.log(`Image ${imageName} not found, pulling...`);
+				const stream = await docker.pull(imageName);
+				await new Promise((resolve, reject) => {
+					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+					// @ts-ignore
+					docker.modem.followProgress(stream, (err: Error, res: any) =>
+						err ? reject(err) : resolve(res),
+					);
+				});
+				console.log(`Image ${imageName} pulled successfully.`);
+			} else {
+				throw error;
+			}
+		}
 
 		// Create and start the new container
 		try {

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -124,26 +124,6 @@ export const initializeTraefik = async ({
 			console.log("No existing container to remove");
 		}
 
-		try {
-			await docker.getImage(imageName).inspect();
-			console.log(`Image ${imageName} already exists locally.`);
-		} catch (error: any) {
-			if (error?.statusCode === 404) {
-				console.log(`Image ${imageName} not found, pulling...`);
-				const stream = await docker.pull(imageName);
-				await new Promise((resolve, reject) => {
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore
-					docker.modem.followProgress(stream, (err: Error, res: any) =>
-						err ? reject(err) : resolve(res),
-					);
-				});
-				console.log(`Image ${imageName} pulled successfully.`);
-			} else {
-				throw error;
-			}
-		}
-
 		// Create and start the new container
 		try {
 			await docker.createContainer(settings);

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -124,6 +124,17 @@ export const initializeTraefik = async ({
 			console.log("No existing container to remove");
 		}
 
+		console.log(`Pulling image ${imageName}...`);
+		const stream = await docker.pull(imageName);
+		await new Promise((resolve, reject) => {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			docker.modem.followProgress(stream, (err: Error, res: any) =>
+				err ? reject(err) : resolve(res),
+			);
+		});
+		console.log(`Image ${imageName} pulled successfully.`);
+
 		// Create and start the new container
 		try {
 			await docker.createContainer(settings);


### PR DESCRIPTION
Hi,

- Fixes #2029 
- Added the pulling of the traefik image name/version during the setup (`pnpm run dokploy:setup`) when it's not present locally otherwise it throws an error if you don't have it.
- I didn't add any tests because it seems like there isn't any on the setup part ? 

