### PR TITLE
Add GitHub Status Checks for Deployments

### DIFF
--- a/apps/dokploy/__test__/deploy/application.command.test.ts
+++ b/apps/dokploy/__test__/deploy/application.command.test.ts
@@ -252,10 +252,13 @@ describe("deployApplication - Command Generation Tests", () => {
 		const execCalls = vi.mocked(execProcess.execAsync).mock.calls;
 		expect(execCalls.length).toBeGreaterThan(0);
 
-		const fullCommand = execCalls[0]?.[0];
-		expect(fullCommand).toContain("set -e");
-		expect(fullCommand).toContain("git clone");
-		expect(fullCommand).toContain("nixpacks build");
+		const cloneCommand = execCalls[0]?.[0];
+		expect(cloneCommand).toContain("set -e");
+		expect(cloneCommand).toContain("git clone");
+
+		const buildCommand = execCalls[1]?.[0];
+		expect(buildCommand).toContain("set -e");
+		expect(buildCommand).toContain("nixpacks build");
 	});
 
 	it("should include log redirection in command", async () => {

--- a/apps/dokploy/components/dashboard/settings/git/github/add-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/github/add-github-provider.tsx
@@ -44,6 +44,7 @@ export const AddGithubProvider = () => {
 					metadata: "read",
 					emails: "read",
 					pull_requests: "write",
+					checks: "write",
 				},
 				default_events: ["pull_request", "push"],
 			},

--- a/packages/server/src/services/checks.ts
+++ b/packages/server/src/services/checks.ts
@@ -1,0 +1,34 @@
+import type { ApplicationNested } from "../utils/builders";
+import { getDokployUrl } from "./admin";
+import * as github from "./github";
+
+export type CheckStatus = "queued" | "in_progress" | "success" | "failure";
+
+export async function setStatusCheck(
+	application: ApplicationNested,
+	head_sha: string,
+	status: CheckStatus,
+) {
+	// @TODO: check for preview deployment and update link
+	const buildLink = `${await getDokployUrl()}/dashboard/project/${application.environment.projectId}/environment/${application.environmentId}/services/application/${application.applicationId}?tab=deployments`;
+
+	try {
+		switch (application.sourceType) {
+			case "github":
+				return await github.setStatusCheck({
+					owner: application.owner!,
+					repository: application.repository!,
+					githubId: application.githubId!,
+					head_sha,
+					name: `Dokploy (${application.environment.project.name}/${application.name})`,
+					status,
+					details_url: buildLink,
+				});
+		}
+	} catch (error) {
+		console.error(
+			`❌ Failed to write status check to "${application.sourceType}"`,
+			error,
+		);
+	}
+}


### PR DESCRIPTION
## What is this PR about?

Adds github status checks for deployments and preview deployments.

## Changes made

- Split the clone and build command, to read the commit hash in between

## Minor quirks

- The "in_progress" status is not set immediately, but only after the initial Git clone has completed.
  Reading the commit hash beforehand via `git ls-remote` could lead to race conditions
- The "queued" status is not feasible to implement.
  As the deployment is based of branches and not on explicits commits, it is prone to race conditions

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related

closes #3405 

