### PR TITLE
feat: set default date range to last 3 days in ShowRequests component

### DIFF
--- a/apps/dokploy/components/dashboard/requests/show-requests.tsx
+++ b/apps/dokploy/components/dashboard/requests/show-requests.tsx
@@ -51,13 +51,19 @@ export const ShowRequests = () => {
 	const { mutateAsync: updateLogCleanup } =
 		api.settings.updateLogCleanup.useMutation();
 	const [cronExpression, setCronExpression] = useState<string | null>(null);
+
+	// Set default date range to last 3 days
+	const getDefaultDateRange = () => {
+		const to = new Date();
+		const from = new Date();
+		from.setDate(from.getDate() - 3);
+		return { from, to };
+	};
+
 	const [dateRange, setDateRange] = useState<{
 		from: Date | undefined;
 		to: Date | undefined;
-	}>({
-		from: undefined,
-		to: undefined,
-	});
+	}>(getDefaultDateRange());
 
 	useEffect(() => {
 		if (logCleanupStatus) {
@@ -169,17 +175,13 @@ export const ShowRequests = () => {
 							{isActive ? (
 								<>
 									<div className="flex justify-end mb-4 gap-2">
-										{(dateRange.from || dateRange.to) && (
-											<Button
-												variant="outline"
-												onClick={() =>
-													setDateRange({ from: undefined, to: undefined })
-												}
-												className="px-3"
-											>
-												Clear dates
-											</Button>
-										)}
+										<Button
+											variant="outline"
+											onClick={() => setDateRange(getDefaultDateRange())}
+											className="px-3"
+										>
+											Reset to Last 3 Days
+										</Button>
 										<Popover>
 											<PopoverTrigger asChild>
 												<Button


### PR DESCRIPTION
- Introduced a function to automatically set the date range to the last 3 days upon component initialization.
- Updated the reset button to restore the default date range instead of clearing the dates.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3054

## Screenshots (if applicable)

