### PR TITLE
feat: add git commit info extraction to deployment logic

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -131,6 +131,8 @@ exit 1;
 exit 1;
 		`;
 	}
+
+	return "";
 };
 export const addDomainToCompose = async (
 	compose: Compose,


### PR DESCRIPTION
- Integrated `getGitCommitInfo` function to retrieve the latest commit message and hash for applications and compose services.
- Updated deployment logic to conditionally include commit information in deployment updates, enhancing traceability.
- Refactored import statements for better organization and clarity.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2508 #2571

## Screenshots (if applicable)

