### PR TITLE
chore(package): version up pnpm to v9.12.0

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,5 +29,9 @@
 		"tsx": "^4.16.2",
 		"typescript": "^5.8.3"
 	},
-	"packageManager": "pnpm@9.5.0"
+	"packageManager": "pnpm@9.12.0",
+	"engines": {
+		"node": "^20.16.0",
+		"pnpm": ">=9.12.0"
+	}
 }

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -187,10 +187,10 @@
 	"ct3aMetadata": {
 		"initVersion": "7.25.2"
 	},
-	"packageManager": "pnpm@9.5.0",
+	"packageManager": "pnpm@9.12.0",
 	"engines": {
 		"node": "^20.16.0",
-		"pnpm": ">=9.5.0"
+		"pnpm": ">=9.12.0"
 	},
 	"lint-staged": {
 		"*": [

--- a/apps/schedules/package.json
+++ b/apps/schedules/package.json
@@ -29,5 +29,9 @@
 		"tsx": "^4.16.2",
 		"typescript": "^5.8.3"
 	},
-	"packageManager": "pnpm@9.5.0"
+	"packageManager": "pnpm@9.12.0",
+	"engines": {
+		"node": "^20.16.0",
+		"pnpm": ">=9.12.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
 		"lint-staged": "^15.5.2",
 		"tsx": "4.16.2"
 	},
-	"packageManager": "pnpm@9.5.0",
+	"packageManager": "pnpm@9.12.0",
 	"engines": {
 		"node": "^20.16.0",
-		"pnpm": ">=9.5.0"
+		"pnpm": ">=9.12.0"
 	},
 	"lint-staged": {
 		"*": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -105,5 +105,10 @@
     "tsc-alias": "1.8.10",
     "tsx": "^4.16.2",
     "typescript": "^5.8.3"
+  },
+  "packageManager": "pnpm@9.12.0",
+  "engines": {
+    "node": "^20.16.0",
+    "pnpm": ">=9.12.0"
   }
 }


### PR DESCRIPTION
## Summary

Update the pnpm version and enforce engine constraints across all packages.

Build:
- Bump packageManager pnpm version to v9.12.0 in all package.json files
- Add engines field to require Node >=20.16.0 and pnpm >=9.12.0 in all packages

## Why?

Dockerfiles specified [pnpm@9.12.0](https://github.com/pnpm/pnpm/releases/tag/v9.12.0) at [`19f7465`](https://github.com/Dokploy/dokploy/commit/19f746591016dc3f456d9bea015d3deb38819072).
It's good to match [`packageManager` field in `package.json` for corepack](https://github.com/nodejs/corepack/tree/main?tab=readme-ov-file#when-authoring-packages).