### PR TITLE
refactor: lint and sort imports on dokploy/server

### DIFF
--- a/packages/server/src/db/schema/deployment.ts
+++ b/packages/server/src/db/schema/deployment.ts
@@ -13,9 +13,9 @@ import { applications } from "./application";
 import { backups } from "./backups";
 import { compose } from "./compose";
 import { previewDeployments } from "./preview-deployments";
+import { rollbacks } from "./rollbacks";
 import { schedules } from "./schedule";
 import { server } from "./server";
-import { rollbacks } from "./rollbacks";
 import { volumeBackups } from "./volume-backups";
 export const deploymentStatus = pgEnum("deploymentStatus", [
 	"running",

--- a/packages/server/src/db/schema/rollbacks.ts
+++ b/packages/server/src/db/schema/rollbacks.ts
@@ -1,14 +1,14 @@
+import type { Application } from "@dokploy/server/services/application";
+import type { Mount } from "@dokploy/server/services/mount";
+import type { Port } from "@dokploy/server/services/port";
+import type { Project } from "@dokploy/server/services/project";
+import type { Registry } from "@dokploy/server/services/registry";
 import { relations } from "drizzle-orm";
 import { jsonb, pgTable, serial, text } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { deployments } from "./deployment";
-import type { Application } from "@dokploy/server/services/application";
-import type { Project } from "@dokploy/server/services/project";
-import type { Mount } from "@dokploy/server/services/mount";
-import type { Port } from "@dokploy/server/services/port";
-import type { Registry } from "@dokploy/server/services/registry";
 
 export const rollbacks = pgTable("rollback", {
 	rollbackId: text("rollbackId")

--- a/packages/server/src/db/schema/user.ts
+++ b/packages/server/src/db/schema/user.ts
@@ -1,3 +1,4 @@
+import { paths } from "@dokploy/server/constants";
 import { relations } from "drizzle-orm";
 import {
 	boolean,
@@ -15,7 +16,6 @@ import { backups } from "./backups";
 import { projects } from "./project";
 import { schedules } from "./schedule";
 import { certificateType } from "./shared";
-import { paths } from "@dokploy/server/constants";
 /**
  * This is an example of how to use the multi-project schema feature of Drizzle ORM. Use the same
  * database instance for multiple projects.

--- a/packages/server/src/db/schema/volume-backups.ts
+++ b/packages/server/src/db/schema/volume-backups.ts
@@ -3,16 +3,16 @@ import { boolean, integer, pgTable, text } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { nanoid } from "nanoid";
 import { z } from "zod";
-import { serviceType } from "./mount";
 import { applications } from "./application";
-import { mongo } from "./mongo";
-import { mysql } from "./mysql";
-import { redis } from "./redis";
 import { compose } from "./compose";
-import { postgres } from "./postgres";
-import { mariadb } from "./mariadb";
-import { destinations } from "./destination";
 import { deployments } from "./deployment";
+import { destinations } from "./destination";
+import { mariadb } from "./mariadb";
+import { mongo } from "./mongo";
+import { serviceType } from "./mount";
+import { mysql } from "./mysql";
+import { postgres } from "./postgres";
+import { redis } from "./redis";
 import { generateAppName } from "./utils";
 
 export const volumeBackups = pgTable("volume_backup", {

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -31,8 +31,8 @@ import {
 	findPreviewDeploymentById,
 	updatePreviewDeployment,
 } from "./preview-deployment";
-import { findScheduleById } from "./schedule";
 import { removeRollbackById } from "./rollbacks";
+import { findScheduleById } from "./schedule";
 import { findVolumeBackupById } from "./volume-backups";
 
 export type Deployment = typeof deployments.$inferSelect;

--- a/packages/server/src/services/rollbacks.ts
+++ b/packages/server/src/services/rollbacks.ts
@@ -1,27 +1,27 @@
+import type { CreateServiceOptions } from "dockerode";
 import { eq } from "drizzle-orm";
+import type { z } from "zod";
 import { db } from "../db";
 import {
 	type createRollbackSchema,
-	rollbacks,
 	deployments as deploymentsSchema,
+	rollbacks,
 } from "../db/schema";
-import type { z } from "zod";
-import { type Application, findApplicationById } from "./application";
-import { getRemoteDocker } from "../utils/servers/remote-docker";
-import { getAuthConfig, type ApplicationNested } from "../utils/builders";
-import { execAsync, execAsyncRemote } from "../utils/process/execAsync";
-import type { CreateServiceOptions } from "dockerode";
-import { findDeploymentById } from "./deployment";
+import { type ApplicationNested, getAuthConfig } from "../utils/builders";
 import {
-	prepareEnvironmentVariables,
 	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateVolumeMounts,
+	prepareEnvironmentVariables,
 } from "../utils/docker/utils";
-import type { Project } from "./project";
+import { execAsync, execAsyncRemote } from "../utils/process/execAsync";
+import { getRemoteDocker } from "../utils/servers/remote-docker";
+import { type Application, findApplicationById } from "./application";
+import { findDeploymentById } from "./deployment";
 import type { Mount } from "./mount";
 import type { Port } from "./port";
+import type { Project } from "./project";
 
 export const createRollback = async (
 	input: z.infer<typeof createRollbackSchema>,

--- a/packages/server/src/services/volume-backups.ts
+++ b/packages/server/src/services/volume-backups.ts
@@ -1,12 +1,12 @@
+import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
+import type { z } from "zod";
+import { db } from "../db";
 import {
 	type createVolumeBackupSchema,
 	type updateVolumeBackupSchema,
 	volumeBackups,
 } from "../db/schema";
-import { db } from "../db";
-import { TRPCError } from "@trpc/server";
-import type { z } from "zod";
 
 export const findVolumeBackupById = async (volumeBackupId: string) => {
 	const volumeBackup = await db.query.volumeBackups.findFirst({

--- a/packages/server/src/utils/docker/collision.ts
+++ b/packages/server/src/utils/docker/collision.ts
@@ -1,8 +1,8 @@
 import { findComposeById } from "@dokploy/server/services/compose";
 import { dump, load } from "js-yaml";
 import { addAppNameToAllServiceNames } from "./collision/root-network";
-import { addSuffixToAllVolumes } from "./compose/volume";
 import { generateRandomHash } from "./compose";
+import { addSuffixToAllVolumes } from "./compose/volume";
 import type { ComposeSpecification } from "./types";
 
 export const addAppNameToPreventCollision = (

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -1,6 +1,6 @@
 import fs, { writeFileSync } from "node:fs";
-import path from "node:path";
 import { createReadStream } from "node:fs";
+import path from "node:path";
 import { createInterface } from "node:readline";
 import { paths } from "@dokploy/server/constants";
 import type { Domain } from "@dokploy/server/services/domain";

--- a/packages/server/src/utils/traefik/middleware.ts
+++ b/packages/server/src/utils/traefik/middleware.ts
@@ -1,12 +1,12 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
+import type { Domain } from "@dokploy/server/services/domain";
 import { dump, load } from "js-yaml";
 import type { ApplicationNested } from "../builders";
 import { execAsyncRemote } from "../process/execAsync";
 import { writeTraefikConfigRemote } from "./application";
 import type { FileConfig } from "./file-types";
-import type { Domain } from "@dokploy/server/services/domain";
 
 export const addMiddleware = (config: FileConfig, middlewareName: string) => {
 	if (config.http?.routers) {

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -1,9 +1,9 @@
-import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
-import { normalizeS3Path } from "../backups/utils";
-import { getS3Credentials } from "../backups/utils";
 import path from "node:path";
 import { paths } from "@dokploy/server/constants";
 import { findComposeById } from "@dokploy/server/services/compose";
+import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
+import { normalizeS3Path } from "../backups/utils";
+import { getS3Credentials } from "../backups/utils";
 
 export const backupVolume = async (
 	volumeBackup: Awaited<ReturnType<typeof findVolumeBackupById>>,

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
 	findApplicationById,
 	findComposeById,
@@ -5,7 +6,6 @@ import {
 	getS3Credentials,
 	paths,
 } from "../..";
-import path from "node:path";
 
 export const restoreVolume = async (
 	id: string,

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -1,4 +1,5 @@
 import { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
+import { scheduleJob, scheduledJobs } from "node-schedule";
 import {
 	createDeploymentVolumeBackup,
 	execAsync,
@@ -6,7 +7,6 @@ import {
 	updateDeploymentStatus,
 } from "../..";
 import { backupVolume } from "./backup";
-import { scheduleJob, scheduledJobs } from "node-schedule";
 
 export const scheduleVolumeBackup = async (volumeBackupId: string) => {
 	const volumeBackup = await findVolumeBackupById(volumeBackupId);


### PR DESCRIPTION
## Summary

Standardize and clean up import statements across the server package by sorting, grouping type imports, and removing duplicates.

Enhancements:
- Sort and group imports alphabetically and separate type imports from value imports in server modules
- Remove duplicate and unused imports across various server files for consistency

## How to test

```bash
pnpm biome check packages/server
```