### PR TITLE
fix(organization): integrate active organization refetching on update/create

### DIFF
--- a/apps/dokploy/components/dashboard/organization/handle-organization.tsx
+++ b/apps/dokploy/components/dashboard/organization/handle-organization.tsx
@@ -24,6 +24,7 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
 import { api } from "@/utils/api";
 
 const organizationSchema = z.object({
@@ -54,6 +55,8 @@ export function AddOrganization({ organizationId }: Props) {
 	const { mutateAsync, isLoading } = organizationId
 		? api.organization.update.useMutation()
 		: api.organization.create.useMutation();
+	const { refetch: refetchActiveOrganization } =
+		authClient.useActiveOrganization();
 
 	const form = useForm<OrganizationFormValues>({
 		resolver: zodResolver(organizationSchema),
@@ -84,6 +87,10 @@ export function AddOrganization({ organizationId }: Props) {
 					`Organization ${organizationId ? "updated" : "created"} successfully`,
 				);
 				utils.organization.all.invalidate();
+				if (organizationId) {
+					utils.organization.one.invalidate({ organizationId });
+					refetchActiveOrganization();
+				}
 				setOpen(false);
 			})
 			.catch((error) => {


### PR DESCRIPTION
## What is this PR about?

When the update organization operation is performed, the `activeOrganization?.name` value is not invalidated. The new organization name value is not visible without refreshing the page, and the old organization name value is rendered.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Video (if applicable)

https://github.com/user-attachments/assets/1bec3e16-0db7-4e24-8a5a-214fc90c4f8e