### PR TITLE
fix: break long project description to avoid ellipse shift

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -419,7 +419,7 @@ export const ShowProjects = () => {
 															) : null}
 															<CardHeader>
 																<CardTitle className="flex items-center justify-between gap-2">
-																	<span className="flex flex-col gap-1.5 truncate">
+																	<span className="flex flex-col gap-1.5 ">
 																		<div className="flex items-center gap-2">
 																			<BookIcon className="size-4 text-muted-foreground" />
 																			<span className="text-base font-medium leading-none">
@@ -427,7 +427,7 @@ export const ShowProjects = () => {
 																			</span>
 																		</div>
 
-																		<span className="text-sm font-medium text-muted-foreground">
+																		<span className="text-sm font-medium text-muted-foreground break-all">
 																			{project.description}
 																		</span>
 																	</span>


### PR DESCRIPTION
## What is this PR about?

Add a `break-all` class to the project description to ensure the ellipse maintains its intended position even when the description becomes excessively long.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Closes #3483

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| <img width="382" height="405" alt="image" src="https://github.com/user-attachments/assets/66afde72-aee0-4ac8-906a-7d3a06a1d7b7" /> | <img width="339" height="421" alt="image" src="https://github.com/user-attachments/assets/e6287f7d-8fc4-4d78-a514-0f9261bc318e" /> |