### PR TITLE
fix: validate webhook trigger type to respect 'On tag' configuration

### DIFF
--- a/apps/dokploy/__test__/deploy/github.test.ts
+++ b/apps/dokploy/__test__/deploy/github.test.ts
@@ -534,6 +534,16 @@ describe("Webhook Trigger Type Validation", () => {
 			expect(validateTriggerType(headers, body, "push")).toBe(true);
 		});
 
+		it("should reject tag push events when triggerType is push", () => {
+			const headers = { "x-event-key": "repo:push" };
+			const body = {
+				push: {
+					changes: [{ new: { type: "tag", name: "v1.0.0" } }],
+				},
+			};
+			expect(validateTriggerType(headers, body, "push")).toBe(false);
+		});
+
 		it("should allow tag push events when triggerType is tag", () => {
 			const headers = { "x-event-key": "repo:push" };
 			const body = {

--- a/apps/dokploy/__test__/deploy/github.test.ts
+++ b/apps/dokploy/__test__/deploy/github.test.ts
@@ -4,6 +4,7 @@ import {
 	extractImageName,
 	extractImageTag,
 	extractImageTagFromRequest,
+	validateTriggerType,
 } from "@/pages/api/deploy/[refreshToken]";
 
 describe("GitHub Webhook Skip CI", () => {
@@ -433,6 +434,143 @@ describe("Docker Image Name and Tag Extraction", () => {
 			expect(extractImageTag("localhost:5000/app:sha-abc123")).toBe(
 				"sha-abc123",
 			);
+		});
+	});
+});
+
+describe("Webhook Trigger Type Validation", () => {
+	describe("GitHub", () => {
+		it("should allow push events when triggerType is push", () => {
+			const headers = { "x-github-event": "push" };
+			const body = { ref: "refs/heads/main" };
+			expect(validateTriggerType(headers, body, "push")).toBe(true);
+		});
+
+		it("should allow registry_package events when triggerType is push", () => {
+			const headers = { "x-github-event": "registry_package" };
+			const body = { registry_package: {} };
+			expect(validateTriggerType(headers, body, "push")).toBe(true);
+		});
+
+		it("should reject push events when triggerType is tag", () => {
+			const headers = { "x-github-event": "push" };
+			const body = { ref: "refs/heads/main" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(false);
+		});
+
+		it("should allow create events with tag ref_type when triggerType is tag", () => {
+			const headers = { "x-github-event": "create" };
+			const body = { ref_type: "tag", ref: "v1.0.0" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(true);
+		});
+
+		it("should reject create events with branch ref_type when triggerType is tag", () => {
+			const headers = { "x-github-event": "create" };
+			const body = { ref_type: "branch", ref: "feature-branch" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(false);
+		});
+	});
+
+	describe("GitLab", () => {
+		it("should allow Push Hook events when triggerType is push", () => {
+			const headers = { "x-gitlab-event": "Push Hook" };
+			const body = { ref: "refs/heads/main" };
+			expect(validateTriggerType(headers, body, "push")).toBe(true);
+		});
+
+		it("should reject Push Hook events when triggerType is tag", () => {
+			const headers = { "x-gitlab-event": "Push Hook" };
+			const body = { ref: "refs/heads/main" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(false);
+		});
+
+		it("should allow Tag Push Hook events when triggerType is tag", () => {
+			const headers = { "x-gitlab-event": "Tag Push Hook" };
+			const body = { ref: "refs/tags/v1.0.0" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(true);
+		});
+
+		it("should reject Tag Push Hook events when triggerType is push", () => {
+			const headers = { "x-gitlab-event": "Tag Push Hook" };
+			const body = { ref: "refs/tags/v1.0.0" };
+			expect(validateTriggerType(headers, body, "push")).toBe(false);
+		});
+	});
+
+	describe("Gitea", () => {
+		it("should allow push events when triggerType is push", () => {
+			const headers = { "x-gitea-event": "push" };
+			const body = { ref: "refs/heads/main" };
+			expect(validateTriggerType(headers, body, "push")).toBe(true);
+		});
+
+		it("should reject push events when triggerType is tag", () => {
+			const headers = { "x-gitea-event": "push" };
+			const body = { ref: "refs/heads/main" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(false);
+		});
+
+		it("should allow create events with tag ref_type when triggerType is tag", () => {
+			const headers = { "x-gitea-event": "create" };
+			const body = { ref_type: "tag", ref: "v1.0.0" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(true);
+		});
+
+		it("should reject create events with branch ref_type when triggerType is tag", () => {
+			const headers = { "x-gitea-event": "create" };
+			const body = { ref_type: "branch", ref: "feature-branch" };
+			expect(validateTriggerType(headers, body, "tag")).toBe(false);
+		});
+	});
+
+	describe("Bitbucket", () => {
+		it("should allow push events when triggerType is push", () => {
+			const headers = { "x-event-key": "repo:push" };
+			const body = {
+				push: {
+					changes: [{ new: { type: "branch", name: "main" } }],
+				},
+			};
+			expect(validateTriggerType(headers, body, "push")).toBe(true);
+		});
+
+		it("should allow tag push events when triggerType is tag", () => {
+			const headers = { "x-event-key": "repo:push" };
+			const body = {
+				push: {
+					changes: [{ new: { type: "tag", name: "v1.0.0" } }],
+				},
+			};
+			expect(validateTriggerType(headers, body, "tag")).toBe(true);
+		});
+
+		it("should allow annotated tag push events when triggerType is tag", () => {
+			const headers = { "x-event-key": "repo:push" };
+			const body = {
+				push: {
+					changes: [{ new: { type: "annotated_tag", name: "v1.0.0" } }],
+				},
+			};
+			expect(validateTriggerType(headers, body, "tag")).toBe(true);
+		});
+
+		it("should reject branch push events when triggerType is tag", () => {
+			const headers = { "x-event-key": "repo:push" };
+			const body = {
+				push: {
+					changes: [{ new: { type: "branch", name: "main" } }],
+				},
+			};
+			expect(validateTriggerType(headers, body, "tag")).toBe(false);
+		});
+	});
+
+	describe("Backward Compatibility", () => {
+		it("should default to allowing events for unknown providers", () => {
+			const headers = { "x-unknown-event": "something" };
+			const body = {};
+			expect(validateTriggerType(headers, body, "push")).toBe(true);
+			expect(validateTriggerType(headers, body, "tag")).toBe(true);
 		});
 	});
 });

--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -32,6 +32,69 @@ const getPackageVersion = (headers: any, body: any) => {
 	return null;
 };
 
+/**
+ * Validate if the webhook event matches the configured trigger type
+ * @param headers - Request headers containing event information
+ * @param body - Request body containing event details
+ * @param triggerType - Configured trigger type ("push" or "tag")
+ * @returns true if the event matches the trigger type, false otherwise
+ */
+export const validateTriggerType = (
+	headers: any,
+	body: any,
+	triggerType: "push" | "tag",
+): boolean => {
+	// GitHub
+	const githubEvent = headers["x-github-event"];
+	if (githubEvent) {
+		if (triggerType === "tag") {
+			// For tag trigger type, only accept "create" events with ref_type "tag"
+			return githubEvent === "create" && body.ref_type === "tag";
+		}
+		// For push trigger type, accept push and registry_package events
+		return githubEvent === "push" || githubEvent === "registry_package";
+	}
+
+	// GitLab
+	const gitlabEvent = headers["x-gitlab-event"];
+	if (gitlabEvent) {
+		if (triggerType === "tag") {
+			// GitLab uses "Tag Push Hook" for tag events
+			return gitlabEvent === "Tag Push Hook";
+		}
+		// For push trigger type, accept push events
+		return gitlabEvent === "Push Hook";
+	}
+
+	// Gitea
+	const giteaEvent = headers["x-gitea-event"];
+	if (giteaEvent) {
+		if (triggerType === "tag") {
+			// For Gitea, check for create event with ref_type tag
+			return giteaEvent === "create" && body.ref_type === "tag";
+		}
+		// For push trigger type, accept push events
+		return giteaEvent === "push";
+	}
+
+	// Bitbucket
+	const bitbucketEvent = headers["x-event-key"];
+	if (bitbucketEvent?.includes("repo:push")) {
+		if (triggerType === "tag") {
+			// For Bitbucket, check if the push is for a tag
+			const changes = body.push?.changes || [];
+			return changes.some(
+				(change: any) => change.new?.type === "tag" || change.new?.type === "annotated_tag",
+			);
+		}
+		// For push trigger type, accept push events that are not tags
+		return true;
+	}
+
+	// Default: if we can't determine the provider, allow the event (backward compatibility)
+	return true;
+};
+
 export default async function handler(
 	req: NextApiRequest,
 	res: NextApiResponse,
@@ -61,6 +124,14 @@ export default async function handler(
 		if (!application?.autoDeploy) {
 			res.status(400).json({
 				message: "Automatic deployments are disabled for this application",
+			});
+			return;
+		}
+
+		// Validate trigger type matches the webhook event
+		if (!validateTriggerType(req.headers, req.body, application.triggerType)) {
+			res.status(200).json({
+				message: `Event type does not match configured trigger type (${application.triggerType})`,
 			});
 			return;
 		}

--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -80,15 +80,17 @@ export const validateTriggerType = (
 	// Bitbucket
 	const bitbucketEvent = headers["x-event-key"];
 	if (bitbucketEvent?.includes("repo:push")) {
+		const changes = body.push?.changes || [];
 		if (triggerType === "tag") {
 			// For Bitbucket, check if the push is for a tag
-			const changes = body.push?.changes || [];
 			return changes.some(
 				(change: any) => change.new?.type === "tag" || change.new?.type === "annotated_tag",
 			);
 		}
 		// For push trigger type, accept push events that are not tags
-		return true;
+		return !changes.some(
+			(change: any) => change.new?.type === "tag" || change.new?.type === "annotated_tag",
+		);
 	}
 
 	// Default: if we can't determine the provider, allow the event (backward compatibility)

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -13,6 +13,7 @@ import {
 	extractHash,
 	getProviderByHeader,
 	logWebhookError,
+	validateTriggerType,
 } from "../[refreshToken]";
 
 export default async function handler(
@@ -44,6 +45,14 @@ export default async function handler(
 		if (!composeResult?.autoDeploy) {
 			res.status(400).json({
 				message: "Automatic deployments are disabled for this compose",
+			});
+			return;
+		}
+
+		// Validate trigger type matches the webhook event
+		if (!validateTriggerType(req.headers, req.body, composeResult.triggerType)) {
+			res.status(200).json({
+				message: `Event type does not match configured trigger type (${composeResult.triggerType})`,
 			});
 			return;
 		}


### PR DESCRIPTION
## What is this PR about?

This PR fixes an issue where the "On tag" trigger type configuration was being ignored, causing deployments to trigger on regular commits/pushes instead of only on tag events. The fix adds proper validation of webhook events against the configured trigger type for all supported Git providers (GitHub, GitLab, Gitea, and Bitbucket), ensuring that deployments only trigger when the appropriate event type is received.

## Changes

- Add validateTriggerType helper function to validate webhook events against configured trigger type
- Support all Git providers: GitHub, GitLab, Gitea, and Bitbucket
- Update application deployment endpoint to validate trigger type before processing
- Update compose deployment endpoint to validate trigger type before processing
- Add comprehensive test suite for trigger type validation
- Fixes #3710

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3710

## Screenshots (if applicable)

N/A - This is a backend webhook validation fix with no UI changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds webhook trigger type validation to respect "On tag" configuration for all Git providers (GitHub, GitLab, Gitea, Bitbucket). The `validateTriggerType` helper correctly validates webhook events against configured trigger types for applications and compose deployments.

- Fixed critical issue where "On tag" configuration was ignored, causing unwanted deployments
- Comprehensive test coverage for all providers and trigger type combinations
- One logic issue: Bitbucket validation incorrectly accepts tag events when `triggerType` is "push"

<h3>Confidence Score: 3/5</h3> (outdated)

- Safe to merge after fixing the Bitbucket logic issue
- The implementation correctly handles GitHub, GitLab, and Gitea providers with comprehensive test coverage. However, Bitbucket validation has a logic flaw where `triggerType: "push"` would accept both branch and tag events instead of rejecting tags. This needs to be fixed before merging.
- apps/dokploy/pages/api/deploy/[refreshToken].ts requires a fix to the Bitbucket trigger type validation logic

<sub>Last reviewed commit: 59b52b8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->