### PR TITLE
feat(settings): add error handling for unsupported resource types in …

### DIFF
--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -342,6 +342,8 @@ export const readPorts = async (
 		command = `docker service inspect ${resourceName} --format '{{json .Spec.EndpointSpec.Ports}}'`;
 	} else if (resourceType === "standalone") {
 		command = `docker container inspect ${resourceName} --format '{{json .NetworkSettings.Ports}}'`;
+	} else {
+		throw new Error("Resource type not found");
 	}
 	let result = "";
 	if (serverId) {
@@ -397,17 +399,20 @@ export const writeTraefikSetup = async (input: TraefikOptions) => {
 		"dokploy-traefik",
 		input.serverId,
 	);
+
 	if (resourceType === "service") {
 		await initializeTraefikService({
 			env: input.env,
 			additionalPorts: input.additionalPorts,
 			serverId: input.serverId,
 		});
-	} else {
+	} else if (resourceType === "standalone") {
 		await initializeStandaloneTraefik({
 			env: input.env,
 			additionalPorts: input.additionalPorts,
 			serverId: input.serverId,
 		});
+	} else {
+		throw new Error("Traefik resource type not found");
 	}
 };

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -88,15 +88,26 @@ export const initializeStandaloneTraefik = async ({
 
 	const docker = await getRemoteDocker(serverId);
 	try {
+		await docker.pull(imageName);
+		await new Promise((resolve) => setTimeout(resolve, 3000));
+		console.log("Traefik Image Pulled ✅");
+	} catch (error) {
+		console.log("Traefik Image Not Found: Pulling ", error);
+	}
+	try {
 		const container = docker.getContainer(containerName);
 		await container.remove({ force: true });
 		await new Promise((resolve) => setTimeout(resolve, 5000));
 	} catch {}
 
-	await docker.createContainer(settings);
-	const newContainer = docker.getContainer(containerName);
-	await newContainer.start();
-	console.log("Traefik Started ✅");
+	try {
+		await docker.createContainer(settings);
+		const newContainer = docker.getContainer(containerName);
+		await newContainer.start();
+		console.log("Traefik Started ✅");
+	} catch (error) {
+		console.log("Traefik Not Found: Starting ", error);
+	}
 };
 
 export const initializeTraefikService = async ({


### PR DESCRIPTION

- Introduced error handling for unsupported resource types in `readPorts` and `writeTraefikSetup` functions.
- Enhanced `initializeStandaloneTraefik` to include image pulling with error logging for better debugging.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2552

## Screenshots (if applicable)

