### PR TITLE
Fix: Add JSON responses to compose endpoints that return empty body

### DIFF
--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -245,6 +245,7 @@ export const composeRouter = createTRPCRouter({
 				});
 			}
 			await cleanQueuesByCompose(input.composeId);
+			return { success: true, message: "Queues cleaned successfully" };
 		}),
 
 	loadServices: protectedProcedure
@@ -405,6 +406,7 @@ export const composeRouter = createTRPCRouter({
 					removeOnFail: true,
 				},
 			);
+			return { success: true, message: "Deployment queued" };
 		}),
 	redeploy: protectedProcedure
 		.input(apiRedeployCompose)
@@ -440,6 +442,7 @@ export const composeRouter = createTRPCRouter({
 					removeOnFail: true,
 				},
 			);
+			return { success: true, message: "Redeployment queued" };
 		}),
 	stop: protectedProcedure
 		.input(apiFindCompose)


### PR DESCRIPTION
## Description
Fixes critical bug where compose API endpoints return HTTP 200 with `Content-Type: application/json` but send empty response body, breaking JSON parsing for external API clients.

Fixes #2940 

## Problem
Three endpoints in the compose router don't return anything (implicit `undefined`):
- `compose.deploy`
- `compose.redeploy`
- `compose.cleanQueues`

This causes:
```bash
# HTTP Response
HTTP/1.1 200 OK
Content-Type: application/json
Content-Length: 0

# Empty body causes JSON.parse() to fail
```

## Solution
Add explicit return statements to these 3 endpoints to return valid JSON responses.

## Changes Made

### 1. compose.deploy endpoint
```diff
  await myQueue.add("deployments", { ...jobData }, {...});
+ return { success: true, message: "Deployment queued" };
```

### 2. compose.redeploy endpoint
```diff
  await myQueue.add("deployments", { ...jobData }, {...});
+ return { success: true, message: "Redeployment queued" };
```

### 3. compose.cleanQueues endpoint
```diff
  await cleanQueuesByCompose(input.composeId);
+ return { success: true, message: "Queues cleaned successfully" };
```

## Impact

### Fixes
- ✅ External API clients can now parse responses
- ✅ No more "Unexpected end of JSON input" errors

## Files Changed
- `apps/dokploy/server/api/routers/compose.ts` (3 lines added)

