### PR TITLE
fix: use configured GitLab URL instead of hardcoded gitlab.com

### DIFF
--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -316,7 +316,7 @@ export const getGitlabBranches = async (input: {
 
 	while (true) {
 		const branchesResponse = await fetch(
-			`https://gitlab.com/api/v4/projects/${input.id}/repository/branches?page=${page}&per_page=${perPage}`,
+			`${gitlabProvider.gitlabUrl}/api/v4/projects/${input.id}/repository/branches?page=${page}&per_page=${perPage}`,
 			{
 				headers: {
 					Authorization: `Bearer ${gitlabProvider.accessToken}`,


### PR DESCRIPTION
The previous pagination implementation accidentally hardcoded the GitLab URL to gitlab.com, breaking the integration for self-hosted GitLab instances.

Changes:
- Replace hardcoded 'https://gitlab.com' with gitlabProvider.gitlabUrl
- Maintains the pagination functionality added in previous commit

Fixes: GitLab branches API calls failing for self-hosted instances

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`, `fixes #ISSUE_NUMBER`, `resolves #ISSUE_NUMBER`

Example: `closes #123`

## Screenshots (if applicable)

If you include a video or screenshot, would be awesome so we can see the changes in action.