### PR TITLE
refactor(git_provider): update userId assignment to use owner_id from…

### DIFF
--- a/apps/dokploy/drizzle/0094_numerous_carmella_unuscione.sql
+++ b/apps/dokploy/drizzle/0094_numerous_carmella_unuscione.sql
@@ -1,12 +1,11 @@
 ALTER TABLE "git_provider" ADD COLUMN "userId" text;--> statement-breakpoint
 
 -- Update existing git providers to be owned by the organization owner
--- We need to get the account.user_id for the organization owner
+-- We can get the owner_id directly from the organization table
 UPDATE "git_provider" 
 SET "userId" = (
-    SELECT a.user_id 
+    SELECT o."owner_id" 
     FROM "organization" o 
-    JOIN "account" a ON o."owner_id" = a.user_id 
     WHERE o.id = "git_provider"."organizationId"
 );--> statement-breakpoint
 


### PR DESCRIPTION
… organization table

- Changed the SQL update statement to directly select the owner_id from the organization table instead of joining with the account table, simplifying the query.