### PR TITLE
fix: ensure proper cleanup of Docker buildx builder container

### DIFF
--- a/packages/server/src/utils/builders/railpack.ts
+++ b/packages/server/src/utils/builders/railpack.ts
@@ -75,6 +75,7 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 	buildArgs.push(buildAppDirectory);
 
 	const bashCommand = `
+
 # Ensure we have a builder with containerd
 docker buildx create --use --name builder-containerd --driver docker-container || true
 docker buildx use builder-containerd
@@ -82,6 +83,7 @@ docker buildx use builder-containerd
 echo "Preparing Railpack build plan..." ;
 railpack ${prepareArgs.join(" ")} || { 
 	echo "❌ Railpack prepare failed" ;
+	docker buildx rm builder-containerd || true
 	exit 1;
 }
 echo "✅ Railpack prepare completed." ;
@@ -91,6 +93,7 @@ echo "Building with Railpack frontend..." ;
 ${exportEnvs.join("\n")}
 docker ${buildArgs.join(" ")} || { 
 	echo "❌ Railpack build failed" ;
+	docker buildx rm builder-containerd || true
 	exit 1;
 }
 echo "✅ Railpack build completed." ;


### PR DESCRIPTION
- Added commands to remove the builder container after Railpack build and prepare failures to prevent resource leaks.
- Improved bash command structure for better readability and maintenance.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #1493


## Screenshots (if applicable)

