### PR TITLE
feat: Bump default MongoDB docker image version to 7

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -55,7 +55,7 @@ import { api } from "@/utils/api";
 type DbType = typeof mySchema._type.type;
 
 const dockerImageDefaultPlaceholder: Record<DbType, string> = {
-	mongo: "mongo:6",
+	mongo: "mongo:7",
 	mariadb: "mariadb:11",
 	mysql: "mysql:8",
 	postgres: "postgres:15",


### PR DESCRIPTION
## What is this PR about?

Bump MongoDB default version 

The previous version of this file used `mongo:6` which **[reached EOL on July 1st 2025](https://www.mongodb.com/legal/support-policy/lifecycles)**

## What does this PR do ? 
Change the default `mongo:6` to `mongo:7`

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

NA

## Screenshots (if applicable)

NA
