### PR TITLE
feat: add unsaved changes tracking and UI indication

### DIFF
--- a/apps/dokploy/components/dashboard/compose/general/compose-file-editor.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/compose-file-editor.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -35,6 +35,7 @@ export const ComposeFileEditor = ({ composeId }: Props) => {
 	);
 
 	const { mutateAsync, isLoading } = api.compose.update.useMutation();
+	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
 	const form = useForm<AddComposeFile>({
 		defaultValues: {
@@ -52,6 +53,12 @@ export const ComposeFileEditor = ({ composeId }: Props) => {
 			});
 		}
 	}, [form, form.reset, data]);
+
+	useEffect(() => {
+		if (data?.composeFile !== undefined) {
+			setHasUnsavedChanges(composeFile !== data.composeFile);
+		}
+	}, [composeFile, data?.composeFile]);
 
 	const onSubmit = async (data: AddComposeFile) => {
 		const { valid, error } = validateAndFormatYAML(data.composeFile);
@@ -71,6 +78,7 @@ export const ComposeFileEditor = ({ composeId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Compose config Updated");
+				setHasUnsavedChanges(false);
 				refetch();
 				await utils.compose.getConvertedCompose.invalidate({
 					composeId,
@@ -99,6 +107,19 @@ export const ComposeFileEditor = ({ composeId }: Props) => {
 	return (
 		<>
 			<div className="w-full flex flex-col gap-4 ">
+				<div className="flex items-center justify-between">
+					<div>
+						<h3 className="text-lg font-medium">Compose File</h3>
+						<p className="text-sm text-muted-foreground">
+							Configure your Docker Compose file for this service.
+							{hasUnsavedChanges && (
+								<span className="text-yellow-500 ml-2">
+									(You have unsaved changes)
+								</span>
+							)}
+						</p>
+					</div>
+				</div>
 				<Form {...form}>
 					<form
 						id="hook-form-save-compose-file"


### PR DESCRIPTION
## What is this PR about?

This PR adds a visual "(You have unsaved changes)" indicator to the compose file editor header that appears when the content differs from the saved version.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes https://github.com/Dokploy/dokploy/issues/2538

## Screenshots (if applicable)
<img width="1087" height="701" alt="Screenshot 2025-09-26 at 8 14 12 PM" src="https://github.com/user-attachments/assets/94b415ce-e745-4567-8d7f-7de976d9fd0d" />
