### PR TITLE
fix: Save Placement button not working for Preferences in Swarm settings

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/cluster/swarm-forms/placement-form.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/cluster/swarm-forms/placement-form.tsx
@@ -17,9 +17,7 @@ import { Input } from "@/components/ui/input";
 import { api } from "@/utils/api";
 
 const PreferenceSchema = z.object({
-	Spread: z.object({
-		SpreadDescriptor: z.string(),
-	}),
+	SpreadDescriptor: z.string(),
 });
 
 const PlatformSchema = z.object({
@@ -116,7 +114,14 @@ export const PlacementForm = ({ id, type }: PlacementFormProps) => {
 				mysqlId: id || "",
 				mariadbId: id || "",
 				mongoId: id || "",
-				placementSwarm: hasAnyValue ? formData : null,
+				placementSwarm: hasAnyValue
+					? {
+							...formData,
+							Preferences: formData.Preferences?.map((p) => ({
+								Spread: { SpreadDescriptor: p.SpreadDescriptor },
+							})),
+						}
+					: null,
 			});
 
 			toast.success("Placement updated successfully");


### PR DESCRIPTION
## What is this PR about?

Clicking "Save Placement" after adding a placement preference (e.g., node.labels.region) did nothing. The button appeared unresponsive.

There was a schema mismatch between the form's internal state and Zod validation in placement-form.tsx:

  - Zod schema expected: { Spread: { SpreadDescriptor: "value" } }
  - Form created: { SpreadDescriptor: "value" }

When submitting, Zod validation failed silently because the flat structure didn't match the nested schema, so handleSubmit never executed.

So I changed `PreferenceSchema` to use a flat structure matching the form state and transform to the nested structure only when submitting to the API.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)

closes https://github.com/Dokploy/dokploy/issues/3555

## Screenshots (if applicable)

