### PR TITLE
fix: match multi line log messages

### DIFF
--- a/apps/dokploy/components/dashboard/docker/logs/utils.ts
+++ b/apps/dokploy/components/dashboard/docker/logs/utils.ts
@@ -49,7 +49,7 @@ export function parseLogs(logString: string): LogLine[] {
 	// { timestamp: new Date("2024-12-10T10:00:00.000Z"),
 	// message: "The server is running on port 8080" }
 	const logRegex =
-		/^(?:(\d+)\s+)?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z|\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} UTC)?\s*(.*)$/;
+		/^(?:(?<lineNumber>\d+)\s+)?(?<timestamp>(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z|\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} UTC))?\s*(?<message>[\s\S]*)$/;
 
 	return logString
 		.split("\n")
@@ -59,7 +59,7 @@ export function parseLogs(logString: string): LogLine[] {
 			const match = line.match(logRegex);
 			if (!match) return null;
 
-			const [, , timestamp, message] = match;
+			const { timestamp, message } = match.groups ?? {};
 
 			if (!message?.trim()) return null;
 


### PR DESCRIPTION
## What is this PR about?

This PR adds support for displaying log messages that have newlines inside of them.

Also changed the regex to use named groups, it felt nicer to get them from a map instead of index based.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2714

## Screenshots (if applicable)

Dont know if these say anyone anything, but it shows all the logs that wasn't included.

<img width="2284" height="1320" alt="image" src="https://github.com/user-attachments/assets/e20f7333-bac7-4264-93ce-77ea1d1db017" />

before:
<img width="2330" height="992" alt="image" src="https://github.com/user-attachments/assets/470c934e-d89e-4a78-a18c-b39be42ee3fc" />

