### PR TITLE
fix(mongo): use appName instead of localhost for replica set

### DIFF
--- a/packages/server/src/utils/databases/mongo.ts
+++ b/packages/server/src/utils/databases/mongo.ts
@@ -54,7 +54,7 @@ if [ "$REPLICA_STATUS" != "1" ]; then
 	mongosh --eval '
 	rs.initiate({
 		_id: "rs0",
-		members: [{ _id: 0, host: "localhost:27017", priority: 1 }]
+		members: [{ _id: 0, host: "${appName}:27017", priority: 1 }]
 	});
 
     // Wait for the replica set to initialize


### PR DESCRIPTION
Fixes MongoDB replica set initialization by replacing `localhost:27017` with `${appName}:27017` in the replica set configuration. Using `localhost` doesn't work properly in containerized environments since it refers to the container itself, not the service name that other containers use to communicate. This change ensures the replica set can be properly initialized using the correct hostname within the Docker network.
