### PR TITLE
fix(upload): refactor registry tag construction for image uploads

### DIFF
--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -1,5 +1,4 @@
 import { createWriteStream } from "node:fs";
-import { join } from "node:path";
 import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { uploadImage, uploadImageRemoteCommand } from "../cluster/upload";
@@ -211,16 +210,20 @@ export const mechanizeDockerContainer = async (
 
 const getImageName = (application: ApplicationNested) => {
 	const { appName, sourceType, dockerImage, registry } = application;
-
+	const imageName = `${appName}:latest`;
 	if (sourceType === "docker") {
 		return dockerImage || "ERROR-NO-IMAGE-PROVIDED";
 	}
 
 	if (registry) {
-		return join(registry.registryUrl, registry.imagePrefix || "", appName);
+		const { registryUrl, imagePrefix, username } = registry;
+		const registryTag = imagePrefix
+			? `${registryUrl}/${imagePrefix}/${imageName}`
+			: `${registryUrl}/${username}/${imageName}`;
+		return registryTag;
 	}
 
-	return `${appName}:latest`;
+	return imageName;
 };
 
 const getAuthConfig = (application: ApplicationNested) => {

--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -1,5 +1,4 @@
 import type { WriteStream } from "node:fs";
-import path, { join } from "node:path";
 import type { ApplicationNested } from "../builders";
 import { spawnAsync } from "../process/spawnAsync";
 
@@ -13,19 +12,22 @@ export const uploadImage = async (
 		throw new Error("Registry not found");
 	}
 
-	const { registryUrl, imagePrefix } = registry;
+	const { registryUrl, imagePrefix, username } = registry;
 	const { appName } = application;
 	const imageName = `${appName}:latest`;
 
 	const finalURL = registryUrl;
 
-	const registryTag = path
-		.join(registryUrl, join(imagePrefix || "", imageName))
-		.replace(/\/+/g, "/");
+	// Build registry tag in correct format: registry.com/owner/image:tag
+	// For ghcr.io: ghcr.io/username/image:tag
+	// For docker.io: docker.io/username/image:tag
+	const registryTag = imagePrefix
+		? `${registryUrl}/${imagePrefix}/${imageName}`
+		: `${registryUrl}/${username}/${imageName}`;
 
 	try {
 		writeStream.write(
-			`📦 [Enabled Registry] Uploading image to ${registry.registryType} | ${imageName} | ${finalURL}\n`,
+			`📦 [Enabled Registry] Uploading image to ${registry.registryType} | ${imageName} | ${finalURL} | ${registryTag}\n`,
 		);
 		const loginCommand = spawnAsync(
 			"docker",
@@ -67,15 +69,16 @@ export const uploadImageRemoteCommand = (
 		throw new Error("Registry not found");
 	}
 
-	const { registryUrl, imagePrefix } = registry;
+	const { registryUrl, imagePrefix, username } = registry;
 	const { appName } = application;
 	const imageName = `${appName}:latest`;
 
 	const finalURL = registryUrl;
 
-	const registryTag = path
-		.join(registryUrl, join(imagePrefix || "", imageName))
-		.replace(/\/+/g, "/");
+	// Build registry tag in correct format: registry.com/owner/image:tag
+	const registryTag = imagePrefix
+		? `${registryUrl}/${imagePrefix}/${imageName}`
+		: `${registryUrl}/${username}/${imageName}`;
 
 	try {
 		const command = `


### PR DESCRIPTION
- Updated the logic for constructing the registry tag in the uploadImage and uploadImageRemoteCommand functions to ensure correct formatting.
- Removed unnecessary path imports and streamlined the code for better readability.