### PR TITLE
UI responsiveness in Deployments tab

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -256,9 +256,9 @@ export const ShowDeployments = ({
 							return (
 								<div
 									key={deployment.deploymentId}
-									className="flex items-center justify-between rounded-lg border p-4 gap-2"
+									className="flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
 								>
-									<div className="flex flex-col">
+									<div className="flex flex-1 flex-col min-w-0">
 										<span className="flex items-center gap-4 font-medium capitalize text-foreground">
 											{index + 1}. {deployment.status}
 											<StatusTooltip
@@ -313,8 +313,8 @@ export const ShowDeployments = ({
 											)}
 										</div>
 									</div>
-									<div className="flex flex-col items-end gap-2 max-w-[300px] w-full justify-start">
-										<div className="text-sm capitalize text-muted-foreground flex items-center gap-2">
+									<div className="flex w-full flex-col items-start gap-2 sm:w-auto sm:max-w-[300px] sm:items-end sm:justify-start">
+										<div className="text-sm capitalize text-muted-foreground flex flex-wrap items-center gap-2">
 											<DateTooltip date={deployment.createdAt} />
 											{deployment.startedAt && deployment.finishedAt && (
 												<Badge
@@ -333,7 +333,7 @@ export const ShowDeployments = ({
 											)}
 										</div>
 
-										<div className="flex flex-row items-center gap-2">
+										<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:justify-end">
 											{deployment.pid && deployment.status === "running" && (
 												<DialogAction
 													title="Kill Process"
@@ -355,6 +355,7 @@ export const ShowDeployments = ({
 														variant="destructive"
 														size="sm"
 														isLoading={isKillingProcess}
+														className="w-full sm:w-auto"
 													>
 														Kill Process
 													</Button>
@@ -364,6 +365,7 @@ export const ShowDeployments = ({
 												onClick={() => {
 													setActiveLog(deployment);
 												}}
+												className="w-full sm:w-auto"
 											>
 												View
 											</Button>
@@ -405,6 +407,7 @@ export const ShowDeployments = ({
 															variant="secondary"
 															size="sm"
 															isLoading={isRollingBack}
+															className="w-full sm:w-auto"
 														>
 															<RefreshCcw className="size-4 text-primary group-hover:text-red-500" />
 															Rollback


### PR DESCRIPTION
Made the deployments list items responsive by stacking the metadata/actions under the status on small screens, then restoring the side-by-side layout at sm and up. This keeps the date/duration and buttons from being squeezed or pushed off-screen in narrow widths.

## What is this PR about?

Made UI improvements on deployments tab.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3406

## Screenshots (if applicable)

