### PR TITLE
fix: database backup on worker

### DIFF
--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -23,7 +23,7 @@ export const runPostgresBackup = async (
 	postgres: Postgres,
 	backup: BackupSchedule,
 ) => {
-	const { name, environmentId } = postgres;
+	const { name, environmentId, databaseUser, appName } = postgres;
 	const environment = await findEnvironmentById(environmentId);
 	const project = await findProjectById(environment.projectId);
 
@@ -85,7 +85,8 @@ export const runPostgresBackup = async (
 			const createDatabaseBackupTempService =
 				getCreateDatabaseBackupTempService(
 					backup,
-					postgres.appName,
+					appName,
+					databaseUser,
 					node,
 					rcloneCommand,
 				);

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -293,6 +293,7 @@ export const getServiceExistsCommand = (appName: string) => {
 export const getCreateDatabaseBackupTempService = (
 	backup: BackupSchedule,
 	appName: string,
+	databaseUser: string,
 	node: string,
 	rcloneCommand: string,
 ) => {
@@ -314,7 +315,7 @@ export const getCreateDatabaseBackupTempService = (
 		'echo "Executing backup test...";',
 		`${backupCommand} > /dev/null || { echo "❌ Error: Backup process failed"; exit 1; };`,
 		'echo "Starting upload to S3...";',
-		`docker exec -i $CONTAINER_ID bash -c "set -o pipefail; pg_dump -Fc --no-acl --no-owner -h localhost -U postgres --no-password ${backup.database} | gzip" |`,
+		`docker exec -i $CONTAINER_ID bash -c "set -o pipefail; pg_dump -Fc --no-acl --no-owner -h localhost -U ${databaseUser} --no-password ${backup.database} | gzip" |`,
 		`${rcloneCommand} || { echo "❌ Error: Upload to S3 failed"; exit 1; };`,
 		"sleep 6;",
 		'echo "Backup done ✅"',


### PR DESCRIPTION
## What is this PR about?

When backing up a database that is located on a worker node (different server), it throws an error `Container not found` due to the backup command being ran on the manager server while the container is on another server.

This PR tried to fix it by deploying a service to the worker node when a backup is triggered with the sole purpose of running the backup command. When a backup is triggered, it will check if the backup service already exist, if it does it will delete it, then it will deploy the service. The backup service will die when the command finished running.

Important note:
- This PR and commit only address the postgres database. If this approach is accepted, then I can make other commits for the other databases in this PR.
- When working on this locally on a macbook, the way I simulate another worker was through docker-in-docker (see below command). There is a limitation on the socket when executing the command on the worker, which will throw an error. The way I tested this was: I console.log the backup command that is supposed to be ran on my local worker, copy it, change the necessary value to be the same as my prod environment (service name, target worker label, and existing database service name), and paste it to my prod. The command was able to upload a backup to my s3. 

```
docker run -d --privileged \
  --hostname worker-1 \
  --name swarm-worker-1 \
  --label type=database \
  docker:dind
```

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3516 

## Screenshots (if applicable)

