### PR TITLE
fix(security): update traefik to v3.6.4

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -22,7 +22,7 @@ import {
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
-		await execAsync("docker pull traefik:v3.6.1");
+		await execAsync("docker pull traefik:v3.6.4");
 		await initializeStandaloneTraefik();
 		await initializeRedis();
 		await initializePostgres();

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -20,7 +20,7 @@ export const TRAEFIK_PORT =
 	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
-export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.1";
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.4";
 
 export interface TraefikOptions {
 	env?: string[];


### PR DESCRIPTION
Update Traefik version from v3.6.1 to v3.6.4 to fix security vulnerabilities

This update addresses the following CVEs:
  - CVE-2025-66490
  - CVE-2025-66491

Changes
  - Updated `TRAEFIK_VERSION` constant in `packages/server/src/setup/traefik-setup.ts`
  - Updated docker pull command in `apps/dokploy/setup.ts`

## Checklist

Before submitting this PR, please make sure that:

- [x ] You created a dedicated branch based on the `canary` branch.
- [x ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ x] You have tested this PR in your local instance.

## Issues related (if applicable)

[DNS Validation fails with queryA ESERVFAIL on custom domain using traefik.me](https://github.com/Dokploy/dokploy/issues/3201)
#3201 