### PR TITLE
feat: Add ability to stop running schedules (#2853)

### DIFF
--- a/apps/dokploy/components/dashboard/application/schedules/show-schedules.tsx
+++ b/apps/dokploy/components/dashboard/application/schedules/show-schedules.tsx
@@ -44,20 +44,18 @@ export const ShowSchedules = ({ id, scheduleType = "application" }: Props) => {
 
 	const utils = api.useUtils();
 
-	const {
-		data: schedules,
-		isLoading: isLoadingSchedules,
-	} = api.schedule.list.useQuery(
-		{
-			id: id || "",
-			scheduleType,
-		},
-		{
-			enabled: !!id,
-			refetchInterval: 3000, // Poll every 3 seconds to check for running status
-			refetchOnWindowFocus: false,
-		},
-	);
+	const { data: schedules, isLoading: isLoadingSchedules } =
+		api.schedule.list.useQuery(
+			{
+				id: id || "",
+				scheduleType,
+			},
+			{
+				enabled: !!id,
+				refetchInterval: 3000, // Poll every 3 seconds to check for running status
+				refetchOnWindowFocus: false,
+			},
+		);
 
 	const { mutateAsync: deleteSchedule, isLoading: isDeleting } =
 		api.schedule.delete.useMutation();
@@ -194,14 +192,18 @@ export const ShowSchedules = ({ id, scheduleType = "application" }: Props) => {
 																	});
 																	// Clear loading state immediately - this triggers a re-render
 																	setStoppingScheduleId(null);
-																	toast.success("Schedule stopped successfully");
+																	toast.success(
+																		"Schedule stopped successfully",
+																	);
 																	// Invalidate in background without awaiting
-																	utils.schedule.list.invalidate({
-																		id,
-																		scheduleType,
-																	}).catch(() => {
-																		// Silently handle background refetch errors
-																	});
+																	utils.schedule.list
+																		.invalidate({
+																			id,
+																			scheduleType,
+																		})
+																		.catch(() => {
+																			// Silently handle background refetch errors
+																		});
 																} catch (error) {
 																	// Clear loading on error too
 																	setStoppingScheduleId(null);
@@ -249,12 +251,14 @@ export const ShowSchedules = ({ id, scheduleType = "application" }: Props) => {
 																	setRunningScheduleId(null);
 																	toast.success("Schedule run successfully");
 																	// Invalidate in background without awaiting
-																	utils.schedule.list.invalidate({
-																		id,
-																		scheduleType,
-																	}).catch(() => {
-																		// Silently handle background refetch errors
-																	});
+																	utils.schedule.list
+																		.invalidate({
+																			id,
+																			scheduleType,
+																		})
+																		.catch(() => {
+																			// Silently handle background refetch errors
+																		});
 																} catch (error) {
 																	setRunningScheduleId(null);
 																	toast.error(

--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -204,10 +204,7 @@ export const scheduleRouter = createTRPCRouter({
 			}
 
 			// Update deployment status to cancelled
-			await updateDeploymentStatus(
-				runningDeployment.deploymentId,
-				"cancelled",
-			);
+			await updateDeploymentStatus(runningDeployment.deploymentId, "cancelled");
 
 			return {
 				success: true,


### PR DESCRIPTION
Implements stop functionality for running schedules.

**Changes:**
- Added `schedule.stop` API endpoint
- Added Running badge and Stop button UI
- Real-time status polling (3s interval)

<img width="630" height="115" alt="Screenshot 2025-11-05 at 12 43 59 PM" src="https://github.com/user-attachments/assets/a50f45e4-be71-4c38-930c-577b0b5f370e" />


Fixes : #2853