### PR TITLE
fix: clear input value after uploading file in dropzone

### DIFF
--- a/apps/dokploy/components/ui/dropzone.tsx
+++ b/apps/dokploy/components/ui/dropzone.tsx
@@ -67,9 +67,10 @@ export const Dropzone = React.forwardRef<HTMLDivElement, DropzoneProps>(
 							ref={inputRef}
 							type="file"
 							className={cn("hidden", className)}
-							onChange={(e: ChangeEvent<HTMLInputElement>) =>
-								onChange(e.target.files)
-							}
+							onChange={(e: ChangeEvent<HTMLInputElement>) => {
+								onChange(e.target.files);
+								e.target.value = "";
+							}}
 						/>
 					</div>
 				</CardContent>


### PR DESCRIPTION
## What is this PR about?

Fix file input not accepting the same file two times in a row by clearing input value.
When the file value changes or is cleared, React creates a fresh input element, allowing users to re-upload the same file without needing to refresh the page. This is a common fix for this issue.

## Issues related (if applicable)
closes #2949 

## Screenshots (if applicable)

### Before the fix
https://github.com/user-attachments/assets/6ed3cd93-a707-4587-b0c6-84d0d03e302e

### After the fix

https://github.com/user-attachments/assets/0139402c-d87c-4b05-a12f-03572e9bfd3a


