### PR TITLE
fix: pr template checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Please describe in a short paragraph what this PR is about.
 
 Before submitting this PR, please make sure that:
 
-- [] You created a dedicated branch based on the `canary` branch.
-- [] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
-- [] You have tested this PR in your local instance.
+- [ ] You created a dedicated branch based on the `canary` branch.
+- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
+- [ ] You have tested this PR in your local instance.
 
 ## Issues related (if applicable)
 


### PR DESCRIPTION
without a space they do not render as checkboxes on github

## before

- [] You created a dedicated branch based on the `canary` branch.
- [] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [] You have tested this PR in your local instance.

## after

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.