### PR TITLE
fix: update Traefik middleware when basic auth credentials change

### DIFF
--- a/packages/server/src/services/security.ts
+++ b/packages/server/src/services/security.ts
@@ -90,6 +90,9 @@ export const updateSecurityById = async (
 	data: Partial<Security>,
 ) => {
 	try {
+		// Get the original record before update
+		const originalRecord = await findSecurityById(securityId);
+
 		const response = await db
 			.update(security)
 			.set({
@@ -97,6 +100,24 @@ export const updateSecurityById = async (
 			})
 			.where(eq(security.securityId, securityId))
 			.returning();
+
+		const updatedRecord = response[0];
+
+		// If username or password changed, update the Traefik middleware
+		if (
+			originalRecord &&
+			updatedRecord &&
+			(data.username !== originalRecord.username ||
+				data.password !== originalRecord.password)
+		) {
+			const application = await findApplicationById(
+				updatedRecord.applicationId,
+			);
+			// Remove old middleware first
+			await removeSecurityMiddleware(application, originalRecord);
+			// Create new middleware with updated credentials
+			await createSecurityMiddleware(application, updatedRecord);
+		}
 
 		return response[0];
 	} catch (error) {


### PR DESCRIPTION
## Summary

When updating basic auth username or password, the Traefik middleware configuration was not being updated.

This fix:
1. Gets the original record before update
2. If username or password changed, removes old middleware
3. Creates new middleware with updated credentials

Fixes #3749

## Testing

1. Create an application with basic auth
2. Update the basic auth password
3. Verify the Traefik middleware is updated with new credentials

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Traefik middleware was not being updated when basic auth credentials were changed. The fix retrieves the original record before update, then removes the old middleware and creates new middleware with updated credentials when username or password changes.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor inefficiency noted
- The logic correctly handles credential updates by removing old middleware and creating new one. The implementation is straightforward and addresses the reported issue. Score is 4 instead of 5 because the code unnecessarily updates middleware even when credentials haven't actually changed (user provides same values), though this is a minor inefficiency rather than a bug.
- No files require special attention

<sub>Last reviewed commit: ca0dc01</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->