### PR TITLE
feat: bump Traefik v3.2.2 and add swarm network label 

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -21,7 +21,7 @@ import {
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
-		await execAsync("docker pull traefik:v3.1.2");
+		await execAsync("docker pull traefik:v3.2.2");
 		await initializeStandaloneTraefik();
 		await initializeRedis();
 		await initializePostgres();

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -13,7 +13,7 @@ export const TRAEFIK_PORT =
 	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
-export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.1.2";
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.2.2";
 
 export interface TraefikOptions {
 	env?: string[];

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -254,6 +254,9 @@ export const addDomainToCompose = async (
 				if (!labels.includes("traefik.docker.network=dokploy-network")) {
 					labels.unshift("traefik.docker.network=dokploy-network");
 				}
+				if (!labels.includes("traefik.swarm.network=dokploy-network")) {
+					labels.unshift("traefik.swarm.network=dokploy-network");
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Bump Traefik to v3.2.2 and enable swarm network label in domain compose configuration

Enhancements:
- Include traefik.swarm.network=dokploy-network label alongside the existing docker network label
- Update default Traefik version fallback from 3.1.2 to 3.2.2

## Description

According to [v3.1 to v3.2 migration guide](https://doc.traefik.io/traefik/v3.2/migration/v3/#v31-to-v32) ...

> In v3.2.2, the `traefik.docker.network` and `traefik.docker.lbswarm` labels have been deprecated, please use the `traefik.swarm.network` and `traefik.swarm.lbswarm` labels instead.

So I added the `traefik.swarm.network` label check like `traefik.docker.network`.

## Reference

- [Migration: Steps needed between the versions](https://doc.traefik.io/traefik/v3.2/migration/v3/#migration-steps-needed-between-the-versions)
- [Comparing changes](https://github.com/traefik/traefik/compare/v3.1.2...v3.2.2) between [v3.1.2](https://github.com/traefik/traefik/releases/tag/v3.1.2) and [v3.2.2](https://github.com/traefik/traefik/releases/tag/v3.2.2).