### PR TITLE
feat: enhance request logging display with formatted status and duration

### DIFF
--- a/apps/dokploy/components/dashboard/requests/columns.tsx
+++ b/apps/dokploy/components/dashboard/requests/columns.tsx
@@ -6,6 +6,9 @@ import { Button } from "@/components/ui/button";
 import type { LogEntry } from "./show-requests";
 
 export const getStatusColor = (status: number) => {
+	if (status === 0) {
+		return "secondary";
+	}
 	if (status >= 100 && status < 200) {
 		return "outline";
 	}
@@ -19,6 +22,24 @@ export const getStatusColor = (status: number) => {
 		return "destructive";
 	}
 	return "destructive";
+};
+
+const formatStatusLabel = (status: number) => {
+	if (status === 0) {
+		return "N/A";
+	}
+	return status;
+};
+
+const formatDuration = (nanos: number) => {
+	const ms = nanos / 1000000;
+	if (ms < 1) {
+		return `${(nanos / 1000).toFixed(2)} µs`;
+	}
+	if (ms < 1000) {
+		return `${ms.toFixed(2)} ms`;
+	}
+	return `${(ms / 1000).toFixed(2)} s`;
 };
 
 export const columns: ColumnDef<LogEntry>[] = [
@@ -59,10 +80,10 @@ export const columns: ColumnDef<LogEntry>[] = [
 					</div>
 					<div className="flex flex-row gap-3 w-full">
 						<Badge variant={getStatusColor(log.OriginStatus)}>
-							Status: {log.OriginStatus}
+							Status: {formatStatusLabel(log.OriginStatus)}
 						</Badge>
 						<Badge variant={"secondary"}>
-							Exec Time: {`${log.Duration / 1000000000}s`}
+							Exec Time: {formatDuration(log.Duration)}
 						</Badge>
 						<Badge variant={"secondary"}>IP: {log.ClientAddr}</Badge>
 					</div>

--- a/apps/dokploy/components/dashboard/requests/requests-table.tsx
+++ b/apps/dokploy/components/dashboard/requests/requests-table.tsx
@@ -152,7 +152,15 @@ export const RequestsTable = ({ dateRange }: RequestsTableProps) => {
 			return JSON.stringify(value, null, 2);
 		}
 		if (key === "Duration" || key === "OriginDuration" || key === "Overhead") {
-			return `${value / 1000000000} s`;
+			const nanos = Number(value);
+			const ms = nanos / 1000000;
+			if (ms < 1) {
+				return `${(nanos / 1000).toFixed(2)} µs`;
+			}
+			if (ms < 1000) {
+				return `${ms.toFixed(2)} ms`;
+			}
+			return `${(ms / 1000).toFixed(2)} s`;
 		}
 		if (key === "level") {
 			return <Badge variant="secondary">{value}</Badge>;
@@ -161,7 +169,11 @@ export const RequestsTable = ({ dateRange }: RequestsTableProps) => {
 			return <Badge variant="outline">{value}</Badge>;
 		}
 		if (key === "DownstreamStatus" || key === "OriginStatus") {
-			return <Badge variant={getStatusColor(value)}>{value}</Badge>;
+			const num = Number(value);
+			if (num === 0) {
+				return <Badge variant="secondary">N/A</Badge>;
+			}
+			return <Badge variant={getStatusColor(num)}>{value}</Badge>;
 		}
 		return value;
 	};

--- a/apps/dokploy/components/ui/command.tsx
+++ b/apps/dokploy/components/ui/command.tsx
@@ -13,7 +13,7 @@ const Command = React.forwardRef<
 	<CommandPrimitive
 		ref={ref}
 		className={cn(
-			"flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+			"flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground p-px",
 			className,
 		)}
 		{...props}
@@ -44,7 +44,7 @@ const CommandInput = React.forwardRef<
 		<CommandPrimitive.Input
 			ref={ref}
 			className={cn(
-				"flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+				"flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0 focus-visible:ring-inset",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
Added helper functions to format status labels and execution durations in the requests dashboard. Updated the display logic to show "N/A" for zero status and improved duration representation in microseconds and milliseconds. This enhances the clarity and usability of the request logs for better monitoring and analysis.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3851
## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the request logging display in the dashboard by replacing the raw nanosecond-to-seconds conversion with a human-readable formatter (`formatDuration`) that auto-scales to µs, ms, or s, and by adding a `formatStatusLabel` helper that shows "N/A" instead of `0` for unknown HTTP statuses. A minor accessibility touch-up to `command.tsx` is also included.

**Key changes:**
- `columns.tsx`: New `formatStatusLabel` and `formatDuration` helper functions; `getStatusColor` now explicitly handles status `0` with the `"secondary"` variant.
- `requests-table.tsx`: `formatValue` updated to use the same duration scaling and `N/A` status display in the detail sheet.
- `command.tsx`: Adds `p-px` padding to the `Command` wrapper and a `focus-visible` ring to `CommandInput` for better keyboard accessibility.

**One maintainability concern:** The `formatDuration` logic is defined privately in `columns.tsx` and then copied verbatim into `requests-table.tsx`. Exporting it from a single location would eliminate the duplication and keep both displays in sync automatically.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; all logic changes are additive display improvements with no impact on data handling or server-side behaviour.
- The duration math is correct across all three scaling tiers, the status "N/A" guard is consistently applied in both display paths, and the command.tsx change is a low-risk accessibility tweak. The only issue is a style concern: the `formatDuration` function is duplicated rather than shared, which could lead to drift if thresholds or formatting are changed in the future.
- No files require special attention.

<sub>Last reviewed commit: 964e3c4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->