### PR TITLE
test: add regression tests for Traefik Host rule format

### DIFF
--- a/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
+++ b/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
@@ -130,7 +130,9 @@ describe("Host rule format regression tests", () => {
 				l.includes(".rule="),
 			);
 
-			expect(parsedRuleLabel).toContain("Host(`example.com`) && PathPrefix(`/api`)");
+			expect(parsedRuleLabel).toContain(
+				"Host(`example.com`) && PathPrefix(`/api`)",
+			);
 		});
 	});
 
@@ -157,7 +159,9 @@ describe("Host rule format regression tests", () => {
 				expect(ruleLabel).toBeDefined();
 				expect(ruleLabel).toContain(`Host(\`${host}\`)`);
 				// Verify parenthesis is present
-				expect(ruleLabel).toMatch(new RegExp(`Host\\(\\\`${host.replace(/\./g, "\\.")}\\\`\\)`));
+				expect(ruleLabel).toMatch(
+					new RegExp(`Host\\(\\\`${host.replace(/\./g, "\\.")}\\\`\\)`),
+				);
 			});
 		}
 	});


### PR DESCRIPTION
## Summary

This PR adds comprehensive regression tests for Traefik Host rule label generation to ensure the correct format `Host(`domain.com`)` is maintained.

**Investigation Results:**
After extensive testing, the current codebase correctly generates Host rules with proper parentheses format. The tests verify:
- Template literals in source code produce correct output
- YAML stringification preserves the format
- Base64 encoding/decoding for compose files preserves all characters
- Docker Compose correctly parses the generated YAML

**Tests Added (17 tests):**
- Basic Host rule format validation with parentheses check
- PathPrefix format validation
- Combined Host and PathPrefix rules
- YAML serialization round-trip preservation
- Edge cases for various domain name formats (subdomains, hyphens, IPs)
- Multiple entrypoints (web/websecure)
- Special characters in paths

These tests explicitly check that the malformed format `Host`domain.com`)` (missing opening parenthesis) does NOT occur.

Related to: #3161

## Test plan
- [x] All 17 new tests pass
- [x] Existing 12 label tests continue to pass
- [x] Tests cover edge cases for domain names and paths
- [x] Tests verify YAML round-trip preservation