### PR TITLE
fix(ui): scroll gutters stable

### DIFF
--- a/apps/dokploy/components/ui/sidebar.tsx
+++ b/apps/dokploy/components/ui/sidebar.tsx
@@ -329,10 +329,11 @@ const SidebarInset = React.forwardRef<
 		<main
 			ref={ref}
 			className={cn(
-				"relative flex min-h-svh  overflow-auto w-full flex-col bg-background",
+				"relative flex min-h-svh overflow-auto w-full flex-col bg-background",
 				"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
 				className,
 			)}
+			style={{ scrollbarGutter: "stable" }}
 			{...props}
 		/>
 	);

--- a/apps/dokploy/components/ui/sidebar.tsx
+++ b/apps/dokploy/components/ui/sidebar.tsx
@@ -148,7 +148,7 @@ const SidebarProvider = React.forwardRef<
 							} as React.CSSProperties
 						}
 						className={cn(
-							"group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
+							"group/sidebar-wrapper flex h-svh w-full has-[[data-variant=inset]]:bg-sidebar",
 							className,
 						)}
 						ref={ref}


### PR DESCRIPTION
## What is this PR about?

Changes the scrollbar styles to eliminate its hiding/appearing when opening a popover, which results in content shifting.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots

Before:

https://github.com/user-attachments/assets/7e8103b2-0bc3-4c30-9192-ad0d42c0c110


After:

https://github.com/user-attachments/assets/efa16a81-0eb8-4704-827c-1fe691aaafd1


