### PR TITLE
fix: return an empty object if yaml file is empty

### DIFF
--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -265,9 +265,10 @@ export const writeTraefikConfigRemote = async (
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
 		if (traefikConfig.http?.middlewares) {
 			// traefik will fail to start if the file contains middlewares entry but no middlewares are defined
-			const hasNoMiddlewares = Object.keys(traefikConfig.http.middlewares).length === 0;
+			const hasNoMiddlewares =
+				Object.keys(traefikConfig.http.middlewares).length === 0;
 			if (hasNoMiddlewares) {
-			// if there aren't any middlewares, remove the whole section
+				// if there aren't any middlewares, remove the whole section
 				delete traefikConfig.http.middlewares;
 			}
 		}

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -263,6 +263,14 @@ export const writeTraefikConfigRemote = async (
 	try {
 		const { DYNAMIC_TRAEFIK_PATH } = paths(true);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
+		if (traefikConfig.http?.middlewares) {
+			// traefik will fail to start if the file contains middlewares entry but no middlewares are defined
+			const hasNoMiddlewares = Object.keys(traefikConfig.http.middlewares).length === 0;
+			if (hasNoMiddlewares) {
+			// if there aren't any middlewares, remove the whole section
+				delete traefikConfig.http.middlewares;
+			}
+		}
 		const yamlStr = stringify(traefikConfig);
 		await execAsyncRemote(serverId, `echo '${yamlStr}' > ${configPath}`);
 	} catch (e) {

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -263,15 +263,6 @@ export const writeTraefikConfigRemote = async (
 	try {
 		const { DYNAMIC_TRAEFIK_PATH } = paths(true);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
-		if (traefikConfig.http?.middlewares) {
-			// traefik will fail to start if the file contains middlewares entry but no middlewares are defined
-			const hasNoMiddlewares =
-				Object.keys(traefikConfig.http.middlewares).length === 0;
-			if (hasNoMiddlewares) {
-				// if there aren't any middlewares, remove the whole section
-				delete traefikConfig.http.middlewares;
-			}
-		}
 		const yamlStr = stringify(traefikConfig);
 		await execAsyncRemote(serverId, `echo '${yamlStr}' > ${configPath}`);
 	} catch (e) {

--- a/packages/server/src/utils/traefik/middleware.ts
+++ b/packages/server/src/utils/traefik/middleware.ts
@@ -195,6 +195,10 @@ export const removePathMiddlewares = async (
 		}
 	}
 
+	if (!config) {
+		return;
+	}
+
 	const { appName } = app;
 
 	if (config.http?.middlewares) {
@@ -205,13 +209,12 @@ export const removePathMiddlewares = async (
 		delete config.http.middlewares[stripPrefixMiddleware];
 	}
 
-	if (config?.http?.middlewares) {
-		// traefik will fail to start if the file contains middlewares entry but no middlewares are defined
-		const hasNoMiddlewares = Object.keys(config.http.middlewares).length === 0;
-		if (hasNoMiddlewares) {
-			// if there aren't any middlewares, remove the whole section
-			delete config.http.middlewares;
-		}
+	if (
+		config?.http?.middlewares &&
+		Object.keys(config.http.middlewares).length === 0
+	) {
+		// if there aren't any middlewares, remove the whole section
+		delete config.http.middlewares;
 	}
 
 	// // If http section is empty, remove it completely

--- a/packages/server/src/utils/traefik/middleware.ts
+++ b/packages/server/src/utils/traefik/middleware.ts
@@ -76,7 +76,7 @@ export const loadMiddlewares = <T>() => {
 		throw new Error(`File not found: ${configPath}`);
 	}
 	const yamlStr = readFileSync(configPath, "utf8");
-	const config = parse(yamlStr) as T;
+	const config = (parse(yamlStr) ?? {}) as T;
 	return config;
 };
 
@@ -94,7 +94,7 @@ export const loadRemoteMiddlewares = async (serverId: string) => {
 			console.error(`Error: ${stderr}`);
 			throw new Error(`File not found: ${configPath}`);
 		}
-		const config = parse(stdout) as FileConfig;
+		const config = (parse(stdout) ?? {}) as FileConfig;
 		return config;
 	} catch (_) {
 		throw new Error(`File not found: ${configPath}`);

--- a/packages/server/src/utils/traefik/middleware.ts
+++ b/packages/server/src/utils/traefik/middleware.ts
@@ -100,9 +100,17 @@ export const loadRemoteMiddlewares = async (serverId: string) => {
 		throw new Error(`File not found: ${configPath}`);
 	}
 };
-export const writeMiddleware = <T>(config: T) => {
+export const writeMiddleware = (config: FileConfig) => {
 	const { DYNAMIC_TRAEFIK_PATH } = paths();
 	const configPath = join(DYNAMIC_TRAEFIK_PATH, "middlewares.yml");
+	if (config.http?.middlewares) {
+		// traefik will fail to start if the file contains middlewares entry but no middlewares are defined
+		const hasNoMiddlewares = Object.keys(config.http.middlewares).length === 0;
+		if (hasNoMiddlewares) {
+			// if there aren't any middlewares, remove the whole section
+			delete config.http.middlewares;
+		}
+	}
 	const newYamlContent = stringify(config);
 	writeFileSync(configPath, newYamlContent, "utf8");
 };


### PR DESCRIPTION
## What is this PR about?

If the middleware.yaml file was empty, the parse function returned null, causing below error later on in various parts of the code, since the result was being cast to an object without any validation:
> Cannot read properties of null

This makes the null fallback to an empty object.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2754

## Screenshots (if applicable)

before:


<img width="888" height="263" alt="Image" src="https://github.com/user-attachments/assets/1fbc1900-8b8c-4de6-b63d-e26750828dfd" />
<img width="643" height="400" alt="Image" src="https://github.com/user-attachments/assets/ae9e7c40-c251-4ae7-902e-bdb0527104b9" />

