### PR TITLE
chore: uninstall `hi-base32` package

### DIFF
--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -109,7 +109,6 @@
 		"drizzle-orm": "^0.39.3",
 		"drizzle-zod": "0.5.1",
 		"fancy-ansi": "^0.1.3",
-		"hi-base32": "^0.5.1",
 		"i18next": "^23.16.8",
 		"input-otp": "^1.4.2",
 		"js-cookie": "^3.0.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -57,7 +57,6 @@
     "drizzle-dbml-generator": "0.10.0",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "0.5.1",
-    "hi-base32": "^0.5.1",
     "yaml": "2.8.1",
     "lodash": "4.17.21",
     "micromatch": "4.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,9 +313,6 @@ importers:
       fancy-ansi:
         specifier: ^0.1.3
         version: 0.1.3
-      hi-base32:
-        specifier: ^0.5.1
-        version: 0.5.1
       i18next:
         specifier: ^23.16.8
         version: 23.16.8
@@ -678,9 +675,6 @@ importers:
       drizzle-zod:
         specifier: 0.5.1
         version: 0.5.1(drizzle-orm@0.39.3(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)(kysely@0.28.7)(postgres@3.4.4))(zod@3.25.32)
-      hi-base32:
-        specifier: ^0.5.1
-        version: 0.5.1
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -5388,9 +5382,6 @@ packages:
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
-
-  hi-base32@0.5.1:
-    resolution: {integrity: sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -12823,8 +12814,6 @@ snapshots:
       space-separated-tokens: 1.1.5
 
   help-me@5.0.0: {}
-
-  hi-base32@0.5.1: {}
 
   highlight.js@10.7.3: {}
 


### PR DESCRIPTION
## What is this PR about?

Uninstalls `hi-base32`. This dependency was used in an early [auth file](https://github.com/bdkopen/dokploy/blob/be56ba046cb3b2b8676d5f8020cf56844d601730/server/api/services/auth.ts), but is not used anywhere anymore.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.