### PR TITLE
fix: disabling of previewRequireCollaboratorPermissions

### DIFF
--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -123,7 +123,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 				previewCertificateType: data.previewCertificateType || "none",
 				previewCustomCertResolver: data.previewCustomCertResolver || "",
 				previewRequireCollaboratorPermissions:
-					data.previewRequireCollaboratorPermissions || true,
+					data.previewRequireCollaboratorPermissions ?? true,
 			});
 		}
 	}, [data]);


### PR DESCRIPTION
## The collaboration permissions were always displayed as required in the form

The form value of `previewRequireCollaboratorPermissions` were always `true`, because it was defaulted to `true` by a simple logical or-operator where the nullish coalescing-operator is required.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

