### PR TITLE
fix: missing https:// in invite url

### DIFF
--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -4,6 +4,7 @@ import {
 	findNotificationById,
 	findOrganizationById,
 	findUserById,
+	getDokployUrl,
 	getUserByToken,
 	IS_CLOUD,
 	removeUserById,
@@ -419,11 +420,7 @@ export const userRouter = createTRPCRouter({
 				});
 			}
 
-			const admin = await findAdmin();
-			const host =
-				process.env.NODE_ENV === "development"
-					? "http://localhost:3000"
-					: admin.user.host;
+			const host = await getDokployUrl();
 			const inviteLink = `${host}/invitation?token=${input.invitationId}`;
 
 			const organization = await findOrganizationById(


### PR DESCRIPTION
## What is this PR about?

The `admin.user.host` is just the domain without the https:// prefix this works quite bad in some mail clients.

There already is a helper which appends the prefix it is `getDokployUrl()`. Calling that also removes the code duplication for the localhost fallback.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Screenshots

This is what macOS outlook desktop shows when clicking on the invite link currently.

<img width="1097" height="354" alt="image" src="https://github.com/user-attachments/assets/f3f8fc88-00d3-4322-b787-82fbf32761d0" />


