### PR TITLE
feat: add server time clock in the dashboard 

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -14,6 +14,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { BreadcrumbSidebar } from "@/components/shared/breadcrumb-sidebar";
 import { DateTooltip } from "@/components/shared/date-tooltip";
+import { FocusShortcutInput } from "@/components/shared/focus-shortcut-input";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
 import {
 	AlertDialog,
@@ -44,7 +45,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { FocusShortcutInput } from "@/components/shared/focus-shortcut-input";
 import {
 	Select,
 	SelectContent,
@@ -52,13 +52,14 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { TimeBadge } from "@/components/ui/time-badge";
 import { api } from "@/utils/api";
 import { HandleProject } from "./handle-project";
 import { ProjectEnvironment } from "./project-environment";
-import { TimeBadge } from "@/components/ui/time-badge";
 
 export const ShowProjects = () => {
 	const utils = api.useUtils();
+	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data, isLoading } = api.project.all.useQuery();
 	const { data: auth } = api.user.get.useQuery();
 	const { mutateAsync } = api.project.remove.useMutation();
@@ -136,9 +137,11 @@ export const ShowProjects = () => {
 			<BreadcrumbSidebar
 				list={[{ name: "Projects", href: "/dashboard/projects" }]}
 			/>
-			<div className="absolute top-5 right-5">
-				<TimeBadge />
-			</div>
+			{!isCloud && (
+				<div className="absolute top-5 right-5">
+					<TimeBadge />
+				</div>
+			)}
 			<div className="w-full">
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl  ">
 					<div className="rounded-xl bg-background shadow-md ">

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -1126,7 +1126,7 @@ export default function Page({ children }: Props) {
 									</BreadcrumbList>
 								</Breadcrumb>
 							</div>
-							<TimeBadge />
+							{!isCloud && <TimeBadge />}
 						</div>
 					</header>
 				)}

--- a/apps/dokploy/components/ui/time-badge.tsx
+++ b/apps/dokploy/components/ui/time-badge.tsx
@@ -4,9 +4,7 @@ import { useEffect, useState } from "react";
 import { api } from "@/utils/api";
 
 export function TimeBadge() {
-	const { data: serverTime } = api.server.getServerTime.useQuery(undefined, {
-		refetchInterval: 60000, // Refetch every 60 seconds
-	});
+	const { data: serverTime } = api.server.getServerTime.useQuery(undefined);
 	const [time, setTime] = useState<Date | null>(null);
 
 	useEffect(() => {

--- a/apps/dokploy/server/api/routers/server.ts
+++ b/apps/dokploy/server/api/routers/server.ts
@@ -384,6 +384,9 @@ export const serverRouter = createTRPCRouter({
 		return ip;
 	}),
 	getServerTime: protectedProcedure.query(() => {
+		if (IS_CLOUD) {
+			return null;
+		}
 		return {
 			time: new Date(),
 			timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,


### PR DESCRIPTION
## What is this PR about?

Adds a responsive Server Time badge showing current server time, timezone, and UTC offset in dashboard header and projects header, polls server time every 60s and ticks client-side each second

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Changes
- New: apps/dokploy/components/ui/time-badge.tsx
- Modified: apps/dokploy/components/layouts/side.tsx, apps/dokploy/components/dashboard/projects/show.tsx

## Issues related (if applicable)

closes #2906 

## Screenshots (if applicable)
Dark Mode:
<img width="1506" height="696" alt="Screenshot 2025-11-01 at 6 16 16 PM" src="https://github.com/user-attachments/assets/1acc2006-0d9a-47ff-85e6-5c33d40c4ca1" />

Light Mode:
<img width="1502" height="709" alt="Screenshot 2025-11-01 at 6 16 53 PM" src="https://github.com/user-attachments/assets/90b0d97a-f591-4128-b526-430650f9c9c0" />
