### PR TITLE
ArvanCloud new IP Ranges

### DIFF
--- a/packages/server/src/services/cdn.ts
+++ b/packages/server/src/services/cdn.ts
@@ -616,6 +616,7 @@ const ARVANCLOUD_IP_RANGES = [
 	"37.32.18.0/27",
 	"37.32.19.0/27",
 	"185.215.232.0/22",
+	"178.131.120.48/28",
 ];
 
 const CDN_PROVIDERS: CDNProvider[] = [


### PR DESCRIPTION
I have recently recieved this email from ArvanCloud:
<img width="1470" height="956" alt="Screenshot 2025-11-01 at 11 08 34 PM" src="https://github.com/user-attachments/assets/90238a26-01eb-4b9c-ac32-392427fcb81f" />

It says that the IP ranges for ArvanCloud have changed.
I have added the new IP ranges to the cdn service so that the users of ArvanCloud's CDN do not encounter any issues when using Dokploy.

(I mean it's just one new IP range but whatever)