### PR TITLE
fix: Improve log level detection with confidence scoring system

### DIFF
--- a/apps/dokploy/__test__/logs/log-type.test.ts
+++ b/apps/dokploy/__test__/logs/log-type.test.ts
@@ -1,0 +1,122 @@
+import { getLogType } from "../../components/dashboard/docker/logs/utils";
+import { describe, expect, test } from "vitest";
+
+describe("getLogType", () => {
+	describe("Structured error patterns", () => {
+		test("should detect [ERROR] format", () => {
+			expect(getLogType("[ERROR] Database connection failed").type).toBe("error");
+		});
+
+		test("should detect ERROR: format", () => {
+			expect(getLogType("ERROR: Connection refused").type).toBe("error");
+		});
+
+		test("should detect level=error format", () => {
+			expect(getLogType('level=error msg="Database connection failed"').type).toBe("error");
+		});
+
+		test("should detect error emojis", () => {
+			expect(getLogType("❌ Operation failed").type).toBe("error");
+			expect(getLogType("🔴 Critical issue").type).toBe("error");
+		});
+	});
+
+	describe("Contextual error patterns", () => {
+		test("should detect uncaught exceptions", () => {
+			expect(getLogType("Uncaught exception in handler").type).toBe("error");
+		});
+
+		test("should detect 'failed to' patterns", () => {
+			expect(getLogType("Failed to start server").type).toBe("error");
+		});
+
+		test("should detect 'X failed with' patterns", () => {
+			expect(getLogType("Token exchange failed with status: 400").type).toBe("error");
+		});
+
+		test("should detect HTTP error codes", () => {
+			expect(getLogType("Request returned status: 400").type).toBe("error");
+			expect(getLogType("500 Internal Server Error").type).toBe("error");
+		});
+
+		test("should detect stack trace lines", () => {
+			expect(getLogType("    at Object.<anonymous> (/app/server.js:123:45)").type).toBe("error");
+		});
+	});
+
+	describe("False positives - should NOT be detected as errors", () => {
+		test("should not flag 'Failed=0' as error", () => {
+			const result = getLogType('time="2025-11-20T08:19:13Z" level=info msg="Session done" Failed=0 Scanned=1');
+			expect(result.type).toBe("info");
+		});
+
+		test("should not flag '0 failed' as error", () => {
+			expect(getLogType("0 practices builds failed, and 0 uploads failed.").type).toBe("info");
+		});
+
+		test("should not flag negative contexts as error", () => {
+			expect(getLogType("The operation did not fail").type).toBe("info");
+		});
+
+		test("should not flag conditional statements as error", () => {
+			expect(getLogType("If failed, retry the operation").type).toBe("info");
+		});
+	});
+
+	describe("Warning patterns", () => {
+		test("should detect [WARN] format", () => {
+			expect(getLogType("[WARN] API rate limit approaching").type).toBe("warning");
+		});
+
+		test("should detect WARNING: format", () => {
+			expect(getLogType("WARNING: Disk space low").type).toBe("warning");
+		});
+
+		test("should detect warning emojis", () => {
+			expect(getLogType("⚠️ Token exchange failed with status: 400 Bad Request").type).not.toBe("info");
+		});
+
+		test("should detect deprecated warnings", () => {
+			expect(getLogType("Deprecated since version 2.0").type).toBe("warning");
+		});
+	});
+
+	describe("Success patterns", () => {
+		test("should detect [SUCCESS] format", () => {
+			expect(getLogType("[SUCCESS] Deployment completed").type).toBe("success");
+		});
+
+		test("should detect 'listening on port' patterns", () => {
+			expect(getLogType("Server listening on port 3000").type).toBe("success");
+		});
+
+		test("should detect 'successfully' patterns", () => {
+			expect(getLogType("Successfully connected to database").type).toBe("success");
+		});
+
+		test("should detect success emojis", () => {
+			expect(getLogType("✅ Build completed").type).toBe("success");
+		});
+	});
+
+	describe("Debug patterns", () => {
+		test("should detect [DEBUG] format", () => {
+			expect(getLogType("[DEBUG] Processing request").type).toBe("debug");
+		});
+
+		test("should detect HTTP method patterns", () => {
+			expect(getLogType("GET /api/users").type).toBe("debug");
+			expect(getLogType("POST /api/login").type).toBe("debug");
+		});
+	});
+
+	describe("Info patterns (default)", () => {
+		test("should default to info for generic messages", () => {
+			expect(getLogType("Server started").type).toBe("info");
+		});
+
+		test("should detect [INFO] format", () => {
+			expect(getLogType("[INFO] Application initialized").type).toBe("info");
+		});
+	});
+});

--- a/apps/dokploy/__test__/logs/log-type.test.ts
+++ b/apps/dokploy/__test__/logs/log-type.test.ts
@@ -1,10 +1,12 @@
-import { getLogType } from "../../components/dashboard/docker/logs/utils";
 import { describe, expect, test } from "vitest";
+import { getLogType } from "../../components/dashboard/docker/logs/utils";
 
 describe("getLogType", () => {
 	describe("Structured error patterns", () => {
 		test("should detect [ERROR] format", () => {
-			expect(getLogType("[ERROR] Database connection failed").type).toBe("error");
+			expect(getLogType("[ERROR] Database connection failed").type).toBe(
+				"error",
+			);
 		});
 
 		test("should detect ERROR: format", () => {
@@ -12,7 +14,9 @@ describe("getLogType", () => {
 		});
 
 		test("should detect level=error format", () => {
-			expect(getLogType('level=error msg="Database connection failed"').type).toBe("error");
+			expect(
+				getLogType('level=error msg="Database connection failed"').type,
+			).toBe("error");
 		});
 
 		test("should detect error emojis", () => {
@@ -31,7 +35,9 @@ describe("getLogType", () => {
 		});
 
 		test("should detect 'X failed with' patterns", () => {
-			expect(getLogType("Token exchange failed with status: 400").type).toBe("error");
+			expect(getLogType("Token exchange failed with status: 400").type).toBe(
+				"error",
+			);
 		});
 
 		test("should detect HTTP error codes", () => {
@@ -40,18 +46,24 @@ describe("getLogType", () => {
 		});
 
 		test("should detect stack trace lines", () => {
-			expect(getLogType("    at Object.<anonymous> (/app/server.js:123:45)").type).toBe("error");
+			expect(
+				getLogType("    at Object.<anonymous> (/app/server.js:123:45)").type,
+			).toBe("error");
 		});
 	});
 
 	describe("False positives - should NOT be detected as errors", () => {
 		test("should not flag 'Failed=0' as error", () => {
-			const result = getLogType('time="2025-11-20T08:19:13Z" level=info msg="Session done" Failed=0 Scanned=1');
+			const result = getLogType(
+				'time="2025-11-20T08:19:13Z" level=info msg="Session done" Failed=0 Scanned=1',
+			);
 			expect(result.type).toBe("info");
 		});
 
 		test("should not flag '0 failed' as error", () => {
-			expect(getLogType("0 practices builds failed, and 0 uploads failed.").type).toBe("info");
+			expect(
+				getLogType("0 practices builds failed, and 0 uploads failed.").type,
+			).toBe("info");
 		});
 
 		test("should not flag negative contexts as error", () => {
@@ -65,7 +77,9 @@ describe("getLogType", () => {
 
 	describe("Warning patterns", () => {
 		test("should detect [WARN] format", () => {
-			expect(getLogType("[WARN] API rate limit approaching").type).toBe("warning");
+			expect(getLogType("[WARN] API rate limit approaching").type).toBe(
+				"warning",
+			);
 		});
 
 		test("should detect WARNING: format", () => {
@@ -73,7 +87,9 @@ describe("getLogType", () => {
 		});
 
 		test("should detect warning emojis", () => {
-			expect(getLogType("⚠️ Token exchange failed with status: 400 Bad Request").type).not.toBe("info");
+			expect(
+				getLogType("⚠️ Token exchange failed with status: 400 Bad Request").type,
+			).not.toBe("info");
 		});
 
 		test("should detect deprecated warnings", () => {
@@ -91,7 +107,9 @@ describe("getLogType", () => {
 		});
 
 		test("should detect 'successfully' patterns", () => {
-			expect(getLogType("Successfully connected to database").type).toBe("success");
+			expect(getLogType("Successfully connected to database").type).toBe(
+				"success",
+			);
 		});
 
 		test("should detect success emojis", () => {


### PR DESCRIPTION
## What is this PR about?

  This PR improves the log type detection system in the Docker logs viewer to significantly reduce
  false positives. The previous implementation used broad regex patterns that incorrectly flagged
  informational messages as errors (e.g., "Failed=0" or "0 builds failed").

### Technical Approach

  The new implementation uses a **confidence-based scoring system** with three levels of pattern
  matching:

  **Level 1 - Structured Patterns (Score: 100pts)**
  - Highest confidence, no false positives
  - Examples: `[ERROR]`, `ERROR:`, `level=error`, `severity=warning`
  - Emoji indicators: ⚠️ (warning), ❌ (error), ✅ (success)

  **Level 2 - Contextual Patterns (Score: 50-70pts)**
  - Requires full phrases with context
  - Examples: "failed to connect", "uncaught exception", "Token exchange failed with status: 400"
  - HTTP error codes: 4xx and 5xx status codes
  - Stack trace detection: `at Object.<anonymous> (/path/file.js:123:45)`

  **Level 3 - Keyword Patterns (Score: 20-30pts)**
  - Simple keywords with **negative context detection**
  - Only applied if keyword is NOT in phrases like: "did not fail", "without errors", "if failed"
  (conditional)
  - Examples: "exception", "crash", "deprecated" (when used standalone)

  ### How Scoring Works

  1. **Multiple patterns can match** - scores accumulate for each log type
  2. **Highest score wins** - the log type with the most points is selected
  3. **Defaults to info** - if no patterns match, the log is marked as info

  **Example:**
  - `"⚠️ Token exchange failed with status: 400"` scores:
    - Warning: 100pts (⚠️ emoji)
    - Error: 135pts (65pts "failed with" + 70pts "status: 400")
    - **Result: Error wins** ✅

  - `"Failed=0 Scanned=1"` scores:
    - No patterns match "Failed=0" as it's not a contextual error phrase
    - **Result: Info (default)** ✅

  ### Key Improvements

  - **Emoji support**: Now detects ⚠️, ❌, ✅ indicators
  - **HTTP error codes**: Properly identifies 4xx/5xx status codes
  - **Negative context detection**: Prevents false positives from phrases like "did not fail"
  - **Improved contextual matching**: "X failed with Y" vs "Failed=0" are now distinguished
  - **Comprehensive tests**: 25 unit tests covering all detection scenarios

This is my proposed approach, but I'm very open to alternative implementations. Feel free to share any suggestions or concerns—I'm happy to adjust based on your feedback.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)

fixes #1996

## Screenshots (if applicable)

**Before:** Logs like `time="2025-11-20T08:19:13Z" level=info msg="Session done" Failed=0` were
incorrectly marked as errors

<img width="964" height="28" alt="image" src="https://github.com/user-attachments/assets/5b518c71-9579-4c48-a36a-19fbb86e31c3" />
<img width="663" height="27" alt="image" src="https://github.com/user-attachments/assets/50fdc024-baf4-4b0e-9f0a-b9ebad479bff" />

**After:** These logs are now correctly displayed as info, while real errors like `⚠️ Token
exchange failed with status: 400 Bad Request` are properly detected

<img width="967" height="25" alt="image" src="https://github.com/user-attachments/assets/d214ab1b-3fdd-4ec7-ada4-181ec2644460" />
<img width="667" height="26" alt="image" src="https://github.com/user-attachments/assets/9a7d26cc-b87a-4055-bcdb-b657c0233c37" />