### PR TITLE
Feat(ui) : Auto-select single-option dropdowns in shared Select -#2553

### DIFF
--- a/apps/dokploy/components/ui/select.tsx
+++ b/apps/dokploy/components/ui/select.tsx
@@ -28,18 +28,34 @@ function collectSelectItemValues(children: React.ReactNode): string[] {
 	return values;
 }
 
-const Select = ({ children, defaultValue, value, onValueChange, ...props }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>) => {
+const Select = ({
+	children,
+	defaultValue,
+	value,
+	onValueChange,
+	...props
+}: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>) => {
 	// Auto-select a single option only when the Select is uncontrolled and has no defaultValue
 	const computedDefaultValue = React.useMemo(() => {
 		if (value !== undefined) return undefined; // controlled
-		if (defaultValue !== undefined && defaultValue !== null && defaultValue !== "") return undefined; // user provided meaningful value
+		if (
+			defaultValue !== undefined &&
+			defaultValue !== null &&
+			defaultValue !== ""
+		)
+			return undefined; // user provided meaningful value
 		const itemValues = collectSelectItemValues(children);
 		return itemValues.length === 1 ? itemValues[0] : undefined;
 	}, [children, value, defaultValue]);
 
 	// Auto-select the only option after async children load for both controlled and uncontrolled usages
 	React.useEffect(() => {
-		if (defaultValue !== undefined && defaultValue !== null && defaultValue !== "") return; // respect explicit non-empty default
+		if (
+			defaultValue !== undefined &&
+			defaultValue !== null &&
+			defaultValue !== ""
+		)
+			return; // respect explicit non-empty default
 		const itemValues = collectSelectItemValues(children);
 		const hasSingleOption = itemValues.length === 1;
 		const hasNoValue = value === undefined || value === null || value === "";


### PR DESCRIPTION
1.Add auto-select when exactly one SelectItem exists
2.Works for both controlled and uncontrolled usage
3.Handles async-loaded options and ignores empty-string defaults


<img width="1250" height="173" alt="Screenshot 2025-10-30 at 5 08 05 PM" src="https://github.com/user-attachments/assets/1e253f71-301b-460e-9407-da2071dfb6fd" />

Fix -#2553