### PR TITLE
fix: prevent removal of current directory in deployment logs

### DIFF
--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -538,9 +538,11 @@ const removeLastTenDeployments = async (
 					await removeRollbackById(oldDeployment.rollbackId);
 				}
 
-				command += `
-				rm -rf ${logPath};
-				`;
+				if (logPath !== ".") {
+					command += `
+					rm -rf ${logPath};
+					`;
+				}
 				await removeDeployment(oldDeployment.deploymentId);
 			}
 
@@ -551,7 +553,11 @@ const removeLastTenDeployments = async (
 					await removeRollbackById(oldDeployment.rollbackId);
 				}
 				const logPath = path.join(oldDeployment.logPath);
-				if (existsSync(logPath) && !oldDeployment.errorMessage) {
+				if (
+					existsSync(logPath) &&
+					!oldDeployment.errorMessage &&
+					logPath !== "."
+				) {
 					await fsPromises.unlink(logPath);
 				}
 				await removeDeployment(oldDeployment.deploymentId);


### PR DESCRIPTION
- Updated the removeLastTenDeployments function to check if logPath is not the current directory before executing the removal command.
- Enhanced the unlink operation to ensure it only attempts to delete valid log paths.