### PR TITLE
fix: profile picture image fit

### DIFF
--- a/apps/dokploy/components/dashboard/impersonation/impersonation-bar.tsx
+++ b/apps/dokploy/components/dashboard/impersonation/impersonation-bar.tsx
@@ -281,6 +281,7 @@ export const ImpersonationBar = () => {
 								<div className="flex items-center gap-4 flex-1 flex-wrap">
 									<Avatar className="h-10 w-10">
 										<AvatarImage
+                      className="object-cover"
 											src={data?.user?.image || ""}
 											alt={data?.user?.name || ""}
 										/>

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -44,6 +44,7 @@ export const UserNav = () => {
 				>
 					<Avatar className="h-8 w-8 rounded-lg">
 						<AvatarImage
+              className="object-cover"
 							src={data?.user?.image || ""}
 							alt={data?.user?.image || ""}
 						/>


### PR DESCRIPTION
## What is this PR about?

Quick fix for the profile picture not having a cover fit since in some cases the profile picture can be stretched.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Screenshots (if applicable)

BEFORE:
<img width="356" height="68" alt="Screenshot 2025-10-11 191020" src="https://github.com/user-attachments/assets/5fc2abe8-3a1d-4c0c-b6f8-85090e18a49a" />

AFTER:
<img width="349" height="53" alt="Screenshot 2025-10-11 191028" src="https://github.com/user-attachments/assets/223f8d57-3d4a-4665-a034-33733cacde9b" />
