### PR TITLE
ci(format): define permissions for security

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [canary]
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

CI:
- Add explicit permissions: contents: read to the format workflow

## Description

If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used.
Repositories created under organizations inherit the organization permissions.
The organizations or repositories created before February 2023 have the default permissions set to read-write.

Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as `issues: write` or `pull-requests: write`.