### PR TITLE
feat: support cloning repositories over HTTP in Gitea integration

### DIFF
--- a/packages/server/src/utils/providers/gitea.ts
+++ b/packages/server/src/utils/providers/gitea.ts
@@ -100,16 +100,16 @@ export const refreshGiteaToken = async (giteaProviderId: string) => {
 };
 
 const buildGiteaCloneUrl = (
-    giteaUrl: string,
-    accessToken: string,
-    owner: string,
-    repository: string
+	giteaUrl: string,
+	accessToken: string,
+	owner: string,
+	repository: string,
 ) => {
-    const protocol = giteaUrl.startsWith("http://") ? "http" : "https";
-    const baseUrl = giteaUrl.replace(/^https?:\/\//, "");
-    const repoClone = `${owner}/${repository}.git`;
-    const cloneUrl = `${protocol}://oauth2:${accessToken}@${baseUrl}/${repoClone}`;
-    return cloneUrl;
+	const protocol = giteaUrl.startsWith("http://") ? "http" : "https";
+	const baseUrl = giteaUrl.replace(/^https?:\/\//, "");
+	const repoClone = `${owner}/${repository}.git`;
+	const cloneUrl = `${protocol}://oauth2:${accessToken}@${baseUrl}/${repoClone}`;
+	return cloneUrl;
 };
 
 export type ApplicationWithGitea = InferResultType<
@@ -161,8 +161,13 @@ export const getGiteaCloneCommand = async (
 	const basePath = isCompose ? COMPOSE_PATH : APPLICATIONS_PATH;
 	const outputPath = join(basePath, appName, "code");
 
-    const repoClone = `${giteaOwner}/${giteaRepository}.git`;
-    const cloneUrl = buildGiteaCloneUrl(gitea?.giteaUrl!, gitea?.accessToken!, giteaOwner!, giteaRepository!);
+	const repoClone = `${giteaOwner}/${giteaRepository}.git`;
+	const cloneUrl = buildGiteaCloneUrl(
+		gitea?.giteaUrl!,
+		gitea?.accessToken!,
+		giteaOwner!,
+		giteaRepository!,
+	);
 
 	const cloneCommand = `
     rm -rf ${outputPath};
@@ -216,8 +221,13 @@ export const cloneGiteaRepository = async (
 	const outputPath = join(basePath, appName, "code");
 	await recreateDirectory(outputPath);
 
-    const repoClone = `${giteaOwner}/${giteaRepository}.git`;
-    const cloneUrl = buildGiteaCloneUrl(giteaProvider.giteaUrl, giteaProvider.accessToken!, giteaOwner!, giteaRepository!);
+	const repoClone = `${giteaOwner}/${giteaRepository}.git`;
+	const cloneUrl = buildGiteaCloneUrl(
+		giteaProvider.giteaUrl,
+		giteaProvider.accessToken!,
+		giteaOwner!,
+		giteaRepository!,
+	);
 
 	writeStream.write(`\nCloning Repo ${repoClone} to ${outputPath}...\n`);
 
@@ -280,7 +290,12 @@ export const cloneRawGiteaRepository = async (entity: Compose) => {
 	const outputPath = join(basePath, appName, "code");
 	await recreateDirectory(outputPath);
 
-    const cloneUrl = buildGiteaCloneUrl(giteaProvider.giteaUrl, giteaProvider.accessToken!, giteaOwner!, giteaRepository!);
+	const cloneUrl = buildGiteaCloneUrl(
+		giteaProvider.giteaUrl,
+		giteaProvider.accessToken!,
+		giteaOwner!,
+		giteaRepository!,
+	);
 
 	try {
 		await spawnAsync("git", [
@@ -326,9 +341,14 @@ export const cloneRawGiteaRepositoryRemote = async (compose: Compose) => {
 	const giteaProvider = await findGiteaById(giteaId);
 	const basePath = COMPOSE_PATH;
 	const outputPath = join(basePath, appName, "code");
-    const cloneUrl = buildGiteaCloneUrl(giteaProvider.giteaUrl, giteaProvider.accessToken!, giteaOwner!, giteaRepository!);
+	const cloneUrl = buildGiteaCloneUrl(
+		giteaProvider.giteaUrl,
+		giteaProvider.accessToken!,
+		giteaOwner!,
+		giteaRepository!,
+	);
 
-    try {
+	try {
 		const command = `
 			rm -rf ${outputPath};
 			git clone --branch ${giteaBranch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath}


### PR DESCRIPTION
## What is this PR about?

Ensure Gitea HTTP connections are respected: when connecting via HTTP, subsequent Gitea operations (clone, API) now use HTTP instead of defaulting to HTTPS, keeping OAuth token authentication intact

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

## Screenshots (if applicable)

