### PR TITLE
feat: support Docker image source for preview deployments

### DIFF
--- a/apps/dokploy/server/api/routers/preview-deployment.ts
+++ b/apps/dokploy/server/api/routers/preview-deployment.ts
@@ -1,4 +1,5 @@
 import {
+	createPreviewDeploymentFromImage,
 	findApplicationById,
 	findPreviewDeploymentById,
 	findPreviewDeploymentsByApplicationId,
@@ -7,7 +8,10 @@ import {
 } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { apiFindAllByApplication } from "@/server/db/schema";
+import {
+	apiFindAllByApplication,
+	apiCreatePreviewDeploymentFromImage,
+} from "@/server/db/schema";
 import type { DeploymentJob } from "@/server/queues/queue-types";
 import { myQueue } from "@/server/queues/queueSetup";
 import { deploy } from "@/server/utils/deploy";
@@ -114,5 +118,62 @@ export const previewDeploymentRouter = createTRPCRouter({
 				},
 			);
 			return true;
+		}),
+	deployFromImage: protectedProcedure
+		.input(apiCreatePreviewDeploymentFromImage)
+		.mutation(async ({ input, ctx }) => {
+			const application = await findApplicationById(input.applicationId);
+			if (
+				application.environment.project.organizationId !==
+				ctx.session.activeOrganizationId
+			) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not authorized to access this application",
+				});
+			}
+
+			if (!application.isPreviewDeploymentsActive) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Preview deployments are not enabled for this application",
+				});
+			}
+
+			const { previewDeployment, previewDomain } =
+				await createPreviewDeploymentFromImage(input);
+
+			const jobData: DeploymentJob = {
+				applicationId: input.applicationId,
+				titleLog: `Deploy image: ${input.dockerImage}`,
+				descriptionLog: "",
+				type: "deploy",
+				applicationType: "application-preview",
+				previewDeploymentId: previewDeployment.previewDeploymentId,
+				server: !!application.serverId,
+			};
+
+			if (IS_CLOUD && application.serverId) {
+				jobData.serverId = application.serverId;
+				deploy(jobData).catch((error) => {
+					console.error("Background deployment failed:", error);
+				});
+				return {
+					previewDeploymentId: previewDeployment.previewDeploymentId,
+					previewDomain,
+				};
+			}
+			await myQueue.add(
+				"deployments",
+				{ ...jobData },
+				{
+					removeOnComplete: true,
+					removeOnFail: true,
+				},
+			);
+			return {
+				previewDeploymentId: previewDeployment.previewDeploymentId,
+				previewDomain,
+			};
 		}),
 });

--- a/packages/server/src/db/schema/preview-deployments.ts
+++ b/packages/server/src/db/schema/preview-deployments.ts
@@ -33,6 +33,7 @@ export const previewDeployments = pgTable("preview_deployments", {
 	domainId: text("domainId").references(() => domains.domainId, {
 		onDelete: "cascade",
 	}),
+	dockerImage: text("dockerImage"),
 	createdAt: text("createdAt")
 		.notNull()
 		.$defaultFn(() => new Date().toISOString()),
@@ -67,8 +68,16 @@ export const apiCreatePreviewDeployment = createSchema
 		pullRequestNumber: true,
 		pullRequestURL: true,
 		pullRequestTitle: true,
+		dockerImage: true,
 	})
 	.extend({
 		applicationId: z.string().min(1),
-		// deploymentId: z.string().min(1),
 	});
+
+export const apiCreatePreviewDeploymentFromImage = z.object({
+	applicationId: z.string().min(1),
+	dockerImage: z.string().min(1),
+	pullRequestNumber: z.string().optional(),
+	pullRequestTitle: z.string().optional(),
+	pullRequestURL: z.string().optional(),
+});

--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -430,10 +430,19 @@ export const deployPreviewApplication = async ({
 				branch: previewDeployment.branch,
 			});
 			command += await getBuildCommand(application);
+		} else if (application.sourceType === "docker") {
+			if (previewDeployment.dockerImage) {
+				application.dockerImage = previewDeployment.dockerImage;
+			}
+			command += await buildRemoteDocker(application);
+		}
 
+		if (command !== "set -e;") {
+			const buildServerId =
+				application.buildServerId || application.serverId;
 			const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
-			if (application.serverId) {
-				await execAsyncRemote(application.serverId, commandWithLog);
+			if (buildServerId) {
+				await execAsyncRemote(buildServerId, commandWithLog);
 			} else {
 				await execAsync(commandWithLog);
 			}
@@ -541,10 +550,17 @@ export const rebuildPreviewApplication = async ({
 		application.rollbackRegistry = null;
 		application.registry = null;
 
-		const serverId = application.serverId;
+		const serverId = application.buildServerId || application.serverId;
 		let command = "set -e;";
-		// Only rebuild, don't clone repository
-		command += await getBuildCommand(application);
+		if (application.sourceType === "docker") {
+			if (previewDeployment.dockerImage) {
+				application.dockerImage = previewDeployment.dockerImage;
+			}
+			command += await buildRemoteDocker(application);
+		} else {
+			// Only rebuild, don't clone repository
+			command += await getBuildCommand(application);
+		}
 		const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (serverId) {
 			await execAsyncRemote(serverId, commandWithLog);

--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -1,6 +1,7 @@
 import { db } from "@dokploy/server/db";
 import {
 	type apiCreatePreviewDeployment,
+	type apiCreatePreviewDeploymentFromImage,
 	deployments,
 	organization,
 	previewDeployments,
@@ -229,6 +230,96 @@ export const findPreviewDeploymentByApplicationId = async (
 	});
 
 	return previewDeploymentResult;
+};
+
+export const createPreviewDeploymentFromImage = async (
+	schema: typeof apiCreatePreviewDeploymentFromImage._type,
+) => {
+	const application = await findApplicationById(schema.applicationId);
+	const appName = `preview-${application.appName}-${generatePassword(6)}`;
+
+	const org = await db.query.organization.findFirst({
+		where: eq(organization.id, application.environment.project.organizationId),
+	});
+	const generateDomain = await generateWildcardDomain(
+		application.previewWildcard || "*.traefik.me",
+		appName,
+		application.server?.ipAddress || "",
+		org?.ownerId || "",
+	);
+
+	const previewDomain = `${application.previewHttps ? "https" : "http"}://${generateDomain}`;
+	let pullRequestCommentId = "";
+
+	// If a GitHub provider is configured and PR number is provided, post a comment
+	if (application.github && schema.pullRequestNumber) {
+		try {
+			const octokit = authGithub(application.github as Github);
+			const runningComment = getIssueComment(
+				application.name,
+				"initializing",
+				previewDomain,
+			);
+			const issue = await octokit.rest.issues.createComment({
+				owner: application.owner || "",
+				repo: application.repository || "",
+				issue_number: Number.parseInt(schema.pullRequestNumber),
+				body: `### Dokploy Preview Deployment\n\n${runningComment}`,
+			});
+			pullRequestCommentId = `${issue.data.id}`;
+		} catch (_error) {
+			// GitHub comment is optional for image-based previews
+		}
+	}
+
+	const previewDeployment = await db
+		.insert(previewDeployments)
+		.values({
+			applicationId: schema.applicationId,
+			appName: appName,
+			dockerImage: schema.dockerImage,
+			branch: "docker-image",
+			pullRequestId: schema.pullRequestNumber || "0",
+			pullRequestNumber: schema.pullRequestNumber || "0",
+			pullRequestURL: schema.pullRequestURL || "",
+			pullRequestTitle: schema.pullRequestTitle || `Preview: ${schema.dockerImage}`,
+			pullRequestCommentId: pullRequestCommentId || "0",
+		})
+		.returning()
+		.then((value) => value[0]);
+
+	if (!previewDeployment) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Error creating the preview deployment",
+		});
+	}
+
+	const newDomain = await createDomain({
+		host: generateDomain,
+		path: application.previewPath,
+		port: application.previewPort,
+		https: application.previewHttps,
+		certificateType: application.previewCertificateType,
+		customCertResolver: application.previewCustomCertResolver,
+		domainType: "preview",
+		previewDeploymentId: previewDeployment.previewDeploymentId,
+	});
+
+	application.appName = appName;
+	await manageDomain(application, newDomain);
+
+	await db
+		.update(previewDeployments)
+		.set({ domainId: newDomain.domainId })
+		.where(
+			eq(
+				previewDeployments.previewDeploymentId,
+				previewDeployment.previewDeploymentId,
+			),
+		);
+
+	return { previewDeployment, previewDomain };
 };
 
 const generateWildcardDomain = async (


### PR DESCRIPTION
## Problem

Preview deployments currently only work with `sourceType: "github"`. Applications using Docker images (`sourceType: "docker"`) have their preview builds silently skipped. Additionally, there is no way for external CI/CD pipelines (GitHub Actions, GitLab CI, etc.) to trigger preview deployments with pre-built Docker images.

This means users who want to offload builds to CI/CD runners -- or who use Docker image registries as their deployment source -- cannot use preview deployments at all.

**Related issues:** #2386, #1365

## Solution

### 1. Docker source type support in preview deploy/rebuild

`deployPreviewApplication()` now handles `sourceType === "docker"` alongside the existing `"github"` branch:

```typescript
if (application.sourceType === "github") {
  // existing: clone + build
} else if (application.sourceType === "docker") {
  // new: docker pull (via buildRemoteDocker)
}
```

Same pattern added to `rebuildPreviewApplication()`.

Both functions also include the `buildServerId` fix from #3781.

### 2. Per-preview Docker image override

New `dockerImage` column on `preview_deployments` table allows each preview to use a different Docker image tag (e.g., `ghcr.io/org/app:pr-42`), independent of the parent application's `dockerImage`.

### 3. New API endpoint: `previewDeployment.deployFromImage`

New tRPC procedure that enables external CI/CD to trigger preview deployments:

```typescript
// Input
{
  applicationId: string;   // required
  dockerImage: string;     // required (e.g., "ghcr.io/org/app:pr-42")
  pullRequestNumber?: string;  // optional: enables PR comment
  pullRequestTitle?: string;
  pullRequestURL?: string;
}

// Output
{
  previewDeploymentId: string;
  previewDomain: string;   // e.g., "https://preview-myapp-abc123.traefik.me"
}
```

The function:
- Creates a preview deployment record with domain and Traefik configuration
- Optionally posts a GitHub PR comment if a GitHub provider is configured and PR number is provided
- Queues the deployment job (docker pull + mechanize container)
- Returns the preview URL immediately

### Example GitHub Actions workflow

```yaml
on:
  pull_request:
    types: [opened, synchronize]

jobs:
  preview:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: docker/login-action@v3
        with:
          registry: ghcr.io
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}
      - uses: docker/build-push-action@v5
        with:
          push: true
          tags: ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}
      - name: Deploy preview
        run: |
          curl -X POST "${{ secrets.DOKPLOY_URL }}/api/trpc/previewDeployment.deployFromImage" \
            -H "x-api-key: ${{ secrets.DOKPLOY_API_KEY }}" \
            -H "Content-Type: application/json" \
            -d '{
              "json": {
                "applicationId": "...",
                "dockerImage": "ghcr.io/${{ github.repository }}:pr-${{ github.event.pull_request.number }}",
                "pullRequestNumber": "${{ github.event.pull_request.number }}",
                "pullRequestTitle": "${{ github.event.pull_request.title }}"
              }
            }'
```

## Changes

| File | Change |
|---|---|
| `packages/server/src/db/schema/preview-deployments.ts` | Add `dockerImage` column, new `apiCreatePreviewDeploymentFromImage` Zod schema |
| `packages/server/src/services/application.ts` | Handle docker sourceType in `deployPreviewApplication` and `rebuildPreviewApplication`, include buildServerId fix |
| `packages/server/src/services/preview-deployment.ts` | New `createPreviewDeploymentFromImage()` function |
| `apps/dokploy/server/api/routers/preview-deployment.ts` | New `deployFromImage` tRPC procedure |

## Behavior

- **Docker source applications**: preview deployments now work (previously silently skipped)
- **GitHub source applications**: no change to existing behavior
- **External CI/CD**: can trigger preview deployments via `deployFromImage` API
- **PR comments**: optional -- posted when GitHub provider is configured and PR number is provided
- **Cleanup**: existing PR close webhook handles preview cleanup as before

## Testing

Tested on a Dokploy v0.27.0 instance with Docker source type applications and GitHub Actions triggered previews.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Docker image source support for preview deployments, enabling external CI/CD pipelines to trigger previews with pre-built images. Also includes `buildServerId` fix for remote builds.

**Critical Issue Found:**
- Docker-based preview deployments will crash when GitHub is not configured because `deployPreviewApplication()` and `rebuildPreviewApplication()` unconditionally call GitHub comment APIs (`issueCommentExists()`, `updateIssueComment()`), which throw errors when `githubId` is empty

**Changes:**
- Added `dockerImage` column to `preview_deployments` table for per-preview Docker image overrides
- Extended `deployPreviewApplication()` and `rebuildPreviewApplication()` to handle `sourceType === "docker"` via `buildRemoteDocker()`
- New `createPreviewDeploymentFromImage()` service function with optional GitHub comment support
- New `deployFromImage` tRPC endpoint for API-triggered preview deployments
- Included `buildServerId` fix from #3781

**Missing:**
- No database migration file for the new `dockerImage` column (need to run `pnpm migration:generate`)
- All GitHub comment operations in `deployPreviewApplication()` and `rebuildPreviewApplication()` must be wrapped in `if (application?.githubId)` checks to prevent crashes for Docker-only applications

<h3>Confidence Score: 1/5</h3>

- This PR will cause deployments to crash for Docker-based applications without GitHub configuration
- The core functionality is well-designed, but there's a critical bug that will break the main use case: Docker-based preview deployments always attempt to update GitHub comments even when GitHub isn't configured, causing `findGithubById("")` to throw NOT_FOUND errors and crash the deployment. This affects both `deployPreviewApplication()` and `rebuildPreviewApplication()` functions in 6+ locations.
- Pay close attention to `packages/server/src/services/application.ts` - all GitHub comment operations need conditional checks before the PR can be safely merged

<sub>Last reviewed commit: d37ab6c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->