### PR TITLE
feat(build): add Railpack version selection with manual input option

### DIFF
--- a/apps/dokploy/components/dashboard/application/build/show.tsx
+++ b/apps/dokploy/components/dashboard/application/build/show.tsx
@@ -184,8 +184,7 @@ export const ShowBuildChooseForm = ({ applicationId }: Props) => {
 
 	const buildType = form.watch("buildType");
 	const railpackVersion = form.watch("railpackVersion");
-	const [isManualRailpackVersion, setIsManualRailpackVersion] =
-		useState(false);
+	const [isManualRailpackVersion, setIsManualRailpackVersion] = useState(false);
 
 	useEffect(() => {
 		if (data) {


### PR DESCRIPTION
- Introduced a dropdown for selecting Railpack versions, including a manual entry option for custom versions.
- Implemented state management to toggle between predefined versions and manual input.
- Updated form handling to accommodate the new selection method and provide user guidance.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related (if applicable)

closes 
## Screenshots (if applicable)

