### PR TITLE
fix: extract ZIP drop deployment to build server when configured

### DIFF
--- a/packages/server/src/utils/builders/drop.ts
+++ b/packages/server/src/utils/builders/drop.ts
@@ -71,10 +71,7 @@ export const unzipDrop = async (zipFile: File, application: Application) => {
 					if (sftp === null) throw new Error("No SFTP connection available");
 					try {
 						const dirPath = path.dirname(fullPath);
-						await execAsyncRemote(
-							targetServerId,
-							`mkdir -p "${dirPath}"`,
-						);
+						await execAsyncRemote(targetServerId, `mkdir -p "${dirPath}"`);
 						await uploadFileToServer(sftp, entry.getData(), fullPath);
 					} catch (err) {
 						console.error(`Error uploading file ${fullPath}:`, err);


### PR DESCRIPTION
## What is this PR about?

When using drop (ZIP upload) deployment with a dedicated build server,
the ZIP was being extracted to the main server instead of the build
server, causing builds to fail with "No such file or directory" errors.

Changed unzipDrop() to use buildServerId when set, falling back to
serverId. This matches the existing pattern used elsewhere in the
codebase for build server handling.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)


## Screenshots (if applicable)

