### PR TITLE
fix: add error handling to dokploy restart notifications

### DIFF
--- a/packages/server/src/utils/notifications/dokploy-restart.ts
+++ b/packages/server/src/utils/notifications/dokploy-restart.ts
@@ -19,27 +19,28 @@ import {
 } from "./utils";
 
 export const sendDokployRestartNotifications = async () => {
-	const date = new Date();
-	const unixDate = ~~(Number(date) / 1000);
-	const notificationList = await db.query.notifications.findMany({
-		where: eq(notifications.dokployRestart, true),
-		with: {
-			email: true,
-			discord: true,
-			telegram: true,
-			slack: true,
-			resend: true,
-			gotify: true,
-			ntfy: true,
-			custom: true,
-			lark: true,
-			pushover: true,
-			teams: true,
-		},
-	});
+	try {
+		const date = new Date();
+		const unixDate = ~~(Number(date) / 1000);
+		const notificationList = await db.query.notifications.findMany({
+			where: eq(notifications.dokployRestart, true),
+			with: {
+				email: true,
+				discord: true,
+				telegram: true,
+				slack: true,
+				resend: true,
+				gotify: true,
+				ntfy: true,
+				custom: true,
+				lark: true,
+				pushover: true,
+				teams: true,
+			},
+		});
 
-	for (const notification of notificationList) {
-		const {
+		for (const notification of notificationList) {
+			const {
 			email,
 			resend,
 			discord,
@@ -267,5 +268,8 @@ export const sendDokployRestartNotifications = async () => {
 		} catch (error) {
 			console.log(error);
 		}
+		}
+	} catch (error) {
+		console.error("[Dokploy] Restart notifications failed:", error);
 	}
 };


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3673 #3553

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps the entire body of `sendDokployRestartNotifications` in a try-catch block to prevent unhandled exceptions (e.g., from a failed database query) from crashing the Dokploy server during startup. Previously, only individual notification sends were wrapped in try-catch, so a failure in the `db.query.notifications.findMany()` call would propagate up and could crash the server process. This addresses issues #3673 and #3553.

- **Outer try-catch added**: The database query and for-loop are now wrapped in a top-level try-catch that logs `"[Dokploy] Restart notifications failed:"` on failure, preventing server startup crashes.
- **Indentation inconsistency**: The inner block (destructuring, inner try-catch, and all notification logic from lines 44–270) was not re-indented after being wrapped in the new `try`, making the nesting structure visually misleading.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds protective error handling that prevents server crashes, with only a minor indentation inconsistency.
- The change is minimal and correct in its logic: wrapping the notification function body in a try-catch prevents unhandled promise rejections from crashing the server during startup. The only issue is cosmetic (inconsistent indentation), which doesn't affect runtime behavior.
- `packages/server/src/utils/notifications/dokploy-restart.ts` has inconsistent indentation in the for-loop body (lines 44–270) that should be cleaned up.

<sub>Last reviewed commit: e3aadf1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->