### PR TITLE
fix(environment): prevent renaming of the default environment

### DIFF
--- a/apps/dokploy/server/api/routers/environment.ts
+++ b/apps/dokploy/server/api/routers/environment.ts
@@ -208,6 +208,14 @@ export const environmentRouter = createTRPCRouter({
 					});
 				}
 
+				// Prevent deletion of the default environment
+				if (environment.isDefault) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "You cannot delete the default environment",
+					});
+				}
+
 				// Check environment deletion permission
 				await checkEnvironmentDeletionPermission(
 					ctx.user.id,


### PR DESCRIPTION
- Updated the logic to disallow renaming the default environment while still allowing updates to its description and other properties.
- Adjusted error message for clarity when attempting to rename the default environment.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3247 

## Screenshots (if applicable)

