### PR TITLE
fix: Added support for Basic Auth present in the GitLab URLs

### DIFF
--- a/apps/dokploy/pages/api/providers/gitlab/callback.ts
+++ b/apps/dokploy/pages/api/providers/gitlab/callback.ts
@@ -12,12 +12,29 @@ export default async function handler(
 	}
 
 	const gitlab = await findGitlabById(gitlabId as string);
+	const gitlabUrl = new URL(gitlab.gitlabUrl)
 
-	const response = await fetch(`${gitlab.gitlabUrl}/oauth/token`, {
+	const headers: HeadersInit = {
+		"Content-Type": "application/x-www-form-urlencoded"
+	}
+
+	// In case of basic auth being present in the URL, we need to remove it from the URL
+	// and add it to the Authorization header.
+	if (gitlabUrl.username && gitlabUrl.password) {
+		headers.Authorization = `Basic ${Buffer.from(`${gitlabUrl.username}:${gitlabUrl.password}`).toString("base64")}`;
+	}
+
+	const url = (gitlabUrl.username && gitlabUrl.password)
+		? new URL(gitlabUrl, {
+			...gitlabUrl,
+			username: "",
+			password: "",
+		}).toString()
+		: gitlabUrl.toString();
+
+	const response = await fetch(`${url}/oauth/token`, {
 		method: "POST",
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-		},
+		headers,
 		body: new URLSearchParams({
 			client_id: gitlab.applicationId as string,
 			client_secret: gitlab.secret as string,


### PR DESCRIPTION
## What is this PR about?

In the Git section, we are having a Gitlab application that is behind Basic HTTP Authentication.

<img width="1017" height="438" alt="image" src="https://github.com/user-attachments/assets/993841ff-0d39-4d07-bf77-2d3e811a2fa4" />

---

So we use the `username:password@host` pattern to fix it:

<img width="674" height="439" alt="image" src="https://github.com/user-attachments/assets/445e514f-bc01-4087-bb37-a989e3652db6" />

---

The problem is that when added to the URL, it does not work:

<img width="398" height="176" alt="image" src="https://github.com/user-attachments/assets/a769e50e-11da-4905-9fc1-ddf310b56762" />

---

So I changed a bit the behavior:

1. When `username:password` is present, it gets pulled out as `base64(username:password)` and set as `Authorization: Basic {base64string}`.
2. For other cases, it will act as-is.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Close automatically the related issues using the keywords: `closes #ISSUE_NUMBER`, `fixes #ISSUE_NUMBER`, `resolves #ISSUE_NUMBER`

Example: `closes #123`

## Screenshots (if applicable)

If you include a video or screenshot, would be awesome so we can see the changes in action.