### PR TITLE
fix(project): include appName in backup processing

### DIFF
--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -506,7 +506,7 @@ export const projectRouter = createTRPCRouter({
 								}
 
 								for (const backup of backups) {
-									const { backupId, ...rest } = backup;
+									const { backupId, appName: _appName, ...rest } = backup;
 									await createBackup({
 										...rest,
 										postgresId: newPostgres.postgresId,
@@ -542,7 +542,7 @@ export const projectRouter = createTRPCRouter({
 								}
 
 								for (const backup of backups) {
-									const { backupId, ...rest } = backup;
+									const { backupId, appName: _appName, ...rest } = backup;
 									await createBackup({
 										...rest,
 										mariadbId: newMariadb.mariadbId,
@@ -578,7 +578,7 @@ export const projectRouter = createTRPCRouter({
 								}
 
 								for (const backup of backups) {
-									const { backupId, ...rest } = backup;
+									const { backupId, appName: _appName, ...rest } = backup;
 									await createBackup({
 										...rest,
 										mongoId: newMongo.mongoId,
@@ -614,7 +614,7 @@ export const projectRouter = createTRPCRouter({
 								}
 
 								for (const backup of backups) {
-									const { backupId, ...rest } = backup;
+									const { backupId, appName: _appName, ...rest } = backup;
 									await createBackup({
 										...rest,
 										mysqlId: newMysql.mysqlId,


### PR DESCRIPTION
- Updated backup processing logic to destructure appName from backup objects, ensuring it is available for further operations.
- This change is applied consistently across multiple sections of the project router.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3581

## Screenshots (if applicable)

