### PR TITLE
feat(ui): add per-service Move action to environment page

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -10,6 +10,7 @@ import {
 	FolderInput,
 	GlobeIcon,
 	Loader2,
+	MoreHorizontalIcon,
 	Play,
 	PlusIcon,
 	Search,
@@ -79,6 +80,7 @@ import {
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
@@ -1098,10 +1100,18 @@ const EnvironmentPage = (
 													</DialogTrigger>
 													<DialogContent>
 														<DialogHeader>
-															<DialogTitle>Move Services</DialogTitle>
+															<DialogTitle>
+																Move{" "}
+																{selectedServices.length === 1
+																	? "Service"
+																	: "Services"}
+															</DialogTitle>
 															<DialogDescription>
 																Select the target project and environment to
-																move {selectedServices.length} services
+																move{" "}
+																{selectedServices.length === 1
+																	? "this service"
+																	: `${selectedServices.length} services`}
 															</DialogDescription>
 														</DialogHeader>
 														<div className="flex flex-col gap-4">
@@ -1206,7 +1216,10 @@ const EnvironmentPage = (
 																	!selectedTargetEnvironment
 																}
 															>
-																Move Services
+																Move{" "}
+																{selectedServices.length === 1
+																	? "Service"
+																	: "Services"}
 															</Button>
 														</DialogFooter>
 													</DialogContent>
@@ -1511,42 +1524,69 @@ const EnvironmentPage = (
 														</div>
 
 														<CardHeader>
-															<CardTitle className="flex items-center justify-between">
-																<div className="flex flex-row items-center gap-2 justify-between w-full">
-																	<div className="flex flex-col gap-2">
-																		<span className="text-base flex items-center gap-2 font-medium leading-none flex-wrap">
+															<CardTitle className="flex items-center justify-between gap-2">
+																<span className="flex flex-col gap-1.5">
+																	<div className="flex items-center gap-2">
+																		<span className="text-muted-foreground">
+																			{service.type === "postgres" && (
+																				<PostgresqlIcon className="size-4" />
+																			)}
+																			{service.type === "redis" && (
+																				<RedisIcon className="size-4" />
+																			)}
+																			{service.type === "mariadb" && (
+																				<MariadbIcon className="size-4" />
+																			)}
+																			{service.type === "mongo" && (
+																				<MongodbIcon className="size-4" />
+																			)}
+																			{service.type === "mysql" && (
+																				<MysqlIcon className="size-4" />
+																			)}
+																			{service.type === "application" && (
+																				<GlobeIcon className="size-4" />
+																			)}
+																			{service.type === "compose" && (
+																				<CircuitBoard className="size-4" />
+																			)}
+																		</span>
+																		<span className="text-base font-medium leading-none">
 																			{service.name}
 																		</span>
-																		{service.description && (
-																			<span className="text-sm font-medium text-muted-foreground">
-																				{service.description}
-																			</span>
-																		)}
 																	</div>
-
-																	<span className="text-sm font-medium text-muted-foreground self-start">
-																		{service.type === "postgres" && (
-																			<PostgresqlIcon className="h-7 w-7" />
-																		)}
-																		{service.type === "redis" && (
-																			<RedisIcon className="h-7 w-7" />
-																		)}
-																		{service.type === "mariadb" && (
-																			<MariadbIcon className="h-7 w-7" />
-																		)}
-																		{service.type === "mongo" && (
-																			<MongodbIcon className="h-7 w-7" />
-																		)}
-																		{service.type === "mysql" && (
-																			<MysqlIcon className="h-7 w-7" />
-																		)}
-																		{service.type === "application" && (
-																			<GlobeIcon className="h-6 w-6" />
-																		)}
-																		{service.type === "compose" && (
-																			<CircuitBoard className="h-6 w-6" />
-																		)}
-																	</span>
+																	{service.description && (
+																		<span className="text-sm font-medium text-muted-foreground">
+																			{service.description}
+																		</span>
+																	)}
+																</span>
+																<div className="flex self-start">
+																	<DropdownMenu>
+																		<DropdownMenuTrigger asChild>
+																			<Button
+																				variant="ghost"
+																				size="icon"
+																				className="px-2"
+																				onClick={(e) => e.stopPropagation()}
+																			>
+																				<MoreHorizontalIcon className="size-5" />
+																			</Button>
+																		</DropdownMenuTrigger>
+																		<DropdownMenuContent
+																			align="end"
+																			onClick={(e) => e.stopPropagation()}
+																		>
+																			<DropdownMenuItem
+																				onSelect={() => {
+																					setSelectedServices([service.id]);
+																					setIsMoveDialogOpen(true);
+																				}}
+																			>
+																				<FolderInput className="mr-2 h-4 w-4" />
+																				Move
+																			</DropdownMenuItem>
+																		</DropdownMenuContent>
+																	</DropdownMenu>
 																</div>
 															</CardTitle>
 														</CardHeader>


### PR DESCRIPTION
## What is this PR about?

Adds a per-service Move action to each service card on the environment page, reusing the existing bulk move infrastructure with zero new components or files.

**Changes (1 file, ~76 additions):**
- Adds a `MoreHorizontalIcon` dropdown menu to each service card (matching the Projects page pattern)
- The "Move" action pre-selects the single service and opens the existing bulk move dialog
- Fixes dialog title/description grammar for singular ("Move Service" / "this service") vs plural
- Repositions the service-type icon to the left of the service name, consistent with the Projects page card layout

**What stays the same:**
- All existing bulk move functionality is untouched
- The same `handleBulkMove` function handles both single and bulk moves
- Same target project/environment selection UI
- Same cache invalidation and error handling

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots (if applicable)

Service card with action menu and icon repositioned to left of name:

- Each card now shows a `⋯` menu on hover with "Move" action
- Clicking Move opens the existing move dialog scoped to that single service
- Service-type icon (globe, database icons, etc.) now appears to the left of the service name

🤖 Generated with [Claude Code](https://claude.com/claude-code)