### PR TITLE
feat(auth): add autocomplete for 2FA OTP input

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -328,7 +328,6 @@ export default function Home({ IS_CLOUD }: Props) {
 									onChange={setTwoFactorCode}
 									maxLength={6}
 									pattern={REGEXP_ONLY_DIGITS}
-									autoComplete="off"
 									autoFocus
 								>
 									<InputOTPGroup>


### PR DESCRIPTION
#### **What’s Changed?**
This PR enables **One-Time Password (OTP) autofill** in the login form by:
1. **Removing `autoComplete="off"`** from the OTP input field.
2. Leveraging the default `autocomplete="one-time-code"` attribute provided by the [`input-otp`](https://github.com/guilhermerodz/input-otp) library (as [documented in its README](https://github.com/guilhermerodz/input-otp?tab=readme-ov-file#features)).

#### **Why This Matters**
- The [`autocomplete="one-time-code"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#one-time-code) attribute is a **W3C standard** that allows:
  - **Password managers** (e.g., Proton Pass, Bitwarden, 1Password) to autofill OTP fields.
  - **Authenticator apps** (e.g., Google Authenticator, Authy) to recognize the field for direct paste/fill.
- Previously, `autoComplete="off"` blocked this functionality, forcing users to manually copy-paste OTPs.

#### **Testing**
- **Verified with Proton Pass**: Autofill now works seamlessly on both **desktop and mobile**.
- **No regressions**: The `input-otp` component already supports this attribute by default (no breaking changes).

#### **Screenshots**
<img width="1881" height="1041" alt="Capture d’écran 2025-11-18 020501" src="https://github.com/user-attachments/assets/80266e8a-6fbc-4552-ab01-d709db7350e0" />


#### **References**
- [MDN: `autocomplete="one-time-code"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#one-time-code)
- [input-otp Library Features](https://github.com/guilhermerodz/input-otp?tab=readme-ov-file#features)


