### PR TITLE
refactor: lint and sort import on dokploy application

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -1,4 +1,5 @@
 import { DateTooltip } from "@/components/shared/date-tooltip";
+import { DialogAction } from "@/components/shared/dialog-action";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,14 +11,13 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { type RouterOutputs, api } from "@/utils/api";
-import { Clock, Loader2, RocketIcon, Settings, RefreshCcw } from "lucide-react";
+import { Clock, Loader2, RefreshCcw, RocketIcon, Settings } from "lucide-react";
 import React, { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ShowRollbackSettings } from "../rollbacks/show-rollback-settings";
 import { CancelQueues } from "./cancel-queues";
 import { RefreshToken } from "./refresh-token";
 import { ShowDeployment } from "./show-deployment";
-import { ShowRollbackSettings } from "../rollbacks/show-rollback-settings";
-import { DialogAction } from "@/components/shared/dialog-action";
-import { toast } from "sonner";
 
 interface Props {
 	id: string;

--- a/apps/dokploy/components/dashboard/application/volume-backups/restore-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/restore-volume-backups.tsx
@@ -1,3 +1,4 @@
+import { AlertBlock } from "@/components/shared/alert-block";
 import { DrawerLogs } from "@/components/shared/drawer-logs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -42,9 +43,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-import { type LogLine, parseLogs } from "../../docker/logs/utils";
 import { formatBytes } from "../../database/backups/restore-backup";
-import { AlertBlock } from "@/components/shared/alert-block";
+import { type LogLine, parseLogs } from "../../docker/logs/utils";
 
 interface Props {
 	id: string;

--- a/apps/dokploy/components/dashboard/application/volume-backups/show-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/show-volume-backups.tsx
@@ -23,8 +23,8 @@ import {
 	Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
-import { HandleVolumeBackups } from "./handle-volume-backups";
 import { ShowDeploymentsModal } from "../deployments/show-deployments-modal";
+import { HandleVolumeBackups } from "./handle-volume-backups";
 import { RestoreVolumeBackups } from "./restore-volume-backups";
 
 interface Props {

--- a/apps/dokploy/components/dashboard/compose/general/generic/show.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/show.tsx
@@ -1,3 +1,4 @@
+import { UnauthorizedGitProvider } from "@/components/dashboard/application/general/generic/unauthorized-git-provider";
 import {
 	BitbucketIcon,
 	GitIcon,
@@ -11,6 +12,7 @@ import { api } from "@/utils/api";
 import { CodeIcon, GitBranch, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { toast } from "sonner";
 import { ComposeFileEditor } from "../compose-file-editor";
 import { ShowConvertedCompose } from "../show-converted-compose";
 import { SaveBitbucketProviderCompose } from "./save-bitbucket-provider-compose";
@@ -18,8 +20,6 @@ import { SaveGitProviderCompose } from "./save-git-provider-compose";
 import { SaveGiteaProviderCompose } from "./save-gitea-provider-compose";
 import { SaveGithubProviderCompose } from "./save-github-provider-compose";
 import { SaveGitlabProviderCompose } from "./save-gitlab-provider-compose";
-import { UnauthorizedGitProvider } from "@/components/dashboard/application/general/generic/unauthorized-git-provider";
-import { toast } from "sonner";
 
 type TabState = "github" | "git" | "raw" | "gitlab" | "bitbucket" | "gitea";
 interface Props {

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -5,14 +5,14 @@ import { myQueue } from "@/server/queues/queueSetup";
 import { deploy } from "@/server/utils/deploy";
 import {
 	IS_CLOUD,
+	checkUserRepositoryPermissions,
 	createPreviewDeployment,
+	createSecurityBlockedComment,
+	findGithubById,
 	findPreviewDeploymentByApplicationId,
 	findPreviewDeploymentsByPullRequestId,
 	removePreviewDeployment,
 	shouldDeploy,
-	findGithubById,
-	checkUserRepositoryPermissions,
-	createSecurityBlockedComment,
 } from "@dokploy/server";
 import { Webhooks } from "@octokit/webhooks";
 import { and, eq } from "drizzle-orm";

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -37,7 +37,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
 import { validateRequest } from "@dokploy/server/lib/auth";

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -33,7 +33,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
 import { validateRequest } from "@dokploy/server/lib/auth";

--- a/apps/dokploy/server/api/root.ts
+++ b/apps/dokploy/server/api/root.ts
@@ -28,6 +28,8 @@ import { projectRouter } from "./routers/project";
 import { redirectsRouter } from "./routers/redirects";
 import { redisRouter } from "./routers/redis";
 import { registryRouter } from "./routers/registry";
+import { rollbackRouter } from "./routers/rollbacks";
+import { scheduleRouter } from "./routers/schedule";
 import { securityRouter } from "./routers/security";
 import { serverRouter } from "./routers/server";
 import { settingsRouter } from "./routers/settings";
@@ -35,8 +37,6 @@ import { sshRouter } from "./routers/ssh-key";
 import { stripeRouter } from "./routers/stripe";
 import { swarmRouter } from "./routers/swarm";
 import { userRouter } from "./routers/user";
-import { scheduleRouter } from "./routers/schedule";
-import { rollbackRouter } from "./routers/rollbacks";
 import { volumeBackupsRouter } from "./routers/volume-backups";
 /**
  * This is the primary router for your server.

--- a/apps/dokploy/server/api/routers/deployment.ts
+++ b/apps/dokploy/server/api/routers/deployment.ts
@@ -20,8 +20,8 @@ import {
 } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
 import { desc, eq } from "drizzle-orm";
-import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const deploymentRouter = createTRPCRouter({
 	all: protectedProcedure

--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -8,9 +8,9 @@ import {
 	getServiceContainersByAppName,
 	getStackContainersByAppName,
 } from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
-import { TRPCError } from "@trpc/server";
 
 export const containerIdRegex = /^[a-zA-Z0-9.\-_]+$/;
 

--- a/apps/dokploy/server/api/routers/mount.ts
+++ b/apps/dokploy/server/api/routers/mount.ts
@@ -12,8 +12,8 @@ import {
 	getServiceContainer,
 	updateMount,
 } from "@dokploy/server";
-import { createTRPCRouter, protectedProcedure } from "../trpc";
 import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const mountRouter = createTRPCRouter({
 	create: protectedProcedure

--- a/apps/dokploy/server/api/routers/swarm.ts
+++ b/apps/dokploy/server/api/routers/swarm.ts
@@ -4,10 +4,10 @@ import {
 	getNodeInfo,
 	getSwarmNodes,
 } from "@dokploy/server";
+import { findServerById } from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
-import { TRPCError } from "@trpc/server";
-import { findServerById } from "@dokploy/server";
 import { containerIdRegex } from "./docker";
 
 export const swarmRouter = createTRPCRouter({

--- a/apps/dokploy/server/api/routers/volume-backups.ts
+++ b/apps/dokploy/server/api/routers/volume-backups.ts
@@ -1,30 +1,30 @@
+import { removeJob, schedule, updateJob } from "@/server/utils/backup";
 import {
 	IS_CLOUD,
-	updateVolumeBackup,
-	removeVolumeBackup,
 	createVolumeBackup,
-	runVolumeBackup,
 	findVolumeBackupById,
-	restoreVolume,
-	scheduleVolumeBackup,
+	removeVolumeBackup,
 	removeVolumeBackupJob,
+	restoreVolume,
+	runVolumeBackup,
+	scheduleVolumeBackup,
+	updateVolumeBackup,
 } from "@dokploy/server";
+import { db } from "@dokploy/server/db";
 import {
 	createVolumeBackupSchema,
 	updateVolumeBackupSchema,
 	volumeBackups,
 } from "@dokploy/server/db/schema";
-import { z } from "zod";
-import { createTRPCRouter, protectedProcedure } from "../trpc";
-import { db } from "@dokploy/server/db";
-import { eq } from "drizzle-orm";
-import { observable } from "@trpc/server/observable";
 import {
 	execAsyncRemote,
 	execAsyncStream,
 } from "@dokploy/server/utils/process/execAsync";
-import { removeJob, schedule, updateJob } from "@/server/utils/backup";
 import { TRPCError } from "@trpc/server";
+import { observable } from "@trpc/server/observable";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const volumeBackupsRouter = createTRPCRouter({
 	list: protectedProcedure

--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -5,6 +5,7 @@ import {
 	initializeTraefik,
 } from "@dokploy/server/setup/traefik-setup";
 
+import { execAsync } from "@dokploy/server";
 import { setupDirectories } from "@dokploy/server/setup/config-paths";
 import { initializePostgres } from "@dokploy/server/setup/postgres-setup";
 import { initializeRedis } from "@dokploy/server/setup/redis-setup";
@@ -12,7 +13,6 @@ import {
 	initializeNetwork,
 	initializeSwarm,
 } from "@dokploy/server/setup/setup";
-import { execAsync } from "@dokploy/server";
 (async () => {
 	try {
 		setupDirectories();


### PR DESCRIPTION
## Summary

Refactor the dokploy application by linting and organising imports, removing dead code, and improving code style consistency.

Enhancements:
- Standardise and alphabetise imports across server API routers and React components
- Remove unused and redundant imports to clean up codebase
- Add missing utility imports where necessary
- Tidy up code formatting and grouping for consistency

## How to test

```bash
pnpm biome check apps/dokploy
```