### PR TITLE
feat(ai):Support Gemini query-param auth for model listing-#2775

### DIFF
--- a/apps/dokploy/server/api/routers/ai.ts
+++ b/apps/dokploy/server/api/routers/ai.ts
@@ -62,12 +62,12 @@ export const aiRouter = createTRPCRouter({
 					case "ollama":
 						response = await fetch(`${input.apiUrl}/api/tags`, { headers });
 						break;
-				    case "gemini":
-                        response = await fetch(
-                        `${input.apiUrl}/models?key=${encodeURIComponent(input.apiKey)}`,
-                        { headers: {} }
-        );
-        break;
+					case "gemini":
+						response = await fetch(
+							`${input.apiUrl}/models?key=${encodeURIComponent(input.apiKey)}`,
+							{ headers: {} },
+						);
+						break;
 					default:
 						if (!input.apiKey)
 							throw new TRPCError({

--- a/packages/server/src/utils/ai/select-ai-provider.ts
+++ b/packages/server/src/utils/ai/select-ai-provider.ts
@@ -69,11 +69,11 @@ export function selectAIProvider(config: { apiUrl: string; apiKey: string }) {
 			});
 		case "gemini":
 			return createOpenAICompatible({
-				name:"gemini",
-				baseURL:config.apiUrl,
-				queryParams:{ key: config.apiKey},
-				headers:{}
-			})
+				name: "gemini",
+				baseURL: config.apiUrl,
+				queryParams: { key: config.apiKey },
+				headers: {},
+			});
 		case "custom":
 			return createOpenAICompatible({
 				name: "custom",


### PR DESCRIPTION
Add support for Gemini endpoints that expect the API key as a query parameter by:

1.Returning an OpenAI-compatible client configured with queryParams for "gemini".
2.Fetching Gemini models using ?key=<apiKey> and no auth header. Frontend should continue to pass apiUrl/apiKey.

<img width="505" height="672" alt="Screenshot 2025-10-09 at 1 36 41 PM" src="https://github.com/user-attachments/assets/b76711b7-64fa-4bab-ab3f-54102fb94f2a" />


Fix -#2775