### PR TITLE
fix: stabilize `TimeBadge` position

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -138,7 +138,7 @@ export const ShowProjects = () => {
 				list={[{ name: "Projects", href: "/dashboard/projects" }]}
 			/>
 			{!isCloud && (
-				<div className="absolute top-5 right-5">
+				<div className="absolute top-4 right-4">
 					<TimeBadge />
 				</div>
 			)}


### PR DESCRIPTION
## What is this PR about?

When toggling the sidebar menu item, the `TimeBadge` would slightly shift its position, causing a subtle but noticeable visual jitter.

![CleanShot 2025-11-29 at 18 55 38](https://github.com/user-attachments/assets/333b2426-c8ae-47b7-ade1-b43bcf62d7bb)


This fix adjusts the layout to ensure the badge maintains a consistent position.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.
