### PR TITLE
chore: add biome settings for vscode editor

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+	"editor.formatOnSave": true,
+	"editor.defaultFormatter": "biomejs.biome",
+	"editor.codeActionsOnSave": {
+		"source.fixAll.biome": "explicit",
+		"source.organizeImports.biome": "explicit"
+	}
+}


### PR DESCRIPTION
## Summary

Add VSCode workspace configurations to recommend the Biome extension and apply its settings

Chores:
- Add .vscode/extensions.json to recommend the Biome editor extension
- Add .vscode/settings.json to configure Biome as the default formatter and enable its features on save