### PR TITLE
fix: correct typo in saveGitProvider function name

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -59,7 +59,7 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 	const router = useRouter();
 
 	const { mutateAsync, isLoading } =
-		api.application.saveGitProdiver.useMutation();
+		api.application.saveGitProvider.useMutation();
 
 	const form = useForm<GitProvider>({
 		defaultValues: {

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -524,7 +524,7 @@ export const applicationRouter = createTRPCRouter({
 
 			return true;
 		}),
-	saveGitProdiver: protectedProcedure
+	saveGitProvider: protectedProcedure
 		.input(apiSaveGitProvider)
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);


### PR DESCRIPTION
## Description
This PR fixes a typo in the `saveGitProvider` function name that was incorrectly spelled as `saveGitProdiver` in two locations.

## Changes Made
- Fixed typo in `apps/dokploy/server/api/routers/application.ts` (line 527)
- Fixed typo in `apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx` (line 62)

## Impact
- Ensures consistency across the codebase
- Fixes potential confusion for developers
- No functional changes, only naming correction

## Testing
- [x] Verified the function name is now consistent across both files
- [x] Confirmed no other references to the misspelled name exist in the codebase

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation.