### PR TITLE
feat: add additional rclone configuration options for S3 integration

### DIFF
--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -53,6 +53,10 @@ export const destinationRouter = createTRPCRouter({
 					`--s3-endpoint=${endpoint}`,
 					"--s3-no-check-bucket",
 					"--s3-force-path-style",
+					"--retries 1",
+					"--low-level-retries 1",
+					"--timeout 10s",
+					"--contimeout 5s",
 				];
 				if (provider) {
 					rcloneFlags.unshift(`--s3-provider=${provider}`);


### PR DESCRIPTION
- Introduced new rclone flags: --retries, --low-level-retries, --timeout, and --contimeout to enhance S3 operations.
- These options aim to improve reliability and performance during file transfers.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2884

## Screenshots (if applicable)

