### PR TITLE
fix(backups): Fix deleting all backups instead of keeping n latest

### DIFF
--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -11,7 +11,7 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, scheduleBackup } from "./utils";
+import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -117,10 +117,8 @@ export const keepLatestNBackups = async (
 
 	try {
 		const rcloneFlags = getS3Credentials(backup.destination);
-		const backupFilesPath = path.join(
-			`:s3:${backup.destination.bucket}`,
-			backup.prefix,
-		);
+		const normalizedPrefix = normalizeS3Path(backup.prefix);
+		const backupFilesPath = `:s3:${backup.destination.bucket}/${normalizedPrefix}`;
 
 		// --include "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
 		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".sql.gz"}" ${backupFilesPath}`;


### PR DESCRIPTION
## What is this PR about?

Fix backup deleting all existing backups, not just the x latest.

Described in the issue https://github.com/Dokploy/dokploy/issues/3855

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3855 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where `path.join()` was used to construct S3 paths in the backup cleanup logic. The Node.js `path.join()` function is designed for filesystem paths and causes issues with S3 URLs: if the prefix contains a leading slash, `path.join()` treats it as an absolute path and discards the bucket portion, resulting in an invalid S3 path. This could cause rclone to fail or behave incorrectly when deleting old backups.

The fix:
- Imports and uses `normalizeS3Path()` which properly handles S3 path semantics (removes leading/trailing slashes, adds trailing slash)
- Constructs the S3 path with template literals instead of `path.join()`
- Ensures cross-platform compatibility and correct S3 path formatting

No issues found. The implementation is clean and the `normalizeS3Path()` function properly handles edge cases.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted bug fix that replaces filesystem path logic with proper S3 path handling
- The fix directly addresses a specific bug by replacing `path.join()` (designed for filesystem paths) with `normalizeS3Path()` (designed for S3 paths). The implementation is straightforward, uses existing utility functions, and doesn't introduce new complexity or side effects. The change is well-scoped to the problematic code path.
- No files require special attention

<sub>Last reviewed commit: bf9d019</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->