### PR TITLE
fix: standardize dokploy version prefix handling

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get version from package.json
         id: package_version
-        run: echo "VERSION=$(jq -r .version ./apps/dokploy/package.json)" >> $GITHUB_ENV
+        run: echo "VERSION=v$(jq -r .version ./apps/dokploy/package.json)" >> $GITHUB_ENV
 
       - name: Get latest GitHub tag
         id: latest_tag

--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             TAG="latest"
-            VERSION=$(node -p "require('./apps/dokploy/package.json').version")
+            VERSION=v$(node -p "require('./apps/dokploy/package.json').version")
           elif [ "${{ github.ref }}" = "refs/heads/canary" ]; then
             TAG="canary"
           else
@@ -67,10 +67,10 @@ jobs:
       - name: Set tag and version
         id: meta
         run: |
-          VERSION=$(node -p "require('./apps/dokploy/package.json').version")
+          VERSION=v$(node -p "require('./apps/dokploy/package.json').version")
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             TAG="latest"
-            VERSION=$(node -p "require('./apps/dokploy/package.json').version")
+            VERSION=v$(node -p "require('./apps/dokploy/package.json').version")
           elif [ "${{ github.ref }}" = "refs/heads/canary" ]; then
             TAG="canary"
           else
@@ -110,7 +110,7 @@ jobs:
       - name: Create and push manifests
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            VERSION=$(node -p "require('./apps/dokploy/package.json').version")
+            VERSION=v$(node -p "require('./apps/dokploy/package.json').version")
             TAG="latest"
 
             docker buildx imagetools create -t ${IMAGE_NAME}:${TAG} \
@@ -147,7 +147,7 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          VERSION=$(node -p "require('./apps/dokploy/package.json').version")
+          VERSION=v$(node -p "require('./apps/dokploy/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Release

--- a/apps/dokploy/docker/build.sh
+++ b/apps/dokploy/docker/build.sh
@@ -6,7 +6,7 @@ BUILD_TYPE=${1:-production}
 if [ "$BUILD_TYPE" == "canary" ]; then
     TAG="canary"
 else
-    VERSION=$(node -p "require('./package.json').version")
+    VERSION=v$(node -p "require('./package.json').version")
     TAG="$VERSION"
 fi
 

--- a/apps/dokploy/docker/push.sh
+++ b/apps/dokploy/docker/push.sh
@@ -11,7 +11,7 @@ if [ "$BUILD_TYPE" == "canary" ]; then
         docker buildx build --platform linux/amd64,linux/arm64 --pull --rm -t "dokploy/dokploy:${TAG}" -f 'Dockerfile' --push .
 else
     echo  "PUSHING PRODUCTION"
-    VERSION=$(node -p "require('./package.json').version")
+    VERSION=v$(node -p "require('./package.json').version")
     docker buildx build --platform linux/amd64,linux/arm64 --pull --rm -t "dokploy/dokploy:latest" -t "dokploy/dokploy:${VERSION}" -f 'Dockerfile' --push .
 fi
 

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dokploy",
-	"version": "v0.24.4",
+	"version": "0.24.4",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",
@@ -33,7 +33,7 @@
 		"docker:push": "./docker/push.sh",
 		"docker:build:canary": "./docker/build.sh canary",
 		"docker:push:canary": "./docker/push.sh canary",
-		"version": "echo $(node -p \"require('./package.json').version\")",
+		"version": "echo v$(node -p \"require('./package.json').version\")",
 		"test": "vitest --config __test__/vitest.config.ts"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary

Standardize semantic version handling by stripping the 'v' prefix from the package manifest and injecting it where needed for CI, release, and Docker image tagging.

Enhancements:
- Unify version tagging by removing the 'v' prefix from package.json and consistently adding it in workflows and Docker scripts

Build:
- Update GitHub workflows to prefix versions with 'v' when setting tags and outputs

Chores:
- Modify build and push shell scripts to apply the 'v' prefix to Docker image tags
- Adjust package.json version field to use raw semver without a 'v' prefix

## Reference

[package.json version](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#version)