### PR TITLE
docs: fix broken README.md sponsers images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 <div align="center">
-   <div>
-    <a href="https://dokploy.com" target="_blank" rel="noopener">
-        <img style="object-fit: cover;" align="center" width="100%"src=".github/sponsors/logo.png" alt="Dokploy - Open Source Alternative to Vercel, Heroku and Netlify." />
-    </a>
-</div>
-
-</br>
-<div align="center">
-  <div>Join us on Discord for help, feedback, and discussions!</div>
+  <a href="https://dokploy.com">
+    <img src=".github/sponsors/logo.png" alt="Dokploy - Open Source Alternative to Vercel, Heroku and Netlify." align="center" width="100%"  />
+  </a>
   </br>
+  </br>
+  <p>Join us on Discord for help, feedback, and discussions!</p>
   <a href="https://discord.gg/2tBnJ3jDJc">
     <img src="https://discordapp.com/api/guilds/1234073262418563112/widget.png?style=banner2" alt="Discord Shield"/>
   </a>
 </div>
-</div>
 <br />
+
 Dokploy is a free, self-hostable Platform as a Service (PaaS) that simplifies the deployment and management of applications and databases.
 
 ### Features
@@ -61,55 +57,52 @@ For detailed documentation, visit [docs.dokploy.com](https://docs.dokploy.com).
 
 ### Hero Sponsors 🎖
 
-<div style="display: flex; align-items: center; gap: 20px;">
-  <a href="https://www.hostinger.com/vps-hosting?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;"><img src=".github/sponsors/hostinger.jpg" alt="Hostinger" height="50"/></a>
-  <a href="https://www.lxaer.com/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;"><img src=".github/sponsors/lxaer.png" alt="LX Aer" height="50"/></a>
-  <a href="https://mandarin3d.com/?ref=dokploy" target="_blank" style="display: inline-block;"><img src=".github/sponsors/mandarin.png" alt="Mandarin" height="50"/></a>
-  <a href="https://lightnode.com/?ref=dokploy" target="_blank" style="display: inline-block;"><img src=".github/sponsors/light-node.webp" alt="Lightnode" height="70"/></a>
-
+<div>
+  <a href="https://www.hostinger.com/vps-hosting?ref=dokploy"><img src=".github/sponsors/hostinger.jpg" alt="Hostinger" width="300"/></a>
+  <a href="https://www.lxaer.com/?ref=dokploy"><img src=".github/sponsors/lxaer.png" alt="LX Aer" width="100"/></a>
+  <a href="https://mandarin3d.com/?ref=dokploy"><img src=".github/sponsors/mandarin.png" alt="Mandarin" width="100"/></a>
+  <a href="https://lightnode.com/?ref=dokploy"><img src=".github/sponsors/light-node.webp" alt="Lightnode" width="300"/></a>
 </div>
+
+<!-- Premium Supporters 🥇 -->
+
+<!-- Add Premium Supporters here -->
 
 ### Premium Supporters 🥇
 
-<div style="display: flex; align-items: center; gap: 20px;">
-  <a href="https://supafort.com/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 20px;"><img src="https://supafort.com/build/q-4Ht4rBZR.webp" alt="Supafort.com" height="50"/></a>
-  <a href="https://agentdock.ai/?ref=dokploy" target="_blank" style="display: inline-block; margin-right: 50px;"><img src=".github/sponsors/agentdock.png" alt="agentdock.ai" height="70"/></a>
-
+<div>
+  <a href="https://supafort.com/?ref=dokploy"><img src="https://supafort.com/build/q-4Ht4rBZR.webp" alt="Supafort.com" width="300"/></a>
+  <a href="https://agentdock.ai/?ref=dokploy"><img src=".github/sponsors/agentdock.png" alt="agentdock.ai" width="100"/></a>
 </div>
 
-### Elite Contributors 🥈
-
-<div style="display: flex; align-items: center; gap: 20px;">
-  <a href="https://americancloud.com/?ref=dokploy" target="_blank" style="display: inline-block; padding: 10px; border-radius: 10px;"><img src=".github/sponsors/american-cloud.png" alt="AmericanCloud" height="70"/></a>
-  <a href="https://tolgee.io/?utm_source=github_dokploy&utm_medium=banner&utm_campaign=dokploy" target="_blank" style="display: inline-block; margin-right: 10px;"><img src="https://dokploy.com/tolgee-logo.png" alt="Tolgee" height="80"/></a>
-
-</div>
 <!-- Elite Contributors 🥈 -->
-
-
 
 <!-- Add Elite Contributors here -->
 
-### Supporting Members 🥉
+### Elite Contributors 🥈
 
-<div style="display: flex; gap: 30px; flex-wrap: wrap;">
-<a href="https://lightspeed.run/?ref=dokploy"><img src="https://github.com/lightspeedrun.png" width="60px" alt="Lightspeed.run"/></a>
-<a href="https://cloudblast.io/?ref=dokploy "><img src="https://cloudblast.io/img/logo-icon.193cf13e.svg" width="250px" alt="Cloudblast.io"/></a>
-<a href="https://startupfa.me/?ref=dokploy "><img src=".github/sponsors/startupfame.png" width="65px" alt="Startupfame"/></a>
-<a href="https://itsdb-center.com?ref=dokploy "><img src=".github/sponsors/its.png" width="65px" alt="Itsdb-center"/></a>
-<a href="https://openalternative.co/?ref=dokploy "><img src=".github/sponsors/openalternative.png" width="65px" alt="Openalternative"/></a>
-<a href="https://synexa.ai/?ref=dokploy"><img src=".github/sponsors/synexa.png" width="65px" alt="Synexa"/></a>
-
+<div>
+  <a href="https://americancloud.com/?ref=dokploy"><img src=".github/sponsors/american-cloud.png" alt="AmericanCloud" width="300"/></a>
+  <a href="https://tolgee.io/?utm_source=github_dokploy&utm_medium=banner&utm_campaign=dokploy"><img src="https://dokploy.com/tolgee-logo.png" alt="Tolgee" width="100"/></a>
 </div>
 
+### Supporting Members 🥉
+
+<div>
+  <a href="https://lightspeed.run/?ref=dokploy"><img src="https://github.com/lightspeedrun.png" width="60px" alt="Lightspeed.run"/></a>
+  <a href="https://cloudblast.io/?ref=dokploy"><img src="https://cloudblast.io/img/logo-icon.193cf13e.svg" width="250px" alt="Cloudblast.io"/></a>
+  <a href="https://startupfa.me/?ref=dokploy"><img src=".github/sponsors/startupfame.png" width="65px" alt="Startupfame"/></a>
+  <a href="https://itsdb-center.com?ref=dokploy"><img src=".github/sponsors/its.png" width="65px" alt="Itsdb-center"/></a>
+  <a href="https://openalternative.co/?ref=dokploy"><img src=".github/sponsors/openalternative.png" width="65px" alt="Openalternative"/></a>
+  <a href="https://synexa.ai/?ref=dokploy"><img src=".github/sponsors/synexa.png" width="65px" alt="Synexa"/></a>
+</div>
 
 ### Community Backers 🤝
 
-<div style="display: flex; gap: 30px; flex-wrap: wrap;">
-<a href="https://steamsets.com/?ref=dokploy"><img src="https://avatars.githubusercontent.com/u/111978405?s=200&v=4" width="60px" alt="Steamsets.com"/></a>
-<a href="https://rivo.gg/?ref=dokploy"><img src="https://avatars.githubusercontent.com/u/126797452?s=200&v=4" width="60px" alt="Rivo.gg"/></a>
-<a href="https://photoquest.wedding/?ref=dokploy"><img src="https://photoquest.wedding/favicon/android-chrome-512x512.png" width="60px" alt="Rivo.gg"/></a>
-
+<div>
+  <a href="https://steamsets.com/?ref=dokploy"><img src="https://avatars.githubusercontent.com/u/111978405?s=200&v=4" width="60px" alt="Steamsets.com"/></a>
+  <a href="https://rivo.gg/?ref=dokploy"><img src="https://avatars.githubusercontent.com/u/126797452?s=200&v=4" width="60px" alt="Rivo.gg"/></a>
+  <a href="https://photoquest.wedding/?ref=dokploy"><img src="https://photoquest.wedding/favicon/android-chrome-512x512.png" width="60px" alt="Rivo.gg"/></a>
 </div>
 
 #### Organizations:
@@ -124,12 +117,12 @@ For detailed documentation, visit [docs.dokploy.com](https://docs.dokploy.com).
 
 <a href="https://github.com/dokploy/dokploy/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=dokploy/dokploy" />
-  </a>
+</a>
 
 ## Video Tutorial
 
 <a href="https://youtu.be/mznYKPvhcfw">
-  <img src="https://dokploy.com/banner.png" alt="Watch the video" width="400" style="border-radius:20px;"/>
+  <img src="https://dokploy.com/banner.png" alt="Watch the video" width="400"/>
 </a>
 
 ## Contributing


### PR DESCRIPTION
## Summary

Fix broken sponsor images and cleanup HTML structure in the [README](https://github.com/Dokploy/dokploy/blob/canary/README.md)

Documentation:
- Update sponsor image tags with correct src paths and width attributes
- Simplify HTML structure by removing redundant wrappers and inline styles
- Comment out empty placeholders for Premium Supporters and Elite Contributors

## Description

At #2108, I updated the [README.md](https://github.com/Dokploy/dokploy/blob/canary/README.md) to fix blue underlink.
However, the sponsers images styles were broken at that time.

This PR improves that appearance.

In addition, according to [GitHub Markup](https://github.com/github/markup) ...

> 2. The HTML is sanitized, aggressively removing things that could harm you and your kin—such as script tags, inline-styles, and class or id attributes.

Then inline-styles aren't enabled in GitHub README.md.
Moreover, `target=_blank` in `<a>` tag doesn't work, either.

In conclusion, remove unnecessary inline-styles and `target=_blank`.

## Appearance

You can see [the preview](https://github.com/Marukome0743/dokploy/blob/sponser/README.md) in my repo.

| Before | After |
|--------|--------|
| ![スクリーンショット 2025-07-07 102918](https://github.com/user-attachments/assets/90296cb2-b6e1-4597-b7f9-5badfa8e5007) | ![スクリーンショット 2025-07-07 102853](https://github.com/user-attachments/assets/675c9119-d735-4de0-92dd-4bbc2c38bbe4) |