### PR TITLE
Pass `DOKPLOY_DEPLOY_URL` as build time argument so it can be used during build

### DIFF
--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -472,7 +472,7 @@ export const deployPreviewApplication = async ({
 		});
 		application.appName = previewDeployment.appName;
 		application.env = `${application.previewEnv}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
-		application.buildArgs = application.previewBuildArgs;
+		application.buildArgs = `${application.previewBuildArgs}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 
 		if (application.sourceType === "github") {
 			await cloneGithubRepository({
@@ -579,7 +579,7 @@ export const deployRemotePreviewApplication = async ({
 		});
 		application.appName = previewDeployment.appName;
 		application.env = `${application.previewEnv}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
-		application.buildArgs = application.previewBuildArgs;
+		application.buildArgs = `${application.previewBuildArgs}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 
 		if (application.serverId) {
 			let command = "set -e;";


### PR DESCRIPTION
## What is this PR about?

This PR adds passing `DOKPLOY_DEPLOY_URL` as build time argument

Useful, for example, for next.js applications that are built with fronted that should be populated with NEXT_PUBLIC_ env vars. So during docker build we can set DOKPLOY_DEPLOY_URL as env var with correct prefix

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [] You have tested this PR in your local instance.


