### PR TITLE
Fix: Update gitlab.ts cloneRawGitlabRepositoryRemote to use gitlabBranch

### DIFF
--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -401,7 +401,7 @@ export const cloneRawGitlabRepositoryRemote = async (compose: Compose) => {
 	const {
 		appName,
 		gitlabPathNamespace,
-		branch,
+		gitlabBranch,
 		gitlabId,
 		serverId,
 		enableSubmodules,
@@ -429,7 +429,7 @@ export const cloneRawGitlabRepositoryRemote = async (compose: Compose) => {
 	try {
 		const command = `
 			rm -rf ${outputPath};
-			git clone --branch ${branch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath}
+			git clone --branch ${gitlabBranch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath}
 		`;
 		await execAsyncRemote(serverId, command);
 	} catch (error) {


### PR DESCRIPTION
## What is this PR about?

Cloning a GitLab repository for a compose service to a remote server incorrectly used the **branch** column from Postgres' **compose** table instead of the **gitlabBranch** column. As the **branch** column is _null_ for GitLab repositories cloning would result in an error.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)
Fixes #2623
## Screenshots (if applicable)

