### PR TITLE
fix s3 signing error

### DIFF
--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -53,6 +53,7 @@ export const destinationRouter = createTRPCRouter({
 					`--s3-endpoint=${endpoint}`,
 					"--s3-no-check-bucket",
 					"--s3-force-path-style",
+					"--s3-sign-accept-encoding=false",
 				];
 				if (provider) {
 					rcloneFlags.unshift(`--s3-provider=${provider}`);

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -68,6 +68,7 @@ export const getS3Credentials = (destination: Destination) => {
 		`--s3-endpoint=${endpoint}`,
 		"--s3-no-check-bucket",
 		"--s3-force-path-style",
+		"--s3-sign-accept-encoding=false",
 	];
 
 	if (provider) {


### PR DESCRIPTION
## What is this PR about?

There's a known issue with rclone versions 1.68+ where it throws "SignatureDoesNotMatch" errors when working with various S3-compatible storage services that modify request headers. Adding "--s3-sign-accept-encoding=false" fixes this issue.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2023

## Screenshots (if applicable)

