### PR TITLE
feat: Self reference env variables

### DIFF
--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -273,6 +273,14 @@ export const prepareEnvironmentVariables = (
 				throw new Error(`Invalid project environment variable: project.${ref}`);
 			});
 		}
+
+		resolvedValue = resolvedValue.replace(/\$\{\{(.*?)\}\}/g, (_, ref) => {
+			if (serviceVars[ref] !== undefined) {
+				return serviceVars[ref];
+			}
+			throw new Error(`Invalid service environment variable: ${ref}`);
+		});
+
 		return `${key}=${resolvedValue}`;
 	});
 


### PR DESCRIPTION
## What is this PR about?

This PR introduces support for **self-referenced environment variables** in services.  
Example:  
```
APP_URL=${{DOKPLOY_DEPLOY_URL}}
```
will now resolve to:  
```
APP_URL=preview-pelican-panel-XX-XXX-XXX-XXX.traefik.me
```

This follows the same concept used by Railway, allowing services to interpolate their own environment variables without needing the `project.` prefix.

## Checklist
- [x] Created a dedicated branch based on `canary`.  
- [x] Read the CONTRIBUTING.md.  
- [x] Tested this PR locally.  

## Issues related (if applicable)
closes #2095 

## Screenshots / Demos (if applicable)

Tests have been added to verify self reference behavior.  
Example resolved output:  
```
APP_URL=preview-pelican-panel-XX-XXX-XXX-XXX.traefik.me
```

<img width="1029" height="895" alt="image" src="https://github.com/user-attachments/assets/9d0a2bb1-a1a2-4c61-ac0d-af9387fe374e" />
