### PR TITLE
fix: add environment in buildLink for docker compose deploy notifications

### DIFF
--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -227,7 +227,7 @@ export const deployCompose = async ({
 
 	const buildLink = `${await getDokployUrl()}/dashboard/project/${
 		compose.environment.projectId
-	}/services/compose/${compose.composeId}?tab=deployments`;
+	}/environment/${compose.environmentId}/services/compose/${compose.composeId}?tab=deployments`;
 	const deployment = await createDeploymentCompose({
 		composeId: composeId,
 		title: titleLog,
@@ -335,7 +335,7 @@ export const deployRemoteCompose = async ({
 
 	const buildLink = `${await getDokployUrl()}/dashboard/project/${
 		compose.environment.projectId
-	}/services/compose/${compose.composeId}?tab=deployments`;
+	}/environment/${compose.environmentId}/services/compose/${compose.composeId}?tab=deployments`;
 	const deployment = await createDeploymentCompose({
 		composeId: composeId,
 		title: titleLog,


### PR DESCRIPTION
## What is this PR about?

The notifications for deployments did not take into account the environment in docker compose projects resulting in a 400.
This PR fixes this issue by adding the environment in the buildLink.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related 

closes #2708 

