### PR TITLE
fix: prevent WebSocket timeout in container logs after 60s of inactivity

### DIFF
--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -46,6 +46,14 @@ export const setupDockerContainerLogsWebSocketServer = (
 			ws.close();
 			return;
 		}
+
+		// Set up keep-alive ping mechanism to prevent timeout
+		// Send ping every 45 seconds to keep connection alive
+		const pingInterval = setInterval(() => {
+			if (ws.readyState === ws.OPEN) {
+				ws.ping();
+			}
+		}, 45000); // 45 seconds
 		try {
 			if (serverId) {
 				const server = await findServerById(serverId);
@@ -86,6 +94,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 					.on("error", (err) => {
 						console.error("SSH connection error:", err);
 						ws.send(`SSH error: ${err.message}`);
+						clearInterval(pingInterval);
 						ws.close(); // Cierra el WebSocket si hay un error con SSH
 						client.end();
 					})
@@ -96,6 +105,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 						privateKey: server.sshKey?.privateKey,
 					});
 				ws.on("close", () => {
+					clearInterval(pingInterval);
 					client.end();
 				});
 			} else {
@@ -121,6 +131,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 					ws.send(data);
 				});
 				ws.on("close", () => {
+					clearInterval(pingInterval);
 					ptyProcess.kill();
 				});
 				ws.on("message", (message) => {


### PR DESCRIPTION
Fixes #3033

The container logs WebSocket connection was closing after approximately 60 seconds of inactivity with error code 1006 (abnormal closure). This required users to manually refresh the page to re-establish the connection, making it difficult to monitor containers that produce logs infrequently.

Changes:
- Added WebSocket ping mechanism sending ping frames every 45 seconds
- Ensures connection stays alive indefinitely during periods of no log activity
- Properly cleanup ping intervals on connection close (3 locations)
- Prevents memory leaks by clearing intervals on error and close events

The browser automatically responds with pong frames, keeping the connection alive without requiring any client-side changes.

Testing:
- Validated >60s connection stability in unit and local tests.
- Verified no abnormal closure occurs.
- Verified no memory leaks on connection cleanup



