### PR TITLE
fix: load remote middleware on app delete if a serverId is provided

### DIFF
--- a/packages/server/src/utils/traefik/middleware.ts
+++ b/packages/server/src/utils/traefik/middleware.ts
@@ -49,11 +49,11 @@ export const deleteAllMiddlewares = async (application: ApplicationNested) => {
 	const { security, appName, redirects, serverId } = application;
 	let config: FileConfig;
 
-    if (serverId) {
-        config = await loadRemoteMiddlewares(serverId);
-    } else {
-        config = loadMiddlewares<FileConfig>();
-    }
+	if (serverId) {
+		config = await loadRemoteMiddlewares(serverId);
+	} else {
+		config = loadMiddlewares<FileConfig>();
+	}
 
 	if (config.http?.middlewares) {
 		if (security.length > 0) {


### PR DESCRIPTION
## What is this PR about?

When an application was deleted, the redirects were removed from the middleware. However, if the application is on a remote server, the local middleware was loaded, not the remote one. 
This PR fixes  #2806 and possibly #2343 by loading the remote middleware instead of the local middleware if the application is hosted on a remote server

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2806

## Screenshots (if applicable)

