### PR TITLE
fix: update rclone S3 flags to use quotes for improved parsing

### DIFF
--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -47,10 +47,10 @@ export const destinationRouter = createTRPCRouter({
 				input;
 			try {
 				const rcloneFlags = [
-					`--s3-access-key-id=${accessKey}`,
-					`--s3-secret-access-key=${secretAccessKey}`,
-					`--s3-region=${region}`,
-					`--s3-endpoint=${endpoint}`,
+					`--s3-access-key-id="${accessKey}"`,
+					`--s3-secret-access-key="${secretAccessKey}"`,
+					`--s3-region="${region}"`,
+					`--s3-endpoint="${endpoint}"`,
 					"--s3-no-check-bucket",
 					"--s3-force-path-style",
 					"--retries 1",
@@ -59,7 +59,7 @@ export const destinationRouter = createTRPCRouter({
 					"--contimeout 5s",
 				];
 				if (provider) {
-					rcloneFlags.unshift(`--s3-provider=${provider}`);
+					rcloneFlags.unshift(`--s3-provider="${provider}"`);
 				}
 				const rcloneDestination = `:s3:${bucket}`;
 				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;


### PR DESCRIPTION
- Added quotes around S3 configuration options in rclone flags to ensure proper handling of special characters and spaces.
- This change enhances the reliability of the S3 integration by preventing potential parsing issues.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2883

## Screenshots (if applicable)

