### PR TITLE
fix(traefik): on setup support serverId as parameter and input

### DIFF
--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -393,7 +393,7 @@ export const readPorts = async (
 
 export const writeTraefikSetup = async (
 	input: TraefikOptions,
-	serverId?: string,
+	serverId = input.serverId,
 ) => {
 	const resourceType = await getDockerResourceType("dokploy-traefik", serverId);
 	if (resourceType === "service") {

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -391,22 +391,22 @@ export const readPorts = async (
 	);
 };
 
-export const writeTraefikSetup = async (
-	input: TraefikOptions,
-	serverId = input.serverId,
-) => {
-	const resourceType = await getDockerResourceType("dokploy-traefik", serverId);
+export const writeTraefikSetup = async (input: TraefikOptions) => {
+	const resourceType = await getDockerResourceType(
+		"dokploy-traefik",
+		input.serverId,
+	);
 	if (resourceType === "service") {
 		await initializeTraefikService({
 			env: input.env,
 			additionalPorts: input.additionalPorts,
-			serverId: serverId,
+			serverId: input.serverId,
 		});
 	} else {
 		await initializeStandaloneTraefik({
 			env: input.env,
 			additionalPorts: input.additionalPorts,
-			serverId: serverId,
+			serverId: input.serverId,
 		});
 	}
 };


### PR DESCRIPTION
## What is this PR about?

Currently, updating a remote server's Traefik environment updates the local server's Traefik container instead instead.

The issue here is that the `serverId` can be passed in two different ways to `writeTraefikSetup`. This PR has the `serverId` parameter default to `input.serverId` if it isn't passed in. 

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Fixes #2351 

## Screenshots (if applicable)

Updating traefik env on a remote server is successful:

<img width="511" height="24" alt="image" src="https://github.com/user-attachments/assets/8129182d-3ad0-47a9-bcc4-8da2bf90a611" />

Inspecting the traefik container on remote server shows the updated env:

<img width="611" height="104" alt="Screenshot 2025-08-09 at 11 45 40" src="https://github.com/user-attachments/assets/9bba9c6e-3dcc-4db2-9e5c-622e85c5337e" />