### PR TITLE
chore(databases): bump default postgres version while creating to 18

### DIFF
--- a/apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx
+++ b/apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx
@@ -129,7 +129,7 @@ export const ShowCustomCommand = ({ id, type }: Props) => {
 											<FormItem>
 												<FormLabel>Docker Image</FormLabel>
 												<FormControl>
-													<Input placeholder="postgres:15" {...field} />
+													<Input placeholder="postgres:18" {...field} />
 												</FormControl>
 
 												<FormMessage />

--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -58,7 +58,7 @@ const dockerImageDefaultPlaceholder: Record<DbType, string> = {
 	mongo: "mongo:7",
 	mariadb: "mariadb:11",
 	mysql: "mysql:8",
-	postgres: "postgres:15",
+	postgres: "postgres:18",
 	redis: "redis:7",
 };
 

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -102,7 +102,7 @@ const createSchema = createInsertSchema(postgres, {
 		}),
 	databaseName: z.string().min(1),
 	databaseUser: z.string().min(1),
-	dockerImage: z.string().default("postgres:15"),
+	dockerImage: z.string().default("postgres:18"),
 	command: z.string().optional(),
 	args: z.array(z.string()).optional(),
 	env: z.string().optional(),


### PR DESCRIPTION
## What is this PR about?

This pull request updates the default PostgreSQL Docker image version from 15 to 18 across the application. This ensures that users are provisioned with the latest supported PostgreSQL version in both the UI and backend.

**PostgreSQL Docker image version update:**

* Updated the default Docker image placeholder for PostgreSQL from `postgres:15` to `postgres:18` in the database addition form (`apps/dokploy/components/dashboard/project/add-database.tsx`).
* Changed the default value for the PostgreSQL Docker image in the schema definition from `postgres:15` to `postgres:18` (`packages/server/src/db/schema/postgres.ts`).
* Updated the placeholder for the Docker image input field in the custom command UI from `postgres:15` to `postgres:18` (`apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx`).

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.
