### PR TITLE
feat: Auto-refresh services list when duplicating to same environment

### DIFF
--- a/apps/dokploy/components/dashboard/project/duplicate-project.tsx
+++ b/apps/dokploy/components/dashboard/project/duplicate-project.tsx
@@ -80,14 +80,18 @@ export const DuplicateProject = ({
 		api.project.duplicate.useMutation({
 			onSuccess: async (newProject) => {
 				await utils.project.all.invalidate();
-				
+
 				// If duplicating to same project+environment, invalidate the environment query
 				// to refresh the services list
 				if (duplicateType === "existing-environment") {
-					await utils.environment.one.invalidate({ environmentId: selectedTargetEnvironment });
-					await utils.environment.byProjectId.invalidate({ projectId: selectedTargetProject });
-					
-					// If duplicating to the same environment we're currently viewing, 
+					await utils.environment.one.invalidate({
+						environmentId: selectedTargetEnvironment,
+					});
+					await utils.environment.byProjectId.invalidate({
+						projectId: selectedTargetProject,
+					});
+
+					// If duplicating to the same environment we're currently viewing,
 					// also invalidate the current environment to refresh the services list
 					if (selectedTargetEnvironment === environmentId) {
 						await utils.environment.one.invalidate({ environmentId });
@@ -98,7 +102,7 @@ export const DuplicateProject = ({
 						}
 					}
 				}
-				
+
 				toast.success(
 					duplicateType === "new-project"
 						? "Project duplicated successfully"

--- a/apps/dokploy/components/dashboard/project/duplicate-project.tsx
+++ b/apps/dokploy/components/dashboard/project/duplicate-project.tsx
@@ -80,6 +80,25 @@ export const DuplicateProject = ({
 		api.project.duplicate.useMutation({
 			onSuccess: async (newProject) => {
 				await utils.project.all.invalidate();
+				
+				// If duplicating to same project+environment, invalidate the environment query
+				// to refresh the services list
+				if (duplicateType === "existing-environment") {
+					await utils.environment.one.invalidate({ environmentId: selectedTargetEnvironment });
+					await utils.environment.byProjectId.invalidate({ projectId: selectedTargetProject });
+					
+					// If duplicating to the same environment we're currently viewing, 
+					// also invalidate the current environment to refresh the services list
+					if (selectedTargetEnvironment === environmentId) {
+						await utils.environment.one.invalidate({ environmentId });
+						// Also invalidate the project query to refresh the project data
+						const projectId = router.query.projectId as string;
+						if (projectId) {
+							await utils.project.one.invalidate({ projectId });
+						}
+					}
+				}
+				
 				toast.success(
 					duplicateType === "new-project"
 						? "Project duplicated successfully"


### PR DESCRIPTION
## 🐛 Fix: Auto-refresh services list when duplicating to same environment

**Problem:** When duplicating services to the same project/environment, the services list doesn't refresh automatically - users need to hard refresh to see duplicated services.

**Solution:** Added proper cache invalidation in `DuplicateProject` component:
- Invalidate `environment.one` query to refresh services list
- Invalidate `environment.byProjectId` query to update environment selector
- Handle same-environment duplication to refresh current page

**Files Changed:**
- `apps/dokploy/components/dashboard/project/duplicate-project.tsx`

**Result:** Services list now refreshes automatically after duplication, no hard refresh needed.

Fixes #2565