### PR TITLE
fix(git-provider): allow all organization members to see git integrations

### DIFF
--- a/apps/dokploy/server/api/routers/bitbucket.ts
+++ b/apps/dokploy/server/api/routers/bitbucket.ts
@@ -41,8 +41,7 @@ export const bitbucketRouter = createTRPCRouter({
 			const bitbucketProvider = await findBitbucketById(input.bitbucketId);
 			if (
 				bitbucketProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				bitbucketProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -61,13 +60,11 @@ export const bitbucketRouter = createTRPCRouter({
 			},
 		});
 
-		result = result.filter((provider) => {
-			return (
+		result = result.filter(
+			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId
-			);
-		});
+				ctx.session.activeOrganizationId,
+		);
 		return result;
 	}),
 
@@ -77,8 +74,7 @@ export const bitbucketRouter = createTRPCRouter({
 			const bitbucketProvider = await findBitbucketById(input.bitbucketId);
 			if (
 				bitbucketProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				bitbucketProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -95,8 +91,7 @@ export const bitbucketRouter = createTRPCRouter({
 			);
 			if (
 				bitbucketProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				bitbucketProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -112,8 +107,7 @@ export const bitbucketRouter = createTRPCRouter({
 				const bitbucketProvider = await findBitbucketById(input.bitbucketId);
 				if (
 					bitbucketProvider.gitProvider.organizationId !==
-						ctx.session.activeOrganizationId &&
-					bitbucketProvider.gitProvider.userId !== ctx.session.userId
+					ctx.session.activeOrganizationId
 				) {
 					throw new TRPCError({
 						code: "UNAUTHORIZED",
@@ -136,8 +130,7 @@ export const bitbucketRouter = createTRPCRouter({
 			const bitbucketProvider = await findBitbucketById(input.bitbucketId);
 			if (
 				bitbucketProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				bitbucketProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",

--- a/apps/dokploy/server/api/routers/git-provider.ts
+++ b/apps/dokploy/server/api/routers/git-provider.ts
@@ -1,6 +1,6 @@
 import { findGitProviderById, removeGitProvider } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { db } from "@/server/db";
 import { apiRemoveGitProvider, gitProvider } from "@/server/db/schema";
@@ -15,10 +15,7 @@ export const gitProviderRouter = createTRPCRouter({
 				gitea: true,
 			},
 			orderBy: desc(gitProvider.createdAt),
-			where: and(
-				eq(gitProvider.userId, ctx.session.userId),
-				eq(gitProvider.organizationId, ctx.session.activeOrganizationId),
-			),
+			where: eq(gitProvider.organizationId, ctx.session.activeOrganizationId),
 		});
 	}),
 	remove: protectedProcedure

--- a/apps/dokploy/server/api/routers/gitea.ts
+++ b/apps/dokploy/server/api/routers/gitea.ts
@@ -44,8 +44,7 @@ export const giteaRouter = createTRPCRouter({
 			const giteaProvider = await findGiteaById(input.giteaId);
 			if (
 				giteaProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				giteaProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -65,8 +64,7 @@ export const giteaRouter = createTRPCRouter({
 		result = result.filter(
 			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId,
+				ctx.session.activeOrganizationId,
 		);
 
 		const filtered = result
@@ -98,8 +96,7 @@ export const giteaRouter = createTRPCRouter({
 			const giteaProvider = await findGiteaById(giteaId);
 			if (
 				giteaProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				giteaProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -135,8 +132,7 @@ export const giteaRouter = createTRPCRouter({
 			const giteaProvider = await findGiteaById(giteaId);
 			if (
 				giteaProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				giteaProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -168,8 +164,7 @@ export const giteaRouter = createTRPCRouter({
 				const giteaProvider = await findGiteaById(giteaId);
 				if (
 					giteaProvider.gitProvider.organizationId !==
-						ctx.session.activeOrganizationId &&
-					giteaProvider.gitProvider.userId !== ctx.session.userId
+					ctx.session.activeOrganizationId
 				) {
 					throw new TRPCError({
 						code: "UNAUTHORIZED",
@@ -197,8 +192,7 @@ export const giteaRouter = createTRPCRouter({
 			const giteaProvider = await findGiteaById(input.giteaId);
 			if (
 				giteaProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				giteaProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -239,8 +233,7 @@ export const giteaRouter = createTRPCRouter({
 			const giteaProvider = await findGiteaById(giteaId);
 			if (
 				giteaProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				giteaProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",

--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -22,8 +22,7 @@ export const githubRouter = createTRPCRouter({
 			const githubProvider = await findGithubById(input.githubId);
 			if (
 				githubProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				githubProvider.gitProvider.userId === ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -38,8 +37,7 @@ export const githubRouter = createTRPCRouter({
 			const githubProvider = await findGithubById(input.githubId);
 			if (
 				githubProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				githubProvider.gitProvider.userId === ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -54,10 +52,8 @@ export const githubRouter = createTRPCRouter({
 			const githubProvider = await findGithubById(input.githubId || "");
 			if (
 				githubProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				githubProvider.gitProvider.userId === ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
-				//TODO: Remove this line when the cloud version is ready
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
 					message: "You are not allowed to access this github provider",
@@ -75,8 +71,7 @@ export const githubRouter = createTRPCRouter({
 		result = result.filter(
 			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId,
+				ctx.session.activeOrganizationId,
 		);
 
 		const filtered = result
@@ -100,8 +95,7 @@ export const githubRouter = createTRPCRouter({
 				const githubProvider = await findGithubById(input.githubId);
 				if (
 					githubProvider.gitProvider.organizationId !==
-						ctx.session.activeOrganizationId &&
-					githubProvider.gitProvider.userId === ctx.session.userId
+					ctx.session.activeOrganizationId
 				) {
 					throw new TRPCError({
 						code: "UNAUTHORIZED",
@@ -123,8 +117,7 @@ export const githubRouter = createTRPCRouter({
 			const githubProvider = await findGithubById(input.githubId);
 			if (
 				githubProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				githubProvider.gitProvider.userId === ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",

--- a/apps/dokploy/server/api/routers/gitlab.ts
+++ b/apps/dokploy/server/api/routers/gitlab.ts
@@ -43,8 +43,7 @@ export const gitlabRouter = createTRPCRouter({
 			const gitlabProvider = await findGitlabById(input.gitlabId);
 			if (
 				gitlabProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				gitlabProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -60,13 +59,11 @@ export const gitlabRouter = createTRPCRouter({
 			},
 		});
 
-		result = result.filter((provider) => {
-			return (
+		result = result.filter(
+			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId
-			);
-		});
+				ctx.session.activeOrganizationId,
+		);
 		const filtered = result
 			.filter((provider) => haveGitlabRequirements(provider))
 			.map((provider) => {
@@ -87,8 +84,7 @@ export const gitlabRouter = createTRPCRouter({
 			const gitlabProvider = await findGitlabById(input.gitlabId);
 			if (
 				gitlabProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				gitlabProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -104,8 +100,7 @@ export const gitlabRouter = createTRPCRouter({
 			const gitlabProvider = await findGitlabById(input.gitlabId || "");
 			if (
 				gitlabProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				gitlabProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",
@@ -121,8 +116,7 @@ export const gitlabRouter = createTRPCRouter({
 				const gitlabProvider = await findGitlabById(input.gitlabId || "");
 				if (
 					gitlabProvider.gitProvider.organizationId !==
-						ctx.session.activeOrganizationId &&
-					gitlabProvider.gitProvider.userId !== ctx.session.userId
+					ctx.session.activeOrganizationId
 				) {
 					throw new TRPCError({
 						code: "UNAUTHORIZED",
@@ -145,8 +139,7 @@ export const gitlabRouter = createTRPCRouter({
 			const gitlabProvider = await findGitlabById(input.gitlabId);
 			if (
 				gitlabProvider.gitProvider.organizationId !==
-					ctx.session.activeOrganizationId &&
-				gitlabProvider.gitProvider.userId !== ctx.session.userId
+				ctx.session.activeOrganizationId
 			) {
 				throw new TRPCError({
 					code: "UNAUTHORIZED",


### PR DESCRIPTION
## What is this PR about?

Previously, git provider integrations (GitHub, GitLab, Bitbucket, Gitea) were only visible to the user who created them due to filtering by both organizationId and userId. This prevented other admins in the same organization from seeing or using shared integrations.

Remove userId filtering from list queries and authorization checks so that all users in an organization can access git integrations created within that organization.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)

closes https://github.com/Dokploy/dokploy/issues/3489

## Screenshots (if applicable)

