### PR TITLE
Feat : Add stop functionality for backups and volume backups -#2962

### DIFF
--- a/apps/dokploy/components/dashboard/application/volume-backups/show-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/show-volume-backups.tsx
@@ -204,10 +204,12 @@ export const ShowVolumeBackups = ({
 																		"Volume backup stopped successfully",
 																	);
 																	refetchVolumeBackups();
-																	utils.volumeBackups.list.invalidate({
-																		id,
-																		volumeBackupType: type,
-																	}).catch(() => {});
+																	utils.volumeBackups.list
+																		.invalidate({
+																			id,
+																			volumeBackupType: type,
+																		})
+																		.catch(() => {});
 																} catch (error) {
 																	setStoppingVolumeBackupId(null);
 																	toast.error(
@@ -255,18 +257,19 @@ export const ShowVolumeBackups = ({
 																);
 																try {
 																	await runManually({
-																		volumeBackupId:
-																			volumeBackup.volumeBackupId,
+																		volumeBackupId: volumeBackup.volumeBackupId,
 																	});
 																	setRunningVolumeBackupId(null);
 																	toast.success(
 																		"Volume backup run successfully",
 																	);
 																	refetchVolumeBackups();
-																	utils.volumeBackups.list.invalidate({
-																		id,
-																		volumeBackupType: type,
-																	}).catch(() => {});
+																	utils.volumeBackups.list
+																		.invalidate({
+																			id,
+																			volumeBackupType: type,
+																		})
+																		.catch(() => {});
 																} catch (error) {
 																	setRunningVolumeBackupId(null);
 																	toast.error(

--- a/apps/dokploy/components/dashboard/database/backups/show-backups.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/show-backups.tsx
@@ -58,22 +58,38 @@ export const ShowBackups = ({
 					postgres: () =>
 						api.postgres.one.useQuery(
 							{ postgresId: id },
-							{ enabled: !!id, refetchInterval: 3000, refetchOnWindowFocus: false },
+							{
+								enabled: !!id,
+								refetchInterval: 3000,
+								refetchOnWindowFocus: false,
+							},
 						),
 					mysql: () =>
 						api.mysql.one.useQuery(
 							{ mysqlId: id },
-							{ enabled: !!id, refetchInterval: 3000, refetchOnWindowFocus: false },
+							{
+								enabled: !!id,
+								refetchInterval: 3000,
+								refetchOnWindowFocus: false,
+							},
 						),
 					mariadb: () =>
 						api.mariadb.one.useQuery(
 							{ mariadbId: id },
-							{ enabled: !!id, refetchInterval: 3000, refetchOnWindowFocus: false },
+							{
+								enabled: !!id,
+								refetchInterval: 3000,
+								refetchOnWindowFocus: false,
+							},
 						),
 					mongo: () =>
 						api.mongo.one.useQuery(
 							{ mongoId: id },
-							{ enabled: !!id, refetchInterval: 3000, refetchOnWindowFocus: false },
+							{
+								enabled: !!id,
+								refetchInterval: 3000,
+								refetchOnWindowFocus: false,
+							},
 						),
 					"web-server": () => api.user.getBackups.useQuery(),
 				}
@@ -81,7 +97,11 @@ export const ShowBackups = ({
 					compose: () =>
 						api.compose.one.useQuery(
 							{ composeId: id },
-							{ enabled: !!id, refetchInterval: 3000, refetchOnWindowFocus: false },
+							{
+								enabled: !!id,
+								refetchInterval: 3000,
+								refetchOnWindowFocus: false,
+							},
 						),
 				};
 	const { data } = api.destination.all.useQuery();
@@ -342,7 +362,9 @@ export const ShowBackups = ({
 																					await stopBackup({
 																						backupId: backup.backupId,
 																					});
-																					toast.success("Backup stopped successfully");
+																					toast.success(
+																						"Backup stopped successfully",
+																					);
 																					refetch();
 																				} catch (error) {
 																					toast.error(

--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -506,10 +506,7 @@ export const backupRouter = createTRPCRouter({
 			}
 
 			// Update deployment status to cancelled
-			await updateDeploymentStatus(
-				runningDeployment.deploymentId,
-				"cancelled",
-			);
+			await updateDeploymentStatus(runningDeployment.deploymentId, "cancelled");
 
 			return {
 				success: true,

--- a/apps/dokploy/server/api/routers/volume-backups.ts
+++ b/apps/dokploy/server/api/routers/volume-backups.ts
@@ -280,10 +280,7 @@ export const volumeBackupsRouter = createTRPCRouter({
 			}
 
 			// Update deployment status to cancelled
-			await updateDeploymentStatus(
-				runningDeployment.deploymentId,
-				"cancelled",
-			);
+			await updateDeploymentStatus(runningDeployment.deploymentId, "cancelled");
 
 			return {
 				success: true,


### PR DESCRIPTION
Adds the ability to stop running backups and volume backups from the UI

**Features:**
- Stop button appears when a backup is running
- Real-time status detection with 3-second polling
- Deployment status updated to "cancelled" on stop
- Visual indicators: "Running" badge and loading states

**Changes:**
- Backend: Added `stop` mutations to backup and volumeBackups routers
- Frontend: Updated ShowBackups and ShowVolumeBackups components with stop UI
- Added polling for real-time status updates

Fixes: #2962 