### PR TITLE
fix: resources tooltips trigger form submission

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
@@ -150,7 +150,10 @@ export const ShowResources = ({ id, type }: Props) => {
 								render={({ field }) => {
 									return (
 										<FormItem>
-											<div className="flex items-center gap-2" onClick={(e) => e.preventDefault()}>
+											<div
+												className="flex items-center gap-2"
+												onClick={(e) => e.preventDefault()}
+											>
 												<FormLabel>Memory Limit</FormLabel>
 												<TooltipProvider>
 													<Tooltip delayDuration={0}>
@@ -182,7 +185,10 @@ export const ShowResources = ({ id, type }: Props) => {
 								name="memoryReservation"
 								render={({ field }) => (
 									<FormItem>
-										<div className="flex items-center gap-2" onClick={(e) => e.preventDefault()}>
+										<div
+											className="flex items-center gap-2"
+											onClick={(e) => e.preventDefault()}
+										>
 											<FormLabel>Memory Reservation</FormLabel>
 											<TooltipProvider>
 												<Tooltip delayDuration={0}>
@@ -215,7 +221,10 @@ export const ShowResources = ({ id, type }: Props) => {
 								render={({ field }) => {
 									return (
 										<FormItem>
-											<div className="flex items-center gap-2" onClick={(e) => e.preventDefault()}>
+											<div
+												className="flex items-center gap-2"
+												onClick={(e) => e.preventDefault()}
+											>
 												<FormLabel>CPU Limit</FormLabel>
 												<TooltipProvider>
 													<Tooltip delayDuration={0}>
@@ -249,7 +258,10 @@ export const ShowResources = ({ id, type }: Props) => {
 								render={({ field }) => {
 									return (
 										<FormItem>
-											<div className="flex items-center gap-2" onClick={(e) => e.preventDefault()}>
+											<div
+												className="flex items-center gap-2"
+												onClick={(e) => e.preventDefault()}
+											>
 												<FormLabel>CPU Reservation</FormLabel>
 												<TooltipProvider>
 													<Tooltip delayDuration={0}>


### PR DESCRIPTION
## What is this PR about?

This is a very simple frontend change to stop the tooltips in the Resources section from submitting the form every time they are clicked.

You can replicate by heading to any application service > Advanced tab > Scroll down to "Resources," then click any of the tooltips.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots
Issue:

![CleanShot_2025-10-15_at_04 51 17](https://github.com/user-attachments/assets/88c7c309-f9ea-4632-8eca-dd9e4b277296)

After fix:
![fix](https://github.com/user-attachments/assets/b4500edf-2a72-4b92-a3f9-7c655c0bb331)
