### PR TITLE
feat: Add domain links in service page headers (#1396)

### DIFF
--- a/apps/dokploy/components/dashboard/compose/general/show.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/show.tsx
@@ -28,10 +28,10 @@ export const ShowGeneralCompose = ({ composeId }: Props) => {
 				<CardHeader>
 					<div className="flex flex-row gap-2 justify-between flex-wrap items-center">
 						<div className="flex flex-row gap-2 items-center flex-wrap">
-						<CardTitle className="text-xl">Deploy Settings</CardTitle>
-						<Badge>
-							{data?.composeType === "docker-compose" ? "Compose" : "Stack"}
-						</Badge>
+							<CardTitle className="text-xl">Deploy Settings</CardTitle>
+							<Badge>
+								{data?.composeType === "docker-compose" ? "Compose" : "Stack"}
+							</Badge>
 						</div>
 					</div>
 

--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -252,251 +252,239 @@ export const ShowProjects = () => {
 													className="w-full lg:max-w-md"
 												>
 													<Card className="group relative w-full h-full bg-transparent transition-colors hover:bg-border cursor-pointer">
-															{haveServicesWithDomains ? (
-																<DropdownMenu>
-																	<DropdownMenuTrigger asChild>
-																		<Button
-																			className="absolute -right-3 -top-3 size-9 translate-y-1 rounded-full p-0 opacity-0 transition-all duration-200 group-hover:translate-y-0 group-hover:opacity-100"
-																			size="sm"
-																			variant="default"
-																		>
-																			<ExternalLinkIcon className="size-3.5" />
-																		</Button>
-																	</DropdownMenuTrigger>
-																	<DropdownMenuContent
-																		className="w-[200px] space-y-2 overflow-y-auto max-h-[400px]"
-																		onClick={(e) => e.stopPropagation()}
+														{haveServicesWithDomains ? (
+															<DropdownMenu>
+																<DropdownMenuTrigger asChild>
+																	<Button
+																		className="absolute -right-3 -top-3 size-9 translate-y-1 rounded-full p-0 opacity-0 transition-all duration-200 group-hover:translate-y-0 group-hover:opacity-100"
+																		size="sm"
+																		variant="default"
 																	>
-																		{project.environments.some(
-																			(env) => env.applications.length > 0,
-																		) && (
-																			<DropdownMenuGroup>
-																				<DropdownMenuLabel>
-																					Applications
-																				</DropdownMenuLabel>
-																				{project.environments.map((env) =>
-																					env.applications.map((app) => (
-																						<div key={app.applicationId}>
+																		<ExternalLinkIcon className="size-3.5" />
+																	</Button>
+																</DropdownMenuTrigger>
+																<DropdownMenuContent
+																	className="w-[200px] space-y-2 overflow-y-auto max-h-[400px]"
+																	onClick={(e) => e.stopPropagation()}
+																>
+																	{project.environments.some(
+																		(env) => env.applications.length > 0,
+																	) && (
+																		<DropdownMenuGroup>
+																			<DropdownMenuLabel>
+																				Applications
+																			</DropdownMenuLabel>
+																			{project.environments.map((env) =>
+																				env.applications.map((app) => (
+																					<div key={app.applicationId}>
+																						<DropdownMenuSeparator />
+																						<DropdownMenuGroup>
+																							<DropdownMenuLabel className="font-normal capitalize text-xs flex items-center justify-between">
+																								{app.name}
+																								<StatusTooltip
+																									status={app.applicationStatus}
+																								/>
+																							</DropdownMenuLabel>
 																							<DropdownMenuSeparator />
-																							<DropdownMenuGroup>
-																								<DropdownMenuLabel className="font-normal capitalize text-xs flex items-center justify-between">
-																									{app.name}
-																									<StatusTooltip
-																										status={
-																											app.applicationStatus
-																										}
-																									/>
-																								</DropdownMenuLabel>
-																								<DropdownMenuSeparator />
-																								{app.domains.map((domain) => (
-																									<DropdownMenuItem
-																										key={domain.domainId}
-																										asChild
-																									>
-																										<Link
-																											className="space-x-4 text-xs cursor-pointer justify-between"
-																											target="_blank"
-																											href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
-																										>
-																											<span className="truncate">
-																												{domain.host}
-																											</span>
-																											<ExternalLinkIcon className="size-4 shrink-0" />
-																										</Link>
-																									</DropdownMenuItem>
-																								))}
-																							</DropdownMenuGroup>
-																						</div>
-																					)),
-																				)}
-																			</DropdownMenuGroup>
-																		)}
-																		{project.environments.some(
-																			(env) => env.compose.length > 0,
-																		) && (
-																			<DropdownMenuGroup>
-																				<DropdownMenuLabel>
-																					Compose
-																				</DropdownMenuLabel>
-																				{project.environments.map((env) =>
-																					env.compose.map((comp) => (
-																						<div key={comp.composeId}>
-																							<DropdownMenuSeparator />
-																							<DropdownMenuGroup>
-																								<DropdownMenuLabel className="font-normal capitalize text-xs flex items-center justify-between">
-																									{comp.name}
-																									<StatusTooltip
-																										status={comp.composeStatus}
-																									/>
-																								</DropdownMenuLabel>
-																								<DropdownMenuSeparator />
-																								{comp.domains.map((domain) => (
-																									<DropdownMenuItem
-																										key={domain.domainId}
-																										asChild
-																									>
-																										<Link
-																											className="space-x-4 text-xs cursor-pointer justify-between"
-																											target="_blank"
-																											href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
-																										>
-																											<span className="truncate">
-																												{domain.host}
-																											</span>
-																											<ExternalLinkIcon className="size-4 shrink-0" />
-																										</Link>
-																									</DropdownMenuItem>
-																								))}
-																							</DropdownMenuGroup>
-																						</div>
-																					)),
-																				)}
-																			</DropdownMenuGroup>
-																		)}
-																	</DropdownMenuContent>
-																</DropdownMenu>
-															) : null}
-															<CardHeader>
-																<CardTitle className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-																	<span className="flex flex-col gap-1.5 flex-1 min-w-0">
-																		<div className="flex items-center gap-2">
-																			<BookIcon className="size-4 text-muted-foreground shrink-0" />
-																			<span className="text-base font-medium leading-none truncate">
-																				{project.name}
-																			</span>
-																		</div>
-
-																		{project.description && (
-																			<span className="text-sm font-medium text-muted-foreground truncate">
-																				{project.description}
-																			</span>
-																		)}
-																	</span>
-																	<div className="flex self-start space-x-1">
-																		<DropdownMenu>
-																			<DropdownMenuTrigger asChild>
-																				<Button
-																					variant="ghost"
-																					size="icon"
-																					className="px-2"
-																				>
-																					<MoreHorizontalIcon className="size-5" />
-																				</Button>
-																			</DropdownMenuTrigger>
-																			<DropdownMenuContent
-																				className="w-[200px] space-y-2 overflow-y-auto max-h-[280px]"
-																				onClick={(e) => e.stopPropagation()}
-																			>
-																				<DropdownMenuLabel className="font-normal">
-																					Actions
-																				</DropdownMenuLabel>
-																				<div
-																					onClick={(e) => e.stopPropagation()}
-																				>
-																					<ProjectEnvironment
-																						projectId={project.projectId}
-																					/>
-																				</div>
-																				<div
-																					onClick={(e) => e.stopPropagation()}
-																				>
-																					<HandleProject
-																						projectId={project.projectId}
-																					/>
-																				</div>
-
-																				<div
-																					onClick={(e) => e.stopPropagation()}
-																				>
-																					{(auth?.role === "owner" ||
-																						auth?.canDeleteProjects) && (
-																						<AlertDialog>
-																							<AlertDialogTrigger className="w-full">
+																							{app.domains.map((domain) => (
 																								<DropdownMenuItem
-																									className="w-full cursor-pointer  space-x-3"
-																									onSelect={(e) =>
-																										e.preventDefault()
-																									}
+																									key={domain.domainId}
+																									asChild
 																								>
-																									<TrashIcon className="size-4" />
-																									<span>Delete</span>
-																								</DropdownMenuItem>
-																							</AlertDialogTrigger>
-																							<AlertDialogContent>
-																								<AlertDialogHeader>
-																									<AlertDialogTitle>
-																										Are you sure to delete this
-																										project?
-																									</AlertDialogTitle>
-																									{!emptyServices ? (
-																										<div className="flex flex-row gap-4 rounded-lg bg-yellow-50 p-2 dark:bg-yellow-950">
-																											<AlertTriangle className="text-yellow-600 dark:text-yellow-400" />
-																											<span className="text-sm text-yellow-600 dark:text-yellow-400">
-																												You have active
-																												services, please delete
-																												them first
-																											</span>
-																										</div>
-																									) : (
-																										<AlertDialogDescription>
-																											This action cannot be
-																											undone
-																										</AlertDialogDescription>
-																									)}
-																								</AlertDialogHeader>
-																								<AlertDialogFooter>
-																									<AlertDialogCancel>
-																										Cancel
-																									</AlertDialogCancel>
-																									<AlertDialogAction
-																										disabled={!emptyServices}
-																										onClick={async () => {
-																											await mutateAsync({
-																												projectId:
-																													project.projectId,
-																											})
-																												.then(() => {
-																													toast.success(
-																														"Project deleted successfully",
-																													);
-																												})
-																												.catch(() => {
-																													toast.error(
-																														"Error deleting this project",
-																													);
-																												})
-																												.finally(() => {
-																													utils.project.all.invalidate();
-																												});
-																										}}
+																									<Link
+																										className="space-x-4 text-xs cursor-pointer justify-between"
+																										target="_blank"
+																										href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
 																									>
-																										Delete
-																									</AlertDialogAction>
-																								</AlertDialogFooter>
-																							</AlertDialogContent>
-																						</AlertDialog>
-																					)}
-																				</div>
-																			</DropdownMenuContent>
-																		</DropdownMenu>
+																										<span className="truncate">
+																											{domain.host}
+																										</span>
+																										<ExternalLinkIcon className="size-4 shrink-0" />
+																									</Link>
+																								</DropdownMenuItem>
+																							))}
+																						</DropdownMenuGroup>
+																					</div>
+																				)),
+																			)}
+																		</DropdownMenuGroup>
+																	)}
+																	{project.environments.some(
+																		(env) => env.compose.length > 0,
+																	) && (
+																		<DropdownMenuGroup>
+																			<DropdownMenuLabel>
+																				Compose
+																			</DropdownMenuLabel>
+																			{project.environments.map((env) =>
+																				env.compose.map((comp) => (
+																					<div key={comp.composeId}>
+																						<DropdownMenuSeparator />
+																						<DropdownMenuGroup>
+																							<DropdownMenuLabel className="font-normal capitalize text-xs flex items-center justify-between">
+																								{comp.name}
+																								<StatusTooltip
+																									status={comp.composeStatus}
+																								/>
+																							</DropdownMenuLabel>
+																							<DropdownMenuSeparator />
+																							{comp.domains.map((domain) => (
+																								<DropdownMenuItem
+																									key={domain.domainId}
+																									asChild
+																								>
+																									<Link
+																										className="space-x-4 text-xs cursor-pointer justify-between"
+																										target="_blank"
+																										href={`${domain.https ? "https" : "http"}://${domain.host}${domain.path}`}
+																									>
+																										<span className="truncate">
+																											{domain.host}
+																										</span>
+																										<ExternalLinkIcon className="size-4 shrink-0" />
+																									</Link>
+																								</DropdownMenuItem>
+																							))}
+																						</DropdownMenuGroup>
+																					</div>
+																				)),
+																			)}
+																		</DropdownMenuGroup>
+																	)}
+																</DropdownMenuContent>
+															</DropdownMenu>
+														) : null}
+														<CardHeader>
+															<CardTitle className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+																<span className="flex flex-col gap-1.5 flex-1 min-w-0">
+																	<div className="flex items-center gap-2">
+																		<BookIcon className="size-4 text-muted-foreground shrink-0" />
+																		<span className="text-base font-medium leading-none truncate">
+																			{project.name}
+																		</span>
 																	</div>
-																</CardTitle>
-															</CardHeader>
-															<CardFooter className="pt-4">
-																<div className="space-y-1 text-sm flex flex-row justify-between max-sm:flex-wrap w-full gap-2 sm:gap-4">
-																	<DateTooltip date={project.createdAt}>
-																		Created
-																	</DateTooltip>
-																	<span>
-																		{totalServices}{" "}
-																		{totalServices === 1
-																			? "service"
-																			: "services"}
-																	</span>
+
+																	{project.description && (
+																		<span className="text-sm font-medium text-muted-foreground truncate">
+																			{project.description}
+																		</span>
+																	)}
+																</span>
+																<div className="flex self-start space-x-1">
+																	<DropdownMenu>
+																		<DropdownMenuTrigger asChild>
+																			<Button
+																				variant="ghost"
+																				size="icon"
+																				className="px-2"
+																			>
+																				<MoreHorizontalIcon className="size-5" />
+																			</Button>
+																		</DropdownMenuTrigger>
+																		<DropdownMenuContent
+																			className="w-[200px] space-y-2 overflow-y-auto max-h-[280px]"
+																			onClick={(e) => e.stopPropagation()}
+																		>
+																			<DropdownMenuLabel className="font-normal">
+																				Actions
+																			</DropdownMenuLabel>
+																			<div onClick={(e) => e.stopPropagation()}>
+																				<ProjectEnvironment
+																					projectId={project.projectId}
+																				/>
+																			</div>
+																			<div onClick={(e) => e.stopPropagation()}>
+																				<HandleProject
+																					projectId={project.projectId}
+																				/>
+																			</div>
+
+																			<div onClick={(e) => e.stopPropagation()}>
+																				{(auth?.role === "owner" ||
+																					auth?.canDeleteProjects) && (
+																					<AlertDialog>
+																						<AlertDialogTrigger className="w-full">
+																							<DropdownMenuItem
+																								className="w-full cursor-pointer  space-x-3"
+																								onSelect={(e) =>
+																									e.preventDefault()
+																								}
+																							>
+																								<TrashIcon className="size-4" />
+																								<span>Delete</span>
+																							</DropdownMenuItem>
+																						</AlertDialogTrigger>
+																						<AlertDialogContent>
+																							<AlertDialogHeader>
+																								<AlertDialogTitle>
+																									Are you sure to delete this
+																									project?
+																								</AlertDialogTitle>
+																								{!emptyServices ? (
+																									<div className="flex flex-row gap-4 rounded-lg bg-yellow-50 p-2 dark:bg-yellow-950">
+																										<AlertTriangle className="text-yellow-600 dark:text-yellow-400" />
+																										<span className="text-sm text-yellow-600 dark:text-yellow-400">
+																											You have active services,
+																											please delete them first
+																										</span>
+																									</div>
+																								) : (
+																									<AlertDialogDescription>
+																										This action cannot be undone
+																									</AlertDialogDescription>
+																								)}
+																							</AlertDialogHeader>
+																							<AlertDialogFooter>
+																								<AlertDialogCancel>
+																									Cancel
+																								</AlertDialogCancel>
+																								<AlertDialogAction
+																									disabled={!emptyServices}
+																									onClick={async () => {
+																										await mutateAsync({
+																											projectId:
+																												project.projectId,
+																										})
+																											.then(() => {
+																												toast.success(
+																													"Project deleted successfully",
+																												);
+																											})
+																											.catch(() => {
+																												toast.error(
+																													"Error deleting this project",
+																												);
+																											})
+																											.finally(() => {
+																												utils.project.all.invalidate();
+																											});
+																									}}
+																								>
+																									Delete
+																								</AlertDialogAction>
+																							</AlertDialogFooter>
+																						</AlertDialogContent>
+																					</AlertDialog>
+																				)}
+																			</div>
+																		</DropdownMenuContent>
+																	</DropdownMenu>
 																</div>
-															</CardFooter>
-														</Card>
-													</Link>
+															</CardTitle>
+														</CardHeader>
+														<CardFooter className="pt-4">
+															<div className="space-y-1 text-sm flex flex-row justify-between max-sm:flex-wrap w-full gap-2 sm:gap-4">
+																<DateTooltip date={project.createdAt}>
+																	Created
+																</DateTooltip>
+																<span>
+																	{totalServices}{" "}
+																	{totalServices === 1 ? "service" : "services"}
+																</span>
+															</div>
+														</CardFooter>
+													</Card>
+												</Link>
 											);
 										})}
 									</div>

--- a/apps/dokploy/components/dashboard/shared/service-domain-links.tsx
+++ b/apps/dokploy/components/dashboard/shared/service-domain-links.tsx
@@ -69,26 +69,24 @@ export const ServiceDomainLinks = ({
 		return () => window.removeEventListener("resize", updateMaxVisible);
 	}, [maxVisible]);
 
-	const {
-		data: domains,
-		isLoading,
-	} = type === "application"
-		? api.domain.byApplicationId.useQuery(
-				{
-					applicationId: id,
-				},
-				{
-					enabled: !!id,
-				},
-			)
-		: api.domain.byComposeId.useQuery(
-				{
-					composeId: id,
-				},
-				{
-					enabled: !!id,
-				},
-			);
+	const { data: domains, isLoading } =
+		type === "application"
+			? api.domain.byApplicationId.useQuery(
+					{
+						applicationId: id,
+					},
+					{
+						enabled: !!id,
+					},
+				)
+			: api.domain.byComposeId.useQuery(
+					{
+						composeId: id,
+					},
+					{
+						enabled: !!id,
+					},
+				);
 
 	// Get service data for navigation
 	const { data: service } =
@@ -171,7 +169,9 @@ export const ServiceDomainLinks = ({
 						variant="outline"
 						className="cursor-pointer hover:bg-primary/10 transition-colors gap-1.5 px-2 py-0.5 text-xs max-w-full"
 					>
-						<span className="truncate max-w-[200px] sm:max-w-none">{domain.label}</span>
+						<span className="truncate max-w-[200px] sm:max-w-none">
+							{domain.label}
+						</span>
 						<ExternalLinkIcon className="size-3 shrink-0 opacity-70 group-hover:opacity-100 transition-opacity" />
 					</Badge>
 				</Link>
@@ -213,7 +213,9 @@ export const ServiceDomainLinks = ({
 										setIsOverflowOpen(false);
 									}}
 								>
-									<span className="whitespace-nowrap flex-1">{domain.label}</span>
+									<span className="whitespace-nowrap flex-1">
+										{domain.label}
+									</span>
 									<ExternalLinkIcon className="size-3 shrink-0" />
 								</Link>
 							</DropdownMenuItem>
@@ -243,4 +245,3 @@ export const ServiceDomainLinks = ({
 		</div>
 	);
 };
-

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -130,7 +130,9 @@ const Service = (
 									<span className="truncate">{data?.name}</span>
 								</CardTitle>
 								{data?.description && (
-									<CardDescription className="truncate">{data?.description}</CardDescription>
+									<CardDescription className="truncate">
+										{data?.description}
+									</CardDescription>
 								)}
 
 								<span className="text-sm text-muted-foreground truncate">
@@ -138,7 +140,11 @@ const Service = (
 								</span>
 								{/* Domain Links */}
 								<div className="mt-1.5 flex-wrap">
-									<ServiceDomainLinks id={applicationId} type="application" maxVisible={5} />
+									<ServiceDomainLinks
+										id={applicationId}
+										type="application"
+										maxVisible={5}
+									/>
 								</div>
 							</div>
 							<div className="flex flex-col h-fit w-fit gap-2 shrink-0">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -122,7 +122,9 @@ const Service = (
 										<span className="truncate">{data?.name}</span>
 									</CardTitle>
 									{data?.description && (
-										<CardDescription className="truncate">{data?.description}</CardDescription>
+										<CardDescription className="truncate">
+											{data?.description}
+										</CardDescription>
 									)}
 
 									<span className="text-sm text-muted-foreground truncate">
@@ -130,7 +132,11 @@ const Service = (
 									</span>
 									{/* Domain Links */}
 									<div className="mt-1.5 flex-wrap">
-										<ServiceDomainLinks id={composeId} type="compose" maxVisible={5} />
+										<ServiceDomainLinks
+											id={composeId}
+											type="compose"
+											maxVisible={5}
+										/>
 									</div>
 								</div>
 								<div className="flex flex-col h-fit w-fit gap-2 shrink-0">


### PR DESCRIPTION
Adds domain links in service page headers with full hostname display.

- Priority navigation (custom domains first)
- Overflow menu with "Add Domain" shortcut
- Responsive design (1/2/3+ domains by screen size)

<img width="1339" height="283" alt="Screenshot 2025-11-04 at 7 23 43 PM" src="https://github.com/user-attachments/assets/4082eaf9-c38d-4f7e-a45c-2cc20bcaf3a9" />


Fixes -#1396