### PR TITLE
fix(restore): replace USE statements with target database during restore

### DIFF
--- a/packages/server/src/utils/restore/utils.ts
+++ b/packages/server/src/utils/restore/utils.ts
@@ -15,14 +15,18 @@ export const getMariadbRestoreCommand = (
 	databaseUser: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -i $CONTAINER_ID sh -c "mariadb -u '${databaseUser}' -p'${databasePassword}' ${database}"`;
+    // Use sed to replace any USE `database` statements with the target database
+    // This prevents restoring into wrong database when backup contains USE statements
+    return `sed "s/USE \\\`[^\\\`]*\\\`/USE \\\`${database}\\\`/g" | docker exec -i $CONTAINER_ID sh -c "mariadb -u '${databaseUser}' -p'${databasePassword}' ${database}"`;
 };
 
 export const getMysqlRestoreCommand = (
 	database: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -i $CONTAINER_ID sh -c "mysql -u root -p'${databasePassword}' ${database}"`;
+    // Use sed to replace any USE `database` statements with the target database
+    // This prevents restoring into wrong database when backup contains USE statements
+    return `sed "s/USE \\\`[^\\\`]*\\\`/USE \\\`${database}\\\`/g" | docker exec -i $CONTAINER_ID sh -c "mysql -u root -p'${databasePassword}' ${database}"`;
 };
 
 export const getMongoRestoreCommand = (


### PR DESCRIPTION
## Summary


 


Fixes #3436


 


When restoring a MySQL/MariaDB backup to a different database, the SQL dump may contain `USE \`original_database\`` statements that override the target database specified in the restore dialog. This causes data to be restored into the wrong database, potentially overwriting production data.


 


## Problem


 


SQL dumps created by `mysqldump`/`mariadb-dump` include explicit database selection:


 


```sql


-- MariaDB dump


USE `production_db`;


DROP TABLE IF EXISTS `users`;


CREATE TABLE `users` ...


INSERT INTO `users` VALUES ...


```


 


When a user restores this backup into a different database (e.g., `dev_db`):


 


```bash


mariadb -u user -p dev_db < backup.sql


```


 


The `USE \`production_db\`` statement inside the dump switches the context to `production_db`, and all subsequent `DROP TABLE`, `CREATE TABLE`, and `INSERT` commands execute against the **production database** instead of the intended `dev_db`.


 


**Result:** Production database is overwritten with old backup data. Critical data loss.


 


## Solution


 


Added a `sed` filter to replace all `USE \`...\`` statements with the target database name before piping to mysql/mariadb:


 


```bash


# Before (vulnerable)


... | docker exec -i $CONTAINER_ID sh -c "mariadb -u user -p db_name"



# After (safe)


... | sed "s/USE \`[^\`]*\`/USE \`db_name\`/g" | docker exec -i $CONTAINER_ID sh -c "mariadb -u user -p db_name"


```


 


This ensures all `USE` statements in the dump are rewritten to point to the user-specified target database.


 


## Changes


 


- `packages/server/src/utils/restore/utils.ts`:


  - Updated `getMariadbRestoreCommand()` - added sed filter for USE statements


  - Updated `getMysqlRestoreCommand()` - added sed filter for USE statements


 


## Testing


 


- [x] Tested restore of MariaDB backup to same database name - works
- [x] Tested restore of MariaDB backup to different database name - USE statements correctly replaced
- [x] Verified sed regex handles multiple USE statements in dump
- [x] Verified database comments (e.g., `-- Database: xyz`) are not affected


 


## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file
- [ ] You have tested this PR in your local instance.

> Note: The sed regex was tested manually on real MariaDB dump files. Full integration testing in Dokploy instance was not performed but the change is minimal and isolated.


 


## Issues related


 


closes #3436