### PR TITLE
fix(environment): clarify .env file creation instructions

### DIFF
--- a/apps/dokploy/components/dashboard/application/environment/show.tsx
+++ b/apps/dokploy/components/dashboard/application/environment/show.tsx
@@ -191,9 +191,10 @@ export const ShowEnvironment = ({ applicationId }: Props) => {
 									<div className="space-y-0.5">
 										<FormLabel>Create Environment File</FormLabel>
 										<FormDescription>
-											When enabled, an .env file will be created during the
-											build process. Disable this if you don't want to generate
-											an environment file.
+											When enabled, an .env file will be created in the same
+											directory as your Dockerfile during the build process.
+											Disable this if you don't want to generate an environment
+											file.
 										</FormDescription>
 									</div>
 									<FormControl>


### PR DESCRIPTION
- Updated the description for the environment file creation option to specify that the .env file will be created in the same directory as the Dockerfile during the build process, enhancing user understanding.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3231

## Screenshots (if applicable)

