### PR TITLE
fix(gitlab): Support dynamically generating clone URLs based on protocols

### DIFF
--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -84,9 +84,14 @@ export type ApplicationWithGitlab = InferResultType<
 
 export type ComposeWithGitlab = InferResultType<"compose", { gitlab: true }>;
 
-export type GitlabInfo = ApplicationWithGitlab['gitlab'] | ComposeWithGitlab['gitlab'];
+export type GitlabInfo =
+	| ApplicationWithGitlab["gitlab"]
+	| ComposeWithGitlab["gitlab"];
 
-const getGitlabRepoClone = (gitlab: GitlabInfo, gitlabPathNamespace: string | null) => {
+const getGitlabRepoClone = (
+	gitlab: GitlabInfo,
+	gitlabPathNamespace: string | null,
+) => {
 	const repoClone = `${gitlab?.gitlabUrl.replace(/^https?:\/\//, "")}/${gitlabPathNamespace}.git`;
 	return repoClone;
 };
@@ -96,7 +101,6 @@ const getGitlabCloneUrl = (gitlab: GitlabInfo, repoClone: string) => {
 	const cloneUrl = `http${isSecure ? "s" : ""}://oauth2:${gitlab?.accessToken}@${repoClone}`;
 	return cloneUrl;
 };
- 
 
 export const cloneGitlabRepository = async (
 	entity: ApplicationWithGitlab | ComposeWithGitlab,


### PR DESCRIPTION
fix(gitlab): Support dynamically generating clone URLs based on protocols


<img width="1042" height="381" alt="image" src="https://github.com/user-attachments/assets/c3d6ff34-5229-4cb8-b4fa-7a987095e9b8" />
