### PR TITLE
fix: GitLab OAuth callback ignores Internal URL, attempts HTTPS causing ECONNREFUSED

### DIFF
--- a/apps/dokploy/pages/api/providers/gitlab/callback.ts
+++ b/apps/dokploy/pages/api/providers/gitlab/callback.ts
@@ -26,7 +26,7 @@ export default async function handler(
 		headers.Authorization = `Basic ${Buffer.from(`${gitlabUrl.username}:${gitlabUrl.password}`).toString("base64")}`;
 	}
 
-	const url = gitlabUrl.origin;
+	const url = gitlabUrl.origin + gitlabUrl.pathname.replace(/\/$/, "");
 
 	const response = await fetch(`${url}/oauth/token`, {
 		method: "POST",

--- a/apps/dokploy/pages/api/providers/gitlab/callback.ts
+++ b/apps/dokploy/pages/api/providers/gitlab/callback.ts
@@ -26,18 +26,12 @@ export default async function handler(
 		headers.Authorization = `Basic ${Buffer.from(`${gitlabUrl.username}:${gitlabUrl.password}`).toString("base64")}`;
 	}
 
-	const url =
-		gitlabUrl.username && gitlabUrl.password
-			? new URL(gitlabUrl, {
-					...gitlabUrl,
-					username: "",
-					password: "",
-				}).toString()
-			: gitlabUrl.toString();
+	const url = gitlabUrl.origin;
 
 	const response = await fetch(`${url}/oauth/token`, {
 		method: "POST",
 		headers,
+		redirect: "manual",
 		body: new URLSearchParams({
 			client_id: gitlab.applicationId as string,
 			client_secret: gitlab.secret as string,
@@ -46,6 +40,12 @@ export default async function handler(
 			redirect_uri: `${gitlab.redirectUri}?gitlabId=${gitlabId}`,
 		}),
 	});
+
+	if (!response.ok) {
+		return res.status(response.status).json({
+			error: `GitLab token exchange failed: ${response.statusText}`,
+		});
+	}
 
 	const result = await response.json();
 

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -25,7 +25,7 @@ export const refreshGitlabToken = async (gitlabProviderId: string) => {
 	// Use internal URL for token refresh when GitLab is on same instance as Dokploy
 	const baseUrl = gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl;
 	const tokenUrl = new URL(baseUrl);
-	const response = await fetch(`${tokenUrl.origin}/oauth/token`, {
+	const response = await fetch(`${tokenUrl.origin}${tokenUrl.pathname.replace(/\/$/, "")}/oauth/token`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/x-www-form-urlencoded",

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -24,11 +24,13 @@ export const refreshGitlabToken = async (gitlabProviderId: string) => {
 
 	// Use internal URL for token refresh when GitLab is on same instance as Dokploy
 	const baseUrl = gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl;
-	const response = await fetch(`${baseUrl}/oauth/token`, {
+	const tokenUrl = new URL(baseUrl);
+	const response = await fetch(`${tokenUrl.origin}/oauth/token`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/x-www-form-urlencoded",
 		},
+		redirect: "manual",
 		body: new URLSearchParams({
 			grant_type: "refresh_token",
 			refresh_token: gitlabProvider.refreshToken as string,


### PR DESCRIPTION
## What is this PR about?

When a self-hosted GitLab is configured with an Internal URL (e.g., `http://gitlab`), the OAuth callback token exchange and token refresh still attempt to connect via HTTPS (port 443), resulting in `ECONNREFUSED`.

Root causes:

1. **Buggy URL constructor** — `new URL(gitlabUrl, {...gitlabUrl, username: "", password: ""})` passed an object as the `base` parameter (coerced to `"[object Object]"`), making credential stripping ineffective.

2. **Trailing slash causing double-slash path** — `URL.toString()` appends a trailing slash (e.g., `"http://gitlab/"`), so the token endpoint became `"http://gitlab//oauth/token"`. This could trigger GitLab's nginx to redirect to the HTTPS `external_url`. Since `fetch` follows redirects by default, it would attempt port 443 internally.

Fix: use `URL.origin` for a clean protocol+host without trailing slash or credentials, and add `redirect: "manual"` to prevent fetch from silently following redirects to unreachable HTTPS endpoints. Also add error handling for non-OK responses.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3848

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes GitLab OAuth callback failures when using internal URLs by preventing automatic HTTPS redirects and cleaning up URL construction. The key improvements are:

- Replaced buggy URL credential-stripping logic with cleaner approach
- Added `redirect: "manual"` to prevent fetch from following redirects to unreachable HTTPS endpoints
- Added error handling for non-OK responses before JSON parsing

However, **using `URL.origin` strips the pathname component**, which will break GitLab installations hosted at subpaths (e.g., `http://example.com/gitlab`). The fix should use `URL.origin + URL.pathname.replace(/\/$/, "")` instead to preserve the path while removing credentials and trailing slashes.

Other endpoints in the codebase (API calls at lines 222 and 300 in `gitlab.ts`, OAuth authorize at line 51 in `show-git-providers.tsx`) expect `gitlabUrl` to include the full base path, confirming that subpath installations should be supported.

<h3>Confidence Score: 2/5</h3>

- This PR fixes the reported issue but introduces a regression for GitLab subpath installations
- While the PR correctly addresses HTTPS redirect issues for domain-root GitLab installations and improves error handling, using `URL.origin` strips pathname components, breaking compatibility with GitLab instances hosted at subpaths (e.g., `http://example.com/gitlab`). The rest of the codebase expects `gitlabUrl` to include paths, making this a functional regression despite fixing the immediate issue.
- Both changed files need the `URL.origin` usage updated to preserve pathname components

<sub>Last reviewed commit: a757c9c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->