### PR TITLE
fix(selectAIProvider): add authorization header for Gemini provider

### DIFF
--- a/packages/server/src/utils/ai/select-ai-provider.ts
+++ b/packages/server/src/utils/ai/select-ai-provider.ts
@@ -71,8 +71,9 @@ export function selectAIProvider(config: { apiUrl: string; apiKey: string }) {
 			return createOpenAICompatible({
 				name: "gemini",
 				baseURL: config.apiUrl,
-				queryParams: { key: config.apiKey },
-				headers: {},
+				headers: {
+					Authorization: `Bearer ${config.apiKey}`,
+				},
 			});
 		case "custom":
 			return createOpenAICompatible({


### PR DESCRIPTION
## What is this PR about?

When creating a template using AI features and using Gemini, it fails with a 400 error :
```
Error in suggestVariants: [Error [AI_APICallError]: Bad Request] {
  cause: undefined,
  url: 'https://generativelanguage.googleapis.com/v1beta/chat/completions?key=<GEMINI_API_KEY>',
  requestBodyValues: [Object],
  statusCode: 400,
  responseHeaders: [Object],
  responseBody: '[{\n' +
    '  "error": {\n' +
    '    "code": 400,\n' +
    '    "message": "Missing Authorization header.",\n' +
    '    "status": "INVALID_ARGUMENT"\n' +
    '  }\n' +
    '}\n' +
    ']',
  isRetryable: false,
  data: undefined
}
```

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

