### PR TITLE
chore: Upgrade Traefik to 3.5.4

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -22,7 +22,7 @@ import {
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
-		await execAsync("docker pull traefik:v3.5.0");
+		await execAsync("docker pull traefik:v3.5.4");
 		await initializeStandaloneTraefik();
 		await initializeRedis();
 		await initializePostgres();

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -20,7 +20,7 @@ export const TRAEFIK_PORT =
 	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
-export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.5.0";
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.5.4";
 
 export interface TraefikOptions {
 	env?: string[];


### PR DESCRIPTION
Upgrades Traefik from 3.5.0 to 3.5.4 to support Hostinger DNS challenge provider.

This change enables the Hostinger DNS challenge functionality introduced in go-acme/lego v4.27.0, which is included in Traefik 3.5.4.

**Changes:**
- Updated default `TRAEFIK_VERSION` in `traefik-setup.ts` from 3.5.0 to 3.5.4
- Updated docker pull command in `setup.ts` to use v3.5.4


<img width="1255" height="486" alt="Screenshot 2025-11-03 at 12 08 19 PM" src="https://github.com/user-attachments/assets/5948c88f-7d65-4d0f-955e-2cca6346f65c" />



Fixes #2942