### PR TITLE
Update Traefik version to 3.6.7

### DIFF
--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -20,7 +20,7 @@ export const TRAEFIK_PORT =
 	Number.parseInt(process.env.TRAEFIK_PORT!, 10) || 80;
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
-export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.4";
+export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.7";
 
 export interface TraefikOptions {
 	env?: string[];


### PR DESCRIPTION
Unknown reason for inconsistency between dokploy setup.ts and current file version. if enable dashboard Traefik version becomes 3.6.4

## What is this PR about?

Update traefik-setup.ts file Traefik version to 3.6.7 

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

