### PR TITLE
fix(ui): modal popover handle close

### DIFF
--- a/apps/dokploy/components/ui/dialog.tsx
+++ b/apps/dokploy/components/ui/dialog.tsx
@@ -123,7 +123,7 @@ const DialogContent = React.forwardRef<
 		<DialogPortal>
 			{/* Custom overlay for modal=false - no click handler to avoid Command conflicts */}
 			<div
-				className="fixed inset-0 z-50 bg-black/80 pointer-events-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+				className="fixed inset-0 z-50 bg-black/80 pointer-events-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
 				onClick={handleInteractOutside}
 			/>
 			<DialogPrimitive.Content

--- a/apps/dokploy/components/ui/dialog.tsx
+++ b/apps/dokploy/components/ui/dialog.tsx
@@ -123,16 +123,17 @@ const DialogContent = React.forwardRef<
 		<DialogPortal>
 			{/* Custom overlay for modal=false - no click handler to avoid Command conflicts */}
 			<div
-				className="fixed inset-0 z-50 bg-black/80 pointer-events-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+				className="fixed inset-0 z-50 bg-black/80 pointer-events-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
 				onClick={handleInteractOutside}
 			/>
 			<DialogPrimitive.Content
 				ref={ref}
 				className={cn(
-					"fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+					"fixed left-[50%] top-[50%] z-50 pointer-events-auto w-full max-w-lg translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
 					"flex flex-col max-h-[90vh]",
 					className,
 				)}
+				style={{ pointerEvents: "auto" }}
 				onInteractOutside={(event) => event.preventDefault()}
 				{...props}
 			>


### PR DESCRIPTION
## What is this PR about?

Clicking outside of tag dropdown in template modal closes the modal cause of conditional pointer events transparency.

Caused:
The problem was that when the popover appeared, the radix assigned the `pointer-event: none` to the modal window.
This made it transparent to the click, which resulted in the backdrop being clicked and subsequently closed.

Changes:
Make modal pointer events defined to prevent the logic described above.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Closes #2400 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/bdf1835b-0c38-41e8-b4b7-9631d76f5667


