### PR TITLE
fix(server): clarify domain->service compose errors

### DIFF
--- a/apps/dokploy/__test__/compose/domains-service-mapping.test.ts
+++ b/apps/dokploy/__test__/compose/domains-service-mapping.test.ts
@@ -1,0 +1,62 @@
+import type { ComposeSpecification, Domain } from "@dokploy/server";
+import { assertDomainsMatchComposeServices } from "@dokploy/server";
+import { expect, test } from "vitest";
+
+const baseDomain: Domain = {
+	applicationId: "",
+	certificateType: "none",
+	createdAt: "",
+	domainId: "",
+	host: "",
+	https: false,
+	path: null,
+	port: null,
+	serviceName: "",
+	composeId: "",
+	customCertResolver: null,
+	domainType: "application",
+	uniqueConfigKey: 1,
+	previewDeploymentId: "",
+	internalPath: "/",
+	stripPath: false,
+};
+
+test("throws a clear error when a domain references a missing compose service", () => {
+	const composeSpec = {
+		services: {
+			"python-backend": {},
+		},
+	} as ComposeSpecification;
+
+	const domains = [
+		{
+			...baseDomain,
+			host: "api.example.com",
+			serviceName: "php-backend",
+		},
+	];
+
+	expect(() => assertDomainsMatchComposeServices(composeSpec, domains)).toThrow(
+		/Domain configuration references a service.*api\.example\.com.*php-backend.*python-backend/i,
+	);
+});
+
+test("does not throw when all domains reference existing services", () => {
+	const composeSpec = {
+		services: {
+			"python-backend": {},
+		},
+	} as ComposeSpecification;
+
+	const domains = [
+		{
+			...baseDomain,
+			host: "api.example.com",
+			serviceName: "python-backend",
+		},
+	];
+
+	expect(() =>
+		assertDomainsMatchComposeServices(composeSpec, domains),
+	).not.toThrow();
+});

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -20,6 +20,36 @@ import type {
 } from "./types";
 import { encodeBase64 } from "./utils";
 
+export const assertDomainsMatchComposeServices = (
+	composeSpec: ComposeSpecification,
+	domains: Domain[],
+) => {
+	const availableServices = Object.keys(composeSpec.services ?? {});
+
+	const missing: Array<{ host: string; serviceName: string }> = [];
+	for (const domain of domains) {
+		const host = domain.host ?? "";
+		const serviceName = domain.serviceName ?? "";
+		if (!host || !serviceName) continue;
+		if (!composeSpec.services?.[serviceName]) {
+			missing.push({ host, serviceName });
+		}
+	}
+
+	if (missing.length === 0) return;
+
+	const missingSummary = missing
+		.map(({ host, serviceName }) => `"${host}" -> "${serviceName}"`)
+		.join(", ");
+
+	const availableSummary =
+		availableServices.length > 0 ? availableServices.join(", ") : "(none)";
+
+	throw new Error(
+		`Domain configuration references a service that no longer exists in the compose. Missing: ${missingSummary}. Available services: ${availableSummary}. Update/remove the affected domain(s) in Dokploy.`,
+	);
+};
+
 export const cloneCompose = async (compose: Compose) => {
 	let command = "set -e;";
 	const entity = {
@@ -125,8 +155,11 @@ exit 1;
 		const encodedContent = encodeBase64(composeString);
 		return `echo "${encodedContent}" | base64 -d > "${path}";`;
 	} catch (error) {
+		// Print error safely (no shell interpolation) and exit with failure.
 		// @ts-ignore
-		return `echo "❌ Has occurred an error: ${error?.message || error}";
+		const message = `❌ Has occurred an error: ${error?.message || error}`;
+		const encodedMessage = encodeBase64(message);
+		return `echo "${encodedMessage}" | base64 -d;
 exit 1;
 		`;
 	}
@@ -161,13 +194,18 @@ export const addDomainToCompose = async (
 		result = randomized;
 	}
 
+	assertDomainsMatchComposeServices(result, domains);
+
 	for (const domain of domains) {
 		const { serviceName, https } = domain;
 		if (!serviceName) {
-			throw new Error("Service name not found");
+			throw new Error(`Domain "${domain.host}" is missing a service name`);
 		}
+		// Defensive check (should be covered by assertDomainsMatchComposeServices).
 		if (!result?.services?.[serviceName]) {
-			throw new Error(`The service ${serviceName} not found in the compose`);
+			throw new Error(
+				`Domain "${domain.host}" is attached to service "${serviceName}" which does not exist in the compose`,
+			);
 		}
 
 		const httpLabels = createDomainLabels(appName, domain, "web");


### PR DESCRIPTION
## What is this PR about?

This PR improves the error reporting when a Dokploy domain is still attached to a service name that no longer exists in the application compose (e.g. renaming `php-backend` -> `python-backend` but the domain is still mapped to `php-backend` in the UI).

Instead of a generic "service not found" message, the error now explicitly states which domain host is pointing to which missing service and lists available compose services.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file.
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

Fixes #3672 

## Screenshots (if applicable)

N/A