### PR TITLE
Upgrade REDIS default image and restore `docker-entrypoint.sh`

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -59,7 +59,7 @@ const dockerImageDefaultPlaceholder: Record<DbType, string> = {
 	mariadb: "mariadb:11",
 	mysql: "mysql:8",
 	postgres: "postgres:18",
-	redis: "redis:7",
+	redis: "redis:8",
 };
 
 const databasesUserDefaultPlaceholder: Record<

--- a/packages/server/src/setup/redis-setup.ts
+++ b/packages/server/src/setup/redis-setup.ts
@@ -3,7 +3,7 @@ import { docker } from "../constants";
 import { pullImage } from "../utils/docker/utils";
 
 export const initializeRedis = async () => {
-	const imageName = "redis:7";
+	const imageName = "redis:8";
 	const containerName = "dokploy-redis";
 
 	const settings: CreateServiceOptions = {
@@ -14,7 +14,7 @@ export const initializeRedis = async () => {
 				Mounts: [
 					{
 						Type: "volume",
-						Source: "dokploy-redis",
+						Source: "redis-data-volume",
 						Target: "/data",
 					},
 				],

--- a/packages/server/src/utils/databases/redis.ts
+++ b/packages/server/src/utils/databases/redis.ts
@@ -71,22 +71,11 @@ export const buildRedis = async (redis: RedisNested) => {
 				Image: dockerImage,
 				Env: envVariables,
 				Mounts: [...volumesMount, ...bindsMount, ...filesMount],
-				...(StopGracePeriod !== null &&
-					StopGracePeriod !== undefined && { StopGracePeriod }),
-				...(command || args
-					? {
-							...(command && {
-								Command: command.split(" "),
-							}),
-							...(args &&
-								args.length > 0 && {
-									Args: args,
-								}),
-						}
-					: {
-							Command: ["/bin/sh"],
-							Args: ["-c", `redis-server --requirepass ${databasePassword}`],
-						}),
+				Command: [command ? "/bin/sh" : "docker-entrypoint.sh"],
+				Args: [
+					"-c",
+					command ? command : `redis-server --requirepass ${databasePassword}`,
+				],
 				Labels,
 			},
 			Networks,
@@ -114,6 +103,8 @@ export const buildRedis = async (redis: RedisNested) => {
 						: [],
 				},
 		UpdateConfig,
+		...(StopGracePeriod !== undefined &&
+			StopGracePeriod !== null && { StopGracePeriod }),
 	};
 
 	try {


### PR DESCRIPTION
## What is this PR about?

- Update default Redis image to v8, which includes new modules + performance improvments (https://redis.io/docs/latest/develop/whats-new/8-0/)
- Restore usage of `docker-entrypoint.sh` to start the Redis image, fixes the load of included modules (JSON for instance)