### PR TITLE
Fix tail error: filter out "inotify cannot be used" informational messages

### DIFF
--- a/apps/dokploy/server/wss/listen-deployment.ts
+++ b/apps/dokploy/server/wss/listen-deployment.ts
@@ -24,7 +24,9 @@ const isInformationalStderr = (message: string): boolean => {
 		"reverting to polling",
 		"too many open files",
 	];
-	return informationalPatterns.some((pattern) => lowerMessage.includes(pattern));
+	return informationalPatterns.some((pattern) =>
+		lowerMessage.includes(pattern),
+	);
 };
 
 export const setupDeploymentLogsWebSocketServer = (


### PR DESCRIPTION
The "tail: inotify cannot be used, reverting to polling: Too many open files" 
message is informational - tail continues to work by falling back to polling 
when inotify is unavailable due to system limits.

**Changes:**
- Added `isInformationalStderr()` helper to filter informational stderr messages
- Applied filter to both local and remote SSH tail processes
- Filters out: "inotify cannot be used", "reverting to polling", "too many open files"

**Result:**
The error message no longer appears in deployment logs while actual errors 
are still displayed.

Fixes -#2974