### PR TITLE
feat: add last deployment date to services and update sorting logic

### DIFF
--- a/packages/server/src/services/environment.ts
+++ b/packages/server/src/services/environment.ts
@@ -34,13 +34,21 @@ export const findEnvironmentById = async (environmentId: string) => {
 	const environment = await db.query.environments.findFirst({
 		where: eq(environments.environmentId, environmentId),
 		with: {
-			applications: true,
+			applications: {
+				with: {
+					deployments: true,
+				},
+			},
 			mariadb: true,
 			mongo: true,
 			mysql: true,
 			postgres: true,
 			redis: true,
-			compose: true,
+			compose: {
+				with: {
+					deployments: true,
+				},
+			},
 			project: true,
 		},
 	});


### PR DESCRIPTION
- Introduced `lastDeployDate` property to track the most recent deployment for applications and compose services.
- Updated the `extractServicesFromEnvironment` function to calculate and include the last deployment date.
- Modified sorting logic to allow sorting by last deployment date, enhancing the user experience on the environment dashboard.
- Adjusted local storage default sort preference to prioritize last deployment date.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #1849 #2503

## Screenshots (if applicable)

<img width="1566" height="639" alt="Screenshot 2025-11-13 at 10 36 11 PM" src="https://github.com/user-attachments/assets/d96921d5-4359-46cd-9797-02ce548af8bb" />
