### PR TITLE
fix: Display Compose service domains in projects dashboard (#2606)

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -291,45 +291,48 @@ export const ShowProjects = () => {
 																				)}
 																			</DropdownMenuGroup>
 																		)}
-																		{/* 
-																		{project.compose.length > 0 && (
+																		{project.environments.some(
+																			(env) => env.compose.length > 0,
+																		) && (
 																			<DropdownMenuGroup>
 																				<DropdownMenuLabel>
 																					Compose
 																				</DropdownMenuLabel>
-																				{project.compose.map((comp) => (
-																					<div key={comp.composeId}>
-																						<DropdownMenuSeparator />
-																						<DropdownMenuGroup>
-																							<DropdownMenuLabel className="font-normal capitalize text-xs flex items-center justify-between">
-																								{comp.name}
-																								<StatusTooltip
-																									status={comp.composeStatus}
-																								/>
-																							</DropdownMenuLabel>
+																				{project.environments.map((env) =>
+																					env.compose.map((comp) => (
+																						<div key={comp.composeId}>
 																							<DropdownMenuSeparator />
-																							{comp.domains.map((domain) => (
-																								<DropdownMenuItem
-																									key={domain.domainId}
-																									asChild
-																								>
-																									<Link
-																										className="space-x-4 text-xs cursor-pointer justify-between"
-																										target="_blank"
-																										href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
+																							<DropdownMenuGroup>
+																								<DropdownMenuLabel className="font-normal capitalize text-xs flex items-center justify-between">
+																									{comp.name}
+																									<StatusTooltip
+																										status={comp.composeStatus}
+																									/>
+																								</DropdownMenuLabel>
+																								<DropdownMenuSeparator />
+																								{comp.domains.map((domain) => (
+																									<DropdownMenuItem
+																										key={domain.domainId}
+																										asChild
 																									>
-																										<span className="truncate">
-																											{domain.host}
-																										</span>
-																										<ExternalLinkIcon className="size-4 shrink-0" />
-																									</Link>
-																								</DropdownMenuItem>
-																							))}
-																						</DropdownMenuGroup>
-																					</div>
-																				))}
+																										<Link
+																											className="space-x-4 text-xs cursor-pointer justify-between"
+																											target="_blank"
+																											href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
+																										>
+																											<span className="truncate">
+																												{domain.host}
+																											</span>
+																											<ExternalLinkIcon className="size-4 shrink-0" />
+																										</Link>
+																									</DropdownMenuItem>
+																								))}
+																							</DropdownMenuGroup>
+																						</div>
+																					)),
+																				)}
 																			</DropdownMenuGroup>
-																		)} */}
+																		)}
 																	</DropdownMenuContent>
 																</DropdownMenu>
 															) : null}


### PR DESCRIPTION
## Description
Fixes the issue where Compose service domains were not displaying in the projects dashboard dropdown menu. The domain display logic for Compose services was commented out, while Applications domains were working correctly.

## Problem
- Template-deployed Compose services (like Nginx, WordPress, etc.) were not showing their configured domains in the projects dashboard
- Users could access the services via their domains, but the UI didn't display the domain links
- The Compose domain rendering code was completely commented out in `ShowProjects.tsx`

## Solution
- Uncommented the Compose domain rendering logic in `/apps/dokploy/components/dashboard/projects/show.tsx`
- Fixed the data structure to properly iterate through `project.environments` and then `env.compose`
- Added proper condition checking for `project.environments.some((env) => env.compose.length > 0)`
- Maintained the same rendering pattern as the working Applications section

## Changes Made
- **File**: `apps/dokploy/components/dashboard/projects/show.tsx`
- **Lines**: 294-335 (uncommented and fixed)
- **Logic**: Added proper Compose domain iteration and display

## Testing
- [x] Deploy a template with a custom domain
- [x] Verify the service appears in projects dashboard
- [x] Confirm the domain link appears in the dropdown menu
- [x] Test that clicking the domain link opens the service correctly

## Screenshots
Before: Compose services showed no domain links in dropdown
After: Compose services display their configured domains with proper links

## Related Issues
Fixes #2606



<img width="638" height="494" alt="Screenshot 2025-09-17 at 2 08 03 PM" src="https://github.com/user-attachments/assets/fc4c27d0-2658-4839-9647-caa4df63ee91" />

