### PR TITLE
fix: pass registry auth to stack deploy

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -90,7 +90,7 @@ export const createCommand = (compose: ComposeNested) => {
 	if (composeType === "docker-compose") {
 		command = `compose -p ${appName} -f ${path} up -d --build --remove-orphans`;
 	} else if (composeType === "stack") {
-		command = `stack deploy -c ${path} ${appName} --prune`;
+		command = `stack deploy -c ${path} ${appName} --prune --with-registry-auth`;
 	}
 
 	return command;


### PR DESCRIPTION
Without registry authentication propagation, services fail to pull images from private registries. This is especially annoying because it requires manually SSHing into each server to pull the image beforehand.

With this change, the image is automatically pulled as part of the deployment process. More information about this parameter can be found in the Docker documentation: https://docs.docker.com/reference/cli/docker/stack/deploy/

Tested on my server and confirmed working.