### PR TITLE
feat(domains): add grid/table view toggle for domains page

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/columns.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/columns.tsx
@@ -3,6 +3,7 @@ import {
 	ArrowUpDown,
 	CheckCircle2,
 	ExternalLink,
+	HelpCircle,
 	Loader2,
 	MoreHorizontal,
 	PenBoxIcon,
@@ -110,7 +111,7 @@ export const createColumns = ({
 		header: "Port",
 		cell: ({ row }) => {
 			const port = row.getValue("port") as number | null;
-			return <span className="text-sm">{port ?? 3000}</span>;
+			return <span className="text-sm">{port != null ? port : "-"}</span>;
 		},
 	},
 	{
@@ -207,7 +208,15 @@ export const createColumns = ({
 									path: domain.path || undefined,
 								}}
 								serverIp={serverIp}
-							/>
+							>
+								<Button
+									variant="ghost"
+									className="w-full justify-start font-normal h-9 px-2"
+								>
+									<HelpCircle className="size-4 mr-2" />
+									DNS Helper
+								</Button>
+							</DnsHelperModal>
 						)}
 						<AddDomain id={id} type={type} domainId={domain.domainId}>
 							<Button

--- a/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/dns-helper-modal.tsx
@@ -18,9 +18,10 @@ interface Props {
 		path?: string;
 	};
 	serverIp?: string;
+	children?: React.ReactNode;
 }
 
-export const DnsHelperModal = ({ domain, serverIp }: Props) => {
+export const DnsHelperModal = ({ domain, serverIp, children }: Props) => {
 	const copyToClipboard = (text: string) => {
 		navigator.clipboard.writeText(text);
 		toast.success("Copied to clipboard!");
@@ -28,10 +29,12 @@ export const DnsHelperModal = ({ domain, serverIp }: Props) => {
 
 	return (
 		<Dialog>
-			<DialogTrigger>
-				<Button variant="ghost" size="icon" className="group">
-					<HelpCircle className="size-4" />
-				</Button>
+			<DialogTrigger asChild>
+				{children ?? (
+					<Button variant="ghost" size="icon" className="group">
+						<HelpCircle className="size-4" />
+					</Button>
+				)}
 			</DialogTrigger>
 			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -75,6 +75,16 @@ export type ValidationState = {
 
 export type ValidationStates = Record<string, ValidationState>;
 
+const columnLabels: Record<string, string> = {
+	host: "Host",
+	serviceName: "Service",
+	path: "Path",
+	port: "Port",
+	https: "Protocol",
+	certificateType: "Certificate",
+	dnsStatus: "DNS Status",
+};
+
 interface Props {
 	id: string;
 	type: "application" | "compose";
@@ -377,7 +387,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 															<TooltipTrigger asChild>
 																<Badge variant="secondary">
 																	<InfoIcon className="size-3 mr-1" />
-																	Port: {item.port}
+																	Port: {item.port ?? "-"}
 																</Badge>
 															</TooltipTrigger>
 															<TooltipContent>
@@ -513,13 +523,12 @@ export const ShowDomains = ({ id, type }: Props) => {
 												return (
 													<DropdownMenuCheckboxItem
 														key={column.id}
-														className="capitalize"
 														checked={column.getIsVisible()}
 														onCheckedChange={(value) =>
 															column.toggleVisibility(!!value)
 														}
 													>
-														{column.id}
+														{columnLabels[column.id] ?? column.id}
 													</DropdownMenuCheckboxItem>
 												);
 											})}


### PR DESCRIPTION
## Summary

- Add view toggle button (LayoutGrid/LayoutList icons) to switch between Grid and Table views
- Implement Table view with sortable columns using `@tanstack/react-table`
- Add search/filter by hostname functionality
- Add column visibility dropdown
- Add pagination controls (Previous/Next)
- Persist view preference in localStorage
- Preserve all existing Grid view functionality as default

## Table View Columns

| Column | Description |
|--------|-------------|
| Host | Sortable, clickable external link to domain |
| Service | Service name badge (for compose) |
| Path | URL path |
| Port | Container port |
| Protocol | HTTP/HTTPS badge |
| Certificate | Certificate type badge (none/letsencrypt/custom) |
| DNS Status | Interactive validation badge (click to validate) |
| Actions | Dropdown with DNS Helper, Edit, Delete |

## Files Changed

- **Created**: `apps/dokploy/components/dashboard/application/domains/columns.tsx`
- **Modified**: `apps/dokploy/components/dashboard/application/domains/show-domains.tsx`

## Test Plan

- [ ] Verify Grid view works as before (default)
- [ ] Verify Table view displays all 8 columns correctly
- [ ] Verify sorting works on Host column
- [ ] Verify filter by hostname works
- [ ] Verify column visibility toggle works
- [ ] Verify pagination works (Previous/Next)
- [ ] Verify DNS validation clickable badge works in table view
- [ ] Verify Edit/Delete actions work via Actions dropdown
- [ ] Verify view preference persists in localStorage
- [ ] Verify table has horizontal scroll on mobile devices

Fixes #3158