### PR TITLE
fix: prevent orphaned docker stacks when compose directory is missing

### DIFF
--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -395,16 +395,14 @@ export const removeCompose = async (
 		if (compose.composeType === "stack") {
 			const command = `
 			docker network disconnect ${compose.appName} dokploy-traefik;
-			cd ${projectPath} && docker stack rm ${compose.appName} && rm -rf ${projectPath}`;
+			docker stack rm ${compose.appName};
+			rm -rf ${projectPath}`;
 
 			if (compose.serverId) {
 				await execAsyncRemote(compose.serverId, command);
 			} else {
 				await execAsync(command);
 			}
-			await execAsync(command, {
-				cwd: projectPath,
-			});
 		} else {
 			const command = `
 			 docker network disconnect ${compose.appName} dokploy-traefik;


### PR DESCRIPTION
## Description

When removing a compose service with `composeType === "stack"`, the `removeCompose` function chains `docker stack rm` after `cd` using `&&`:

```typescript
cd ${projectPath} && docker stack rm ${compose.appName} && rm -rf ${projectPath}
```

If `projectPath` doesn't exist (e.g. after container restart, migration, or prior partial cleanup), `cd` fails and `docker stack rm` **never executes**. The database entry is still deleted by the caller, leaving an orphaned Docker stack with its port occupied.

Additionally, there is a duplicate `execAsync(command, { cwd: projectPath })` call after the `if/else` block that always runs — even for remote servers — which causes errors when the directory has already been removed by the first call.

### Changes

1. Removed `cd ${projectPath} &&` dependency — `docker stack rm` doesn't need to run from any specific directory
2. Changed `&&` to `;` between `docker stack rm` and `rm -rf` so directory cleanup runs regardless of stack removal result
3. Removed the duplicate `execAsync` call outside the `if/else` block

### Before
```typescript
const command = `
    docker network disconnect ${compose.appName} dokploy-traefik;
    cd ${projectPath} && docker stack rm ${compose.appName} && rm -rf ${projectPath}`;

if (compose.serverId) {
    await execAsyncRemote(compose.serverId, command);
} else {
    await execAsync(command);
}
await execAsync(command, {   // always runs, even for remote
    cwd: projectPath,
});
```

### After
```typescript
const command = `
    docker network disconnect ${compose.appName} dokploy-traefik;
    docker stack rm ${compose.appName};
    rm -rf ${projectPath}`;

if (compose.serverId) {
    await execAsyncRemote(compose.serverId, command);
} else {
    await execAsync(command);
}
```

## Checklist

- [x] My branch is based on the `canary` branch.
- [x] I have read the contributing guidelines.
- [x] I have tested this fix on a production Docker Swarm instance.

## Issues related

Fixes #3691

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a critical bug where Docker stacks could be orphaned when removing compose services, leaving ports occupied and resources dangling. The fix addresses two issues: (1) removed the unnecessary `cd ${projectPath}` dependency that caused stack removal to fail when the directory didn't exist, and (2) removed a duplicate `execAsync` call that would execute cleanup commands twice for local servers.

**Key improvements:**
- `docker stack rm` no longer depends on the compose directory existing
- Changed `&&` to `;` between commands so directory cleanup runs regardless of stack removal result
- Removed duplicate command execution that ran even for remote servers

**Issues found:**
- The `docker network disconnect` command on line 397 will fail and prevent subsequent cleanup if the network connection doesn't exist (e.g., if the stack is already partially removed)

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge with one logical issue that should be addressed
- The fix correctly addresses the orphaned stack problem by removing unnecessary directory dependencies and duplicate command execution. However, the unprotected `docker network disconnect` command could still cause cleanup failures in edge cases where the network connection doesn't exist
- The `docker network disconnect` command in `packages/server/src/services/compose.ts` should be made fault-tolerant

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->