### PR TITLE
fix: Add gitlabUrl calculation logic and update link references

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -43,7 +43,7 @@ import { api } from "@/utils/api";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CheckIcon, ChevronsUpDown, HelpCircle, Plus, X } from "lucide-react";
 import Link from "next/link";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -95,6 +95,16 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 
 	const repository = form.watch("repository");
 	const gitlabId = form.watch("gitlabId");
+
+	const gitlabUrl = useMemo(() => {
+		const url = gitlabProviders?.find(
+			(provider) => provider.gitlabId === gitlabId,
+		)?.gitlabUrl;
+
+		const gitlabUrl = url?.replace(/\/$/, "");
+
+		return gitlabUrl || "https://gitlab.com";
+	}, [gitlabId, gitlabProviders]);
 
 	const {
 		data: repositories,
@@ -224,7 +234,7 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 										<FormLabel>Repository</FormLabel>
 										{field.value.owner && field.value.repo && (
 											<Link
-												href={`https://gitlab.com/${field.value.owner}/${field.value.repo}`}
+												href={`${gitlabUrl}/${field.value.owner}/${field.value.repo}`}
 												target="_blank"
 												rel="noopener noreferrer"
 												className="flex items-center gap-1 text-sm text-muted-foreground hover:text-primary"

--- a/apps/dokploy/server/api/routers/gitlab.ts
+++ b/apps/dokploy/server/api/routers/gitlab.ts
@@ -76,6 +76,7 @@ export const gitlabRouter = createTRPCRouter({
 					gitProvider: {
 						...provider.gitProvider,
 					},
+					gitlabUrl: provider.gitlabUrl,
 				};
 			});
 


### PR DESCRIPTION
- Use the useMemo hook to calculate gitlabUrl in the SaveGitlabProvider component.
- Update link references to use the dynamically generated gitlabUrl, ensuring links correctly point to the corresponding GitLab repositories.