### PR TITLE
fix(registries): special character passwords not working in registry creation.

### DIFF
--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -11,15 +11,19 @@ import { IS_CLOUD } from "../constants";
 export type Registry = typeof registry.$inferSelect;
 
 function shEscape(s: string | undefined): string {
-  if (!s) return "''";
-  return `'${s.replace(/'/g, `'\\''`)}'`;
+	if (!s) return "''";
+	return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-function safeDockerLoginCommand(registry: string | undefined, user: string | undefined, pass: string | undefined) {
-  const escapedRegistry = shEscape(registry)
-  const escapedUser = shEscape(user)
-  const escapedPassword = shEscape(pass)
-  return `printf %s ${escapedPassword} | docker login ${escapedRegistry} -u ${escapedUser} --password-stdin`;
+function safeDockerLoginCommand(
+	registry: string | undefined,
+	user: string | undefined,
+	pass: string | undefined,
+) {
+	const escapedRegistry = shEscape(registry);
+	const escapedUser = shEscape(user);
+	const escapedPassword = shEscape(pass);
+	return `printf %s ${escapedPassword} | docker login ${escapedRegistry} -u ${escapedUser} --password-stdin`;
 }
 
 export const createRegistry = async (
@@ -49,7 +53,11 @@ export const createRegistry = async (
 				message: "Select a server to add the registry",
 			});
 		}
-		const loginCommand = safeDockerLoginCommand(input.registryUrl, input.username, input.password)
+		const loginCommand = safeDockerLoginCommand(
+			input.registryUrl,
+			input.username,
+			input.password,
+		);
 		if (input.serverId && input.serverId !== "none") {
 			await execAsyncRemote(input.serverId, loginCommand);
 		} else if (newRegistry.registryType === "cloud") {
@@ -103,7 +111,11 @@ export const updateRegistry = async (
 			.returning()
 			.then((res) => res[0]);
 
-		const loginCommand = safeDockerLoginCommand(response?.registryUrl, response?.username, response?.password)
+		const loginCommand = safeDockerLoginCommand(
+			response?.registryUrl,
+			response?.username,
+			response?.password,
+		);
 
 		if (
 			IS_CLOUD &&


### PR DESCRIPTION
## What is this PR about?

As described in #2500, it was not possible to use passwords containing special characters when creating a registry in the dokploy interface. 
The way I implemented this fix every input username, password or registryUrl gets surrounded by `'` so that characters like `$` don't cause problems.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2500

## Notes
I tested this for registry creation and updating a registry.
For testing I used the password described by the author and a password containing a `'` (`12$j%QrQ*7HvaGb'Scf&D^`) to test resilience against `'` inside the password.
