### PR TITLE
feat: implement postgres password update and fix swarm container resolution

### DIFF
--- a/apps/dokploy/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/apps/dokploy/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -1,5 +1,18 @@
+import { Loader2, Pen } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
@@ -28,11 +41,12 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-4 items-center">
 									<ToggleVisibilityInput
 										value={data?.databasePassword}
 										disabled
 									/>
+									<UpdatePassword postgresId={postgresId} />
 								</div>
 							</div>
 							<div className="flex flex-col gap-2">
@@ -59,4 +73,68 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 		</>
 	);
 };
-// ReplyError: MISCONF Redis is configured to save RDB snapshots, but it's currently unable to persist to disk. Commands that may modify the data set are disabled, because this instance is configured to report errors during writes if RDB snapshotting fails (stop-w
+
+const UpdatePassword = ({ postgresId }: { postgresId: string }) => {
+	const [open, setOpen] = useState(false);
+	const [password, setPassword] = useState("");
+	const utils = api.useUtils();
+
+	const { mutateAsync, isLoading } = api.postgres.changePassword.useMutation();
+
+	const onSave = async () => {
+		if (!password) {
+			toast.error("Password is required");
+			return;
+		}
+		try {
+			await mutateAsync({
+				postgresId,
+				databasePassword: password,
+			});
+			await utils.postgres.one.invalidate({ postgresId });
+			toast.success("Password updated successfully");
+			setOpen(false);
+			setPassword("");
+		} catch (error) {
+			toast.error("Error updating password");
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="icon">
+					<Pen className="size-4 text-muted-foreground" />
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Update Password</DialogTitle>
+					<DialogDescription>
+						This will update the password in the database and in the dependent
+						applications.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<div className="flex flex-col gap-2">
+						<Label>New Password</Label>
+						<Input
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+							placeholder="Enter new password"
+							type="password"
+						/>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button onClick={onSave} disabled={isLoading}>
+						{isLoading && <Loader2 className="animate-spin size-4 mr-2" />}
+						Save
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -194,3 +194,10 @@ export const apiRebuildPostgres = createSchema
 		postgresId: true,
 	})
 	.required();
+
+export const apiChangePostgresPassword = createSchema
+	.pick({
+		postgresId: true,
+		databasePassword: true,
+	})
+	.required();


### PR DESCRIPTION
**Description:**

This PR implements the ability to update the Postgres database password directly from the Dokploy Dashboard. It ensures that the password is synchronously updated in three places: the Docker container (via `ALTER USER`), the Dokploy internal database, and the environment variables of any dependent applications within the same organization.

Additionally, it includes a critical fix for Docker Swarm environments where `docker exec` commands were failing because they attempted to use the Service Name instead of the Container ID.

**Changes:**

- **Backend (`packages/server/src/services/postgres.ts`):**
    - Added `changePostgresPassword` service function.
    - Implemented logic to dynamically resolve the Container ID from the Service Name (`docker ps -q -f name=...`) before executing commands, solving stability issues in Swarm.
    - Added logic to automatically update `DATABASE_URL` in dependent apps when the password changes.
    - Refactored `execAsyncRemote` calls to properly handle stdout.

- **API (`apps/dokploy/server/api/routers/postgres.ts`):**
    - Added `changePassword` protected procedure to the postgres router.

- **Frontend (`show-internal-postgres-credentials.tsx`):**
    - Added a secure "Edit" dialog for updating the password.
    - Cleaned up the UI logic.

**Type of Change:**

- [x] **feat**: A new feature (Postgres Password Update)
- [x] **fix**: A bug fix (Docker Swarm Container Resolution)
- [x] **refactor**: Code cleanup and linting fixes (Biome)

**How Has This Been Tested?**

- [x] Manual verification: Changed password via UI and verified connection strings in dependent apps.
- [x] Verified that `docker exec` commands successfully target the running container in a Swarm environment.
- [x] Verified that invalid inputs or container states return appropriate errors.

**Checklist:**

- [x] My code follows the code style of this project (Biome linting passed).
- [x] I have performed a self-review of my own code.
- [x] I have verified that new and existing unit tests pass locally with my changes.
