### PR TITLE
fix: use buildServerId for preview deployments

### DIFF
--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -431,9 +431,11 @@ export const deployPreviewApplication = async ({
 			});
 			command += await getBuildCommand(application);
 
+			const buildServerId =
+				application.buildServerId || application.serverId;
 			const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
-			if (application.serverId) {
-				await execAsyncRemote(application.serverId, commandWithLog);
+			if (buildServerId) {
+				await execAsyncRemote(buildServerId, commandWithLog);
 			} else {
 				await execAsync(commandWithLog);
 			}
@@ -541,7 +543,7 @@ export const rebuildPreviewApplication = async ({
 		application.rollbackRegistry = null;
 		application.registry = null;
 
-		const serverId = application.serverId;
+		const serverId = application.buildServerId || application.serverId;
 		let command = "set -e;";
 		// Only rebuild, don't clone repository
 		command += await getBuildCommand(application);

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -161,6 +161,10 @@ export const createDeploymentPreview = async (
 		deployment.previewDeploymentId,
 	);
 	try {
+		const buildServerId =
+			previewDeployment?.application?.buildServerId ||
+			previewDeployment?.application?.serverId;
+
 		await removeLastTenDeployments(
 			deployment.previewDeploymentId,
 			"previewDeployment",
@@ -168,15 +172,13 @@ export const createDeploymentPreview = async (
 		);
 
 		const appName = `${previewDeployment.appName}`;
-		const { LOGS_PATH } = paths(!!previewDeployment?.application?.serverId);
+		const { LOGS_PATH } = paths(!!buildServerId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");
 		const fileName = `${appName}-${formattedDateTime}.log`;
 		const logFilePath = path.join(LOGS_PATH, appName, fileName);
 
-		if (previewDeployment?.application?.serverId) {
-			const server = await findServerById(
-				previewDeployment?.application?.serverId,
-			);
+		if (buildServerId) {
+			const server = await findServerById(buildServerId);
 
 			const command = `
 				mkdir -p ${LOGS_PATH}/${appName};
@@ -200,6 +202,10 @@ export const createDeploymentPreview = async (
 				description: deployment.description || "",
 				previewDeploymentId: deployment.previewDeploymentId,
 				startedAt: new Date().toISOString(),
+				...(previewDeployment?.application?.buildServerId && {
+					buildServerId:
+						previewDeployment.application.buildServerId,
+				}),
 			})
 			.returning();
 		if (deploymentCreate.length === 0 || !deploymentCreate[0]) {


### PR DESCRIPTION
## Problem

Preview deployments always build on the application server (`serverId`), ignoring the configured build server (`buildServerId`). This is inconsistent with production deployments, which correctly use `buildServerId || serverId`.

This means users who set up a separate build server to offload resource-intensive builds still have preview builds running on their production server, potentially causing memory pressure and OOM issues.

**Related issues:** #3450

## Root Cause

In `packages/server/src/services/application.ts`:
- `deployPreviewApplication()` uses `application.serverId` directly
- `rebuildPreviewApplication()` uses `application.serverId` in the try block (interestingly, the catch block already uses the correct `application.buildServerId || application.serverId` pattern)

In `packages/server/src/services/deployment.ts`:
- `createDeploymentPreview()` uses `previewDeployment.application.serverId` for log path resolution and remote execution, and does not store `buildServerId` in the deployment record

Meanwhile, their production counterparts (`deployApplication()` and `createDeployment()`) correctly use the `buildServerId || serverId` fallback pattern.

## Changes

**`packages/server/src/services/application.ts`:**
- `deployPreviewApplication()`: resolve `buildServerId || serverId` before executing the build command remotely
- `rebuildPreviewApplication()`: change `const serverId = application.serverId` to `const serverId = application.buildServerId || application.serverId` (aligns try block with existing catch block)

**`packages/server/src/services/deployment.ts`:**
- `createDeploymentPreview()`: resolve `buildServerId` from the application, use it for `paths()`, `findServerById()`, and `execAsyncRemote()`. Store `buildServerId` in the deployment record (matching `createDeployment()` behavior)

## Behavior

- If `buildServerId` is configured: preview builds run on the build server
- If `buildServerId` is not configured: no change, builds run on the application server (same as before)
- Production deployments: unaffected

## Testing

Tested on a Dokploy v0.27.0 instance with a separate build server configured. Preview deployments now correctly execute on the build server and logs are written to the correct remote path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes preview deployments to respect the `buildServerId` configuration, aligning them with production deployment behavior. The changes ensure that when a separate build server is configured, preview builds execute on that server instead of incorrectly running on the application server.

**Key changes:**
- `deployPreviewApplication()`: now resolves `buildServerId || serverId` before remote execution
- `rebuildPreviewApplication()`: changed to use `buildServerId || serverId` consistently in both try and catch blocks
- `createDeploymentPreview()`: resolves `buildServerId` for log paths, remote execution, and stores it in deployment records

**Minor issue found:**
- Line 171 in `deployment.ts` still passes `serverId` to `removeLastTenDeployments()` instead of `buildServerId`, which could cause old logs to be cleaned up from the wrong server

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor fix needed
- The changes correctly implement `buildServerId` support for preview deployments and align well with the existing production deployment patterns. The logic is sound and the implementation is consistent. However, there's one logical issue at line 171 where old log cleanup uses `serverId` instead of `buildServerId`, which could cause logs to be deleted from the wrong server. This should be fixed before merging to ensure complete correctness.
- Pay close attention to `packages/server/src/services/deployment.ts` line 171

<sub>Last reviewed commit: 1e56fe7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->