### PR TITLE
fix: server time is incorrect

### DIFF
--- a/apps/dokploy/components/ui/time-badge.tsx
+++ b/apps/dokploy/components/ui/time-badge.tsx
@@ -44,17 +44,21 @@ export function TimeBadge() {
 			.padStart(2, "0")}`;
 	};
 
-	const formattedTime = new Intl.DateTimeFormat("en-US", {timeZone: serverTime.timezone, timeStyle: "medium", hour12:false}).format(time)
+	const formattedTime = new Intl.DateTimeFormat("en-US", {
+		timeZone: serverTime.timezone,
+		timeStyle: "medium",
+		hour12: false,
+	}).format(time);
 
 	return (
 		<div className="inline-flex items-center rounded-full border p-1 text-xs whitespace-nowrap max-w-full overflow-hidden gap-1">
-          <div className="inline-flex items-center px-1 gap-1">
-            <span className="hidden sm:inline">Server Time:</span>
-            <span className="font-medium tabular-nums">{formattedTime}</span>
-          </div>
-          <span className="hidden sm:inline text-primary/70 border rounded-full bg-foreground/5 px-1.5 py-0.5">
-		  {serverTime.timezone} | {getUtcOffset(serverTime.timezone)}
-          </span>
-        </div>
+			<div className="inline-flex items-center px-1 gap-1">
+				<span className="hidden sm:inline">Server Time:</span>
+				<span className="font-medium tabular-nums">{formattedTime}</span>
+			</div>
+			<span className="hidden sm:inline text-primary/70 border rounded-full bg-foreground/5 px-1.5 py-0.5">
+				{serverTime.timezone} | {getUtcOffset(serverTime.timezone)}
+			</span>
+		</div>
 	);
 }


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related (if applicable)


## Screenshots (if applicable)

the server time in Dokploy
<img width="328" height="46" alt="Tangkapan Layar 2025-11-19 pukul 19 10 29" src="https://github.com/user-attachments/assets/83f7e884-e346-4d5a-87c3-36e973a71cc9" />

and it differs from the actual UTC time
<img width="472" height="239" alt="Tangkapan Layar 2025-11-19 pukul 19 11 59" src="https://github.com/user-attachments/assets/6807f6fd-926b-4cb9-a413-dbad967f1f40" />

I thought this was an issue with new Date(), which always converts the server’s time response to the client’s browser timezone.

and I changed the UI to 
<img width="317" height="42" alt="Tangkapan Layar 2025-11-19 pukul 19 10 09" src="https://github.com/user-attachments/assets/a94d2c4a-0544-4f37-baf4-f96ad29efc64" />
make it look better
