### PR TITLE
fix: prevent self-reinforcing error loop in deployment creation

### DIFF
--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -581,9 +581,7 @@ export const removeDeployment = async (
 		return deployment;
 	} catch (error) {
 		const message =
-			error instanceof Error
-				? error.message
-				: "Error removing the deployment";
+			error instanceof Error ? error.message : "Error removing the deployment";
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message,
@@ -846,11 +844,7 @@ export const removeLastFiveDeployments = async (serverId: string) => {
 		for (const oldDeployment of deploymentsToDelete) {
 			try {
 				const logPath = path.join(oldDeployment.logPath);
-				if (
-					existsSync(logPath) &&
-					logPath !== "." &&
-					logPath !== "none"
-				) {
+				if (existsSync(logPath) && logPath !== "." && logPath !== "none") {
 					await fsPromises.unlink(logPath);
 				}
 				await removeDeployment(oldDeployment.deploymentId);

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -135,7 +135,7 @@ export const createDeployment = async (
 				applicationId: deployment.applicationId,
 				title: deployment.title || "Deployment",
 				status: "error",
-				logPath: "",
+				logPath: "none",
 				description: deployment.description || "",
 				errorMessage: `An error have occured: ${error instanceof Error ? error.message : error}`,
 				startedAt: new Date().toISOString(),
@@ -216,7 +216,7 @@ export const createDeploymentPreview = async (
 				previewDeploymentId: deployment.previewDeploymentId,
 				title: deployment.title || "Deployment",
 				status: "error",
-				logPath: "",
+				logPath: "none",
 				description: deployment.description || "",
 				errorMessage: `An error have occured: ${error instanceof Error ? error.message : error}`,
 				startedAt: new Date().toISOString(),
@@ -293,7 +293,7 @@ echo "Initializing deployment\n" >> ${logFilePath};
 				composeId: deployment.composeId,
 				title: deployment.title || "Deployment",
 				status: "error",
-				logPath: "",
+				logPath: "none",
 				description: deployment.description || "",
 				errorMessage: `An error have occured: ${error instanceof Error ? error.message : error}`,
 				startedAt: new Date().toISOString(),
@@ -377,7 +377,7 @@ echo "Initializing backup\n" >> ${logFilePath};
 				backupId: deployment.backupId,
 				title: deployment.title || "Backup",
 				status: "error",
-				logPath: "",
+				logPath: "none",
 				description: deployment.description || "",
 				errorMessage: `An error have occured: ${error instanceof Error ? error.message : error}`,
 				startedAt: new Date().toISOString(),
@@ -452,7 +452,7 @@ export const createDeploymentSchedule = async (
 				scheduleId: deployment.scheduleId,
 				title: deployment.title || "Deployment",
 				status: "error",
-				logPath: "",
+				logPath: "none",
 				description: deployment.description || "",
 				errorMessage: `An error have occured: ${error instanceof Error ? error.message : error}`,
 				startedAt: new Date().toISOString(),
@@ -537,7 +537,7 @@ export const createDeploymentVolumeBackup = async (
 				volumeBackupId: deployment.volumeBackupId,
 				title: deployment.title || "Deployment",
 				status: "error",
-				logPath: "",
+				logPath: "none",
 				description: deployment.description || "",
 				errorMessage: `An error have occured: ${error instanceof Error ? error.message : error}`,
 				startedAt: new Date().toISOString(),
@@ -552,7 +552,9 @@ export const createDeploymentVolumeBackup = async (
 	}
 };
 
-export const removeDeployment = async (deploymentId: string) => {
+export const removeDeployment = async (
+	deploymentId: string,
+): Promise<Deployment | undefined> => {
 	try {
 		const deployment = await db
 			.delete(deployments)
@@ -561,24 +563,27 @@ export const removeDeployment = async (deploymentId: string) => {
 			.then((result) => result[0]);
 
 		if (!deployment) {
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: "Deployment not found",
-			});
+			return undefined;
 		}
-		const command = `
-			rm -f ${deployment.logPath};
-		`;
-		if (deployment.serverId) {
-			await execAsyncRemote(deployment.serverId, command);
-		} else {
-			await execAsync(command);
+		if (
+			deployment.logPath &&
+			deployment.logPath !== "." &&
+			deployment.logPath !== "none"
+		) {
+			const command = `rm -f ${deployment.logPath};`;
+			if (deployment.serverId) {
+				await execAsyncRemote(deployment.serverId, command);
+			} else {
+				await execAsync(command);
+			}
 		}
 
 		return deployment;
 	} catch (error) {
 		const message =
-			error instanceof Error ? error.message : "Error creating the deployment";
+			error instanceof Error
+				? error.message
+				: "Error removing the deployment";
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message,
@@ -646,34 +651,49 @@ const removeLastTenDeployments = async (
 		if (serverId) {
 			let command = "";
 			for (const oldDeployment of deploymentsToDelete) {
-				const logPath = path.join(oldDeployment.logPath);
-				if (oldDeployment.rollbackId) {
-					await removeRollbackById(oldDeployment.rollbackId);
-				}
+				try {
+					const logPath = path.join(oldDeployment.logPath);
+					if (oldDeployment.rollbackId) {
+						await removeRollbackById(oldDeployment.rollbackId);
+					}
 
-				if (logPath !== ".") {
-					command += `
-					rm -rf ${logPath};
-					`;
+					if (logPath !== "." && logPath !== "none") {
+						command += `rm -rf ${logPath};\n`;
+					}
+					await removeDeployment(oldDeployment.deploymentId);
+				} catch (error) {
+					console.error(
+						`Failed to remove old deployment ${oldDeployment.deploymentId}:`,
+						error,
+					);
 				}
-				await removeDeployment(oldDeployment.deploymentId);
 			}
 
-			await execAsyncRemote(serverId, command);
+			if (command.trim()) {
+				await execAsyncRemote(serverId, command);
+			}
 		} else {
 			for (const oldDeployment of deploymentsToDelete) {
-				if (oldDeployment.rollbackId) {
-					await removeRollbackById(oldDeployment.rollbackId);
+				try {
+					if (oldDeployment.rollbackId) {
+						await removeRollbackById(oldDeployment.rollbackId);
+					}
+					const logPath = path.join(oldDeployment.logPath);
+					if (
+						existsSync(logPath) &&
+						!oldDeployment.errorMessage &&
+						logPath !== "." &&
+						logPath !== "none"
+					) {
+						await fsPromises.unlink(logPath);
+					}
+					await removeDeployment(oldDeployment.deploymentId);
+				} catch (error) {
+					console.error(
+						`Failed to remove old deployment ${oldDeployment.deploymentId}:`,
+						error,
+					);
 				}
-				const logPath = path.join(oldDeployment.logPath);
-				if (
-					existsSync(logPath) &&
-					!oldDeployment.errorMessage &&
-					logPath !== "."
-				) {
-					await fsPromises.unlink(logPath);
-				}
-				await removeDeployment(oldDeployment.deploymentId);
 			}
 		}
 	}
@@ -824,11 +844,22 @@ export const removeLastFiveDeployments = async (serverId: string) => {
 	if (deploymentList.length >= 5) {
 		const deploymentsToDelete = deploymentList.slice(4);
 		for (const oldDeployment of deploymentsToDelete) {
-			const logPath = path.join(oldDeployment.logPath);
-			if (existsSync(logPath)) {
-				await fsPromises.unlink(logPath);
+			try {
+				const logPath = path.join(oldDeployment.logPath);
+				if (
+					existsSync(logPath) &&
+					logPath !== "." &&
+					logPath !== "none"
+				) {
+					await fsPromises.unlink(logPath);
+				}
+				await removeDeployment(oldDeployment.deploymentId);
+			} catch (error) {
+				console.error(
+					`Failed to remove old deployment ${oldDeployment.deploymentId}:`,
+					error,
+				);
 			}
-			await removeDeployment(oldDeployment.deploymentId);
 		}
 	}
 };


### PR DESCRIPTION
## Summary

Fixes #3752

A transient failure during `removeLastTenDeployments()` (called at the start of every `createDeployment()`) creates a **permanent, self-reinforcing error loop** that prevents all future deployments for the affected application.

### Root Cause

1. `createDeployment()` calls `removeLastTenDeployments()` first
2. If any old deployment removal fails (e.g. transient DB/network error), the catch block inserts an error deployment record with `logPath: ""`
3. `path.join("")` returns `"."`, so the `logPath !== "."` guard is bypassed
4. On the next deploy attempt, `removeLastTenDeployments()` tries to clean up this poisoned record
5. `removeDeployment()` runs `rm -f .` (or `rm -f` with empty string) which fails
6. The failure triggers the catch block again, inserting another error record with `logPath: ""`
7. **The error count grows by 1+ on every attempt**, and the application can never deploy again

### Changes

**1. Make `removeDeployment()` idempotent**
- Return `undefined` instead of throwing when a deployment is already deleted (race condition / concurrent cleanup)
- Guard against empty/invalid `logPath` before running shell `rm -f` command
- Fix copy-paste error: `"Error creating the deployment"` → `"Error removing the deployment"`

**2. Make `removeLastTenDeployments()` resilient**
- Wrap each individual deployment removal in its own try-catch
- Log errors with `console.error` (including deployment ID) but don't propagate
- Guard `execAsyncRemote` against empty command strings
- Cleanup of old records should never block creation of new deployments

**3. Make `removeLastFiveDeployments()` resilient**
- Same try-catch pattern for server deployment cleanup
- Add `logPath !== "."` and `logPath !== "none"` guards (consistent with `removeLastTenDeployments`)

**4. Fix poisoned `logPath: ""` in error records**
- Change `logPath: ""` to `logPath: "none"` in all catch blocks of:
  - `createDeployment()`
  - `createDeploymentPreview()`
  - `createDeploymentCompose()`
  - `createDeploymentBackup()`
  - `createDeploymentSchedule()`
  - `createDeploymentVolumeBackup()`
- Update `removeDeployment()` logPath guard to also skip `"none"`

### How to Reproduce

1. Deploy an application with >10 deployment records
2. Simulate a transient failure during `removeLastTenDeployments()` (e.g. DB connection timeout)
3. Observe error deployment record created with `logPath: ""`
4. Attempt to deploy again — it will fail permanently with "Error creating the deployment"
5. Each retry adds more error records, making recovery progressively harder

### Verification

- `pnpm check` passes (Biome formatting/linting)
- `pnpm --filter=server typecheck` passes (TypeScript)
- `removeDeployment` return type changes from `Deployment` to `Deployment | undefined` — no callers use the return value from cleanup paths

## Test Plan

- [ ] Verify `pnpm check` passes
- [ ] Verify `pnpm --filter=server typecheck` passes
- [ ] Manual test: deploy an application normally (no regression)
- [ ] Manual test: insert a deployment record with `logPath: ""` or `logPath: "none"`, verify next deployment succeeds instead of looping
- [ ] Review: confirm no callers depend on `removeDeployment` throwing when already deleted

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical self-reinforcing error loop that permanently blocked deployments after transient failures.

**Key Changes:**
- Changed error deployment records from `logPath: ""` to `logPath: "none"` to prevent `path.join("")` returning `"."`, which bypassed safety guards and caused `rm -f .` commands to fail
- Made `removeDeployment()` idempotent by returning `undefined` instead of throwing when deployment already deleted (handles race conditions in concurrent cleanup)
- Added resilient error handling in `removeLastTenDeployments()` and `removeLastFiveDeployments()` - each deployment removal is wrapped in try-catch, logged on failure, but doesn't block cleanup of other deployments
- Added guards to prevent file operations on empty, `"."`, or `"none"` paths before executing shell commands
- Added safety check to skip `execAsyncRemote()` when command string is empty

**Impact:**
The fix prevents a scenario where a single transient failure during deployment cleanup creates a poisoned database record that causes all subsequent deployments to fail, with the error count growing on each attempt. The changes make the system self-healing by ensuring cleanup operations never block new deployments.

**API Note:**
The `deployment.removeDeployment` tRPC endpoint now returns `Deployment | undefined` instead of throwing when the deployment doesn't exist. This makes the endpoint idempotent and the frontend handles this correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it fixes a critical production bug with well-designed defensive changes
- Score reflects: (1) clear identification and fix of root cause, (2) consistent implementation across all affected functions with proper guards, (3) improved error isolation prevents cascading failures, (4) type changes are backward compatible in practice, (5) changes are focused and don't introduce new complexity
- No files require special attention - the single modified file contains focused, well-structured changes

<sub>Last reviewed commit: bf1f1cf</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->