### PR TITLE
docs: remove blue underlink from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,46 +62,26 @@ For detailed documentation, visit [docs.dokploy.com](https://docs.dokploy.com).
 ### Hero Sponsors 🎖
 
 <div style="display: flex; align-items: center; gap: 20px;">
-  <a href="https://www.hostinger.com/vps-hosting?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;">
-    <img src=".github/sponsors/hostinger.jpg" alt="Hostinger" height="50"/>
-  </a>
-  <a href="https://www.lxaer.com/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;">
-    <img src=".github/sponsors/lxaer.png" alt="LX Aer" height="50"/>
-  </a>
-    <a href="https://mandarin3d.com/?ref=dokploy" target="_blank" style="display: inline-block;">
-    <img src=".github/sponsors/mandarin.png" alt="Mandarin" height="50"/>
-  </a>
-    <a href="https://lightnode.com/?ref=dokploy" target="_blank" style="display: inline-block;">
-    <img src=".github/sponsors/light-node.webp" alt="Lightnode" height="70"/>
-  </a>
+  <a href="https://www.hostinger.com/vps-hosting?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;"><img src=".github/sponsors/hostinger.jpg" alt="Hostinger" height="50"/></a>
+  <a href="https://www.lxaer.com/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;"><img src=".github/sponsors/lxaer.png" alt="LX Aer" height="50"/></a>
+  <a href="https://mandarin3d.com/?ref=dokploy" target="_blank" style="display: inline-block;"><img src=".github/sponsors/mandarin.png" alt="Mandarin" height="50"/></a>
+  <a href="https://lightnode.com/?ref=dokploy" target="_blank" style="display: inline-block;"><img src=".github/sponsors/light-node.webp" alt="Lightnode" height="70"/></a>
 
-  
 </div>
 
 ### Premium Supporters 🥇
 
 <div style="display: flex; align-items: center; gap: 20px;">
-  <a href="https://supafort.com/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 20px;">
-    <img src="https://supafort.com/build/q-4Ht4rBZR.webp" alt="Supafort.com" height="50"/>
-  </a>
-
-  <a href="https://agentdock.ai/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 50px;">
-    <img src=".github/sponsors/agentdock.png" alt="agentdock.ai" height="70"/>
-  </a>
+  <a href="https://supafort.com/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 20px;"><img src="https://supafort.com/build/q-4Ht4rBZR.webp" alt="Supafort.com" height="50"/></a>
+  <a href="https://agentdock.ai/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 50px;"><img src=".github/sponsors/agentdock.png" alt="agentdock.ai" height="70"/></a>
 
 </div>
 
 ### Elite Contributors 🥈
 
 <div style="display: flex; align-items: center; gap: 20px;">
-
-  <a href="https://americancloud.com/?ref=dokploy" target="_blank" style="display: inline-block; padding: 10px; border-radius: 10px;">
-    <img src=".github/sponsors/american-cloud.png" alt="AmericanCloud" height="70"/>
-  </a>
-
-  <a href="https://tolgee.io/?utm_source=github_dokploy&utm_medium=banner&utm_campaign=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;">
-    <img src="https://dokploy.com/tolgee-logo.png" alt="Tolgee" height="80"/>
-  </a>
+  <a href="https://americancloud.com/?ref=dokploy" target="_blank" style="display: inline-block; padding: 10px; border-radius: 10px;"><img src=".github/sponsors/american-cloud.png" alt="AmericanCloud" height="70"/></a>
+  <a href="https://tolgee.io/?utm_source=github_dokploy&utm_medium=banner&utm_campaign=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;"><img src="https://dokploy.com/tolgee-logo.png" alt="Tolgee" height="80"/></a>
 
 </div>
 <!-- Elite Contributors 🥈 -->


### PR DESCRIPTION
## Summary

Documentation:
- Inline anchor and image tags in Hero Sponsors, Premium Supporters, and Elite Contributors sections to remove blue underlines

## Appearance

| Before | After |
|--------|--------|
| ![スクリーンショット 2025-06-30 170342](https://github.com/user-attachments/assets/f682f266-6bc4-4115-9d5a-be6988ff884d) | ![スクリーンショット 2025-06-30 170352](https://github.com/user-attachments/assets/b9afd419-b131-42ba-8a83-67edf907bbcf) | 

## Why?

Previously, the images were displayed with line breaks between them, causing blue link lines to appear, which disrupted the clean look of the images. By removing these line breaks, the images now appear without the blue link lines, providing a more cohesive and visually appealing README.