### PR TITLE
fix: cap monitoring chart data to prevent memory leak

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -183,12 +183,13 @@ export const ContainerFreeMonitoring = ({
 
 			setCurrentData(data);
 
+			const MAX_DATA_POINTS = 300;
 			setAcummulativeData((prevData) => ({
-				cpu: [...prevData.cpu, data.cpu],
-				memory: [...prevData.memory, data.memory],
-				block: [...prevData.block, data.block],
-				network: [...prevData.network, data.network],
-				disk: [...prevData.disk, data.disk],
+				cpu: [...prevData.cpu, data.cpu].slice(-MAX_DATA_POINTS),
+				memory: [...prevData.memory, data.memory].slice(-MAX_DATA_POINTS),
+				block: [...prevData.block, data.block].slice(-MAX_DATA_POINTS),
+				network: [...prevData.network, data.network].slice(-MAX_DATA_POINTS),
+				disk: [...prevData.disk, data.disk].slice(-MAX_DATA_POINTS),
 			}));
 		};
 


### PR DESCRIPTION
Fixes #3712

The monitoring page's WebSocket handler appends new data points to the chart arrays on every message without any limit. Over time this causes unbounded memory growth (~300-550 MB every 5 minutes as reported).

This caps each chart data array to the most recent 300 data points using `.slice(-MAX_DATA_POINTS)`, keeping memory usage stable while still showing enough history for meaningful charts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Capped monitoring chart data arrays to 300 points to prevent unbounded memory growth. The WebSocket handler now applies `.slice(-MAX_DATA_POINTS)` to each accumulated data array (cpu, memory, block, network, disk) when new data arrives, keeping only the most recent 300 points.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, correctly implements array capping using `.slice(-300)`, and addresses a confirmed memory leak issue. The change is localized to a single callback and doesn't affect any other functionality.
- No files require special attention

<sub>Last reviewed commit: e874b2c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->