### PR TITLE
fix: invalidate query missing for s3 destination

### DIFF
--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -122,6 +122,9 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 			.then(async () => {
 				toast.success(`Destination ${destinationId ? "Updated" : "Created"}`);
 				await utils.destination.all.invalidate();
+				if (destinationId) {
+					await utils.destination.one.invalidate({ destinationId });
+				}
 				setOpen(false);
 			})
 			.catch(() => {


### PR DESCRIPTION
## What is this PR about?

A user reported a problem: S3 bucket endpoints cannot be updated.
In fact, they can. It was a problem caused by query one not being invalidated.

When an endpoint was updated and then the modal reopened, the old value remained in the input. 

## Issues related (if applicable)

closes #3308 

## Screenshots (if applicable)

https://github.com/user-attachments/assets/a4a11845-c155-4960-b33b-fb4e1d94bbdb



