### PR TITLE
feat: add git commit info extraction and GIT_HASH injection for manual deployments-#2508

### DIFF
--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -70,7 +70,11 @@ import { createRollback } from "./rollbacks";
 export type Application = typeof applications.$inferSelect;
 
 const updateDeploymentWithGitInfo = async (
-	application: Application & { appName: string; env: string | null; serverId?: string | null },
+	application: Application & {
+		appName: string;
+		env: string | null;
+		serverId?: string | null;
+	},
 	deploymentId: string,
 	defaultTitle: string,
 	defaultDescription: string,
@@ -85,10 +89,12 @@ const updateDeploymentWithGitInfo = async (
 		const { gitInfo, updatedEnv } = gitInfoResult;
 		application.env = updatedEnv;
 		await updateApplication(application.applicationId, { env: updatedEnv });
-		
+
 		await updateDeployment(deploymentId, {
 			title: gitInfo.gitMessage || defaultTitle,
-			description: gitInfo.gitHash ? `Hash: ${gitInfo.gitHash}` : defaultDescription,
+			description: gitInfo.gitHash
+				? `Hash: ${gitInfo.gitHash}`
+				: defaultDescription,
 		});
 	}
 };

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -70,7 +70,11 @@ import { validUniqueServerAppName } from "./project";
 export type Compose = typeof compose.$inferSelect;
 
 const updateDeploymentWithGitInfo = async (
-	composeEntity: Compose & { appName: string; env: string | null; serverId?: string | null },
+	composeEntity: Compose & {
+		appName: string;
+		env: string | null;
+		serverId?: string | null;
+	},
 	deploymentId: string,
 	defaultTitle: string,
 	defaultDescription: string,
@@ -83,16 +87,18 @@ const updateDeploymentWithGitInfo = async (
 
 	if (gitInfoResult) {
 		const { gitInfo, updatedEnv } = gitInfoResult;
-		
+
 		// Update the database immediately
 		await updateCompose(composeEntity.composeId as string, { env: updatedEnv });
 
 		// Update the local entity for consistency
 		composeEntity.env = updatedEnv;
-		
+
 		await updateDeployment(deploymentId, {
 			title: gitInfo.gitMessage || defaultTitle,
-			description: gitInfo.gitHash ? `Hash: ${gitInfo.gitHash}` : defaultDescription,
+			description: gitInfo.gitHash
+				? `Hash: ${gitInfo.gitHash}`
+				: defaultDescription,
 		});
 	}
 };

--- a/packages/server/src/utils/git-info.ts
+++ b/packages/server/src/utils/git-info.ts
@@ -1,6 +1,9 @@
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
-import { execAsync, execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
+import {
+	execAsync,
+	execAsyncRemote,
+} from "@dokploy/server/utils/process/execAsync";
 
 export interface GitInfo {
 	gitHash: string;
@@ -31,7 +34,7 @@ export const extractGitInfo = async (
 		// Determine if we should use remote or local execution
 		const isRemote = !!serverId;
 		const { APPLICATIONS_PATH, COMPOSE_PATH } = paths(isRemote);
-		
+
 		// Try both application and compose paths to find the git repository
 		const possiblePaths = [
 			join(APPLICATIONS_PATH, appName, "code"),


### PR DESCRIPTION
## PR Title
```
feat: add git commit info extraction and GIT_HASH injection for manual deployments
```

## Description

**Add Git commit info extraction and GIT_HASH injection for manual deployments**

### ✨ Features
- **Git Integration**: Extract commit message and hash for manual deployments from Git providers (GitHub, GitLab, Bitbucket, Gitea, Git)
- **Environment Variable Injection**: Inject `GIT_HASH` environment variable into applications and compose services
- **Enhanced Deployment Display**: Display actual commit message as deployment title instead of "Manual deployment"
- **Provider Support**: Exclude Docker provider from git info extraction (maintains existing behavior)
- **Backward Compatibility**: Maintain backward compatibility with auto-deploy functionality

### 📁 Files Changed
- `packages/server/src/services/application.ts`
- `packages/server/src/services/compose.ts`


<img width="1654" height="883" alt="Screenshot 2025-09-09 at 7 08 47 PM" src="https://github.com/user-attachments/assets/33360714-43bf-4a9a-bfa4-0f37fa6af553" />

<img width="1312" height="707" alt="Screenshot 2025-09-09 at 7 09 14 PM" src="https://github.com/user-attachments/assets/c8c1bf2f-78b8-452d-b8e9-8973e9997d86" />
