### PR TITLE
fix: return database instance as response on db creation (mongo, mysq…

### DIFF
--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -87,7 +87,7 @@ export const mariadbRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMariadb;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -87,7 +87,7 @@ export const mongoRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMongo;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -89,7 +89,7 @@ export const mysqlRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMysql;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -91,7 +91,7 @@ export const postgresRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newPostgres;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;


### PR DESCRIPTION
The database creation APIs will now return newly created database instance on the following endpoints
`/mongo.create`
`/mariadb.create`
`/mysql.create`
`/postgres.create`