### PR TITLE
fix(template): duplicate key issue causing wrong formatting in template search

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -307,9 +307,9 @@ export const AddTemplate = ({ projectId, baseUrl }: Props) => {
 										: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6",
 								)}
 							>
-								{templates?.map((template) => (
+								{templates?.map((template, idx) => (
 									<div
-										key={template?.id}
+										key={`${template.id}-${template.version || 'default'}-${idx}`}
 										className={cn(
 											"flex flex-col border rounded-lg overflow-hidden relative",
 											viewMode === "icon" && "h-[200px]",


### PR DESCRIPTION
## What is this PR about?

This PR fixes some wrong formatting that happened when using the template search function (as described in #2382).

## Explanation

I believe the issue was caused by duplicate keys, as the key prop only contained the template ID. This resulted in multiple elements sharing the same key, which caused React to incorrectly update the templates due to the ambiguity.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

FIXES #2382 
