### PR TITLE
feat(ui): move Deployments tab to position 4 after Domains tab

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -226,6 +226,7 @@ const Service = (
 											<TabsTrigger value="general">General</TabsTrigger>
 											<TabsTrigger value="environment">Environment</TabsTrigger>
 											<TabsTrigger value="domains">Domains</TabsTrigger>
+											<TabsTrigger value="deployments">Deployments</TabsTrigger>
 											<TabsTrigger value="preview-deployments">
 												Preview Deployments
 											</TabsTrigger>
@@ -233,7 +234,6 @@ const Service = (
 											<TabsTrigger value="volume-backups">
 												Volume Backups
 											</TabsTrigger>
-											<TabsTrigger value="deployments">Deployments</TabsTrigger>
 											<TabsTrigger value="logs">Logs</TabsTrigger>
 											{((data?.serverId && isCloud) || !data?.server) && (
 												<TabsTrigger value="monitoring">Monitoring</TabsTrigger>


### PR DESCRIPTION
## What is this PR about?

This PR reorders the tabs on the service page by moving the **Deployments** tab to appear right after **Domains** for improved navigation.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2675 

## Screenshots (if applicable)

<img width="2404" height="1656" alt="image" src="https://github.com/user-attachments/assets/1e889143-0850-423d-9641-ea8b07440984" />
