### PR TITLE
fix: use the same traefik version everywhere

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -12,6 +12,7 @@ import {
 	createDefaultServerTraefikConfig,
 	createDefaultTraefikConfig,
 	initializeStandaloneTraefik,
+	TRAEFIK_VERSION,
 } from "@dokploy/server/setup/traefik-setup";
 
 (async () => {
@@ -22,7 +23,7 @@ import {
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
-		await execAsync("docker pull traefik:v3.6.7");
+		await execAsync(`docker pull traefik:v${TRAEFIK_VERSION}`);
 		await initializeStandaloneTraefik();
 		await initializeRedis();
 		await initializePostgres();

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -20,7 +20,7 @@ export const TRAEFIK_PORT =
 	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
-export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.4";
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.7";
 
 export interface TraefikOptions {
 	env?: string[];


### PR DESCRIPTION
## What is this PR about?

Use the same Traefik version everywhere by setting the single source of truth in a single file.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)


## Screenshots (if applicable)

