### PR TITLE
feat(backup): add more destination types support

### DIFF
--- a/apps/dokploy/components/dashboard/settings/destination/constants.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/constants.ts
@@ -1,3 +1,4 @@
+// S3 Compatible Providers
 export const S3_PROVIDERS: Array<{
 	key: string;
 	name: string;
@@ -129,5 +130,60 @@ export const S3_PROVIDERS: Array<{
 	{
 		key: "Other",
 		name: "Any other S3 compatible provider",
+	},
+];
+
+// Non-S3 Providers (using rclone native protocols)
+export const NON_S3_PROVIDERS: Array<{
+	key: string;
+	name: string;
+}> = [
+	{
+		key: "ftp",
+		name: "FTP Server",
+	},
+	{
+		key: "sftp",
+		name: "SFTP (SSH File Transfer)",
+	},
+	{
+		key: "drive",
+		name: "Google Drive",
+	},
+	{
+		key: "onedrive",
+		name: "Microsoft OneDrive",
+	},
+	{
+		key: "dropbox",
+		name: "Dropbox",
+	},
+	{
+		key: "webdav",
+		name: "WebDAV",
+	},
+	{
+		key: "b2",
+		name: "Backblaze B2",
+	},
+	{
+		key: "mega",
+		name: "MEGA",
+	},
+	{
+		key: "pcloud",
+		name: "pCloud",
+	},
+	{
+		key: "box",
+		name: "Box",
+	},
+	{
+		key: "hubic",
+		name: "hubic",
+	},
+	{
+		key: "yandex",
+		name: "Yandex Disk",
 	},
 ];

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -40,29 +40,74 @@ export const destinationRouter = createTRPCRouter({
 				});
 			}
 		}),
+	// Non-S3 providers that use rclone native protocols
+	const NON_S3_PROVIDERS = [
+		"ftp", "sftp", "drive", "onedrive", "dropbox", "webdav",
+		"b2", "mega", "pcloud", "box", "hubic", "yandex"
+	];
+
 	testConnection: adminProcedure
 		.input(apiCreateDestination)
 		.mutation(async ({ input }) => {
 			const { secretAccessKey, bucket, region, endpoint, accessKey, provider } =
 				input;
+			
+			// Check if it's a non-S3 provider
+			const isNonS3 = provider && NON_S3_PROVIDERS.includes(provider);
+			
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
+				let rcloneCommand: string;
+				
+				if (isNonS3) {
+					// Non-S3 providers use rclone native protocols
+					const providerConfig: Record<string, string> = {
+						ftp: `:ftp:${bucket || ""}`,
+						sftp: `:sftp:${bucket || ""}`,
+						drive: `:drive:${bucket || ""}`,
+						onedrive: `:onedrive:${bucket || ""}`,
+						dropbox: `:dropbox:${bucket || ""}`,
+						webdav: `:webdav:${bucket || ""}`,
+						b2: `:b2:${bucket || ""}`,
+						mega: `:mega:${bucket || ""}`,
+						pcloud: `:pcloud:${bucket || ""}`,
+						box: `:box:${bucket || ""}`,
+						hubic: `:hubic:${bucket || ""}`,
+						yandex: `:yandex:${bucket || ""}`,
+					};
+					
+					const rcloneFlags = [
+						"--retries 1",
+						"--low-level-retries 1",
+						"--timeout 10s",
+						"--contimeout 5s",
+					];
+					
+					// Add authentication if provided
+					if (accessKey) rcloneFlags.push(`--${provider}-user="${accessKey}"`);
+					if (secretAccessKey) rcloneFlags.push(`--${provider}-pass="${secretAccessKey}"`);
+					if (endpoint) rcloneFlags.push(`--${provider}-url="${endpoint}"`);
+					
+					rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${providerConfig[provider]}"`;
+				} else {
+					// S3 compatible providers
+					const rcloneFlags = [
+						`--s3-access-key-id="${accessKey}"`,
+						`--s3-secret-access-key="${secretAccessKey}"`,
+						`--s3-region="${region}"`,
+						`--s3-endpoint="${endpoint}"`,
+						"--s3-no-check-bucket",
+						"--s3-force-path-style",
+						"--retries 1",
+						"--low-level-retries 1",
+						"--timeout 10s",
+						"--contimeout 5s",
+					];
+					if (provider) {
+						rcloneFlags.unshift(`--s3-provider="${provider}"`);
+					}
+					const rcloneDestination = `:s3:${bucket}`;
+					rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({


### PR DESCRIPTION
## Summary
Adds support for additional backup destinations using rclone:

### New Providers Added
- **File Transfer**: FTP, SFTP (SSH File Transfer)
- **Cloud Storage**: Google Drive, OneDrive, Dropbox
- **Other**: WebDAV, Backblaze B2, MEGA, pCloud, Box, hubic, Yandex Disk

### Changes
1. **Frontend** (): Added NON_S3_PROVIDERS array with 12 new provider options
2. **Backend** (): Updated testConnection to support both S3 and non-S3 (native rclone) protocols

### Technical Details
- Non-S3 providers use rclone native protocols instead of S3 API
- Authentication parameters are passed via provider-specific flags
- Maintains backward compatibility with existing S3 providers

Fixes #416

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added support for 12 new backup destination providers (FTP, SFTP, Google Drive, OneDrive, Dropbox, WebDAV, Backblaze B2, MEGA, pCloud, Box, hubic, Yandex Disk) using rclone native protocols instead of S3 API.

**Critical Issues:**
- Syntax error on line 43-47 prevents compilation - `const` declaration inside router object
- Incorrect rclone flag format won't work with most providers (each has unique flag names)
- OAuth-based providers (Drive, OneDrive, Dropbox, Box) require OAuth tokens, not username/password
- Missing validation for unsupported providers in `providerConfig` mapping

**Impact:**
The code will not compile due to syntax error and won't function correctly for non-S3 providers even after fixing syntax issues.

<h3>Confidence Score: 0/5</h3>

- This PR contains a critical syntax error that prevents compilation and multiple logical errors that break functionality
- Score of 0 due to: (1) syntax error on line 43-47 that will cause compilation failure, (2) incorrect rclone flag format that won't work with any of the new providers, (3) fundamental authentication misunderstanding for OAuth providers, (4) missing type safety for provider mapping. The code cannot be merged in its current state.
- apps/dokploy/server/api/routers/destination.ts requires immediate attention to fix syntax error and rclone implementation

<sub>Last reviewed commit: b664fed</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->