### PR TITLE
feat(dashboard): hide builder section for Docker source type

### DIFF
--- a/apps/dokploy/components/dashboard/application/build/show.tsx
+++ b/apps/dokploy/components/dashboard/application/build/show.tsx
@@ -207,6 +207,11 @@ export const ShowBuildChooseForm = ({ applicationId }: Props) => {
 		}
 	}, [data, form]);
 
+	// Hide builder section when Docker provider is selected
+	if (data?.sourceType === "docker") {
+		return null;
+	}
+
 	const onSubmit = async (data: AddTemplate) => {
 		await mutateAsync({
 			applicationId,


### PR DESCRIPTION
- Added logic to conditionally hide the builder section when the Docker provider is selected, improving user experience by reducing unnecessary UI elements.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related (if applicable)



## Screenshots (if applicable)

