### PR TITLE
fix: double bearer for mistral provider

### DIFF
--- a/packages/server/src/utils/ai/select-ai-provider.ts
+++ b/packages/server/src/utils/ai/select-ai-provider.ts
@@ -103,7 +103,7 @@ export const getProviderHeaders = (
 	// Mistral
 	if (apiUrl.includes("mistral")) {
 		return {
-			Authorization: apiKey,
+			Authorization: `Bearer ${apiKey}`,
 		};
 	}
 


### PR DESCRIPTION
## What is this PR about?

The request for Mistral models requires Bearer to be present in the header. This forced the user to include it in their key, which caused problems later on during use.

I just added `Bearer ` for the model request.

## Issues related (if applicable)

closes #3576

## Screenshots (if applicable)

<img width="629" height="731" alt="Capture d’écran 2026-02-02 à 11 44 47" src="https://github.com/user-attachments/assets/783c1657-6653-4780-b01c-f0e70b64467c" />
<img width="664" height="758" alt="Capture d’écran 2026-02-02 à 11 44 51" src="https://github.com/user-attachments/assets/fd440cf9-c315-477f-92ef-78877fd74176" />
