### PR TITLE
 fix: tolerate zip exit code 18 in web server backup

### DIFF
--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -9,7 +9,7 @@ import {
 	updateDeploymentStatus,
 } from "@dokploy/server/services/deployment";
 import { findDestinationById } from "@dokploy/server/services/destination";
-import { execAsync } from "../process/execAsync";
+import { execAsync, ExecError } from "../process/execAsync";
 import { getS3Credentials, normalizeS3Path } from "./utils";
 
 export const runWebServerBackup = async (backup: BackupSchedule) => {
@@ -72,10 +72,17 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 
 			writeStream.write("Copied filesystem to temp directory\n");
 
-			await execAsync(
-				// Zip all .sql files since we created more than one
-				`cd ${tempDir} && zip -r ${backupFileName} *.sql filesystem/ > /dev/null 2>&1`,
-			);
+			try {
+				await execAsync(
+					`cd ${tempDir} && zip -r ${backupFileName} *.sql filesystem/ > /dev/null 2>&1`,
+				);
+			} catch (error) {
+				// zip exit code 18 = "completed with warnings, some files not readable"
+				// This happens when sockets/pipes exist under /etc/dokploy/ — the archive is still valid
+				if (!(error instanceof ExecError && error.exitCode === 18)) {
+					throw error;
+				}
+			}
 
 			writeStream.write("Zipped database and filesystem\n");
 


### PR DESCRIPTION
Addresses this issue: https://github.com/Dokploy/dokploy/issues/3853

The `zip` command exits with code 18 ("completed with warnings, some files not readable"), which `execAsync` treats as a fatal error — even though

The fix is to wrap the zip `execAsync` call in a try/catch that tolerates exit code 18 specifically. All other non-zero exit codes still throw as before

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wrapped the zip command in a try/catch block to specifically tolerate exit code 18 (warnings about unreadable files like sockets/pipes), allowing backups to succeed despite non-critical warnings. All other errors continue to be thrown as expected. The fix correctly imports `ExecError` and uses proper instanceof checking with the exit code comparison.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a focused, well-implemented fix that addresses the specific issue without introducing new risks. The error handling is correct and preserves all other error conditions.
- No files require special attention

<sub>Last reviewed commit: 245ad90</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->