### PR TITLE
fix(api): return database object from create endpoints

### DIFF
--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -87,7 +87,7 @@ export const mariadbRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMariadb;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -87,7 +87,7 @@ export const mongoRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMongo;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -89,7 +89,7 @@ export const mysqlRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newMysql;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -91,7 +91,7 @@ export const postgresRouter = createTRPCRouter({
 					type: "volume",
 				});
 
-				return true;
+				return newPostgres;
 			} catch (error) {
 				if (error instanceof TRPCError) {
 					throw error;


### PR DESCRIPTION
## Summary
- Database creation APIs (mysql, mariadb, postgres, mongo) now return the created database object with databaseID instead of boolean `true`
- This enables automation workflows to deploy databases immediately after creation
- Aligns behavior with existing patterns (redis.create already returns the object, as do application.create and compose.create)

## Test plan
- [ ] Call `mysql.create` API and verify response contains `mysqlId`
- [ ] Call `mariadb.create` API and verify response contains `mariadbId`
- [ ] Call `postgres.create` API and verify response contains `postgresId`
- [ ] Call `mongo.create` API and verify response contains `mongoId`
- [ ] Verify existing UI functionality still works (create operations should handle object response)

Fixes #3268