### PR TITLE
fix(ui): modal double scroll

### DIFF
--- a/apps/dokploy/components/ui/dialog.tsx
+++ b/apps/dokploy/components/ui/dialog.tsx
@@ -139,7 +139,7 @@ const DialogContent = React.forwardRef<
 				<div
 					ref={contentRef}
 					className={cn(
-						"overflow-y-auto overflow-x-hidden flex-1 min-h-0 overscroll-contain",
+						"flex flex-col overflow-auto flex-1 min-h-0 overscroll-contain",
 						!hasPaddingOverride && "p-6",
 					)}
 				>


### PR DESCRIPTION
## What is this PR about?

Changes display layout to fix overflow inside the modals with scrollable content like Templates.
This is the reason why the content is cut off and the second scrollbar appears.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots (if applicable)

Before:

<img width="1619" height="890" alt="image" src="https://github.com/user-attachments/assets/8ad783a1-8161-4191-b6dc-07f5151725ca" />
<img width="1615" height="884" alt="image" src="https://github.com/user-attachments/assets/a21c86a2-126e-42b1-8748-7260bed90ebc" />

https://github.com/user-attachments/assets/5d11dc96-76f4-460f-a03f-dff8e6f562b5



After:

<img width="1605" height="886" alt="image" src="https://github.com/user-attachments/assets/2ac7af79-bdcc-4f12-8a4e-521f66123f4d" />
<img width="1598" height="880" alt="image" src="https://github.com/user-attachments/assets/8c298f60-47af-4b50-893a-080a66f0d33d" />

https://github.com/user-attachments/assets/1e65d8d6-1586-4573-9928-e106713d5415

