### PR TITLE
feat(scheduler): auto-switch to 'Custom' on manual input

### DIFF
--- a/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
@@ -1,11 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-	DatabaseZap,
-	Info,
-	PenBoxIcon,
-	PlusCircle,
-	RefreshCw,
-} from "lucide-react";
+import { DatabaseZap, PenBoxIcon, PlusCircle, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -47,7 +41,7 @@ import {
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 import type { CacheType } from "../domains/handle-domain";
-import { commonCronExpressions } from "../schedules/handle-schedules";
+import { ScheduleFormField } from "../schedules/handle-schedules";
 
 const formSchema = z
 	.object({
@@ -306,64 +300,9 @@ export const HandleVolumeBackups = ({
 								</FormItem>
 							)}
 						/>
-
-						<FormField
-							control={form.control}
+						<ScheduleFormField
 							name="cronExpression"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel className="flex items-center gap-2">
-										Schedule
-										<TooltipProvider>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<Info className="w-4 h-4 text-muted-foreground cursor-help" />
-												</TooltipTrigger>
-												<TooltipContent>
-													<p>
-														Cron expression format: minute hour day month
-														weekday
-													</p>
-													<p>Example: 0 0 * * * (daily at midnight)</p>
-												</TooltipContent>
-											</Tooltip>
-										</TooltipProvider>
-									</FormLabel>
-									<div className="flex flex-col gap-2">
-										<Select
-											onValueChange={(value) => {
-												field.onChange(value);
-											}}
-										>
-											<FormControl>
-												<SelectTrigger>
-													<SelectValue placeholder="Select a predefined schedule" />
-												</SelectTrigger>
-											</FormControl>
-											<SelectContent>
-												{commonCronExpressions.map((expr) => (
-													<SelectItem key={expr.value} value={expr.value}>
-														{expr.label} ({expr.value})
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										<div className="relative">
-											<FormControl>
-												<Input
-													placeholder="Custom cron expression (e.g., 0 0 * * *)"
-													{...field}
-												/>
-											</FormControl>
-										</div>
-									</div>
-									<FormDescription>
-										Choose a predefined schedule or enter a custom cron
-										expression
-									</FormDescription>
-									<FormMessage />
-								</FormItem>
-							)}
+							formControl={form.control}
 						/>
 
 						<FormField

--- a/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
@@ -3,7 +3,6 @@ import {
 	CheckIcon,
 	ChevronsUpDown,
 	DatabaseZap,
-	Info,
 	PenBoxIcon,
 	PlusIcon,
 	RefreshCw,
@@ -62,7 +61,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
-import { commonCronExpressions } from "../../application/schedules/handle-schedules";
+import { ScheduleFormField } from "../../application/schedules/handle-schedules";
 
 type CacheType = "cache" | "fetch";
 
@@ -579,66 +578,9 @@ export const HandleBackup = ({
 									);
 								}}
 							/>
-							<FormField
-								control={form.control}
-								name="schedule"
-								render={({ field }) => {
-									return (
-										<FormItem>
-											<FormLabel className="flex items-center gap-2">
-												Schedule
-												<TooltipProvider>
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<Info className="w-4 h-4 text-muted-foreground cursor-help" />
-														</TooltipTrigger>
-														<TooltipContent>
-															<p>
-																Cron expression format: minute hour day month
-																weekday
-															</p>
-															<p>Example: 0 0 * * * (daily at midnight)</p>
-														</TooltipContent>
-													</Tooltip>
-												</TooltipProvider>
-											</FormLabel>
-											<div className="flex flex-col gap-2">
-												<Select
-													onValueChange={(value) => {
-														field.onChange(value);
-													}}
-												>
-													<FormControl>
-														<SelectTrigger>
-															<SelectValue placeholder="Select a predefined schedule" />
-														</SelectTrigger>
-													</FormControl>
-													<SelectContent>
-														{commonCronExpressions.map((expr) => (
-															<SelectItem key={expr.value} value={expr.value}>
-																{expr.label} ({expr.value})
-															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
-												<div className="relative">
-													<FormControl>
-														<Input
-															placeholder="Custom cron expression (e.g., 0 0 * * *)"
-															{...field}
-														/>
-													</FormControl>
-												</div>
-											</div>
-											<FormDescription>
-												Choose a predefined schedule or enter a custom cron
-												expression
-											</FormDescription>
-											<FormMessage />
-										</FormItem>
-									);
-								}}
-							/>
+
+							<ScheduleFormField name="schedule" formControl={form.control} />
+
 							<FormField
 								control={form.control}
 								name="prefix"


### PR DESCRIPTION
## What is this PR about?

Dropdown list will be inferred based on what user types, if it matches a common expression it will auto-select it, if not it will auto select the "Custom" option

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Resolves #2665

## Screenshots (if applicable)
<img width="688" height="233" alt="image" src="https://github.com/user-attachments/assets/6f909f20-e182-4298-9cbc-561ebcf75f30" />
<img width="633" height="208" alt="image" src="https://github.com/user-attachments/assets/5b611cb0-d7ee-4aab-b29b-81243a130e51" />
<img width="641" height="228" alt="image" src="https://github.com/user-attachments/assets/150096ef-4b99-4e31-8986-c0a181468659" />
<img width="743" height="477" alt="image" src="https://github.com/user-attachments/assets/3a12739e-137d-4aac-95e3-9e70e5df6fc1" />

