### PR TITLE
fix: replace full lodash imports with per-function imports

### DIFF
--- a/apps/dokploy/components/dashboard/application/volume-backups/restore-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/restore-volume-backups.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import copy from "copy-to-clipboard";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { CheckIcon, ChevronsUpDown, Copy, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";

--- a/apps/dokploy/components/dashboard/database/backups/restore-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/restore-backup.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import copy from "copy-to-clipboard";
-import _ from "lodash";
+import debounce from "lodash/debounce";
 import {
 	CheckIcon,
 	ChevronsUpDown,
@@ -236,7 +236,7 @@ export const RestoreBackup = ({
 	const currentDatabaseType = form.watch("databaseType");
 	const metadata = form.watch("metadata");
 
-	const debouncedSetSearch = _.debounce((value: string) => {
+	const debouncedSetSearch = debounce((value: string) => {
 		setDebouncedSearchTerm(value);
 	}, 350);
 

--- a/apps/dokploy/components/dashboard/docker/logs/line-count-filter.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/line-count-filter.tsx
@@ -1,5 +1,5 @@
 import { Command as CommandPrimitive } from "cmdk";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { CheckIcon, Hash } from "lucide-react";
 import React, { useCallback, useRef } from "react";
 import { Badge } from "@/components/ui/badge";

--- a/apps/dokploy/components/dashboard/docker/logs/terminal-line.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/terminal-line.tsx
@@ -1,5 +1,5 @@
 import { FancyAnsi } from "fancy-ansi";
-import _ from "lodash";
+import escapeRegExp from "lodash/escapeRegExp";
 import { Badge } from "@/components/ui/badge";
 import {
 	Tooltip,
@@ -47,7 +47,7 @@ export function TerminalLine({ log, noTimestamp, searchTerm }: LogLineProps) {
 		}
 
 		const htmlContent = fancyAnsi.toHtml(text);
-		const searchRegex = new RegExp(`(${_.escapeRegExp(term)})`, "gi");
+		const searchRegex = new RegExp(`(${escapeRegExp(term)})`, "gi");
 
 		const modifiedContent = htmlContent.replace(
 			searchRegex,


### PR DESCRIPTION
## What is this PR about?

Importing the entire lodash library adds ~70kb to the bundle. Switch to specific imports (lodash/debounce, lodash/escapeRegExp) so only the used functions are included.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced full lodash imports with specific function imports (`lodash/debounce`, `lodash/escapeRegExp`) across 4 frontend component files to reduce bundle size by approximately 70kb.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward import refactoring with no logic changes - simply replacing full lodash imports with specific function imports, which is a best practice for bundle optimization
- No files require special attention

<sub>Last reviewed commit: 0b1c1e8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->