### PR TITLE
fix: use functional setState to avoid stale closures in show-billing

### DIFF
--- a/apps/dokploy/components/dashboard/settings/billing/show-billing.tsx
+++ b/apps/dokploy/components/dashboard/settings/billing/show-billing.tsx
@@ -1082,7 +1082,9 @@ export const ShowBilling = () => {
 																onClick={() => {
 																	if (serverQuantity <= 1) return;
 
-																	setServerQuantity(serverQuantity - 1);
+																	setServerQuantity((prev) =>
+																		prev <= 1 ? prev : prev - 1,
+																	);
 																}}
 															>
 																<MinusIcon className="h-4 w-4" />
@@ -1099,7 +1101,7 @@ export const ShowBilling = () => {
 															<Button
 																variant="outline"
 																onClick={() => {
-																	setServerQuantity(serverQuantity + 1);
+																	setServerQuantity((prev) => prev + 1);
 																}}
 															>
 																<PlusIcon className="h-4 w-4" />


### PR DESCRIPTION
## What is this PR about?

Direct reads of serverQuantity inside onClick handlers can produce stale values in closures. Use the callback form setState(prev => ...) so React always supplies the latest state value.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed stale closure issue by converting `setServerQuantity` calls to use functional setState pattern with `prev =>` callback, ensuring React always provides the latest state value.

- Changed decrement handler from `serverQuantity - 1` to `(prev) => prev <= 1 ? prev : prev - 1`
- Changed increment handler from `serverQuantity + 1` to `(prev) => prev + 1`
- This aligns with other instances in the same file that already use the functional form (lines 731, 753, 865-867, 890)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor refinement needed
- The functional setState pattern correctly addresses stale closure issues, which is a React best practice. However, there's one inconsistency where line 1083 still checks the stale `serverQuantity` value before calling setState - this check is now redundant since the functional setState handles the boundary condition. The button's disabled attribute already prevents invalid states, making this a low-risk issue.
- apps/dokploy/components/dashboard/settings/billing/show-billing.tsx:1083 - remove redundant stale closure check

<sub>Last reviewed commit: 29083c9</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->