### PR TITLE
chore: uninstall `otpauth` package

### DIFF
--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -126,7 +126,6 @@
 		"node-schedule": "2.1.1",
 		"nodemailer": "6.9.14",
 		"octokit": "3.1.2",
-		"otpauth": "^9.4.0",
 		"pino": "9.4.0",
 		"pino-pretty": "11.2.2",
 		"postgres": "3.4.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -67,7 +67,6 @@
     "node-schedule": "2.1.1",
     "nodemailer": "6.9.14",
     "octokit": "3.1.2",
-    "otpauth": "^9.4.0",
     "pino": "9.4.0",
     "pino-pretty": "11.2.2",
     "postgres": "3.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,9 +364,6 @@ importers:
       octokit:
         specifier: 3.1.2
         version: 3.1.2
-      otpauth:
-        specifier: ^9.4.0
-        version: 9.4.0
       pino:
         specifier: 9.4.0
         version: 9.4.0
@@ -705,9 +702,6 @@ importers:
       octokit:
         specifier: 3.1.2
         version: 3.1.2
-      otpauth:
-        specifier: ^9.4.0
-        version: 9.4.0
       pino:
         specifier: 9.4.0
         version: 9.4.0
@@ -6425,9 +6419,6 @@ packages:
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-
-  otpauth@9.4.0:
-    resolution: {integrity: sha512-fHIfzIG5RqCkK9cmV8WU+dPQr9/ebR5QOwGZn2JAr1RQF+lmAuLL2YdtdqvmBjNmgJlYk3KZ4a0XokaEhg1Jsw==}
 
   p-cancelable@3.0.0:
     resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
@@ -13961,10 +13952,6 @@ snapshots:
       apg-lite: 1.0.4
 
   openapi-types@12.1.3: {}
-
-  otpauth@9.4.0:
-    dependencies:
-      '@noble/hashes': 1.7.1
 
   p-cancelable@3.0.0: {}
 


### PR DESCRIPTION
## What is this PR about?

Uninstalls `otpauth`. `input-otp` and `better-auth` are now used for OTP generation. This package is no longer used anywhere.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.