### PR TITLE
chore: bump traefik to 3.6.1

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -22,7 +22,7 @@ import {
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
-		await execAsync("docker pull traefik:v3.5.0");
+		await execAsync("docker pull traefik:v3.6.1");
 		await initializeStandaloneTraefik();
 		await initializeRedis();
 		await initializePostgres();

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -20,7 +20,7 @@ export const TRAEFIK_PORT =
 	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
-export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.5.0";
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.1";
 
 export interface TraefikOptions {
 	env?: string[];


### PR DESCRIPTION
## What is this PR about?

Bump traefik to latest `3.6.1` release in order to fix the Docker API deprecation

## Issues related (if applicable)

closes #2990 

## Additional 

- Migration documentation is available [here](https://doc.traefik.io/traefik/migrate/v3/#v354). I didnt see any big changes from `v3.5.0` -> `v3.6.1`  that could break anything but **I may have missed something**
- The fix made by Traefik is available in [this PR](https://github.com/traefik/traefik/pull/12256) and has been merged for [this release](https://github.com/traefik/traefik/releases/tag/v3.6.1)
- You can find the website update in [this PR](https://github.com/Dokploy/website/pull/84)

