### PR TITLE
fix(dashboard): Update app security view to hide password

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
@@ -7,13 +7,13 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { Input } from "@/components/ui/input";
 import { api } from "@/utils/api";
 import { LockKeyhole, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { HandleSecurity } from "./handle-security";
-import { Label } from "@/components/ui/label";
-import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
-import { Input } from "@/components/ui/input";
 
 interface Props {
 	applicationId: string;

--- a/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/security/show-security.tsx
@@ -11,6 +11,9 @@ import { api } from "@/utils/api";
 import { LockKeyhole, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { HandleSecurity } from "./handle-security";
+import { Label } from "@/components/ui/label";
+import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { Input } from "@/components/ui/input";
 
 interface Props {
 	applicationId: string;
@@ -58,19 +61,18 @@ export const ShowSecurity = ({ applicationId }: Props) => {
 						<div className="flex flex-col gap-6 ">
 							{data?.security.map((security) => (
 								<div key={security.securityId}>
-									<div className="flex w-full flex-col sm:flex-row justify-between sm:items-center gap-4 sm:gap-10 border rounded-lg p-4">
-										<div className="grid grid-cols-1 sm:grid-cols-2 flex-col gap-4 sm:gap-8">
-											<div className="flex flex-col gap-1">
-												<span className="font-medium">Username</span>
-												<span className="text-sm text-muted-foreground">
-													{security.username}
-												</span>
+									<div className="flex w-full flex-col md:flex-row justify-between md:items-center gap-4 md:gap-10 border rounded-lg p-4">
+										<div className="grid grid-cols-1 md:grid-cols-2 flex-col gap-4 md:gap-8">
+											<div className="flex flex-col gap-2">
+												<Label>Username</Label>
+												<Input disabled value={security.username} />
 											</div>
-											<div className="flex flex-col gap-1">
-												<span className="font-medium">Password</span>
-												<span className="text-sm text-muted-foreground">
-													{security.password}
-												</span>
+											<div className="flex flex-col gap-2">
+												<Label>Password</Label>
+												<ToggleVisibilityInput
+													value={security.password}
+													disabled
+												/>
 											</div>
 										</div>
 										<div className="flex flex-row gap-2">


### PR DESCRIPTION
Updated the App > Advanced > Security view to hide the basic-auth password behind a ToggleVisibilityInput. This follows a similar theme for password fields elsewhere in the app.

Before
<img width="2080" height="338" alt="image" src="https://github.com/user-attachments/assets/5436d63c-5903-4490-9b0c-8e6fee1f9ba8" />

After
<img width="2071" height="359" alt="image" src="https://github.com/user-attachments/assets/6a60c812-8e67-4607-bb35-6f3138d275fc" />
