### PR TITLE
feat: add template registry management

### DIFF
--- a/apps/dokploy/components/dashboard/settings/template-registries/add-template-registry.tsx
+++ b/apps/dokploy/components/dashboard/settings/template-registries/add-template-registry.tsx
@@ -1,0 +1,162 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import type React from "react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { api } from "@/utils/api";
+
+const formSchema = z.object({
+	name: z.string().min(1, "Name is required"),
+	baseUrl: z.string().url("Must be a valid URL"),
+	description: z.string().optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+interface Props {
+	children: React.ReactNode;
+}
+
+export const AddTemplateRegistry = ({ children }: Props) => {
+	const [open, setOpen] = useState(false);
+	const utils = api.useUtils();
+
+	const form = useForm<FormData>({
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			name: "",
+			baseUrl: "",
+			description: "",
+		},
+	});
+
+	const { mutateAsync: createRegistry, isLoading } =
+		api.templateRegistry.create.useMutation({
+			onSuccess: () => {
+				utils.templateRegistry.all.invalidate();
+				form.reset();
+				setOpen(false);
+			},
+		});
+
+	const onSubmit = async (data: FormData) => {
+		try {
+			await createRegistry(data);
+			toast.success("Template registry added successfully");
+		} catch (error) {
+			toast.error(
+				(error as Error).message || "Failed to add template registry",
+			);
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>{children}</DialogTrigger>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Add Template Registry</DialogTitle>
+					<DialogDescription>
+						Add a new template registry to fetch application templates from.
+					</DialogDescription>
+				</DialogHeader>
+
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+						<FormField
+							control={form.control}
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name</FormLabel>
+									<FormControl>
+										<Input
+											placeholder="My Custom Registry"
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={form.control}
+							name="baseUrl"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Base URL</FormLabel>
+									<FormControl>
+										<Input
+											placeholder="https://templates.example.com"
+											{...field}
+										/>
+									</FormControl>
+									<FormDescription>
+										The registry must have a <code>meta.json</code> file and
+										templates in the <code>blueprints/</code> directory.
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<FormField
+							control={form.control}
+							name="description"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Description (optional)</FormLabel>
+									<FormControl>
+										<Textarea
+											placeholder="A brief description of this registry"
+											className="resize-none"
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => setOpen(false)}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" isLoading={isLoading}>
+								Add Registry
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+};
+

--- a/apps/dokploy/components/dashboard/settings/template-registries/show-template-registries.tsx
+++ b/apps/dokploy/components/dashboard/settings/template-registries/show-template-registries.tsx
@@ -1,0 +1,269 @@
+import {
+	AlertTriangle,
+	Check,
+	ExternalLink,
+	Loader2,
+	MoreVertical,
+	Plus,
+	RefreshCw,
+	Trash2,
+	X,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
+import { api } from "@/utils/api";
+import { AddTemplateRegistry } from "./add-template-registry";
+
+export const ShowTemplateRegistries = () => {
+	const { data: registries, isLoading, refetch } =
+		api.templateRegistry.all.useQuery();
+
+	const { mutateAsync: toggleRegistry, isLoading: isToggling } =
+		api.templateRegistry.toggle.useMutation({
+			onSuccess: () => {
+				refetch();
+			},
+		});
+
+	const { mutateAsync: syncRegistry } = api.templateRegistry.sync.useMutation({
+		onSuccess: () => {
+			refetch();
+		},
+	});
+
+	const { mutateAsync: removeRegistry, isLoading: isRemoving } =
+		api.templateRegistry.remove.useMutation({
+			onSuccess: () => {
+				refetch();
+			},
+		});
+
+	const [syncingId, setSyncingId] = useState<string | null>(null);
+
+	const handleSync = async (templateRegistryId: string) => {
+		setSyncingId(templateRegistryId);
+		try {
+			await syncRegistry({ templateRegistryId });
+			toast.success("Registry synced successfully");
+		} catch (error) {
+			toast.error((error as Error).message || "Failed to sync registry");
+		} finally {
+			setSyncingId(null);
+		}
+	};
+
+	const handleToggle = async (
+		templateRegistryId: string,
+		isEnabled: boolean,
+	) => {
+		try {
+			await toggleRegistry({ templateRegistryId, isEnabled });
+			toast.success(
+				isEnabled ? "Registry enabled" : "Registry disabled",
+			);
+		} catch (error) {
+			toast.error((error as Error).message || "Failed to toggle registry");
+		}
+	};
+
+	const handleRemove = async (templateRegistryId: string) => {
+		try {
+			await removeRegistry({ templateRegistryId });
+			toast.success("Registry removed successfully");
+		} catch (error) {
+			toast.error((error as Error).message || "Failed to remove registry");
+		}
+	};
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center h-64">
+				<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+
+	return (
+		<Card className="bg-sidebar p-2.5 rounded-xl w-full">
+			<div className="rounded-xl bg-background shadow-md">
+				<CardHeader className="flex flex-row items-center justify-between">
+					<div>
+						<CardTitle className="text-xl">Template Registries</CardTitle>
+						<CardDescription>
+							Manage template registries for deploying applications from
+							templates
+						</CardDescription>
+					</div>
+					<AddTemplateRegistry>
+						<Button variant="default" className="gap-2">
+							<Plus className="h-4 w-4" />
+							Add Registry
+						</Button>
+					</AddTemplateRegistry>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					{registries?.length === 0 ? (
+						<div className="flex flex-col items-center justify-center py-12 text-center">
+							<AlertTriangle className="h-12 w-12 text-muted-foreground mb-4" />
+							<p className="text-lg font-medium text-muted-foreground">
+								No template registries configured
+							</p>
+							<p className="text-sm text-muted-foreground">
+								Add a registry to start deploying templates
+							</p>
+						</div>
+					) : (
+						<div className="grid gap-4">
+							{registries?.map((registry) => (
+								<Card
+									key={registry.templateRegistryId}
+									className="bg-transparent"
+								>
+									<CardContent className="p-4">
+										<div className="flex items-start justify-between gap-4">
+											<div className="flex-1 min-w-0">
+												<div className="flex items-center gap-2 mb-1">
+													<h3 className="font-medium truncate">
+														{registry.name}
+													</h3>
+													{registry.isDefault && (
+														<Badge variant="secondary" className="text-xs">
+															Default
+														</Badge>
+													)}
+													{registry.isEnabled ? (
+														<Badge variant="green" className="text-xs">
+															<Check className="h-3 w-3 mr-1" />
+															Enabled
+														</Badge>
+													) : (
+														<Badge variant="secondary" className="text-xs">
+															<X className="h-3 w-3 mr-1" />
+															Disabled
+														</Badge>
+													)}
+												</div>
+												{registry.description && (
+													<p className="text-sm text-muted-foreground mb-2 line-clamp-2">
+														{registry.description}
+													</p>
+												)}
+												<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+													<a
+														href={registry.baseUrl}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="flex items-center gap-1 hover:text-foreground transition-colors"
+													>
+														<ExternalLink className="h-3 w-3" />
+														{registry.baseUrl}
+													</a>
+													{registry.templateCount && (
+														<span>
+															{registry.templateCount} templates
+														</span>
+													)}
+													{registry.lastSyncAt && (
+														<span>
+															Last synced:{" "}
+															{new Date(registry.lastSyncAt).toLocaleDateString()}
+														</span>
+													)}
+												</div>
+											</div>
+
+											<div className="flex items-center gap-2">
+												<Switch
+													checked={registry.isEnabled}
+													onCheckedChange={(checked) =>
+														handleToggle(
+															registry.templateRegistryId,
+															checked,
+														)
+													}
+													disabled={isToggling}
+												/>
+												<DropdownMenu>
+													<DropdownMenuTrigger asChild>
+														<Button variant="ghost" size="icon">
+															<MoreVertical className="h-4 w-4" />
+														</Button>
+													</DropdownMenuTrigger>
+													<DropdownMenuContent align="end">
+														<DropdownMenuItem
+															onClick={() =>
+																handleSync(registry.templateRegistryId)
+															}
+															disabled={syncingId === registry.templateRegistryId}
+														>
+															<RefreshCw
+																className={`h-4 w-4 mr-2 ${
+																	syncingId === registry.templateRegistryId
+																		? "animate-spin"
+																		: ""
+																}`}
+															/>
+															Sync Templates
+														</DropdownMenuItem>
+														<DropdownMenuItem
+															onClick={() =>
+																window.open(registry.baseUrl, "_blank")
+															}
+														>
+															<ExternalLink className="h-4 w-4 mr-2" />
+															Open Registry
+														</DropdownMenuItem>
+														{!registry.isDefault && (
+															<>
+																<DropdownMenuSeparator />
+																<DropdownMenuItem
+																	onClick={() =>
+																		handleRemove(registry.templateRegistryId)
+																	}
+																	disabled={isRemoving}
+																	className="text-destructive focus:text-destructive"
+																>
+																	<Trash2 className="h-4 w-4 mr-2" />
+																	Delete
+																</DropdownMenuItem>
+															</>
+														)}
+													</DropdownMenuContent>
+												</DropdownMenu>
+											</div>
+										</div>
+									</CardContent>
+								</Card>
+							))}
+						</div>
+					)}
+
+					<AlertBlock type="info">
+						Template registries are used to fetch application templates. The
+						default registry is the official Dokploy template repository. You
+						can add custom registries that follow the same format.
+					</AlertBlock>
+				</CardContent>
+			</div>
+		</Card>
+	);
+};
+

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -20,6 +20,7 @@ import {
 	GitBranch,
 	HeartIcon,
 	KeyRound,
+	LayoutTemplate,
 	Loader2,
 	type LucideIcon,
 	Package,
@@ -348,6 +349,15 @@ const MENU: Menu = {
 			title: "Registry",
 			url: "/dashboard/settings/registry",
 			icon: Package,
+			// Only enabled for admins
+			isEnabled: ({ auth }) =>
+				!!(auth?.role === "owner" || auth?.role === "admin"),
+		},
+		{
+			isSingle: true,
+			title: "Template Registries",
+			url: "/dashboard/settings/template-registries",
+			icon: LayoutTemplate,
 			// Only enabled for admins
 			isEnabled: ({ auth }) =>
 				!!(auth?.role === "owner" || auth?.role === "admin"),

--- a/apps/dokploy/drizzle/0133_template_registry.sql
+++ b/apps/dokploy/drizzle/0133_template_registry.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "template_registry" (
+	"templateRegistryId" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"baseUrl" text NOT NULL,
+	"isDefault" boolean DEFAULT false NOT NULL,
+	"isEnabled" boolean DEFAULT true NOT NULL,
+	"lastSyncAt" text,
+	"templateCount" text,
+	"createdAt" text NOT NULL,
+	"organizationId" text NOT NULL
+);
+
+DO $$ BEGIN
+ ALTER TABLE "template_registry" ADD CONSTRAINT "template_registry_organizationId_organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+

--- a/apps/dokploy/drizzle/meta/_journal.json
+++ b/apps/dokploy/drizzle/meta/_journal.json
@@ -932,6 +932,13 @@
       "when": 1765346573500,
       "tag": "0132_clean_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 133,
+      "version": "7",
+      "when": 1765500000000,
+      "tag": "0133_template_registry",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dokploy/pages/dashboard/settings/template-registries.tsx
+++ b/apps/dokploy/pages/dashboard/settings/template-registries.tsx
@@ -1,0 +1,60 @@
+import { validateRequest } from "@dokploy/server";
+import { createServerSideHelpers } from "@trpc/react-query/server";
+import type { GetServerSidePropsContext } from "next";
+import type { ReactElement } from "react";
+import superjson from "superjson";
+import { ShowTemplateRegistries } from "@/components/dashboard/settings/template-registries/show-template-registries";
+import { DashboardLayout } from "@/components/layouts/dashboard-layout";
+import { appRouter } from "@/server/api/root";
+
+const Page = () => {
+	return (
+		<div className="flex flex-col gap-4 w-full">
+			<ShowTemplateRegistries />
+		</div>
+	);
+};
+
+export default Page;
+
+Page.getLayout = (page: ReactElement) => {
+	return (
+		<DashboardLayout metaName="Template Registries">{page}</DashboardLayout>
+	);
+};
+
+export async function getServerSideProps(
+	ctx: GetServerSidePropsContext<{ serviceId: string }>,
+) {
+	const { req, res } = ctx;
+	const { user, session } = await validateRequest(req);
+	if (!user || user.role === "member") {
+		return {
+			redirect: {
+				permanent: true,
+				destination: "/",
+			},
+		};
+	}
+	const helpers = createServerSideHelpers({
+		router: appRouter,
+		ctx: {
+			req: req as any,
+			res: res as any,
+			db: null as any,
+			session: session as any,
+			user: user as any,
+		},
+		transformer: superjson,
+	});
+	await helpers.user.get.prefetch();
+	await helpers.settings.isCloud.prefetch();
+	await helpers.templateRegistry.all.prefetch();
+
+	return {
+		props: {
+			trpcState: helpers.dehydrate(),
+		},
+	};
+}
+

--- a/apps/dokploy/server/api/root.ts
+++ b/apps/dokploy/server/api/root.ts
@@ -37,6 +37,7 @@ import { settingsRouter } from "./routers/settings";
 import { sshRouter } from "./routers/ssh-key";
 import { stripeRouter } from "./routers/stripe";
 import { swarmRouter } from "./routers/swarm";
+import { templateRegistryRouter } from "./routers/template-registry";
 import { userRouter } from "./routers/user";
 import { volumeBackupsRouter } from "./routers/volume-backups";
 /**
@@ -86,6 +87,7 @@ export const appRouter = createTRPCRouter({
 	rollback: rollbackRouter,
 	volumeBackups: volumeBackupsRouter,
 	environment: environmentRouter,
+	templateRegistry: templateRegistryRouter,
 });
 
 // export type definition of API

--- a/apps/dokploy/server/api/routers/template-registry.ts
+++ b/apps/dokploy/server/api/routers/template-registry.ts
@@ -1,0 +1,126 @@
+import {
+	createTemplateRegistry,
+	ensureDefaultRegistry,
+	findEnabledTemplateRegistries,
+	findTemplateRegistriesByOrganizationId,
+	findTemplateRegistryById,
+	removeTemplateRegistry,
+	syncTemplateRegistry,
+	toggleTemplateRegistry,
+	updateTemplateRegistry,
+} from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
+import {
+	apiCreateTemplateRegistry,
+	apiFindOneTemplateRegistry,
+	apiRemoveTemplateRegistry,
+	apiToggleTemplateRegistry,
+	apiUpdateTemplateRegistry,
+} from "@/server/db/schema";
+import { adminProcedure, createTRPCRouter, protectedProcedure } from "../trpc";
+
+export const templateRegistryRouter = createTRPCRouter({
+	create: adminProcedure
+		.input(apiCreateTemplateRegistry)
+		.mutation(async ({ ctx, input }) => {
+			return await createTemplateRegistry(
+				input,
+				ctx.session.activeOrganizationId,
+			);
+		}),
+
+	remove: adminProcedure
+		.input(apiRemoveTemplateRegistry)
+		.mutation(async ({ ctx, input }) => {
+			const registry = await findTemplateRegistryById(
+				input.templateRegistryId,
+			);
+			if (registry.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to delete this registry",
+				});
+			}
+			return await removeTemplateRegistry(input.templateRegistryId);
+		}),
+
+	update: adminProcedure
+		.input(apiUpdateTemplateRegistry)
+		.mutation(async ({ input, ctx }) => {
+			const registry = await findTemplateRegistryById(
+				input.templateRegistryId,
+			);
+			if (registry.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to update this registry",
+				});
+			}
+			return await updateTemplateRegistry(input);
+		}),
+
+	toggle: adminProcedure
+		.input(apiToggleTemplateRegistry)
+		.mutation(async ({ input, ctx }) => {
+			const registry = await findTemplateRegistryById(
+				input.templateRegistryId,
+			);
+			if (registry.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to modify this registry",
+				});
+			}
+			return await toggleTemplateRegistry(
+				input.templateRegistryId,
+				input.isEnabled,
+			);
+		}),
+
+	sync: adminProcedure
+		.input(apiFindOneTemplateRegistry)
+		.mutation(async ({ input, ctx }) => {
+			const registry = await findTemplateRegistryById(
+				input.templateRegistryId,
+			);
+			if (registry.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to sync this registry",
+				});
+			}
+			return await syncTemplateRegistry(input.templateRegistryId);
+		}),
+
+	all: protectedProcedure.query(async ({ ctx }) => {
+		// Ensure default registry exists
+		await ensureDefaultRegistry(ctx.session.activeOrganizationId);
+		return await findTemplateRegistriesByOrganizationId(
+			ctx.session.activeOrganizationId,
+		);
+	}),
+
+	enabled: protectedProcedure.query(async ({ ctx }) => {
+		// Ensure default registry exists
+		await ensureDefaultRegistry(ctx.session.activeOrganizationId);
+		return await findEnabledTemplateRegistries(
+			ctx.session.activeOrganizationId,
+		);
+	}),
+
+	one: protectedProcedure
+		.input(apiFindOneTemplateRegistry)
+		.query(async ({ input, ctx }) => {
+			const registry = await findTemplateRegistryById(
+				input.templateRegistryId,
+			);
+			if (registry.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to access this registry",
+				});
+			}
+			return registry;
+		}),
+});
+

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -35,3 +35,4 @@ export * from "./ssh-key";
 export * from "./user";
 export * from "./utils";
 export * from "./volume-backups";
+export * from "./template-registry";

--- a/packages/server/src/db/schema/template-registry.ts
+++ b/packages/server/src/db/schema/template-registry.ts
@@ -1,0 +1,73 @@
+import { relations } from "drizzle-orm";
+import { boolean, pgTable, text } from "drizzle-orm/pg-core";
+import { createInsertSchema } from "drizzle-zod";
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { organization } from "./account";
+
+export const templateRegistry = pgTable("template_registry", {
+	templateRegistryId: text("templateRegistryId")
+		.notNull()
+		.primaryKey()
+		.$defaultFn(() => nanoid()),
+	name: text("name").notNull(),
+	description: text("description"),
+	baseUrl: text("baseUrl").notNull(),
+	isDefault: boolean("isDefault").notNull().default(false),
+	isEnabled: boolean("isEnabled").notNull().default(true),
+	lastSyncAt: text("lastSyncAt"),
+	templateCount: text("templateCount"),
+	createdAt: text("createdAt")
+		.notNull()
+		.$defaultFn(() => new Date().toISOString()),
+	organizationId: text("organizationId")
+		.notNull()
+		.references(() => organization.id, { onDelete: "cascade" }),
+});
+
+export const templateRegistryRelations = relations(
+	templateRegistry,
+	({ one }) => ({
+		organization: one(organization, {
+			fields: [templateRegistry.organizationId],
+			references: [organization.id],
+		}),
+	}),
+);
+
+const createSchema = createInsertSchema(templateRegistry, {
+	name: z.string().min(1, "Name is required"),
+	baseUrl: z.string().url("Must be a valid URL"),
+	description: z.string().optional(),
+	isEnabled: z.boolean().optional(),
+	isDefault: z.boolean().optional(),
+});
+
+export const apiCreateTemplateRegistry = createSchema
+	.pick({
+		name: true,
+		baseUrl: true,
+		description: true,
+	})
+	.required({
+		name: true,
+		baseUrl: true,
+	});
+
+export const apiUpdateTemplateRegistry = createSchema.partial().extend({
+	templateRegistryId: z.string().min(1),
+});
+
+export const apiFindOneTemplateRegistry = z.object({
+	templateRegistryId: z.string().min(1),
+});
+
+export const apiRemoveTemplateRegistry = z.object({
+	templateRegistryId: z.string().min(1),
+});
+
+export const apiToggleTemplateRegistry = z.object({
+	templateRegistryId: z.string().min(1),
+	isEnabled: z.boolean(),
+});
+

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -34,6 +34,7 @@ export * from "./services/redirect";
 export * from "./services/redis";
 export * from "./services/registry";
 export * from "./services/rollbacks";
+export * from "./services/template-registry";
 export * from "./services/schedule";
 export * from "./services/security";
 export * from "./services/server";

--- a/packages/server/src/services/template-registry.ts
+++ b/packages/server/src/services/template-registry.ts
@@ -1,0 +1,250 @@
+import { db } from "@dokploy/server/db";
+import {
+	type apiCreateTemplateRegistry,
+	type apiUpdateTemplateRegistry,
+	templateRegistry,
+} from "@dokploy/server/db/schema";
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { fetchTemplatesList } from "../templates/github";
+
+export type TemplateRegistry = typeof templateRegistry.$inferSelect;
+
+const DEFAULT_REGISTRY_URL = "https://templates.dokploy.com";
+const DEFAULT_REGISTRY_NAME = "Dokploy Official";
+
+export const createTemplateRegistry = async (
+	input: typeof apiCreateTemplateRegistry._type,
+	organizationId: string,
+) => {
+	// Validate the registry URL by trying to fetch templates
+	try {
+		const templates = await fetchTemplatesList(input.baseUrl);
+		const templateCount = templates.length.toString();
+
+		const newRegistry = await db
+			.insert(templateRegistry)
+			.values({
+				...input,
+				organizationId,
+				templateCount,
+				lastSyncAt: new Date().toISOString(),
+			})
+			.returning()
+			.then((value) => value[0]);
+
+		if (!newRegistry) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: "Error creating template registry",
+			});
+		}
+
+		return newRegistry;
+	} catch (error) {
+		if (error instanceof TRPCError) throw error;
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Failed to validate registry URL: ${(error as Error).message}`,
+		});
+	}
+};
+
+export const findTemplateRegistryById = async (templateRegistryId: string) => {
+	const result = await db.query.templateRegistry.findFirst({
+		where: eq(templateRegistry.templateRegistryId, templateRegistryId),
+	});
+
+	if (!result) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Template registry not found",
+		});
+	}
+
+	return result;
+};
+
+export const findTemplateRegistriesByOrganizationId = async (
+	organizationId: string,
+) => {
+	const registries = await db.query.templateRegistry.findMany({
+		where: eq(templateRegistry.organizationId, organizationId),
+		orderBy: (tr, { desc }) => [desc(tr.isDefault), desc(tr.createdAt)],
+	});
+
+	return registries;
+};
+
+export const findEnabledTemplateRegistries = async (organizationId: string) => {
+	const registries = await db.query.templateRegistry.findMany({
+		where: and(
+			eq(templateRegistry.organizationId, organizationId),
+			eq(templateRegistry.isEnabled, true),
+		),
+		orderBy: (tr, { desc }) => [desc(tr.isDefault), desc(tr.createdAt)],
+	});
+
+	return registries;
+};
+
+export const updateTemplateRegistry = async (
+	input: typeof apiUpdateTemplateRegistry._type,
+) => {
+	const { templateRegistryId, ...rest } = input;
+
+	const registry = await findTemplateRegistryById(templateRegistryId);
+
+	// If updating baseUrl, validate it
+	if (rest.baseUrl && rest.baseUrl !== registry.baseUrl) {
+		try {
+			await fetchTemplatesList(rest.baseUrl);
+		} catch (error) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Failed to validate registry URL: ${(error as Error).message}`,
+			});
+		}
+	}
+
+	const result = await db
+		.update(templateRegistry)
+		.set(rest)
+		.where(eq(templateRegistry.templateRegistryId, templateRegistryId))
+		.returning()
+		.then((res) => res[0]);
+
+	if (!result) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Template registry not found",
+		});
+	}
+
+	return result;
+};
+
+export const removeTemplateRegistry = async (templateRegistryId: string) => {
+	const registry = await findTemplateRegistryById(templateRegistryId);
+
+	if (registry.isDefault) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Cannot delete the default registry",
+		});
+	}
+
+	const result = await db
+		.delete(templateRegistry)
+		.where(eq(templateRegistry.templateRegistryId, templateRegistryId))
+		.returning()
+		.then((res) => res[0]);
+
+	if (!result) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Template registry not found",
+		});
+	}
+
+	return result;
+};
+
+export const toggleTemplateRegistry = async (
+	templateRegistryId: string,
+	isEnabled: boolean,
+) => {
+	const result = await db
+		.update(templateRegistry)
+		.set({ isEnabled })
+		.where(eq(templateRegistry.templateRegistryId, templateRegistryId))
+		.returning()
+		.then((res) => res[0]);
+
+	if (!result) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Template registry not found",
+		});
+	}
+
+	return result;
+};
+
+export const syncTemplateRegistry = async (templateRegistryId: string) => {
+	const registry = await findTemplateRegistryById(templateRegistryId);
+
+	try {
+		const templates = await fetchTemplatesList(registry.baseUrl);
+
+		const result = await db
+			.update(templateRegistry)
+			.set({
+				templateCount: templates.length.toString(),
+				lastSyncAt: new Date().toISOString(),
+			})
+			.where(eq(templateRegistry.templateRegistryId, templateRegistryId))
+			.returning()
+			.then((res) => res[0]);
+
+		return result;
+	} catch (error) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Failed to sync registry: ${(error as Error).message}`,
+		});
+	}
+};
+
+export const ensureDefaultRegistry = async (organizationId: string) => {
+	// Check if default registry exists
+	const existingDefault = await db.query.templateRegistry.findFirst({
+		where: and(
+			eq(templateRegistry.organizationId, organizationId),
+			eq(templateRegistry.isDefault, true),
+		),
+	});
+
+	if (existingDefault) {
+		return existingDefault;
+	}
+
+	// Create default registry
+	try {
+		const templates = await fetchTemplatesList(DEFAULT_REGISTRY_URL);
+
+		const newRegistry = await db
+			.insert(templateRegistry)
+			.values({
+				name: DEFAULT_REGISTRY_NAME,
+				description: "Official Dokploy template registry",
+				baseUrl: DEFAULT_REGISTRY_URL,
+				isDefault: true,
+				isEnabled: true,
+				organizationId,
+				templateCount: templates.length.toString(),
+				lastSyncAt: new Date().toISOString(),
+			})
+			.returning()
+			.then((value) => value[0]);
+
+		return newRegistry;
+	} catch (error) {
+		// If we can't fetch templates, still create the registry but without count
+		const newRegistry = await db
+			.insert(templateRegistry)
+			.values({
+				name: DEFAULT_REGISTRY_NAME,
+				description: "Official Dokploy template registry",
+				baseUrl: DEFAULT_REGISTRY_URL,
+				isDefault: true,
+				isEnabled: true,
+				organizationId,
+			})
+			.returning()
+			.then((value) => value[0]);
+
+		return newRegistry;
+	}
+};
+


### PR DESCRIPTION
- Add database schema for template_registry table
- Add API routes for CRUD operations (create, read, update, delete, toggle, sync)
- Create settings page for managing template registries
- Add Template Registries menu item in sidebar
- Update template creation flow with registry selector dropdown
- Support enabling/disabling registries
- Auto-create default Dokploy Official registry
- Add database migration for template_registry table

## What is this PR about?

For me that's great opportunity to publish some local or junky templates and not be shy, maybe someone would need that feat too. When you see 1panel in my regisitry i guess you'll understand my craziness ;))

Sorry for ugly PR. w love <3

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

<img width="289" height="145" alt="1 - sidepanel" src="https://github.com/user-attachments/assets/4bd57b7d-670d-40d8-9ebe-7ac872fc5844" />
<img width="1587" height="765" alt="2 - page" src="https://github.com/user-attachments/assets/d3dc3462-7a01-4393-9e3c-7a05dc5ca65f" />
<img width="375" height="665" alt="3 - sync" src="https://github.com/user-attachments/assets/6818d659-c9eb-486f-84a8-73e1aab59cb3" />
<img width="1759" height="568" alt="4 - list" src="https://github.com/user-attachments/assets/a64cff72-bac1-45a1-861e-33a412e28102" />




