### PR TITLE
fix: swap middleware order so stripPrefix runs before addPrefix

### DIFF
--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -137,14 +137,15 @@ export const createRouterConfig = async (
 	};
 
 	// Add path rewriting middleware if needed
-	if (internalPath && internalPath !== "/" && internalPath !== path) {
-		const pathMiddleware = `addprefix-${appName}-${uniqueConfigKey}`;
-		routerConfig.middlewares?.push(pathMiddleware);
-	}
-
+	// Strip path must come before add prefix so the prefix is applied to the stripped path
 	if (stripPath && path && path !== "/") {
 		const stripMiddleware = `stripprefix-${appName}-${uniqueConfigKey}`;
 		routerConfig.middlewares?.push(stripMiddleware);
+	}
+
+	if (internalPath && internalPath !== "/" && internalPath !== path) {
+		const pathMiddleware = `addprefix-${appName}-${uniqueConfigKey}`;
+		routerConfig.middlewares?.push(pathMiddleware);
 	}
 
 	if (entryPoint === "web" && https) {


### PR DESCRIPTION
Fixes #3709

When both Strip Path and Internal Path are configured on a domain, the `addPrefix` middleware was being pushed onto the middlewares array before `stripPrefix`. Since Traefik executes middlewares in array order, this caused the prefix to be added to the full unstripped path.

Swapped the two blocks so `stripPrefix` runs first, matching the documented behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Swapped middleware order in `packages/server/src/utils/traefik/domain.ts:140-149` so `stripPrefix` executes before `addPrefix`. When both Strip Path and Internal Path are configured, Traefik processes middlewares in array order, so the strip operation must happen first to remove the external path before the internal path is added.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple logic fix that corrects middleware execution order - no breaking changes, security issues, or complex logic introduced
- No files require special attention

<sub>Last reviewed commit: 05c80f4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->