### PR TITLE
fix: print error when docker build fails

### DIFF
--- a/packages/server/src/utils/providers/docker.ts
+++ b/packages/server/src/utils/providers/docker.ts
@@ -42,7 +42,7 @@ export const buildDocker = async (
 		await mechanizeDockerContainer(application);
 		writeStream.write("\nDocker Deployed: ✅\n");
 	} catch (error) {
-		writeStream.write("❌ Error");
+		writeStream.write("❌ ${error}");
 		throw error;
 	} finally {
 		writeStream.end();


### PR DESCRIPTION
## What is this PR about?

We keep getting errors like:

```
Initializing deployment
Build static
Pulling registry.dev.paperchemis.com/paper_chemis/backend:latest: ✅
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
latest: Pulling from paper_chemis/backend
Digest: sha256:2120ec5911d210f2addc380e1f1e2838cee59ace83750ad0918bc3da2069f9ea
Status: Image is up to date for registry.dev.paperchemis.com/paper_chemis/backend:latest
registry.dev.paperchemis.com/paper_chemis/backend:latest
❌ Error
```

No one knows what the problem is...

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.