### PR TITLE
fix: profile firstName field not updating

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -41,7 +41,7 @@ const profileSchema = z.object({
 	password: z.string().nullable(),
 	currentPassword: z.string().nullable(),
 	image: z.string().optional(),
-	name: z.string().optional(),
+	firstName: z.string().optional(),
 	lastName: z.string().optional(),
 	allowImpersonation: z.boolean().optional().default(false),
 });
@@ -91,7 +91,7 @@ export const ProfileForm = () => {
 			image: data?.user?.image || "",
 			currentPassword: "",
 			allowImpersonation: data?.user?.allowImpersonation || false,
-			name: data?.user?.firstName || "",
+			firstName: data?.user?.firstName || "",
 			lastName: data?.user?.lastName || "",
 		},
 		resolver: zodResolver(profileSchema),
@@ -106,7 +106,7 @@ export const ProfileForm = () => {
 					image: data?.user?.image || "",
 					currentPassword: form.getValues("currentPassword") || "",
 					allowImpersonation: data?.user?.allowImpersonation,
-					name: data?.user?.firstName || "",
+					firstName: data?.user?.firstName || "",
 					lastName: data?.user?.lastName || "",
 				},
 				{
@@ -131,7 +131,7 @@ export const ProfileForm = () => {
 				image: values.image,
 				currentPassword: values.currentPassword || undefined,
 				allowImpersonation: values.allowImpersonation,
-				name: values.name || undefined,
+				firstName: values.firstName || undefined,
 				lastName: values.lastName || undefined,
 			});
 			await refetch();
@@ -141,7 +141,7 @@ export const ProfileForm = () => {
 				password: "",
 				image: values.image,
 				currentPassword: "",
-				name: values.name || "",
+				firstName: values.firstName || "",
 				lastName: values.lastName || "",
 			});
 		} catch (error) {
@@ -184,7 +184,7 @@ export const ProfileForm = () => {
 										<div className="space-y-4">
 											<FormField
 												control={form.control}
-												name="name"
+												name="firstName"
 												render={({ field }) => (
 													<FormItem>
 														<FormLabel>First Name</FormLabel>

--- a/packages/server/src/db/schema/user.ts
+++ b/packages/server/src/db/schema/user.ts
@@ -214,6 +214,6 @@ export const apiUpdateUser = createSchema.partial().extend({
 		.optional(),
 	password: z.string().optional(),
 	currentPassword: z.string().optional(),
-	name: z.string().optional(),
+	firstName: z.string().optional(),
 	lastName: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- Fixed profile form sending `name` field instead of `firstName` to the API
- The API schema expected `firstName` but the form was using `name`, causing first name updates to be silently ignored

## Changes
- Updated `apiUpdateUser` schema in `user.ts` to use `firstName` instead of `name`
- Updated profile form to use `firstName` field name

## Test plan
- Go to `/dashboard/settings/profile`
- Edit the "First Name" field
- Save and verify the name updates correctly