### PR TITLE
Fix: Database Create APIs now return databaseID in response

### DIFF
--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -87,7 +87,7 @@ export const mariadbRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMariadb;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -87,7 +87,7 @@ export const mongoRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMongo;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -89,7 +89,7 @@ export const mysqlRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMysql;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -91,7 +91,7 @@ export const postgresRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newPostgres;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;


### PR DESCRIPTION
Fixes #3268

## Description

This PR fixes an issue where database creation endpoints (`mysql.create`, `mariadb.create`, `postgres.create`, and `mongo.create`) were returning `true` instead of the created database object. This prevented automation workflows from obtaining the database ID needed to deploy/activate databases after creation.

## Changes Made

Updated the following database creation endpoints to return the created database object (which includes the database ID) instead of `true`:

- **`mysql.create`**: Now returns `newMysql` object (includes `mysqlId`)
- **`mariadb.create`**: Now returns `newMariadb` object (includes `mariadbId`)
- **`postgres.create`**: Now returns `newPostgres` object (includes `postgresId`)
- **`mongo.create`**: Now returns `newMongo` object (includes `mongoId`)

This change makes these endpoints consistent with the existing `redis.create` endpoint, which already returns the created database object.

## Impact

- ✅ Automation workflows can now extract the database ID from the creation response
- ✅ Users can immediately deploy/activate databases after creation without needing to query for the database separately
- ✅ Consistent API behavior across all database types
- ✅ No breaking changes - the response now includes more information instead of just `true`

## Example Response

Before:

```json
true
```

After:

```json
{
  "mysqlId": "7UZ3qqYvTvcPXiAoNVpDD",
  "name": "mysql",
  "appName": "mysqldb-loddhw",
  "description": "string",
  "databaseName": "database_name",
  "databaseUser": "database_user",
  "databasePassword": "password",
  "databaseRootPassword": "password",
  "dockerImage": "mysql:8",
  // ... other database fields
}
```

## Testing

- [x] Verified that all four database creation endpoints return the database object
- [x] Confirmed that the returned objects include the respective ID fields (`mysqlId`, `mariadbId`, `postgresId`, `mongoId`)
- [x] No linting errors introduced