### PR TITLE
FEAT: improve webserver backups by adding including and excluding patterns

### DIFF
--- a/packages/server/src/db/schema/backups.ts
+++ b/packages/server/src/db/schema/backups.ts
@@ -95,6 +95,9 @@ export const backups = pgTable("backup", {
 		  }
 		| undefined
 	>(),
+	// Path filtering for web-server backups
+	includePaths: jsonb("includePaths").$type<string[] | undefined>(),
+	excludePaths: jsonb("excludePaths").$type<string[] | undefined>(),
 });
 
 export const backupsRelations = relations(backups, ({ one, many }) => ({
@@ -144,6 +147,8 @@ const createSchema = createInsertSchema(backups, {
 	mongoId: z.string().optional(),
 	userId: z.string().optional(),
 	metadata: z.any().optional(),
+	includePaths: z.array(z.string()).optional(),
+	excludePaths: z.array(z.string()).optional(),
 });
 
 export const apiCreateBackup = createSchema.pick({
@@ -163,6 +168,8 @@ export const apiCreateBackup = createSchema.pick({
 	composeId: true,
 	serviceName: true,
 	metadata: true,
+	includePaths: true,
+	excludePaths: true,
 });
 
 export const apiFindOneBackup = createSchema
@@ -189,6 +196,8 @@ export const apiUpdateBackup = createSchema
 		serviceName: true,
 		metadata: true,
 		databaseType: true,
+		includePaths: true,
+		excludePaths: true,
 	})
 	.required();
 


### PR DESCRIPTION
## What is this PR about?

This PR adds a new feature on the webserver backup to set a pattern to include and/or exclude specific paths. 
By default the webserver backup takes everything from /etc/dokploy, but if you have apps or other data in subfolders like eg /etc/dokploy/apps, you don't want those to be included with the webserver backups. 
This PR fix that problem. 

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2860

## Screenshots (if applicable)

