### PR TITLE
Fix: Allow organization members to access requests functionality (#2687)

### DIFF
--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -587,7 +587,7 @@ export const settingsRouter = createTRPCRouter({
 			return ports.some((port) => port.targetPort === 8080);
 		}),
 
-	readStatsLogs: adminProcedure
+	readStatsLogs: protectedProcedure
 		.meta({
 			openapi: {
 				path: "/read-stats-logs",
@@ -650,7 +650,7 @@ export const settingsRouter = createTRPCRouter({
 			const processedLogs = processLogs(rawConfig as string, input?.dateRange);
 			return processedLogs || [];
 		}),
-	haveActivateRequests: adminProcedure.query(async () => {
+	haveActivateRequests: protectedProcedure.query(async () => {
 		if (IS_CLOUD) {
 			return true;
 		}
@@ -665,7 +665,7 @@ export const settingsRouter = createTRPCRouter({
 
 		return !!parsedConfig?.accessLog?.filePath;
 	}),
-	toggleRequests: adminProcedure
+	toggleRequests: protectedProcedure
 		.input(
 			z.object({
 				enable: z.boolean(),
@@ -835,7 +835,7 @@ export const settingsRouter = createTRPCRouter({
 			const ports = await readPorts("dokploy-traefik", input?.serverId);
 			return ports;
 		}),
-	updateLogCleanup: adminProcedure
+	updateLogCleanup: protectedProcedure
 		.input(
 			z.object({
 				cronExpression: z.string().nullable(),
@@ -851,7 +851,7 @@ export const settingsRouter = createTRPCRouter({
 			return stopLogCleanup();
 		}),
 
-	getLogCleanupStatus: adminProcedure.query(async () => {
+	getLogCleanupStatus: protectedProcedure.query(async () => {
 		return getLogCleanupStatus();
 	}),
 


### PR DESCRIPTION
## Description
Fixes the issue where organization members with all permissions were unable to see or activate the requests functionality, even when the owner had granted them all permissions.

## Problem
- Users reported that even with "all permissions" granted by the organization owner, they couldn't access the requests module
- The requests page showed "UNAUTHORIZED" for non-owner users
- Members couldn't activate requests or see when requests were activated by the owner

## Root Cause
The requests-related API procedures were using `adminProcedure` which only allows users with the "owner" role to access them. This meant that even members with all permissions couldn't access the requests functionality.

## Solution
Changed the following procedures from `adminProcedure` to `protectedProcedure`:
- `readStatsLogs` - Used to display requests data in the table
- `haveActivateRequests` - Used to check if requests are activated  
- `toggleRequests` - Used to activate/deactivate requests
- `updateLogCleanup` - Used to update log cleanup schedule
- `getLogCleanupStatus` - Used to get current log cleanup status

## Changes Made
- **File**: `apps/dokploy/server/api/routers/settings.ts`
- **Procedures updated**: 5 procedures changed from `adminProcedure` to `protectedProcedure`
- **Impact**: All authenticated organization members can now access requests functionality

## Testing
- [x] Verified no TypeScript compilation errors
- [x] Verified no linting errors
- [x] Confirmed procedures now use `protectedProcedure` (allows any authenticated user)

## Related Issue
Fixes #2687

