### PR TITLE
fix: wrap user prompt in ai modal to prevent text stretch

### DIFF
--- a/apps/dokploy/components/dashboard/project/ai/step-two.tsx
+++ b/apps/dokploy/components/dashboard/project/ai/step-two.tsx
@@ -199,7 +199,7 @@ export const StepTwo = ({ templateInfo, setTemplateInfo }: StepProps) => {
 				<p className="text-muted-foreground">
 					Generating template suggestions based on your input...
 				</p>
-				<pre>{templateInfo.userInput}</pre>
+				<pre className="whitespace-normal">{templateInfo.userInput}</pre>
 			</div>
 		);
 	}


### PR DESCRIPTION
adds a whitespace-normal className for preformatted tag to override default pre behavior of `whitespace: no-wrap`

Before:
<img width="991" height="609" alt="image" src="https://github.com/user-attachments/assets/87125805-8018-4f3d-885f-8220a5275d52" />


After:
<img width="966" height="686" alt="image" src="https://github.com/user-attachments/assets/cac4c524-d97f-4bcf-9f00-d17f9738081a" />
