### PR TITLE
refactor(network-service): enhance network addition logic to include …

### DIFF
--- a/apps/dokploy/__test__/compose/domain/network-service.test.ts
+++ b/apps/dokploy/__test__/compose/domain/network-service.test.ts
@@ -4,21 +4,30 @@ import { describe, expect, it } from "vitest";
 describe("addDokployNetworkToService", () => {
 	it("should add network to an empty array", () => {
 		const result = addDokployNetworkToService([]);
-		expect(result).toEqual(["dokploy-network"]);
+		expect(result).toEqual(["dokploy-network", "default"]);
 	});
 
 	it("should not add duplicate network to an array", () => {
 		const result = addDokployNetworkToService(["dokploy-network"]);
-		expect(result).toEqual(["dokploy-network"]);
+		expect(result).toEqual(["dokploy-network", "default"]);
 	});
 
 	it("should add network to an existing array with other networks", () => {
 		const result = addDokployNetworkToService(["other-network"]);
-		expect(result).toEqual(["other-network", "dokploy-network"]);
+		expect(result).toEqual(["other-network", "dokploy-network", "default"]);
 	});
 
 	it("should add network to an object if networks is an object", () => {
 		const result = addDokployNetworkToService({ "other-network": {} });
-		expect(result).toEqual({ "other-network": {}, "dokploy-network": {} });
+		expect(result).toEqual({
+			"other-network": {},
+			"dokploy-network": {},
+			default: {},
+		});
+	});
+
+	it("should not duplicate default network when already present", () => {
+		const result = addDokployNetworkToService(["default", "dokploy-network"]);
+		expect(result).toEqual(["default", "dokploy-network"]);
 	});
 });

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -330,6 +330,7 @@ export const addDokployNetworkToService = (
 ) => {
 	let networks = networkService;
 	const network = "dokploy-network";
+	const defaultNetwork = "default";
 	if (!networks) {
 		networks = [];
 	}
@@ -338,9 +339,15 @@ export const addDokployNetworkToService = (
 		if (!networks.includes(network)) {
 			networks.push(network);
 		}
+		if (!networks.includes(defaultNetwork)) {
+			networks.push(defaultNetwork);
+		}
 	} else if (networks && typeof networks === "object") {
 		if (!(network in networks)) {
 			networks[network] = {};
+		}
+		if (!(defaultNetwork in networks)) {
+			networks[defaultNetwork] = {};
 		}
 	}
 


### PR DESCRIPTION
…default network

- Updated the addDokployNetworkToService function to automatically include the "default" network when adding new networks.
- Modified test cases to reflect the new behavior, ensuring no duplicates of the default network are added.
- Improved handling of network addition for both arrays and objects.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #3562

## Screenshots (if applicable)

