### PR TITLE
feat: Add expandable commit messages for deployment logs

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -100,24 +100,10 @@ export const ShowDeployments = ({
 		}
 		const truncated = description.slice(0, MAX_DESCRIPTION_LENGTH);
 		const lastSpace = truncated.lastIndexOf(" ");
-		// Truncate at word boundary if found near the end
 		if (lastSpace > MAX_DESCRIPTION_LENGTH - 20 && lastSpace > 0) {
 			return `${truncated.slice(0, lastSpace)}...`;
 		}
 		return `${truncated}...`;
-	};
-
-	// Toggle expand/collapse state for a specific deployment
-	const toggleDescription = (deploymentId: string) => {
-		setExpandedDescriptions((prev) => {
-			const next = new Set(prev);
-			if (next.has(deploymentId)) {
-				next.delete(deploymentId);
-			} else {
-				next.add(deploymentId);
-			}
-			return next;
-		});
 	};
 
 	// Check for stuck deployment (more than 9 minutes) - only for the most recent deployment
@@ -286,9 +272,15 @@ export const ShowDeployments = ({
 											{needsTruncation && (
 												<button
 													type="button"
-													onClick={() =>
-														toggleDescription(deployment.deploymentId)
-													}
+													onClick={() => {
+														const next = new Set(expandedDescriptions);
+														if (next.has(deployment.deploymentId)) {
+															next.delete(deployment.deploymentId);
+														} else {
+															next.add(deployment.deploymentId);
+														}
+														setExpandedDescriptions(next);
+													}}
 													className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors w-fit mt-1 cursor-pointer"
 													aria-label={
 														isExpanded


### PR DESCRIPTION
Adds expandable/collapsible functionality for long commit messages in deployment logs.

- Truncates commit messages longer than 150 characters
- Shows "Show more" / "Show less" button for truncated messages
- Displays hash separately in compact format
- Each deployment can be expanded independently

<img width="1254" height="276" alt="Screenshot 2025-11-11 at 1 05 46 PM" src="https://github.com/user-attachments/assets/2769af14-2e9f-4378-b5e7-3c1aa7bb7c5b" />


Fixes #2973