### PR TITLE
fix: zod object for assign domain

### DIFF
--- a/packages/server/src/db/schema/web-server-settings.ts
+++ b/packages/server/src/db/schema/web-server-settings.ts
@@ -131,7 +131,10 @@ export const apiAssignDomain = z
 	.object({
 		host: z.string(),
 		certificateType: z.enum(["letsencrypt", "none", "custom"]),
-		letsEncryptEmail: z.string().email().optional().nullable(),
+		letsEncryptEmail: z
+			.union([z.string().email(), z.literal("")])
+			.optional()
+			.nullable(),
 		https: z.boolean().optional(),
 	})
 	.required()


### PR DESCRIPTION
## What is this PR about?

User case was to assign a domain without email. I've updated the schema to accept empty strings so the settings can be saved without forcing a valid email when Let's Encrypt isn't active.

## Issues related (if applicable)

closes #3503

