### PR TITLE
Fix GitHub external link URL not updating after provider renaming - #2529 

### DIFF
--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -131,13 +131,13 @@ export const githubRouter = createTRPCRouter({
 					message: "You are not allowed to access this github provider",
 				});
 			}
-			
+
 			// Update the git provider name
 			await updateGitProvider(input.gitProviderId, {
 				name: input.name,
 				organizationId: ctx.session.activeOrganizationId,
 			});
-			
+
 			// Update the GitHub app URL to match the new name
 			// The GitHub app URL follows the pattern: https://github.com/apps/{app-name}
 			const newGithubAppUrl = `https://github.com/apps/${input.name}`;

--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -4,6 +4,7 @@ import {
 	getGithubRepositories,
 	haveGithubRequirements,
 	updateGitProvider,
+	updateGithub,
 } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
@@ -130,9 +131,18 @@ export const githubRouter = createTRPCRouter({
 					message: "You are not allowed to access this github provider",
 				});
 			}
+			
+			// Update the git provider name
 			await updateGitProvider(input.gitProviderId, {
 				name: input.name,
 				organizationId: ctx.session.activeOrganizationId,
+			});
+			
+			// Update the GitHub app URL to match the new name
+			// The GitHub app URL follows the pattern: https://github.com/apps/{app-name}
+			const newGithubAppUrl = `https://github.com/apps/${input.name}`;
+			await updateGithub(input.githubId, {
+				githubAppName: newGithubAppUrl,
 			});
 		}),
 });


### PR DESCRIPTION
## 🐛 Bug Fix

**Issue:** External links for GitHub providers continue to point to old GitHub app URLs after renaming, resulting in 404 errors.

**Root Cause:** When updating a GitHub provider name, only the `gitProvider.name` field was updated, but the `github.githubAppName` field (containing the actual GitHub app URL) remained unchanged.

## �� Changes Made

- **Modified GitHub update mutation** (`apps/dokploy/server/api/routers/github.ts`)
  - Added `updateGithub` import
  - Updated both `gitProvider.name` and `github.githubAppName` fields
  - Construct new GitHub app URL using pattern: `https://github.com/apps/{new-name}`

## �� Testing

- [x] External links now correctly point to renamed GitHub apps
- [x] Test Connection functionality remains intact
- [x] GitHub Account selector displays updated names
- [x] No breaking changes to existing functionality

## �� Files Changed

- `apps/dokploy/server/api/routers/github.ts` - Updated GitHub provider mutation

## �� Impact

- **Before:** External links showed 404 errors after renaming GitHub providers
- **After:** External links correctly navigate to the renamed GitHub app

Fixes #2529