### PR TITLE
fix: change default DOCKER_CONFIG to a config directory instead of config.json file

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -193,7 +193,7 @@ const createEnvFile = (compose: ComposeNested) => {
 	let envContent = `APP_NAME=${appName}\n`;
 	envContent += env || "";
 	if (!envContent.includes("DOCKER_CONFIG")) {
-		envContent += "\nDOCKER_CONFIG=/root/.docker/config.json";
+		envContent += "\nDOCKER_CONFIG=/root/.docker";
 	}
 
 	if (compose.randomize) {
@@ -223,7 +223,7 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 	let envContent = `APP_NAME=${appName}\n`;
 	envContent += env || "";
 	if (!envContent.includes("DOCKER_CONFIG")) {
-		envContent += "\nDOCKER_CONFIG=/root/.docker/config.json";
+		envContent += "\nDOCKER_CONFIG=/root/.docker";
 	}
 
 	if (compose.randomize) {


### PR DESCRIPTION
Closes #2098 

`DOCKER_CONFIG` should be "The location of your client configuration files." according to docker documentation: https://docs.docker.com/reference/cli/docker/

Seems that with one of the latest docker updates, this rule became stricter.

### Steps to reproduce:
1. Create compose deployment with https://github.com/SashkaHavr/docker-config-compose-bug-repro
2. Set branch to "main" and compose path to "./docker-compose.yaml"
3. Deploy
An error occures: "Error loading config file: open /root/.docker/config.json/config.json: not a directory"

### Workaround
Add "DOCKER_CONFIG=/root/.docker" to "Environment"
