### PR TITLE
fix: align `DOCKER_VERSION` with official installation script

### DIFF
--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -494,7 +494,7 @@ if ! [ -x "$(command -v docker)" ]; then
                     echo "Please install Docker manually."
                 exit 1
             fi
-            curl -s https://releases.rancher.com/install-docker/$DOCKER_VERSION.sh | sh 2>&1
+						
             if ! [ -x "$(command -v docker)" ]; then
                 curl -s https://get.docker.com | sh -s -- --version $DOCKER_VERSION 2>&1
                 if ! [ -x "$(command -v docker)" ]; then


### PR DESCRIPTION
## What is this PR about?

The current remote-server setup script defines:

```bash
DOCKER_VERSION=27.0.3
```

However, the official installation method:

```bash
// https://dokploy.com/install.sh line:55
curl -sSL https://get.docker.com | sh -s -- --version 28.5.0
```

This mismatch can lead to inconsistent environments between remote deployments and standard installations.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.
