### PR TITLE
chore: remove `apps/monitoring` from `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 packages:
   - "apps/api"
   - "apps/dokploy"
-  - "apps/monitoring"
   - "apps/schedules"
   - "packages/server"


### PR DESCRIPTION
## Summary

Chores:
- Remove `apps/monitoring` from `pnpm-workspace.yaml` packages list

## Why?

At #1267, [`apps/monitoring`](https://github.com/Dokploy/dokploy/tree/canary/apps/monitoring) was added to [`pnpm-workspace.yaml`](https://github.com/Dokploy/dokploy/blob/canary/pnpm-workspace.yaml).
However, pnpm can't manage it due to [Go](https://go.dev/) application.