### PR TITLE
fix(ui): adjust tablist item width for compose services

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -214,12 +214,12 @@ const Service = (
 									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-scroll">
 										<TabsList
 											className={cn(
-												"xl:grid xl:w-fit max-md:overflow-y-scroll justify-start",
+												"flex gap-8 justify-start max-xl:overflow-x-scroll overflow-y-hidden",
 												isCloud && data?.serverId
-													? "xl:grid-cols-10"
+													? "md:grid-cols-7"
 													: data?.serverId
-														? "xl:grid-cols-9"
-														: "xl:grid-cols-10",
+														? "md:grid-cols-6"
+														: "md:grid-cols-7",
 											)}
 										>
 											<TabsTrigger value="general">General</TabsTrigger>


### PR DESCRIPTION
Looks like "Volume Backup" was introduced recently, causing some UI issues.
The changes here is to simply to use the same tab list logic in compose as applications.

## Before

![before](https://github.com/user-attachments/assets/9074d0e2-d712-49ea-bad6-32d8f52f13c4)

## After

![after](https://github.com/user-attachments/assets/3f95729c-5fda-440a-9d50-669303318e47)
