### PR TITLE
fix:traefik 3.5.0 error

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -251,11 +251,15 @@ export const addDomainToCompose = async (
 			}
 			labels.unshift(...httpLabels);
 			if (!compose.isolatedDeployment) {
-				if (!labels.includes("traefik.docker.network=dokploy-network")) {
-					labels.unshift("traefik.docker.network=dokploy-network");
-				}
-				if (!labels.includes("traefik.swarm.network=dokploy-network")) {
-					labels.unshift("traefik.swarm.network=dokploy-network");
+				if (compose.composeType === "docker-compose") {
+					if (!labels.includes("traefik.docker.network=dokploy-network")) {
+						labels.unshift("traefik.docker.network=dokploy-network");
+					}
+				} else {
+					// Stack Case
+					if (!labels.includes("traefik.swarm.network=dokploy-network")) {
+						labels.unshift("traefik.swarm.network=dokploy-network");
+					}
 				}
 			}
 		}


### PR DESCRIPTION


## What is this PR about?

Fix traefik 3.5.0  error:"both Docker and Swarm labels are defined"

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [] You have tested this PR in your local instance.
I’m very sorry. I didn’t actually test it because I don’t have a Docker Swarm environment locally, and my only Docker Swarm setup is on my server, which isn’t convenient for testing.
## Issues related (if applicable)

closes #2561
