### PR TITLE
fix(cluster): ensure Replicas value is correctly converted to number …

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/cluster/swarm-forms/mode-form.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/cluster/swarm-forms/mode-form.tsx
@@ -105,7 +105,14 @@ export const ModeForm = ({ id, type }: ModeFormProps) => {
 
 			const modeData =
 				formData.type === "Replicated"
-					? { Replicated: { Replicas: formData.Replicas } }
+					? {
+							Replicated: {
+								Replicas:
+									formData.Replicas !== undefined && formData.Replicas !== ""
+										? Number(formData.Replicas)
+										: undefined,
+							},
+						}
 					: { Global: {} };
 
 			await mutateAsync({


### PR DESCRIPTION
…in mode-form

- Updated the mode-form component to convert the Replicas value to a number only if it is defined and not an empty string, improving data handling for Replicated mode.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3717 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a type mismatch bug in the Swarm mode form where the `Replicas` value from an HTML number input was passed as a string instead of being converted to a number. The `ServiceModeSwarm` interface and `ReplicatedSchema` Zod validator both expect `Replicas` to be `number | undefined`, so submitting a string would either fail validation or cause unexpected behavior downstream when Docker processes the service spec.

- Adds a guard to convert `Replicas` to a number only when the value is defined and non-empty, falling back to `undefined` otherwise
- Correctly avoids `Number("")` (which produces `0`) and `Number(undefined)` (which produces `NaN`)
- Note: the sibling `placement-form.tsx` uses `z.coerce.number().optional()` in its Zod schema for a similar field — adopting a Zod schema for `mode-form.tsx` could be a future improvement to handle coercion more consistently

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted, correct fix for a type coercion bug with no risk of regression.
- The change is minimal (single file, single function), correctly addresses the reported bug, and aligns with the expected types defined in the schema. The guard conditions handle all realistic edge cases from the form input.
- No files require special attention.

<sub>Last reviewed commit: 33192ce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->