### PR TITLE
Change gitea permissions to new instances

### DIFF
--- a/apps/dokploy/utils/gitea-utils.ts
+++ b/apps/dokploy/utils/gitea-utils.ts
@@ -22,7 +22,7 @@ export const getGiteaOAuthUrl = (
 	}
 
 	const redirectUri = `${baseUrl}/api/providers/gitea/callback`;
-	const scopes = "repo repo:status read:user read:org";
+	const scopes = "read:repository read:user read:organization";
 
 	return `${giteaUrl}/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(
 		redirectUri,


### PR DESCRIPTION
## What is this PR about?

This changes the requested permission scopes for gitea providers, to more modern ones, and also allows forgejo to be compatible with dokploy.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Fixes #1832