### PR TITLE
fix: Lazy-load database connection to prevent unnecessary instantiations

### DIFF
--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -12,7 +12,7 @@ function getDbInstance(): PostgresJsDatabase<typeof schema> {
   if (process.env.NODE_ENV === "production") {
     // Log database connection for debugging in non-production or when DEBUG is set
     if (process.env.DEBUG) {
-    console.log(`[RUNTIME] Connecting to database: ${sanitizeDbUrl(dbUrl)}`);
+    console.log(`[DB] Connecting to database: ${sanitizeDbUrl(dbUrl)}`);
     }
     return drizzle(postgres(dbUrl), { schema });
   }


### PR DESCRIPTION
Previously, the database connection was initialized on import, even when unused. This commit defers connection initialization until the `db` variable is first accessed, preventing redundant database connections when the module is imported.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

_No response_

## Screenshots (if applicable)

_No response_