### PR TITLE
[CRITICAL] fix: volume cleaning should not be performed

### DIFF
--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -284,34 +284,36 @@ export const cleanupAll = async (serverId?: string) => {
 };
 
 export const cleanupAllBackground = async (serverId?: string) => {
-  Promise.allSettled(
-    (Object.entries(cleanupCommands) as [
-      keyof typeof cleanupCommands,
-      string
-    ][])
-      .filter(([key]) => !excludedCleanupAllCommands.includes(key))
-      .map(async ([, command]) => {
-        if (serverId) {
-          await execAsyncRemote(serverId, dockerSafeExec(command));
-        } else {
-          await execAsync(dockerSafeExec(command));
-        }
-      })
-  )
-    .then((results) => {
-      const failed = results.filter((r) => r.status === "rejected");
-      if (failed.length > 0) {
-        console.error(`Docker cleanup: ${failed.length} operations failed`);
-      } else {
-        console.log("Docker cleanup completed successfully");
-      }
-    })
-    .catch((error) => console.error("Error in cleanup:", error));
+	Promise.allSettled(
+		(
+			Object.entries(cleanupCommands) as [
+				keyof typeof cleanupCommands,
+				string,
+			][]
+		)
+			.filter(([key]) => !excludedCleanupAllCommands.includes(key))
+			.map(async ([, command]) => {
+				if (serverId) {
+					await execAsyncRemote(serverId, dockerSafeExec(command));
+				} else {
+					await execAsync(dockerSafeExec(command));
+				}
+			}),
+	)
+		.then((results) => {
+			const failed = results.filter((r) => r.status === "rejected");
+			if (failed.length > 0) {
+				console.error(`Docker cleanup: ${failed.length} operations failed`);
+			} else {
+				console.log("Docker cleanup completed successfully");
+			}
+		})
+		.catch((error) => console.error("Error in cleanup:", error));
 
-  return {
-    status: "scheduled",
-    message: "Docker cleanup has been initiated in the background",
-  };
+	return {
+		status: "scheduled",
+		message: "Docker cleanup has been initiated in the background",
+	};
 };
 
 export const startService = async (appName: string) => {


### PR DESCRIPTION
## What is this PR about?

As I mentioned before (https://github.com/Dokploy/dokploy/pull/3188), cleaning volumes during a full cleanup is dangerous. Due to this PR (https://github.com/Dokploy/dokploy/pull/3258), volume cleanup is currently being performed during a full cleanup. Volume cleanup should only happen when the user explicitly requests it, for example by clicking the “Clean unused volumes” button. The reason is that during automatic cleanup, a volume may be deleted due to a stopped container, which is a dangerous situation.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)

## Screenshots (if applicable)

