### PR TITLE
Style: Make Node Applications more readable.

### DIFF
--- a/apps/dokploy/components/dashboard/settings/cluster/nodes/show-nodes-modal.tsx
+++ b/apps/dokploy/components/dashboard/settings/cluster/nodes/show-nodes-modal.tsx
@@ -20,7 +20,7 @@ export const ShowNodesModal = ({ serverId }: Props) => {
 					Show Swarm Nodes
 				</DropdownMenuItem>
 			</DialogTrigger>
-			<DialogContent className="sm:max-w-5xl  overflow-y-auto max-h-screen ">
+			<DialogContent className="min-w-[70vw] overflow-y-auto max-h-screen">
 				<div className="grid w-full gap-1">
 					<ShowNodes serverId={serverId} />
 				</div>

--- a/apps/dokploy/components/ui/badge.tsx
+++ b/apps/dokploy/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-	"inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+	"inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold whitespace-nowrap transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
Before
<img width="1919" alt="Before" src="https://github.com/user-attachments/assets/e01aab29-0656-4634-a235-79101e629951" />
After
<img width="1919" alt="After" src="https://github.com/user-attachments/assets/4fba6f2d-6170-40d6-9950-2c6fe6dbf1cf" />

