### PR TITLE
Trim ip address

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -112,7 +112,7 @@ export const HandleServers = ({ serverId }: Props) => {
 		await mutateAsync({
 			name: data.name,
 			description: data.description || "",
-			ipAddress: data.ipAddress || "",
+			ipAddress: data.ipAddress?.trim() || "",
 			port: data.port || 22,
 			username: data.username || "root",
 			sshKeyId: data.sshKeyId || "",

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -91,7 +91,7 @@ export const CreateServer = ({ stepper }: Props) => {
 		await mutateAsync({
 			name: data.name,
 			description: data.description || "",
-			ipAddress: data.ipAddress || "",
+			ipAddress: data.ipAddress?.trim() || "",
 			port: data.port || 22,
 			username: data.username || "root",
 			sshKeyId: data.sshKeyId || "",


### PR DESCRIPTION
## What is this PR about?

Users sometimes when they copy a server ip, they copy spaces with the ip accidentally 
ex: `192.168.1.101 ` instead of `192.168.1.101`. which causes the ssh connection to not work.

this is a simple fix that trims the ip from any white space, knowing that IP addresses never have white spaces, this should not cause any issue.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. (its a simple enough fix, doesn't need testing.

## Screenshots (if applicable)
<img width="799" height="906" alt="image" src="https://github.com/user-attachments/assets/57ed028e-3155-4333-bc8c-60bd1cf11c2d" />
<img width="1306" height="691" alt="image" src="https://github.com/user-attachments/assets/fa77c8e9-3261-407f-98d7-7589daff5e32" />
as seen in the picture, any white space in the ip address, causes the ssh connection to fail.