### PR TITLE
refactor(backup): replace docker service scale with update command

### DIFF
--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -50,10 +50,10 @@ export const backupVolume = async (
 		echo "Stopping application to 0 replicas"
 		ACTUAL_REPLICAS=$(docker service inspect ${volumeBackup.application?.appName} --format "{{.Spec.Mode.Replicated.Replicas}}")
 		echo "Actual replicas: $ACTUAL_REPLICAS"
-		docker service scale ${volumeBackup.application?.appName}=0
+		docker service update --replicas=0 ${volumeBackup.application?.appName}
         ${baseCommand}
 		echo "Starting application to $ACTUAL_REPLICAS replicas"
-        docker service scale ${volumeBackup.application?.appName}=$ACTUAL_REPLICAS
+        docker service update --replicas=$ACTUAL_REPLICAS --with-registry-auth ${volumeBackup.application?.appName}
   `;
 	}
 	if (serviceType === "compose") {
@@ -69,10 +69,10 @@ export const backupVolume = async (
 			echo "Service name: ${compose.appName}_${volumeBackup.serviceName}"
             ACTUAL_REPLICAS=$(docker service inspect ${compose.appName}_${volumeBackup.serviceName} --format "{{.Spec.Mode.Replicated.Replicas}}")
             echo "Actual replicas: $ACTUAL_REPLICAS"
-            docker service scale ${compose.appName}_${volumeBackup.serviceName}=0`;
+            docker service update --replicas=0 ${compose.appName}_${volumeBackup.serviceName}`;
 			startCommand = `
 			echo "Starting compose to $ACTUAL_REPLICAS replicas"
-			docker service scale ${compose.appName}_${volumeBackup.serviceName}=$ACTUAL_REPLICAS`;
+			docker service update --replicas=$ACTUAL_REPLICAS --with-registry-auth ${compose.appName}_${volumeBackup.serviceName}`;
 		} else {
 			stopCommand = `
 			echo "Stopping compose container"


### PR DESCRIPTION
- Updated the backupVolume function to use `docker service update --replicas` instead of `docker service scale` for stopping and starting application replicas.
- This change enhances the backup process by ensuring proper handling of service updates with registry authentication.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3403

## Screenshots (if applicable)

