### PR TITLE
fix: prevent the shrinking of icon button for view mode on add template dialog

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -171,7 +171,7 @@ export const AddTemplate = ({ environmentId, baseUrl }: Props) => {
 								<Input
 									placeholder="Search Template"
 									onChange={(e) => setQuery(e.target.value)}
-									className="w-full sm:w-[200px]"
+									className="w-full"
 									value={query}
 								/>
 								<Input

--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -248,7 +248,7 @@ export const AddTemplate = ({ environmentId, baseUrl }: Props) => {
 									onClick={() =>
 										setViewMode(viewMode === "detailed" ? "icon" : "detailed")
 									}
-									className="h-9 w-9"
+									className="h-9 w-9 flex-shrink-0"
 								>
 									{viewMode === "detailed" ? (
 										<LayoutGrid className="size-4" />


### PR DESCRIPTION
## What is this PR about?

This PR fixes the shrinking behaviour of view mode icon button that can be observed on the "Create from Template" dialog on the project page.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots (if applicable)
**Before**
<img width="256" height="141" alt="Screenshot From 2025-09-19 21-19-30" src="https://github.com/user-attachments/assets/874dfdd3-8d15-444d-b935-c7f1ebfbddbe" />
**After**
<img width="256" height="141" alt="Screenshot From 2025-09-19 21-19-20" src="https://github.com/user-attachments/assets/82ce0a47-0cba-4c9e-8ec5-b90d56d1e2bc" />

