### PR TITLE
fix(ui): tabs overflow and Tailwind config

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/show.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/show.tsx
@@ -153,8 +153,8 @@ export const ShowProviderForm = ({ applicationId }: Props) => {
 						setSab(e as TabState);
 					}}
 				>
-					<div className="flex flex-row items-center justify-between w-full gap-4">
-						<TabsList className="md:grid md:w-fit md:grid-cols-7 max-md:overflow-x-scroll justify-start bg-transparent overflow-y-hidden">
+					<div className="flex flex-row items-center justify-between w-full overflow-auto">
+						<TabsList className="flex gap-4 justify-start bg-transparent">
 							<TabsTrigger
 								value="github"
 								className="rounded-none border-b-2 gap-2 border-b-transparent data-[state=active]:border-b-2 data-[state=active]:border-b-border"

--- a/apps/dokploy/components/dashboard/compose/general/generic/show.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/show.tsx
@@ -142,8 +142,8 @@ export const ShowProviderFormCompose = ({ composeId }: Props) => {
 						setSab(e as TabState);
 					}}
 				>
-					<div className="flex flex-row items-center justify-between w-full gap-4">
-						<TabsList className="md:grid md:w-fit md:grid-cols-6 max-md:overflow-x-scroll justify-start bg-transparent overflow-y-hidden">
+					<div className="flex flex-row items-center justify-between w-full overflow-auto">
+						<TabsList className="flex gap-4 justify-start bg-transparent">
 							<TabsTrigger
 								value="github"
 								className="rounded-none border-b-2 gap-2 border-b-transparent data-[state=active]:border-b-2 data-[state=active]:border-b-border"

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -111,13 +111,13 @@ const Service = (
 				</title>
 			</Head>
 			<div className="w-full">
-				<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
+				<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 					<div className="rounded-xl bg-background shadow-md ">
 						<CardHeader className="flex flex-row justify-between items-center">
 							<div className="flex flex-col">
 								<CardTitle className="text-xl flex flex-row gap-2">
 									<div className="relative flex flex-row gap-4">
-										<div className="absolute -right-1  -top-2">
+										<div className="absolute -right-1 -top-2">
 											<StatusTooltip status={data?.applicationStatus} />
 										</div>
 
@@ -299,7 +299,7 @@ const Service = (
 									</TabsContent>
 
 									<TabsContent value="logs">
-										<div className="flex flex-col gap-4  pt-2.5">
+										<div className="flex flex-col gap-4 pt-2.5">
 											<ShowDockerLogs
 												appName={data?.appName || ""}
 												serverId={data?.serverId || ""}
@@ -307,7 +307,7 @@ const Service = (
 										</div>
 									</TabsContent>
 									<TabsContent value="schedules">
-										<div className="flex flex-col gap-4  pt-2.5">
+										<div className="flex flex-col gap-4 pt-2.5">
 											<ShowSchedules
 												id={applicationId}
 												scheduleType="application"
@@ -315,7 +315,7 @@ const Service = (
 										</div>
 									</TabsContent>
 									<TabsContent value="deployments" className="w-full pt-2.5">
-										<div className="flex flex-col gap-4  border rounded-lg">
+										<div className="flex flex-col gap-4 border rounded-lg">
 											<ShowDeployments
 												id={applicationId}
 												type="application"
@@ -325,7 +325,7 @@ const Service = (
 										</div>
 									</TabsContent>
 									<TabsContent value="volume-backups" className="w-full pt-2.5">
-										<div className="flex flex-col gap-4  border rounded-lg">
+										<div className="flex flex-col gap-4 border rounded-lg">
 											<ShowVolumeBackups
 												id={applicationId}
 												type="application"

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -218,17 +218,9 @@ const Service = (
 										router.push(newPath);
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-scroll">
+									<div className="flex flex-row items-center justify-between w-full overflow-auto">
 										<TabsList
-											className={cn(
-												"flex gap-8 justify-start max-xl:overflow-x-scroll overflow-y-hidden",
-												isCloud && data?.serverId
-													? "md:grid-cols-7"
-													: data?.serverId
-														? "md:grid-cols-6"
-														: "md:grid-cols-7",
-											)}
-										>
+											className="flex gap-8 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -219,7 +219,7 @@ const Service = (
 									}}
 								>
 									<div className="flex flex-row items-center justify-between w-full overflow-auto">
-										<TabsList className="flex gap-8 justify-start">
+										<TabsList className="flex gap-8 max-md:gap-4 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -219,8 +219,7 @@ const Service = (
 									}}
 								>
 									<div className="flex flex-row items-center justify-between w-full overflow-auto">
-										<TabsList
-											className="flex gap-8 justify-start">
+										<TabsList className="flex gap-8 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -102,14 +102,14 @@ const Service = (
 				</title>
 			</Head>
 			<div className="w-full">
-				<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
+				<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 					<div className="rounded-xl bg-background shadow-md ">
 						<div className="flex flex-col gap-4">
 							<CardHeader className="flex flex-row justify-between items-center">
 								<div className="flex flex-col">
 									<CardTitle className="text-xl flex flex-row gap-2">
 										<div className="relative flex flex-row gap-4">
-											<div className="absolute -right-1  -top-2">
+											<div className="absolute -right-1 -top-2">
 												<StatusTooltip status={data?.composeStatus} />
 											</div>
 
@@ -331,7 +331,7 @@ const Service = (
 									</TabsContent>
 
 									<TabsContent value="deployments" className="w-full pt-2.5">
-										<div className="flex flex-col gap-4  border rounded-lg">
+										<div className="flex flex-col gap-4 border rounded-lg">
 											<ShowDeployments
 												id={composeId}
 												type="compose"

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -211,17 +211,8 @@ const Service = (
 										router.push(newPath);
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-scroll">
-										<TabsList
-											className={cn(
-												"flex gap-8 justify-start max-xl:overflow-x-scroll overflow-y-hidden",
-												isCloud && data?.serverId
-													? "md:grid-cols-7"
-													: data?.serverId
-														? "md:grid-cols-6"
-														: "md:grid-cols-7",
-											)}
-										>
+									<div className="flex flex-row items-center w-full overflow-auto">
+										<TabsList className="flex gap-8 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -212,7 +212,7 @@ const Service = (
 									}}
 								>
 									<div className="flex flex-row items-center w-full overflow-auto">
-										<TabsList className="flex gap-8 justify-start">
+										<TabsList className="flex gap-8 max-md:gap-4 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>

--- a/apps/dokploy/tailwind.config.ts
+++ b/apps/dokploy/tailwind.config.ts
@@ -23,7 +23,7 @@ const config = {
 				sans: ["var(--font-inter)", ...defaultTheme.fontFamily.sans],
 			},
 			screens: {
-				"3xl": "120rem",
+				"3xl": "1920px",
 			},
 			maxWidth: {
 				"2xl": "40rem",


### PR DESCRIPTION
There are improvements:
- Removed `overflow-x: scroll` as this CSS creates empty scrollbar at wide screens.
- Changed grid layout to flex since this is not a table view, but a row of elements.
- Removed double `overflow-x: scroll` and `overflow-y: hidden` because in the first case you get a double scroll, and in the second case something may be unexpectedly hidden.
Now the entire tablist is a row of elements that are horizontally located with some indentation from each other. It is wrapped by an element that has a fixed width of 100%. It is responsible for scrolling if something does not fit.
- Fixed provider tabs layout.
- Fixed not working min-* max-* tailwind variants: `warn - The 'min-*' and 'max-*' variants are not supported with a 'screens' configuration containing mixed units`. As default config has [screens breakpoints defined in px](https://v3.tailwindcss.com/docs/screens) I've changed screen `3xl: 120rem` -> `1920px`

**Before**
small screen has a double scroll bar and the tabs don't fit vertically
![image](https://github.com/user-attachments/assets/502adf67-5df6-4075-ba82-6be9729284a2)

large screen has empty x scrollbar
![image](https://github.com/user-attachments/assets/815ab8ae-1184-49c4-afcc-8c9a61488372)

provider tablist looks like a mess with some screen width
![image](https://github.com/user-attachments/assets/06d547a7-8d84-4ba1-8185-adbb793ecfd7)
![image](https://github.com/user-attachments/assets/09e168cf-6c23-4604-91b0-8e1cb4d6cff6)

got warning and not working `max-*:` directives
![Снимок экрана 2025-07-09 181355](https://github.com/user-attachments/assets/c57c3c21-a157-41aa-a7b9-958b4d57e94e)



**After**
small screen has a single scrollbar and the tabs fit vertically
![image](https://github.com/user-attachments/assets/2a0cff3c-4f7b-4807-95cd-f8e52e920aec)

large screen dosn't have empty scrollbar
![image](https://github.com/user-attachments/assets/284c759e-84e3-437c-9599-8f087aceefe8)

provider tablist looks good and scrolls with any screen width
![image](https://github.com/user-attachments/assets/a2b6d5d9-bc52-4877-8d0b-8ac2d5950d1e)

`max-*:` directives work
![image](https://github.com/user-attachments/assets/918c32fd-d96d-403f-a160-ba44a53c2988)

