### PR TITLE
fix(notifications): prevent blank email field on dialog reopen

### DIFF
--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -208,10 +208,10 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 	});
 
 	useEffect(() => {
-		if (type === "email") {
+		if (type === "email" && fields.length === 0) {
 			append("");
 		}
-	}, [type, append]);
+	}, [type, append, fields.length]);
 
 	useEffect(() => {
 		if (notification) {


### PR DESCRIPTION
## What is this PR about?

Fixed issue where editing existing email notifications automatically added a blank required field - users had to manually click "Remove" on the blank field before being able to update their notification settings. Now only adds empty field for new notifications when no addresses exist.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots (if applicable)

<img width="764" height="740" alt="Screenshot 2025-10-09 at 11 37 04" src="https://github.com/user-attachments/assets/40c2f376-ab6b-4e1d-bc5c-d5732c327bee" />


