### PR TITLE
feat: add Railpack installation command to builder script

### DIFF
--- a/packages/server/src/utils/builders/railpack.ts
+++ b/packages/server/src/utils/builders/railpack.ts
@@ -85,6 +85,9 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 	const bashCommand = `
 
 # Ensure we have a builder with containerd
+
+export RAILPACK_VERSION=${application.railpackVersion}
+bash -c "$(curl -fsSL https://railpack.com/install.sh)"
 docker buildx create --use --name builder-containerd --driver docker-container || true
 docker buildx use builder-containerd
 


### PR DESCRIPTION
- Introduced a command to set the RAILPACK_VERSION environment variable and execute the Railpack installation script.
- This enhancement ensures that the correct version of Railpack is used during the build process.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2535

## Screenshots (if applicable)

