### PR TITLE
feat: preview deployments for pull requests with specific labels

### DIFF
--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -42,6 +42,7 @@ const schema = z
 		wildcardDomain: z.string(),
 		port: z.number(),
 		previewLimit: z.number(),
+        previewLabels: z.string(),
 		previewHttps: z.boolean(),
 		previewPath: z.string(),
 		previewCertificateType: z.enum(["letsencrypt", "none", "custom"]),
@@ -81,6 +82,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 			wildcardDomain: "*.traefik.me",
 			port: 3000,
 			previewLimit: 3,
+            previewLabels: "",
 			previewHttps: false,
 			previewPath: "/",
 			previewCertificateType: "none",
@@ -102,6 +104,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 				buildArgs: data.previewBuildArgs || "",
 				wildcardDomain: data.previewWildcard || "*.traefik.me",
 				port: data.previewPort || 3000,
+                previewLabels: data.previewLabels || "",
 				previewLimit: data.previewLimit || 3,
 				previewHttps: data.previewHttps || false,
 				previewPath: data.previewPath || "/",
@@ -119,6 +122,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 			previewBuildArgs: formData.buildArgs,
 			previewWildcard: formData.wildcardDomain,
 			previewPort: formData.port,
+            previewLabels: formData.previewLabels,
 			applicationId,
 			previewLimit: formData.previewLimit,
 			previewHttps: formData.previewHttps,
@@ -195,6 +199,19 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 												<FormLabel>Port</FormLabel>
 												<FormControl>
 													<NumberInput placeholder="3000" {...field} />
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={form.control}
+										name="previewLabels"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Labels</FormLabel>
+												<FormControl>
+													<Input placeholder="enhancement,needs-review (Leave empty for all labels)" {...field} />
 												</FormControl>
 												<FormMessage />
 											</FormItem>

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -442,6 +442,19 @@ export default async function handler(
 			}
 
 			for (const app of secureApps) {
+				// check for labels
+				let hasLabel: boolean = false;
+				const labels = githubBody?.pull_request?.labels;
+				const previewLabels = app?.previewLabels?.split(",");
+				for (const label of labels) {
+					if (previewLabels.contains(label.name)) {
+						hasLabel = true;
+						break;
+					}
+				}
+				if (hasLabel)
+				    continue;
+
 				const previewLimit = app?.previewLimit || 0;
 				if (app?.previewDeployments?.length > previewLimit) {
 					continue;

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -119,6 +119,7 @@ export const applications = pgTable("application", {
 	previewEnv: text("previewEnv"),
 	watchPaths: text("watchPaths").array(),
 	previewBuildArgs: text("previewBuildArgs"),
+	previewLabels: text("previewLabels"),
 	previewWildcard: text("previewWildcard"),
 	previewPort: integer("previewPort").default(3000),
 	previewHttps: boolean("previewHttps").notNull().default(false),


### PR DESCRIPTION
## Summary

Dokploy will now check for specified labels on pull requests before creating preview deployments.  

## Changes

- Add `previewLables` field to application schema
- Add updating of the preview labels to the preview settings UI'
- Check the pull request has one of the labels before deploying a preview deployment

## TODO

- [ ] Properly test the feature

I will be opening a pull request on the documentation repository shortly
Closes #1989 