### PR TITLE
feat(requests): conditionally render traefik reload warning

### DIFF
--- a/apps/dokploy/components/dashboard/requests/show-requests.tsx
+++ b/apps/dokploy/components/dashboard/requests/show-requests.tsx
@@ -59,6 +59,25 @@ export const ShowRequests = () => {
 		to: undefined,
 	});
 
+	// Check if logs exist to determine if traefik has been reloaded
+	// Only fetch when active to minimize network calls
+	const { data: statsLogsCheck } = api.settings.readStatsLogs.useQuery(
+		{
+			page: {
+				pageIndex: 0,
+				pageSize: 1,
+			},
+		},
+		{
+			enabled: !!isActive,
+			refetchInterval: 5000, // Check every 5 seconds when active
+		},
+	);
+
+	// Determine if warning should be shown
+	// Show warning only if active but no logs exist yet
+	const shouldShowWarning = isActive && (statsLogsCheck?.totalCount ?? 0) === 0;
+
 	useEffect(() => {
 		if (logCleanupStatus) {
 			setCronExpression(logCleanupStatus.cronExpression || "0 0 * * *");
@@ -79,16 +98,18 @@ export const ShowRequests = () => {
 								See all the incoming requests that pass trough Traefik
 							</CardDescription>
 
-							<AlertBlock type="warning">
-								When you activate, you need to reload traefik to apply the
-								changes, you can reload traefik in{" "}
-								<Link
-									href="/dashboard/settings/server"
-									className="text-primary"
-								>
-									Settings
-								</Link>
-							</AlertBlock>
+							{shouldShowWarning && (
+								<AlertBlock type="warning">
+									When you activate, you need to reload traefik to apply the
+									changes, you can reload traefik in{" "}
+									<Link
+										href="/dashboard/settings/server"
+										className="text-primary"
+									>
+										Settings
+									</Link>
+								</AlertBlock>
+							)}
 						</CardHeader>
 						<CardContent className="space-y-2 py-8 border-t">
 							<div className="flex w-full gap-4 justify-end items-center">


### PR DESCRIPTION
Conditionally renders the Traefik reload warning only when request monitoring is active but no logs exist yet. The warning automatically disappears once logs appear.

## Changes

- Added minimal log check query (pageSize: 1) to detect log availability
- Warning only shows when `isActive && totalCount === 0`
- Query only runs when active to minimize network calls
- Polls every 5 seconds to detect when logs appear

<img width="1349" height="462" alt="Screenshot 2025-11-07 at 11 42 54 AM" src="https://github.com/user-attachments/assets/0e9931a5-3b8c-44bd-b02a-78d41e019498" />


Fixes #2971