### PR TITLE
fix: ensure Compose Traefik domain labels are written to local daemons

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -2,7 +2,7 @@ import { dirname, join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import type { InferResultType } from "@dokploy/server/types/with";
 import boxen from "boxen";
-import { writeDomainsToComposeRemote } from "../docker/domain";
+import { writeDomainsToCompose } from "../docker/domain";
 import {
 	encodeBase64,
 	getEnviromentVariablesObject,
@@ -22,7 +22,7 @@ export const getBuildComposeCommand = async (compose: ComposeNested) => {
 	const projectPath = join(COMPOSE_PATH, compose.appName, "code");
 	const exportEnvCommand = getExportEnvCommand(compose);
 
-	const newCompose = await writeDomainsToComposeRemote(compose, domains);
+	const newCompose = await writeDomainsToCompose(compose, domains);
 	const logContent = `
 App Name: ${appName}
 Build Compose 🐳

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -102,7 +102,7 @@ export const readComposeFile = async (compose: Compose) => {
 	return null;
 };
 
-export const writeDomainsToComposeRemote = async (
+export const writeDomainsToCompose = async (
 	compose: Compose,
 	domains: Domain[],
 ) => {
@@ -120,19 +120,16 @@ echo "❌ Error: Compose file not found";
 exit 1;
 			`;
 		}
-		if (compose.serverId) {
-			const composeString = stringify(composeConverted, { lineWidth: 1000 });
-			const encodedContent = encodeBase64(composeString);
-			return `echo "${encodedContent}" | base64 -d > "${path}";`;
-		}
+
+		const composeString = stringify(composeConverted, { lineWidth: 1000 });
+		const encodedContent = encodeBase64(composeString);
+		return `echo "${encodedContent}" | base64 -d > "${path}";`;
 	} catch (error) {
 		// @ts-ignore
-		return `echo "❌ Has occured an error: ${error?.message || error}";
+		return `echo "❌ Has occurred an error: ${error?.message || error}";
 exit 1;
 		`;
 	}
-
-	return "";
 };
 export const addDomainToCompose = async (
 	compose: Compose,


### PR DESCRIPTION
## What is this PR about?

I recently upgraded the Docker daemon of a server running Dokploy to version v29. This update broke Dokploy's Traefik v3.5.0 integration due to stricter Docker daemon API version requirements. Luckily, this issue was fixed in PR #3000, which prompted me to update Dokploy to the latest canary build to get proper support for Traefik v3.6.1.

However, after I attempted to re-deploy Docker Compose projects with the newer Dokploy build, the services no longer had any associated domain routers in Traefik's dashboard and were therefore externally unreachable.

A quick `docker inspect` on the affected containers showed that they lacked any Traefik labels, which Dokploy should have attached, despite the "Preview Compose" button displaying the expected extra labels. Increasing Traefik's logging verbosity further confirmed that these containers were being treated as disabled.

To investigate why Dokploy had stopped applying these labels, I remote-debugged my production Dokploy container by modifying its entrypoint to `node --inspect=0.0.0.0 -r dotenv/config dist/server.mjs` and attaching a debugger. Stepping through the deployment logic revealed that the `writeDomainsToComposeRemote` function was refusing to write the modified Docker Compose file to disk for local Dokploy deployments (i.e., when `serverId` is `null`). As a result, the domain configuration labels were never applied, because the unmodified raw Docker Compose file was used instead.

After bypassing this remote server check, Traefik integration for these deployments began working again, and I have not observed any regressions so far.

Therefore, this PR includes the necessary change to resolve the regression, which I strongly suspect was introduced by #2978, as the issue only began occurring after I updated Dokploy.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Tackles a root cause of #2682 in the latest canary builds, but it may not fix other root causes of that issue.
