### PR TITLE
fix: Add protocol prefix to invitation links (#2986)

### DIFF
--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -4,6 +4,7 @@ import {
 	findNotificationById,
 	findOrganizationById,
 	findUserById,
+	getDokployUrl,
 	getUserByToken,
 	IS_CLOUD,
 	removeUserById,
@@ -419,11 +420,10 @@ export const userRouter = createTRPCRouter({
 				});
 			}
 
-			const admin = await findAdmin();
 			const host =
 				process.env.NODE_ENV === "development"
 					? "http://localhost:3000"
-					: admin.user.host;
+					: await getDokployUrl();
 			const inviteLink = `${host}/invitation?token=${input.invitationId}`;
 
 			const organization = await findOrganizationById(

--- a/packages/server/src/services/admin.ts
+++ b/packages/server/src/services/admin.ts
@@ -110,7 +110,8 @@ export const getDokployUrl = async () => {
 	const admin = await findAdmin();
 
 	if (admin.user.host) {
-		return `https://${admin.user.host}`;
+		const protocol = admin.user.https ? "https" : "http";
+		return `${protocol}://${admin.user.host}`;
 	}
 	return `http://${admin.user.serverIp}:${process.env.PORT}`;
 };


### PR DESCRIPTION
Fixes invitation links missing protocol prefix that caused Outlook on Mac to treat them as relative paths.

**Changes:**
- Updated `getDokployUrl()` to respect HTTPS configuration
- Modified `sendInvitation` to use `getDokployUrl()` instead of raw host

Fixes #2986