### PR TITLE
fix: improve domain and letsencrypt email validation

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-domain.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-domain.tsx
@@ -33,9 +33,19 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { api } from "@/utils/api";
 
+const hostnameRegex =
+	/^(?=.{1,253}$)(?!-)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.(?!-)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$/;
+
 const addServerDomain = z
 	.object({
-		domain: z.string(),
+		domain: z
+			.string()
+			.trim()
+			.toLowerCase()
+			.regex(
+				hostnameRegex,
+				"Invalid hostname (no http://, no slash, no port).",
+			),
 		letsEncryptEmail: z.string(),
 		https: z.boolean().optional(),
 		certificateType: z.enum(["letsencrypt", "none", "custom"]),
@@ -48,7 +58,11 @@ const addServerDomain = z
 				message: "Required",
 			});
 		}
-		if (data.certificateType === "letsencrypt" && !data.letsEncryptEmail) {
+		if (
+			data.https &&
+			data.certificateType === "letsencrypt" &&
+			!data.letsEncryptEmail
+		) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				message:


### PR DESCRIPTION
## What is this PR about?

This PR improves the server domain form validation logic:

- Domain: reject invalid hostnames that include http://, https://, paths, or ports.
- Let’s Encrypt email: now required only when HTTPS is enabled and certificate type is letsencrypt.

### Why

- Prevents users from misconfiguring domains (fixes the HostSNI("https://...") error).
- Ensures email is requested only when necessary for Let’s Encrypt.

### Notes

Straightforward validation changes, no impact on existing flows except improved error handling.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

