### PR TITLE
feat: enhance DNS resolution in domain service

### DIFF
--- a/packages/server/src/services/domain.ts
+++ b/packages/server/src/services/domain.ts
@@ -141,7 +141,9 @@ export const getDomainHost = (domain: Domain) => {
 	return `${domain.https ? "https" : "http"}://${domain.host}`;
 };
 
-const resolveDns = promisify(dns.resolve4);
+const externalResolver = new dns.Resolver();
+externalResolver.setServers(["1.1.1.1", "8.8.8.8"]);
+const resolveDns = promisify(externalResolver.resolve4);
 
 export const validateDomain = async (
 	domain: string,


### PR DESCRIPTION
## What is this PR about?

Updated the DNS resolution method to use an external resolver with specified servers (1.1.1.1 and 8.8.8.8) for improved reliability. This change allows for more consistent domain resolution across different environments.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)


