### PR TITLE
chore: remove unknown `apps/models` from pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 packages:
-  - "apps/dokploy"
   - "apps/api"
+  - "apps/dokploy"
   - "apps/monitoring"
   - "apps/schedules"
-  - "apps/models"
   - "packages/server"


### PR DESCRIPTION
## Summary

Chores:
- Remove unknown 'apps/models' entry from pnpm-workspace.yaml