### PR TITLE
fix: avoid database connection during setup by using native exec

### DIFF
--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -1,5 +1,8 @@
 import { exit } from "node:process";
-import { execAsync } from "@dokploy/server";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
 import { setupDirectories } from "@dokploy/server/setup/config-paths";
 import { initializePostgres } from "@dokploy/server/setup/postgres-setup";
 import { initializeRedis } from "@dokploy/server/setup/redis-setup";


### PR DESCRIPTION
The setup.ts script imports execAsync from @dokploy/server, which triggers the entire package to load including lib/auth.ts. This module initializes betterAuth() with a database connection at import time, causing the setup script to fail with ECONNREFUSED before the database container is created.

This fix replaces the import with Node.js native promisify(exec), avoiding the module side-effect that attempts database connection during setup.

## What is this PR about?

Running pnpm run dokploy:setup fails with ECONNREFUSED error when the PostgreSQL database container doesn't exist yet. This is a chicken-and-egg problem: the setup script is supposed to create the database, but it fails before creating it because it tries to connect to the database during module import.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes https://github.com/Dokploy/dokploy/issues/2241

## Screenshots (if applicable)

