### PR TITLE
fix(setup): properly handle dokploy-traefik container absence

### DIFF
--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -89,21 +89,14 @@ export const initializeStandaloneTraefik = async ({
 	const docker = await getRemoteDocker(serverId);
 	try {
 		const container = docker.getContainer(containerName);
-		try {
-			await container.remove({ force: true });
-			await new Promise((resolve) => setTimeout(resolve, 5000));
-			await docker.createContainer(settings);
-			const newContainer = docker.getContainer(containerName);
-			await newContainer.start();
-			console.log("Traefik Started ✅");
-		} catch (error) {
-			console.error("Error in initializeStandaloneTraefik", error);
-		}
-	} catch (error) {
-		await docker.createContainer(settings);
-		console.error("Error in initializeStandaloneTraefik", error);
-		throw error;
-	}
+		await container.remove({ force: true });
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+	} catch {}
+
+	await docker.createContainer(settings);
+	const newContainer = docker.getContainer(containerName);
+	await newContainer.start();
+	console.log("Traefik Started ✅");
 };
 
 export const initializeTraefikService = async ({


### PR DESCRIPTION
## What is this PR about?

When starting from scratch on the canary branch, this error occurs:

```
Swarm was initilized
Network was initilized
Main config already exists
Default traefik config already exists
Error in initializeStandaloneTraefik Error: (HTTP code 404) no such container - No such container: dokploy-traefik
    at /home/depado/dev/github.com/dokploy/dokploy/node_modules/.pnpm/docker-modem@5.0.6/node_modules/docker-modem/lib/modem.js:383:17
    at getCause (/home/depado/dev/github.com/dokploy/dokploy/node_modules/.pnpm/docker-modem@5.0.6/node_modules/docker-modem/lib/modem.js:418:7)
    at Modem.buildPayload (/home/depado/dev/github.com/dokploy/dokploy/node_modules/.pnpm/docker-modem@5.0.6/node_modules/docker-modem/lib/modem.js:379:5)
    at IncomingMessage.<anonymous> (/home/depado/dev/github.com/dokploy/dokploy/node_modules/.pnpm/docker-modem@5.0.6/node_modules/docker-modem/lib/modem.js:347:16)
    at IncomingMessage.emit (node:events:536:35)
    at endReadableNT (node:internal/streams/readable:1698:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  reason: 'no such container',
  statusCode: 404,
  json: { message: 'No such container: dokploy-traefik' }
}
```

This is due to the fact that the catched error if the container doesn't exist isn't properly re-thrown, thus skipping the traefik container creation altogether. 

With these changes, if the container already exists it gets deleted and recreated, and if it doesn't it gets created. 

Do tell me if that's not the desired behavior though!
Cheers and thanks for the amazing project!