### PR TITLE
feat: add autofocus to two-factor authentication input

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -329,6 +329,7 @@ export default function Home({ IS_CLOUD }: Props) {
 									maxLength={6}
 									pattern={REGEXP_ONLY_DIGITS}
 									autoComplete="off"
+									autoFocus
 								>
 									<InputOTPGroup>
 										<InputOTPSlot index={0} className="border-border" />


### PR DESCRIPTION
## What is this PR about?

This PR adds auto-focus functionality to the two-factor authentication form. When the OTP input component becomes visible after successful login form submission, the first input field automatically receives focus, improving the user experience by eliminating the need for users to manually click on the input field.

## Checklist

Before submitting this PR, please make sure that:

- [* ] You created a dedicated branch based on the `canary` branch.
- [ *] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ *] You have tested this PR in your local instance.
