### PR TITLE
feat(notifications): add Google Chat/Spaces as notification provider

### DIFF
--- a/apps/dokploy/components/icons/notification-icons.tsx
+++ b/apps/dokploy/components/icons/notification-icons.tsx
@@ -231,3 +231,30 @@ export const NtfyIcon = ({ className }: Props) => {
 		</svg>
 	);
 };
+
+export const GoogleChatIcon = ({ className }: Props) => {
+	return (
+		<svg
+			viewBox="0 0 48 48"
+			className={cn("size-9", className)}
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				fill="#00AC47"
+				d="M12 24V14c0-1.1.9-2 2-2h20c1.1 0 2 .9 2 2v10l6-6V8c0-2.2-1.8-4-4-4H10C7.8 4 6 5.8 6 8v20l6-4z"
+			/>
+			<path
+				fill="#FFBA00"
+				d="M40 18l-4 4v8c0 1.1-.9 2-2 2H22l-6 6v2c0 2.2 1.8 4 4 4h14l10 6V24c0-2.2-1.8-4-4-4h-2l2-2z"
+			/>
+			<path
+				fill="#4285F4"
+				d="M16 40h-2c-2.2 0-4-1.8-4-4v-2l6 6z"
+			/>
+			<path
+				fill="#00832D"
+				d="M22 32H14c-1.1 0-2-.9-2-2V14l-6 4v18c0 2.2 1.8 4 4 4h18l-6-6V32z"
+			/>
+		</svg>
+	);
+};

--- a/apps/dokploy/server/api/routers/notification.ts
+++ b/apps/dokploy/server/api/routers/notification.ts
@@ -2,6 +2,7 @@ import {
 	createCustomNotification,
 	createDiscordNotification,
 	createEmailNotification,
+	createGoogleChatNotification,
 	createGotifyNotification,
 	createLarkNotification,
 	createNtfyNotification,
@@ -13,6 +14,7 @@ import {
 	sendCustomNotification,
 	sendDiscordNotification,
 	sendEmailNotification,
+	sendGoogleChatNotification,
 	sendGotifyNotification,
 	sendLarkNotification,
 	sendNtfyNotification,
@@ -22,6 +24,7 @@ import {
 	updateCustomNotification,
 	updateDiscordNotification,
 	updateEmailNotification,
+	updateGoogleChatNotification,
 	updateGotifyNotification,
 	updateLarkNotification,
 	updateNtfyNotification,
@@ -42,6 +45,7 @@ import {
 	apiCreateCustom,
 	apiCreateDiscord,
 	apiCreateEmail,
+	apiCreateGoogleChat,
 	apiCreateGotify,
 	apiCreateLark,
 	apiCreateNtfy,
@@ -51,6 +55,7 @@ import {
 	apiTestCustomConnection,
 	apiTestDiscordConnection,
 	apiTestEmailConnection,
+	apiTestGoogleChatConnection,
 	apiTestGotifyConnection,
 	apiTestLarkConnection,
 	apiTestNtfyConnection,
@@ -59,6 +64,7 @@ import {
 	apiUpdateCustom,
 	apiUpdateDiscord,
 	apiUpdateEmail,
+	apiUpdateGoogleChat,
 	apiUpdateGotify,
 	apiUpdateLark,
 	apiUpdateNtfy,
@@ -342,6 +348,7 @@ export const notificationRouter = createTRPCRouter({
 				ntfy: true,
 				custom: true,
 				lark: true,
+				googleChat: true,
 			},
 			orderBy: desc(notifications.createdAt),
 			where: eq(notifications.organizationId, ctx.session.activeOrganizationId),
@@ -625,6 +632,60 @@ export const notificationRouter = createTRPCRouter({
 					content: {
 						text: "Hi, From Dokploy 👋",
 					},
+				});
+				return true;
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error testing the notification",
+					cause: error,
+				});
+			}
+		}),
+	createGoogleChat: adminProcedure
+		.input(apiCreateGoogleChat)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				return await createGoogleChatNotification(
+					input,
+					ctx.session.activeOrganizationId,
+				);
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error creating the notification",
+					cause: error,
+				});
+			}
+		}),
+	updateGoogleChat: adminProcedure
+		.input(apiUpdateGoogleChat)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const notification = await findNotificationById(input.notificationId);
+				if (
+					IS_CLOUD &&
+					notification.organizationId !== ctx.session.activeOrganizationId
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You are not authorized to update this notification",
+					});
+				}
+				return await updateGoogleChatNotification({
+					...input,
+					organizationId: ctx.session.activeOrganizationId,
+				});
+			} catch (error) {
+				throw error;
+			}
+		}),
+	testGoogleChatConnection: adminProcedure
+		.input(apiTestGoogleChatConnection)
+		.mutation(async ({ input }) => {
+			try {
+				await sendGoogleChatNotification(input, {
+					text: "Hi, From Dokploy 👋",
 				});
 				return true;
 			} catch (error) {

--- a/packages/server/src/db/schema/notification.ts
+++ b/packages/server/src/db/schema/notification.ts
@@ -21,6 +21,7 @@ export const notificationType = pgEnum("notificationType", [
 	"ntfy",
 	"custom",
 	"lark",
+	"googleChat",
 ]);
 
 export const notifications = pgTable("notification", {
@@ -62,6 +63,9 @@ export const notifications = pgTable("notification", {
 		onDelete: "cascade",
 	}),
 	larkId: text("larkId").references(() => lark.larkId, {
+		onDelete: "cascade",
+	}),
+	googleChatId: text("googleChatId").references(() => googleChat.googleChatId, {
 		onDelete: "cascade",
 	}),
 	organizationId: text("organizationId")
@@ -149,6 +153,14 @@ export const lark = pgTable("lark", {
 	webhookUrl: text("webhookUrl").notNull(),
 });
 
+export const googleChat = pgTable("google_chat", {
+	googleChatId: text("googleChatId")
+		.notNull()
+		.primaryKey()
+		.$defaultFn(() => nanoid()),
+	webhookUrl: text("webhookUrl").notNull(),
+});
+
 export const notificationsRelations = relations(notifications, ({ one }) => ({
 	slack: one(slack, {
 		fields: [notifications.slackId],
@@ -181,6 +193,10 @@ export const notificationsRelations = relations(notifications, ({ one }) => ({
 	lark: one(lark, {
 		fields: [notifications.larkId],
 		references: [lark.larkId],
+	}),
+	googleChat: one(googleChat, {
+		fields: [notifications.googleChatId],
+		references: [googleChat.googleChatId],
 	}),
 	organization: one(organization, {
 		fields: [notifications.organizationId],
@@ -436,6 +452,32 @@ export const apiUpdateLark = apiCreateLark.partial().extend({
 });
 
 export const apiTestLarkConnection = apiCreateLark.pick({
+	webhookUrl: true,
+});
+
+export const apiCreateGoogleChat = notificationsSchema
+	.pick({
+		appBuildError: true,
+		databaseBackup: true,
+		volumeBackup: true,
+		dokployRestart: true,
+		name: true,
+		appDeploy: true,
+		dockerCleanup: true,
+		serverThreshold: true,
+	})
+	.extend({
+		webhookUrl: z.string().min(1),
+	})
+	.required();
+
+export const apiUpdateGoogleChat = apiCreateGoogleChat.partial().extend({
+	notificationId: z.string().min(1),
+	googleChatId: z.string().min(1),
+	organizationId: z.string().optional(),
+});
+
+export const apiTestGoogleChatConnection = apiCreateGoogleChat.pick({
 	webhookUrl: true,
 });
 

--- a/packages/server/src/utils/notifications/build-error.ts
+++ b/packages/server/src/utils/notifications/build-error.ts
@@ -8,6 +8,7 @@ import {
 	sendCustomNotification,
 	sendDiscordNotification,
 	sendEmailNotification,
+	sendGoogleChatNotification,
 	sendGotifyNotification,
 	sendLarkNotification,
 	sendNtfyNotification,
@@ -48,12 +49,22 @@ export const sendBuildErrorNotifications = async ({
 			ntfy: true,
 			custom: true,
 			lark: true,
+			googleChat: true,
 		},
 	});
 
 	for (const notification of notificationList) {
-		const { email, discord, telegram, slack, gotify, ntfy, custom, lark } =
-			notification;
+		const {
+			email,
+			discord,
+			telegram,
+			slack,
+			gotify,
+			ntfy,
+			custom,
+			lark,
+			googleChat,
+		} = notification;
 		try {
 			if (email) {
 				const template = await renderAsync(
@@ -347,6 +358,21 @@ export const sendBuildErrorNotifications = async ({
 							],
 						},
 					},
+				});
+			}
+
+			if (googleChat) {
+				const limitCharacter = 500;
+				const truncatedErrorMessage = errorMessage.substring(0, limitCharacter);
+				await sendGoogleChatNotification(googleChat, {
+					text:
+						`*⚠️ Build Failed*\n\n` +
+						`*Project:* ${projectName}\n` +
+						`*Application:* ${applicationName}\n` +
+						`*Type:* ${applicationType}\n` +
+						`*Date:* ${format(date, "PP pp")}\n\n` +
+						`*Error:*\n\`\`\`${truncatedErrorMessage}\`\`\`\n\n` +
+						`Build Details: ${buildLink}`,
 				});
 			}
 		} catch (error) {

--- a/packages/server/src/utils/notifications/build-success.ts
+++ b/packages/server/src/utils/notifications/build-success.ts
@@ -9,6 +9,7 @@ import {
 	sendCustomNotification,
 	sendDiscordNotification,
 	sendEmailNotification,
+	sendGoogleChatNotification,
 	sendGotifyNotification,
 	sendLarkNotification,
 	sendNtfyNotification,
@@ -51,12 +52,22 @@ export const sendBuildSuccessNotifications = async ({
 			ntfy: true,
 			custom: true,
 			lark: true,
+			googleChat: true,
 		},
 	});
 
 	for (const notification of notificationList) {
-		const { email, discord, telegram, slack, gotify, ntfy, custom, lark } =
-			notification;
+		const {
+			email,
+			discord,
+			telegram,
+			slack,
+			gotify,
+			ntfy,
+			custom,
+			lark,
+			googleChat,
+		} = notification;
 		try {
 			if (email) {
 				const template = await renderAsync(
@@ -361,6 +372,19 @@ export const sendBuildSuccessNotifications = async ({
 							],
 						},
 					},
+				});
+			}
+
+			if (googleChat) {
+				await sendGoogleChatNotification(googleChat, {
+					text:
+						`*✅ Build Success*\n\n` +
+						`*Project:* ${projectName}\n` +
+						`*Application:* ${applicationName}\n` +
+						`*Environment:* ${environmentName}\n` +
+						`*Type:* ${applicationType}\n` +
+						`*Date:* ${format(date, "PP pp")}\n\n` +
+						`Build Details: ${buildLink}`,
 				});
 			}
 		} catch (error) {

--- a/packages/server/src/utils/notifications/database-backup.ts
+++ b/packages/server/src/utils/notifications/database-backup.ts
@@ -8,6 +8,7 @@ import {
 	sendCustomNotification,
 	sendDiscordNotification,
 	sendEmailNotification,
+	sendGoogleChatNotification,
 	sendGotifyNotification,
 	sendLarkNotification,
 	sendNtfyNotification,
@@ -48,12 +49,22 @@ export const sendDatabaseBackupNotifications = async ({
 			ntfy: true,
 			custom: true,
 			lark: true,
+			googleChat: true,
 		},
 	});
 
 	for (const notification of notificationList) {
-		const { email, discord, telegram, slack, gotify, ntfy, custom, lark } =
-			notification;
+		const {
+			email,
+			discord,
+			telegram,
+			slack,
+			gotify,
+			ntfy,
+			custom,
+			lark,
+			googleChat,
+		} = notification;
 		try {
 			if (email) {
 				const template = await renderAsync(
@@ -375,6 +386,26 @@ export const sendDatabaseBackupNotifications = async ({
 							],
 						},
 					},
+				});
+			}
+
+			if (googleChat) {
+				const statusEmoji = type === "success" ? "✅" : "❌";
+				const statusText = type === "success" ? "Successful" : "Failed";
+				const errorMsg =
+					type === "error" && errorMessage
+						? `\n\n*Error:*\n\`\`\`${errorMessage.substring(0, 500)}\`\`\``
+						: "";
+
+				await sendGoogleChatNotification(googleChat, {
+					text:
+						`*${statusEmoji} Database Backup ${statusText}*\n\n` +
+						`*Project:* ${projectName}\n` +
+						`*Application:* ${applicationName}\n` +
+						`*Database Type:* ${databaseType}\n` +
+						`*Database Name:* ${databaseName}\n` +
+						`*Date:* ${format(date, "PP pp")}` +
+						errorMsg,
 				});
 			}
 		} catch (error) {

--- a/packages/server/src/utils/notifications/docker-cleanup.ts
+++ b/packages/server/src/utils/notifications/docker-cleanup.ts
@@ -8,6 +8,7 @@ import {
 	sendCustomNotification,
 	sendDiscordNotification,
 	sendEmailNotification,
+	sendGoogleChatNotification,
 	sendGotifyNotification,
 	sendLarkNotification,
 	sendNtfyNotification,
@@ -35,12 +36,22 @@ export const sendDockerCleanupNotifications = async (
 			ntfy: true,
 			custom: true,
 			lark: true,
+			googleChat: true,
 		},
 	});
 
 	for (const notification of notificationList) {
-		const { email, discord, telegram, slack, gotify, ntfy, custom, lark } =
-			notification;
+		const {
+			email,
+			discord,
+			telegram,
+			slack,
+			gotify,
+			ntfy,
+			custom,
+			lark,
+			googleChat,
+		} = notification;
 		try {
 			if (email) {
 				const template = await renderAsync(
@@ -228,6 +239,16 @@ export const sendDockerCleanupNotifications = async (
 							],
 						},
 					},
+				});
+			}
+
+			if (googleChat) {
+				await sendGoogleChatNotification(googleChat, {
+					text:
+						`*✅ Docker Cleanup*\n\n` +
+						`*Status:* Successful\n` +
+						`*Date:* ${format(date, "PP pp")}\n\n` +
+						`*Message:*\n${message}`,
 				});
 			}
 		} catch (error) {

--- a/packages/server/src/utils/notifications/dokploy-restart.ts
+++ b/packages/server/src/utils/notifications/dokploy-restart.ts
@@ -8,6 +8,7 @@ import {
 	sendCustomNotification,
 	sendDiscordNotification,
 	sendEmailNotification,
+	sendGoogleChatNotification,
 	sendGotifyNotification,
 	sendLarkNotification,
 	sendNtfyNotification,
@@ -29,12 +30,22 @@ export const sendDokployRestartNotifications = async () => {
 			ntfy: true,
 			custom: true,
 			lark: true,
+			googleChat: true,
 		},
 	});
 
 	for (const notification of notificationList) {
-		const { email, discord, telegram, slack, gotify, ntfy, custom, lark } =
-			notification;
+		const {
+			email,
+			discord,
+			telegram,
+			slack,
+			gotify,
+			ntfy,
+			custom,
+			lark,
+			googleChat,
+		} = notification;
 
 		try {
 			if (email) {
@@ -217,6 +228,15 @@ export const sendDokployRestartNotifications = async () => {
 							],
 						},
 					},
+				});
+			}
+
+			if (googleChat) {
+				await sendGoogleChatNotification(googleChat, {
+					text:
+						`*✅ Dokploy Server Restarted*\n\n` +
+						`*Status:* Successful\n` +
+						`*Restart Time:* ${format(date, "PP pp")}`,
 				});
 			}
 		} catch (error) {

--- a/packages/server/src/utils/notifications/server-threshold.ts
+++ b/packages/server/src/utils/notifications/server-threshold.ts
@@ -4,6 +4,7 @@ import { notifications } from "../../db/schema";
 import {
 	sendCustomNotification,
 	sendDiscordNotification,
+	sendGoogleChatNotification,
 	sendLarkNotification,
 	sendSlackNotification,
 	sendTelegramNotification,
@@ -38,6 +39,7 @@ export const sendServerThresholdNotifications = async (
 			slack: true,
 			custom: true,
 			lark: true,
+			googleChat: true,
 		},
 	});
 
@@ -45,7 +47,7 @@ export const sendServerThresholdNotifications = async (
 	const typeColor = 0xff0000; // Rojo para indicar alerta
 
 	for (const notification of notificationList) {
-		const { discord, telegram, slack, custom, lark } = notification;
+		const { discord, telegram, slack, custom, lark, googleChat } = notification;
 
 		if (discord) {
 			const decorate = (decoration: string, text: string) =>
@@ -264,6 +266,19 @@ export const sendServerThresholdNotifications = async (
 						],
 					},
 				},
+			});
+		}
+
+		if (googleChat) {
+			await sendGoogleChatNotification(googleChat, {
+				text:
+					`*⚠️ Server ${payload.Type} Alert*\n\n` +
+					`*Server Name:* ${payload.ServerName}\n` +
+					`*Type:* ${typeEmoji} ${payload.Type}\n` +
+					`*Current Value:* ${payload.Value.toFixed(2)}%\n` +
+					`*Threshold:* ${payload.Threshold.toFixed(2)}%\n` +
+					`*Message:* ${payload.Message}\n` +
+					`*Time:* ${date.toLocaleString()}`,
 			});
 		}
 	}

--- a/packages/server/src/utils/notifications/utils.ts
+++ b/packages/server/src/utils/notifications/utils.ts
@@ -2,6 +2,7 @@ import type {
 	custom,
 	discord,
 	email,
+	googleChat,
 	gotify,
 	lark,
 	ntfy,
@@ -212,6 +213,21 @@ export const sendCustomNotification = async (
 export const sendLarkNotification = async (
 	connection: typeof lark.$inferInsert,
 	message: any,
+) => {
+	try {
+		await fetch(connection.webhookUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(message),
+		});
+	} catch (err) {
+		console.log(err);
+	}
+};
+
+export const sendGoogleChatNotification = async (
+	connection: typeof googleChat.$inferInsert,
+	message: { text: string },
 ) => {
 	try {
 		await fetch(connection.webhookUrl, {


### PR DESCRIPTION
## Summary

- Adds Google Chat/Spaces as a new notification provider
- Users can configure a Google Chat incoming webhook URL to receive formatted notifications for all Dokploy events
- Follows the existing Lark implementation pattern (webhook-only, simplest provider type)

## Changes

### Backend
- Database schema: Added `googleChat` table, enum value, and API schemas
- Service layer: Added `createGoogleChatNotification` and `updateGoogleChatNotification` functions
- API routes: Added `createGoogleChat`, `updateGoogleChat`, `testGoogleChatConnection` endpoints
- Notification utils: Added `sendGoogleChatNotification` function

### Event Handlers
Updated all 7 notification event files to support Google Chat:
- Build success/error notifications
- Database/volume backup notifications
- Docker cleanup notifications
- Dokploy restart notifications
- Server threshold alerts

### Frontend
- Added `GoogleChatIcon` component
- Added full UI support in notification settings form

## Test plan

- [ ] Generate database migration with `pnpm --filter dokploy run migration:generate`
- [ ] Run migrations
- [ ] Navigate to Settings > Notifications
- [ ] Add new Google Chat notification with webhook URL
- [ ] Test connection button sends test message
- [ ] Trigger a deployment and verify notification received in Google Chat

## Related Issue

Closes #3153