### PR TITLE
Feat: "Most services" sorting to count total services across environments -2691 

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -96,8 +96,26 @@ export const ShowProjects = () => {
 						new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
 					break;
 				case "services": {
-					const aTotalServices = a.environments.length;
-					const bTotalServices = b.environments.length;
+					const aTotalServices = a.environments.reduce((total, env) => {
+						return total + 
+							(env.applications?.length || 0) +
+							(env.mariadb?.length || 0) +
+							(env.mongo?.length || 0) +
+							(env.mysql?.length || 0) +
+							(env.postgres?.length || 0) +
+							(env.redis?.length || 0) +
+							(env.compose?.length || 0);
+					}, 0);
+					const bTotalServices = b.environments.reduce((total, env) => {
+						return total + 
+							(env.applications?.length || 0) +
+							(env.mariadb?.length || 0) +
+							(env.mongo?.length || 0) +
+							(env.mysql?.length || 0) +
+							(env.postgres?.length || 0) +
+							(env.redis?.length || 0) +
+							(env.compose?.length || 0);
+					}, 0);
 					comparison = aTotalServices - bTotalServices;
 					break;
 				}

--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -97,24 +97,28 @@ export const ShowProjects = () => {
 					break;
 				case "services": {
 					const aTotalServices = a.environments.reduce((total, env) => {
-						return total + 
+						return (
+							total +
 							(env.applications?.length || 0) +
 							(env.mariadb?.length || 0) +
 							(env.mongo?.length || 0) +
 							(env.mysql?.length || 0) +
 							(env.postgres?.length || 0) +
 							(env.redis?.length || 0) +
-							(env.compose?.length || 0);
+							(env.compose?.length || 0)
+						);
 					}, 0);
 					const bTotalServices = b.environments.reduce((total, env) => {
-						return total + 
+						return (
+							total +
 							(env.applications?.length || 0) +
 							(env.mariadb?.length || 0) +
 							(env.mongo?.length || 0) +
 							(env.mysql?.length || 0) +
 							(env.postgres?.length || 0) +
 							(env.redis?.length || 0) +
-							(env.compose?.length || 0);
+							(env.compose?.length || 0)
+						);
 					}, 0);
 					comparison = aTotalServices - bTotalServices;
 					break;


### PR DESCRIPTION
## Problem
The "Most services" sorting option in the Projects page was not working correctly. It was sorting projects by the number of environments instead of the total number of services across all environments, resulting in ascending order instead of the expected descending order.

## Solution
Updated the sorting logic in `apps/dokploy/components/dashboard/projects/show.tsx` to properly count total services across all environments by summing up:
- Applications
- MariaDB instances  
- MongoDB instances
- MySQL instances
- PostgreSQL instances
- Redis instances
- Compose services

## Changes
- Modified the `services` case in the sorting switch statement
- Changed from `a.environments.length` to proper service counting logic
- Maintains existing display logic which was already correct

## Testing
Verified the fix with test data showing proper descending order by total service count.

<img width="1367" height="531" alt="Screenshot 2025-09-26 at 2 17 27 PM" src="https://github.com/user-attachments/assets/69ea4b5e-edc5-411c-a4ed-d449f1fbf32e" />


Fixes #2691