### PR TITLE
feat(settings): add query to retrieve Dokploy cloud IPs

### DIFF
--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -837,6 +837,14 @@ export const settingsRouter = createTRPCRouter({
 	getLogCleanupStatus: adminProcedure.query(async () => {
 		return getLogCleanupStatus();
 	}),
+
+	getDokployCloudIps: adminProcedure.query(async () => {
+		if (!IS_CLOUD) {
+			return [];
+		}
+		const ips = process.env.DOKPLOY_CLOUD_IPS?.split(",");
+		return ips;
+	}),
 });
 
 export const getTraefikPorts = async (serverId?: string) => {


### PR DESCRIPTION
- Implemented a new admin procedure to fetch cloud IPs from environment variables.
- Returns an empty array if not in cloud mode.