### PR TITLE
feat(deployment): add cancellation functionality for deployments

### DIFF
--- a/apps/api/src/schema.ts
+++ b/apps/api/src/schema.ts
@@ -32,3 +32,16 @@ export const deployJobSchema = z.discriminatedUnion("applicationType", [
 ]);
 
 export type DeployJob = z.infer<typeof deployJobSchema>;
+
+export const cancelDeploymentSchema = z.discriminatedUnion("applicationType", [
+	z.object({
+		applicationId: z.string(),
+		applicationType: z.literal("application"),
+	}),
+	z.object({
+		composeId: z.string(),
+		applicationType: z.literal("compose"),
+	}),
+]);
+
+export type CancelDeploymentJob = z.infer<typeof cancelDeploymentSchema>;

--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -81,22 +81,28 @@ export const ShowDeployments = ({
 
 	const [url, setUrl] = React.useState("");
 
-	// Check for stuck deployments (more than 9 minutes)
+	// Check for stuck deployment (more than 9 minutes) - only for the most recent deployment
 	const stuckDeployment = useMemo(() => {
 		if (!isCloud || !deployments || deployments.length === 0) return null;
 
 		const now = Date.now();
-		const NINE_MINUTES = 8 * 60 * 1000; // 9 minutes in milliseconds
+		const NINE_MINUTES = 10 * 60 * 1000; // 9 minutes in milliseconds
 
-		return deployments.find((deployment) => {
-			if (deployment.status !== "running" || !deployment.startedAt)
-				return false;
+		// Get the most recent deployment (first in the list since they're sorted by date)
+		const mostRecentDeployment = deployments[0];
 
-			const startTime = new Date(deployment.startedAt).getTime();
-			const elapsed = now - startTime;
+		if (
+			!mostRecentDeployment ||
+			mostRecentDeployment.status !== "running" ||
+			!mostRecentDeployment.startedAt
+		) {
+			return null;
+		}
 
-			return elapsed > NINE_MINUTES;
-		});
+		const startTime = new Date(mostRecentDeployment.startedAt).getTime();
+		const elapsed = now - startTime;
+
+		return elapsed > NINE_MINUTES ? mostRecentDeployment : null;
 	}, [isCloud, deployments]);
 	useEffect(() => {
 		setUrl(document.location.origin);

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -24,6 +24,7 @@ import {
 	unzipDrop,
 	updateApplication,
 	updateApplicationStatus,
+	updateDeploymentStatus,
 	writeConfig,
 	writeConfigRemote,
 	// uploadFileSchema
@@ -919,6 +920,14 @@ export const applicationRouter = createTRPCRouter({
 			if (IS_CLOUD && application.serverId) {
 				try {
 					await updateApplicationStatus(input.applicationId, "idle");
+
+					if (application.deployments[0]) {
+						await updateDeploymentStatus(
+							application.deployments[0].deploymentId,
+							"done",
+						);
+					}
+
 					await cancelDeployment({
 						applicationId: input.applicationId,
 						applicationType: "application",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -29,6 +29,7 @@ import {
 	startCompose,
 	stopCompose,
 	updateCompose,
+	updateDeploymentStatus,
 } from "@dokploy/server";
 import {
 	type CompleteTemplate,
@@ -953,6 +954,14 @@ export const composeRouter = createTRPCRouter({
 					await updateCompose(input.composeId, {
 						composeStatus: "idle",
 					});
+
+					if (compose.deployments[0]) {
+						await updateDeploymentStatus(
+							compose.deployments[0].deploymentId,
+							"done",
+						);
+					}
+
 					await cancelDeployment({
 						composeId: input.composeId,
 						applicationType: "compose",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -58,9 +58,14 @@ import {
 } from "@/server/db/schema";
 import type { DeploymentJob } from "@/server/queues/queue-types";
 import { cleanQueuesByCompose, myQueue } from "@/server/queues/queueSetup";
-import { deploy } from "@/server/utils/deploy";
+import { cancelDeployment, deploy } from "@/server/utils/deploy";
 import { generatePassword } from "@/templates/utils";
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
+
+// Schema for canceling deployment
+const apiCancelDeployment = z.object({
+	composeId: z.string().min(1),
+});
 
 export const composeRouter = createTRPCRouter({
 	create: protectedProcedure
@@ -927,5 +932,50 @@ export const composeRouter = createTRPCRouter({
 					message: `Error importing template: ${error instanceof Error ? error.message : error}`,
 				});
 			}
+		}),
+
+	cancelDeployment: protectedProcedure
+		.input(apiCancelDeployment)
+		.mutation(async ({ input, ctx }) => {
+			const compose = await findComposeById(input.composeId);
+			if (
+				compose.environment.project.organizationId !==
+				ctx.session.activeOrganizationId
+			) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not authorized to cancel this deployment",
+				});
+			}
+
+			if (IS_CLOUD && compose.serverId) {
+				try {
+					await updateCompose(input.composeId, {
+						composeStatus: "idle",
+					});
+					await cancelDeployment({
+						composeId: input.composeId,
+						applicationType: "compose",
+					});
+
+					return {
+						success: true,
+						message: "Deployment cancellation requested",
+					};
+				} catch (error) {
+					throw new TRPCError({
+						code: "INTERNAL_SERVER_ERROR",
+						message:
+							error instanceof Error
+								? error.message
+								: "Failed to cancel deployment",
+					});
+				}
+			}
+
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "Deployment cancellation only available in cloud version",
+			});
 		}),
 });

--- a/apps/dokploy/server/utils/deploy.ts
+++ b/apps/dokploy/server/utils/deploy.ts
@@ -23,3 +23,30 @@ export const deploy = async (jobData: DeploymentJob) => {
 		throw error;
 	}
 };
+
+type CancelDeploymentData =
+	| { applicationId: string; applicationType: "application" }
+	| { composeId: string; applicationType: "compose" };
+
+export const cancelDeployment = async (cancelData: CancelDeploymentData) => {
+	try {
+		const result = await fetch(`${process.env.SERVER_URL}/cancel-deployment`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-API-Key": process.env.API_KEY || "NO-DEFINED",
+			},
+			body: JSON.stringify(cancelData),
+		});
+
+		if (!result.ok) {
+			const errorData = await result.json().catch(() => ({}));
+			throw new Error(errorData.message || "Failed to cancel deployment");
+		}
+
+		const data = await result.json();
+		return data;
+	} catch (error) {
+		throw error;
+	}
+};


### PR DESCRIPTION
- Introduced a new endpoint for cancelling deployments, allowing users to cancel both application and compose deployments.
- Implemented validation schemas for cancellation requests.
- Enhanced the deployment dashboard to provide a cancellation option for stuck deployments.
- Updated server-side logic to handle cancellation requests and send appropriate events.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [] You created a dedicated branch based on the `canary` branch.
- [] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

