### PR TITLE
fix(postgres): add default StopGracePeriod to prevent WAL corruption

### DIFF
--- a/packages/server/src/utils/databases/postgres.ts
+++ b/packages/server/src/utils/databases/postgres.ts
@@ -73,8 +73,7 @@ export const buildPostgres = async (postgres: PostgresNested) => {
 				Image: dockerImage,
 				Env: envVariables,
 				Mounts: [...volumesMount, ...bindsMount, ...filesMount],
-				...(StopGracePeriod !== null &&
-					StopGracePeriod !== undefined && { StopGracePeriod }),
+				StopGracePeriod: StopGracePeriod ?? 30_000_000_000,
 				...(command && {
 					Command: command.split(" "),
 				}),


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Summary
Adds a default 30-second StopGracePeriod for PostgreSQL Swarm services to prevent WAL corruption on redeployment and service stop/restart

##  Issues related
https://github.com/Dokploy/dokploy/issues/3595

## Problem
When redeploying or stopping a PostgreSQL service (especially on external servers), Docker Swarm sends SIGTERM and then SIGKILL after the grace period expires. Previously, StopGracePeriod was only applied if the user explicitly configured it — otherwise Docker's default of 10 seconds was used.

10 seconds is often not enough for PostgreSQL to complete its shutdown sequence (flush WAL buffers, write a final checkpoint). If SIGKILL arrives before that finishes, the WAL is left in an inconsistent state, causing this on the next startup:


PANIC: could not locate a valid checkpoint record
This makes the database unrecoverable without manual intervention (pg_resetwal).

## Fix
Changed StopGracePeriod in buildPostgres() from opt-in to always-present, with a default fallback of 30 seconds (30,000,000,000 nanoseconds). If the user has configured a custom value, that value is still respected.


- ...(StopGracePeriod !== null &&
-     StopGracePeriod !== undefined && { StopGracePeriod }),
+ StopGracePeriod: StopGracePeriod ?? 30_000_000_000,
closes https://github.com/Dokploy/dokploy/issues/3595

