### PR TITLE
BUG: Use logical OR (||) in selecting the command for RS MongoDB

### DIFF
--- a/packages/server/src/utils/databases/mongo.ts
+++ b/packages/server/src/utils/databases/mongo.ts
@@ -76,7 +76,7 @@ fi
 		: ""
 }
 
-${command ?? "wait $MONGOD_PID"}`;
+${command || "wait $MONGOD_PID"}`;
 
 	const defaultMongoEnv = `MONGO_INITDB_ROOT_USERNAME="${databaseUser}"\nMONGO_INITDB_ROOT_PASSWORD="${databasePassword}"${replicaSets ? "\nMONGO_INITDB_DATABASE=admin" : ""}${
 		env ? `\n${env}` : ""


### PR DESCRIPTION
## What is this PR about?

Use logical OR (||) in selecting the command for RS MongoDB. When changing the default image or just saving the empty command field in the general, the command selection will fail as it fails to account for empty strings.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.


