### PR TITLE
feat(environment): add service check before environment deletion

### DIFF
--- a/packages/server/src/services/environment.ts
+++ b/packages/server/src/services/environment.ts
@@ -101,12 +101,31 @@ export const findEnvironmentsByProjectId = async (projectId: string) => {
 	return projectEnvironments;
 };
 
+const environmentHasServices = (env: Awaited<ReturnType<typeof findEnvironmentById>>) => {
+	return (
+		(env.applications?.length ?? 0) > 0 ||
+		(env.compose?.length ?? 0) > 0 ||
+		(env.mariadb?.length ?? 0) > 0 ||
+		(env.mongo?.length ?? 0) > 0 ||
+		(env.mysql?.length ?? 0) > 0 ||
+		(env.postgres?.length ?? 0) > 0 ||
+		(env.redis?.length ?? 0) > 0
+	);
+};
+
 export const deleteEnvironment = async (environmentId: string) => {
 	const currentEnvironment = await findEnvironmentById(environmentId);
 	if (currentEnvironment.isDefault) {
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message: "You cannot delete the default environment",
+		});
+	}
+	if (environmentHasServices(currentEnvironment)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message:
+				"Cannot delete environment: it has active services. Delete all services first.",
 		});
 	}
 	const deletedEnvironment = await db


### PR DESCRIPTION
- Implemented a new function to verify if an environment has active services before allowing its deletion. This prevents accidental deletion of environments that are still in use.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3722


## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side validation to prevent deletion of environments that still contain active services (applications, compose, mariadb, mongo, mysql, postgres, redis). A new `environmentHasServices` helper checks if any service arrays are non-empty, and `deleteEnvironment` throws a `BAD_REQUEST` error if services exist.

- Adds `environmentHasServices` helper function using `Awaited<ReturnType<typeof findEnvironmentById>>` for type safety
- Integrates the check into `deleteEnvironment`, throwing a clear error message instructing users to delete services first
- Complements the existing client-side check in `advanced-environment-selector.tsx` (defense in depth)
- Notably, all service tables already have `onDelete: "cascade"` on the `environmentId` FK — this PR prevents the accidental cascade deletion of services when an environment is deleted directly (e.g., via API bypass of the frontend)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a defensive server-side guard that prevents accidental data loss.
- The change is minimal (two small additions to a single file), logically correct, and consistent with the existing frontend behavior. The `environmentHasServices` function properly checks all seven service types that match the DB schema relations. The error handling follows existing patterns in the codebase. No regressions are expected since this only adds a new guard before deletion — existing callers that pass environments without services are unaffected.
- No files require special attention.

<sub>Last reviewed commit: 7e8d3b7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->