### PR TITLE
fix: update mount path for PostgreSQL 18+ to use /var/lib/postgresql/{version}/docker

### DIFF
--- a/packages/server/src/services/postgres.ts
+++ b/packages/server/src/services/postgres.ts
@@ -19,7 +19,8 @@ export function getMountPath(dockerImage: string): string {
 	if (versionMatch?.[1]) {
 		const version = Number.parseInt(versionMatch[1], 10);
 		if (version >= 18) {
-			return `/var/lib/postgresql/${version}/data`;
+			// PostgreSQL 18+ uses /var/lib/postgresql/{version}/docker as the default PGDATA
+			return `/var/lib/postgresql/${version}/docker`;
 		}
 	}
 	return "/var/lib/postgresql/data";


### PR DESCRIPTION
## What is this PR about?

Fixes PostgreSQL data loss when changing external port on PostgreSQL 18+. The issue was a volume mount path mismatch - Dokploy was mounting to `/var/lib/postgresql/18/data`, but PostgreSQL 18+ stores data in `/var/lib/postgresql/18/docker`. This caused data to be written outside the mounted volume, so when the container restarted (e.g., on port change), PostgreSQL would see an empty directory and initialize a fresh database.

The fix updates `getMountPath()` to return the correct path (`/var/lib/postgresql/{version}/docker`) for PostgreSQL 18+.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #2436

## Screenshots (if applicable)

N/A