### PR TITLE
add keyboard nav for compose/database pages

### DIFF
--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -111,7 +111,8 @@ export function UseKeyboardNav({ forPage }: { forPage: Page }) {
 					tag === "TEXTAREA" ||
 					tag === "SELECT" ||
 					active.getAttribute("role") === "textbox"
-				) return;
+				)
+					return;
 			}
 
 			if (isModPressed) {

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -3,7 +3,26 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-const SHORTCUTS = {
+const PAGES = ["compose", "application", "postgres", "redis"] as const;
+type Page = typeof PAGES[number];
+
+type Shortcuts = Record<string, string>;
+type ShortcutsDictionary = Record<Page, Shortcuts>;
+
+const COMPOSE_SHORTCUTS: Shortcuts = {
+	g: "general",
+	e: "environment",
+	u: "domains",
+	d: "deployments",
+	b: "backups",
+	s: "schedules",
+	v: "volumeBackups",
+	l: "logs",
+	m: "monitoring",
+	a: "advanced",
+};
+
+const APPLICATION_SHORTCUTS: Shortcuts = {
 	g: "general",
 	e: "environment",
 	u: "domains",
@@ -16,28 +35,48 @@ const SHORTCUTS = {
 	a: "advanced",
 };
 
+const POSTGRES_SHORTCUTS: Shortcuts = {
+	g: "general",
+	e: "environment",
+	l: "logs",
+	m: "monitoring",
+	b: "backups",
+	a: "advanced",
+};
+
+const REDIS_SHORTCUTS: Shortcuts = {
+	g: "general",
+	e: "environment",
+	l: "logs",
+	m: "monitoring",
+	a: "advanced",
+};
+
+const SHORTCUTS: ShortcutsDictionary = {
+  application: APPLICATION_SHORTCUTS,
+  compose: COMPOSE_SHORTCUTS,
+  postgres: POSTGRES_SHORTCUTS,
+  redis: REDIS_SHORTCUTS,
+};
+
 /**
- * Use this to register keyboard shortcuts for the application page. Each
- * shortcut must be prefixed with `g` (like GitHub).
+ * Use this to register keyboard shortcuts for different pages. Each shortcut
+ * must be prefixed with `g` (like GitHub).
  *
+ * @example
  * - `g g` "General",
  * - `g e` "Environment",
  * - `g u` "Domains",
- * - `g p` "Preview Deployments",
- * - `g s` "Schedules",
- * - `g v` "Volume Backups",
- * - `g d` "Deployments",
- * - `g l` "Logs",
- * - `g m` "Monitoring",
- * - `g a` "Advanced"
  */
-export function UseKeyboardNavForApplications() {
+export function UseKeyboardNav({ forPage }: { forPage: Page }) {
 	const [isModPressed, setModPressed] = useState(false);
 	const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
 
 	const sp = useSearchParams();
 	const router = useRouter();
 	const pathname = usePathname();
+
+  const shortcuts = SHORTCUTS[forPage];
 
 	const updateSearchParam = useCallback(
 		(name: string, value: string) => {
@@ -55,10 +94,10 @@ export function UseKeyboardNavForApplications() {
 				if (timer) clearTimeout(timer);
 				setModPressed(false);
 
-				if (key in SHORTCUTS) {
-					const tab = SHORTCUTS[key as keyof typeof SHORTCUTS];
+				if (key in shortcuts) {
+					const tab = shortcuts[key]!;
 					router.push(
-						`${pathname}?${updateSearchParam("tab", tab.toLowerCase())}`,
+						`${pathname}?${updateSearchParam("tab", tab)}`,
 					);
 				}
 			} else {

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -3,7 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-const PAGES = ["compose", "application", "postgres", "redis"] as const;
+const PAGES = ["compose", "application", "postgres", "redis", "mysql"] as const;
 type Page = typeof PAGES[number];
 
 type Shortcuts = Record<string, string>;
@@ -57,6 +57,7 @@ const SHORTCUTS: ShortcutsDictionary = {
   compose: COMPOSE_SHORTCUTS,
   postgres: POSTGRES_SHORTCUTS,
   redis: REDIS_SHORTCUTS,
+  mysql: POSTGRES_SHORTCUTS,
 };
 
 /**

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -3,7 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-const PAGES = ["compose", "application", "postgres", "redis", "mysql"] as const;
+const PAGES = ["compose", "application", "postgres", "redis", "mysql", "mariadb", "mongodb"] as const;
 type Page = (typeof PAGES)[number];
 
 type Shortcuts = Record<string, string>;
@@ -58,6 +58,8 @@ const SHORTCUTS: ShortcutsDictionary = {
 	postgres: POSTGRES_SHORTCUTS,
 	redis: REDIS_SHORTCUTS,
 	mysql: POSTGRES_SHORTCUTS,
+	mariadb: POSTGRES_SHORTCUTS,
+	mongodb: POSTGRES_SHORTCUTS,
 };
 
 /**

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -100,7 +100,20 @@ export function UseKeyboardNav({ forPage }: { forPage: Page }) {
 	);
 
 	useEffect(() => {
-		const handleKeyDown = ({ key }: KeyboardEvent) => {
+		const handleKeyDown = ({ key, target }: KeyboardEvent) => {
+			const active = target as HTMLElement | null;
+
+			if (active) {
+				const tag = active.tagName;
+				if (
+					active.isContentEditable ||
+					tag === "INPUT" ||
+					tag === "TEXTAREA" ||
+					tag === "SELECT" ||
+					active.getAttribute("role") === "textbox"
+				) return;
+			}
+
 			if (isModPressed) {
 				if (timer) clearTimeout(timer);
 				setModPressed(false);
@@ -109,11 +122,9 @@ export function UseKeyboardNav({ forPage }: { forPage: Page }) {
 					const tab = shortcuts[key]!;
 					router.push(`${pathname}?${updateSearchParam("tab", tab)}`);
 				}
-			} else {
-				if (key === "g") {
-					setModPressed(true);
-					setTimer(setTimeout(() => setModPressed(false), 5000));
-				}
+			} else if (key === "g") {
+				setModPressed(true);
+				setTimer(setTimeout(() => setModPressed(false), 5000));
 			}
 		};
 

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -3,7 +3,15 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-const PAGES = ["compose", "application", "postgres", "redis", "mysql", "mariadb", "mongodb"] as const;
+const PAGES = [
+	"compose",
+	"application",
+	"postgres",
+	"redis",
+	"mysql",
+	"mariadb",
+	"mongodb",
+] as const;
 type Page = (typeof PAGES)[number];
 
 type Shortcuts = Record<string, string>;

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -124,7 +124,7 @@ export function UseKeyboardNav({ forPage }: { forPage: Page }) {
 				}
 			} else if (key === "g") {
 				setModPressed(true);
-				setTimer(setTimeout(() => setModPressed(false), 5000));
+				setTimer(setTimeout(() => setModPressed(false), 1500));
 			}
 		};
 

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -10,46 +10,46 @@ type Shortcuts = Record<string, string>;
 type ShortcutsDictionary = Record<Page, Shortcuts>;
 
 const COMPOSE_SHORTCUTS: Shortcuts = {
-	g: "general",
-	e: "environment",
-	u: "domains",
-	d: "deployments",
-	b: "backups",
-	s: "schedules",
-	v: "volumeBackups",
-	l: "logs",
-	m: "monitoring",
-	a: "advanced",
+  g: "general",
+  e: "environment",
+  u: "domains",
+  d: "deployments",
+  b: "backups",
+  s: "schedules",
+  v: "volumeBackups",
+  l: "logs",
+  m: "monitoring",
+  a: "advanced",
 };
 
 const APPLICATION_SHORTCUTS: Shortcuts = {
-	g: "general",
-	e: "environment",
-	u: "domains",
-	p: "preview-deployments",
-	s: "schedules",
-	v: "volume-backups",
-	d: "deployments",
-	l: "logs",
-	m: "monitoring",
-	a: "advanced",
+  g: "general",
+  e: "environment",
+  u: "domains",
+  p: "preview-deployments",
+  s: "schedules",
+  v: "volume-backups",
+  d: "deployments",
+  l: "logs",
+  m: "monitoring",
+  a: "advanced",
 };
 
 const POSTGRES_SHORTCUTS: Shortcuts = {
-	g: "general",
-	e: "environment",
-	l: "logs",
-	m: "monitoring",
-	b: "backups",
-	a: "advanced",
+  g: "general",
+  e: "environment",
+  l: "logs",
+  m: "monitoring",
+  b: "backups",
+  a: "advanced",
 };
 
 const REDIS_SHORTCUTS: Shortcuts = {
-	g: "general",
-	e: "environment",
-	l: "logs",
-	m: "monitoring",
-	a: "advanced",
+  g: "general",
+  e: "environment",
+  l: "logs",
+  m: "monitoring",
+  a: "advanced",
 };
 
 const SHORTCUTS: ShortcutsDictionary = {
@@ -60,57 +60,57 @@ const SHORTCUTS: ShortcutsDictionary = {
 };
 
 /**
- * Use this to register keyboard shortcuts for different pages. Each shortcut
- * must be prefixed with `g` (like GitHub).
- *
- * @example
- * - `g g` "General",
- * - `g e` "Environment",
- * - `g u` "Domains",
- */
+* Use this to register keyboard shortcuts for different pages. Each shortcut
+* must be prefixed with `g` (like GitHub).
+*
+* @example
+* - `g g` "General",
+* - `g e` "Environment",
+* - `g u` "Domains",
+*/
 export function UseKeyboardNav({ forPage }: { forPage: Page }) {
-	const [isModPressed, setModPressed] = useState(false);
-	const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+  const [isModPressed, setModPressed] = useState(false);
+  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
 
-	const sp = useSearchParams();
-	const router = useRouter();
-	const pathname = usePathname();
+  const sp = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
 
   const shortcuts = SHORTCUTS[forPage];
 
-	const updateSearchParam = useCallback(
-		(name: string, value: string) => {
-			const params = new URLSearchParams(sp.toString());
-			params.set(name, value);
+  const updateSearchParam = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(sp.toString());
+      params.set(name, value);
 
-			return params.toString();
-		},
-		[sp],
-	);
+      return params.toString();
+    },
+    [sp],
+  );
 
-	useEffect(() => {
-		const handleKeyDown = ({ key }: KeyboardEvent) => {
-			if (isModPressed) {
-				if (timer) clearTimeout(timer);
-				setModPressed(false);
+  useEffect(() => {
+    const handleKeyDown = ({ key }: KeyboardEvent) => {
+      if (isModPressed) {
+        if (timer) clearTimeout(timer);
+        setModPressed(false);
 
-				if (key in shortcuts) {
-					const tab = shortcuts[key]!;
-					router.push(
-						`${pathname}?${updateSearchParam("tab", tab)}`,
-					);
-				}
-			} else {
-				if (key === "g") {
-					setModPressed(true);
-					setTimer(setTimeout(() => setModPressed(false), 5000));
-				}
-			}
-		};
+        if (key in shortcuts) {
+          const tab = shortcuts[key]!;
+          router.push(
+            `${pathname}?${updateSearchParam("tab", tab)}`,
+          );
+        }
+      } else {
+        if (key === "g") {
+          setModPressed(true);
+          setTimer(setTimeout(() => setModPressed(false), 5000));
+        }
+      }
+    };
 
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [isModPressed, timer, updateSearchParam, router, pathname]);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isModPressed, timer, updateSearchParam, router, pathname]);
 
-	return null;
+  return null;
 }

--- a/apps/dokploy/hooks/use-keyboard-nav.tsx
+++ b/apps/dokploy/hooks/use-keyboard-nav.tsx
@@ -4,114 +4,112 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 const PAGES = ["compose", "application", "postgres", "redis", "mysql"] as const;
-type Page = typeof PAGES[number];
+type Page = (typeof PAGES)[number];
 
 type Shortcuts = Record<string, string>;
 type ShortcutsDictionary = Record<Page, Shortcuts>;
 
 const COMPOSE_SHORTCUTS: Shortcuts = {
-  g: "general",
-  e: "environment",
-  u: "domains",
-  d: "deployments",
-  b: "backups",
-  s: "schedules",
-  v: "volumeBackups",
-  l: "logs",
-  m: "monitoring",
-  a: "advanced",
+	g: "general",
+	e: "environment",
+	u: "domains",
+	d: "deployments",
+	b: "backups",
+	s: "schedules",
+	v: "volumeBackups",
+	l: "logs",
+	m: "monitoring",
+	a: "advanced",
 };
 
 const APPLICATION_SHORTCUTS: Shortcuts = {
-  g: "general",
-  e: "environment",
-  u: "domains",
-  p: "preview-deployments",
-  s: "schedules",
-  v: "volume-backups",
-  d: "deployments",
-  l: "logs",
-  m: "monitoring",
-  a: "advanced",
+	g: "general",
+	e: "environment",
+	u: "domains",
+	p: "preview-deployments",
+	s: "schedules",
+	v: "volume-backups",
+	d: "deployments",
+	l: "logs",
+	m: "monitoring",
+	a: "advanced",
 };
 
 const POSTGRES_SHORTCUTS: Shortcuts = {
-  g: "general",
-  e: "environment",
-  l: "logs",
-  m: "monitoring",
-  b: "backups",
-  a: "advanced",
+	g: "general",
+	e: "environment",
+	l: "logs",
+	m: "monitoring",
+	b: "backups",
+	a: "advanced",
 };
 
 const REDIS_SHORTCUTS: Shortcuts = {
-  g: "general",
-  e: "environment",
-  l: "logs",
-  m: "monitoring",
-  a: "advanced",
+	g: "general",
+	e: "environment",
+	l: "logs",
+	m: "monitoring",
+	a: "advanced",
 };
 
 const SHORTCUTS: ShortcutsDictionary = {
-  application: APPLICATION_SHORTCUTS,
-  compose: COMPOSE_SHORTCUTS,
-  postgres: POSTGRES_SHORTCUTS,
-  redis: REDIS_SHORTCUTS,
-  mysql: POSTGRES_SHORTCUTS,
+	application: APPLICATION_SHORTCUTS,
+	compose: COMPOSE_SHORTCUTS,
+	postgres: POSTGRES_SHORTCUTS,
+	redis: REDIS_SHORTCUTS,
+	mysql: POSTGRES_SHORTCUTS,
 };
 
 /**
-* Use this to register keyboard shortcuts for different pages. Each shortcut
-* must be prefixed with `g` (like GitHub).
-*
-* @example
-* - `g g` "General",
-* - `g e` "Environment",
-* - `g u` "Domains",
-*/
+ * Use this to register keyboard shortcuts for different pages. Each shortcut
+ * must be prefixed with `g` (like GitHub).
+ *
+ * @example
+ * - `g g` "General",
+ * - `g e` "Environment",
+ * - `g u` "Domains",
+ */
 export function UseKeyboardNav({ forPage }: { forPage: Page }) {
-  const [isModPressed, setModPressed] = useState(false);
-  const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
+	const [isModPressed, setModPressed] = useState(false);
+	const [timer, setTimer] = useState<NodeJS.Timeout | null>(null);
 
-  const sp = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
+	const sp = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
 
-  const shortcuts = SHORTCUTS[forPage];
+	const shortcuts = SHORTCUTS[forPage];
 
-  const updateSearchParam = useCallback(
-    (name: string, value: string) => {
-      const params = new URLSearchParams(sp.toString());
-      params.set(name, value);
+	const updateSearchParam = useCallback(
+		(name: string, value: string) => {
+			const params = new URLSearchParams(sp.toString());
+			params.set(name, value);
 
-      return params.toString();
-    },
-    [sp],
-  );
+			return params.toString();
+		},
+		[sp],
+	);
 
-  useEffect(() => {
-    const handleKeyDown = ({ key }: KeyboardEvent) => {
-      if (isModPressed) {
-        if (timer) clearTimeout(timer);
-        setModPressed(false);
+	useEffect(() => {
+		const handleKeyDown = ({ key }: KeyboardEvent) => {
+			if (isModPressed) {
+				if (timer) clearTimeout(timer);
+				setModPressed(false);
 
-        if (key in shortcuts) {
-          const tab = shortcuts[key]!;
-          router.push(
-            `${pathname}?${updateSearchParam("tab", tab)}`,
-          );
-        }
-      } else {
-        if (key === "g") {
-          setModPressed(true);
-          setTimer(setTimeout(() => setModPressed(false), 5000));
-        }
-      }
-    };
+				if (key in shortcuts) {
+					const tab = shortcuts[key]!;
+					router.push(`${pathname}?${updateSearchParam("tab", tab)}`);
+				}
+			} else {
+				if (key === "g") {
+					setModPressed(true);
+					setTimer(setTimeout(() => setModPressed(false), 5000));
+				}
+			}
+		};
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isModPressed, timer, updateSearchParam, router, pathname]);
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [isModPressed, timer, updateSearchParam, router, pathname]);
 
-  return null;
+	return null;
 }

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -51,7 +51,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { UseKeyboardNavForApplications } from "@/hooks/use-keyboard-nav";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
 
@@ -92,7 +92,7 @@ const Service = (
 
 	return (
 		<div className="pb-10">
-			<UseKeyboardNavForApplications />
+      <UseKeyboardNav forPage="application" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/application/[applicationId].tsx
@@ -92,7 +92,7 @@ const Service = (
 
 	return (
 		<div className="pb-10">
-      <UseKeyboardNav forPage="application" />
+			<UseKeyboardNav forPage="application" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -83,7 +83,7 @@ const Service = (
 
 	return (
 		<div className="pb-10">
-		  <UseKeyboardNav forPage="compose" />
+			<UseKeyboardNav forPage="compose" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/compose/[composeId].tsx
@@ -48,6 +48,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
 
@@ -82,6 +83,7 @@ const Service = (
 
 	return (
 		<div className="pb-10">
+		  <UseKeyboardNav forPage="compose" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mariadb/[mariadbId].tsx
@@ -29,6 +29,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
@@ -63,6 +64,7 @@ const Mariadb = (
 
 	return (
 		<div className="pb-10">
+      <UseKeyboardNav forPage="mariadb" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mariadb/[mariadbId].tsx
@@ -64,7 +64,7 @@ const Mariadb = (
 
 	return (
 		<div className="pb-10">
-      <UseKeyboardNav forPage="mariadb" />
+			<UseKeyboardNav forPage="mariadb" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mongo/[mongoId].tsx
@@ -29,6 +29,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
@@ -63,6 +64,7 @@ const Mongo = (
 
 	return (
 		<div className="pb-10">
+		  <UseKeyboardNav forPage="mongodb" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mongo/[mongoId].tsx
@@ -64,7 +64,7 @@ const Mongo = (
 
 	return (
 		<div className="pb-10">
-		  <UseKeyboardNav forPage="mongodb" />
+			<UseKeyboardNav forPage="mongodb" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mysql/[mysqlId].tsx
@@ -63,7 +63,7 @@ const MySql = (
 
 	return (
 		<div className="pb-10">
-		  <UseKeyboardNav forPage="mysql" />
+			<UseKeyboardNav forPage="mysql" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/mysql/[mysqlId].tsx
@@ -29,6 +29,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
@@ -62,6 +63,7 @@ const MySql = (
 
 	return (
 		<div className="pb-10">
+		  <UseKeyboardNav forPage="mysql" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/postgres/[postgresId].tsx
@@ -63,7 +63,7 @@ const Postgresql = (
 
 	return (
 		<div className="pb-10">
-		  <UseKeyboardNav forPage="postgres" />
+			<UseKeyboardNav forPage="postgres" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/postgres/[postgresId].tsx
@@ -29,6 +29,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
@@ -62,6 +63,7 @@ const Postgresql = (
 
 	return (
 		<div className="pb-10">
+		  <UseKeyboardNav forPage="postgres" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/redis/[redisId].tsx
@@ -28,6 +28,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { UseKeyboardNav } from "@/hooks/use-keyboard-nav";
 import { cn } from "@/lib/utils";
 import { appRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
@@ -62,6 +63,7 @@ const Redis = (
 
 	return (
 		<div className="pb-10">
+      <UseKeyboardNav forPage="redis" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },

--- a/apps/dokploy/pages/dashboard/project/[projectId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/services/redis/[redisId].tsx
@@ -63,7 +63,7 @@ const Redis = (
 
 	return (
 		<div className="pb-10">
-      <UseKeyboardNav forPage="redis" />
+			<UseKeyboardNav forPage="redis" />
 			<BreadcrumbSidebar
 				list={[
 					{ name: "Projects", href: "/dashboard/projects" },


### PR DESCRIPTION
yesterday i added the application page shortcuts and this is just for more pages to have similar functionality. all the database pages and the compose page now have the shortcuts

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.