### PR TITLE
fix: use lazy initializer for useState with function calls

### DIFF
--- a/apps/dokploy/components/dashboard/requests/show-requests.tsx
+++ b/apps/dokploy/components/dashboard/requests/show-requests.tsx
@@ -63,7 +63,7 @@ export const ShowRequests = () => {
 	const [dateRange, setDateRange] = useState<{
 		from: Date | undefined;
 		to: Date | undefined;
-	}>(getDefaultDateRange());
+	}>(() => getDefaultDateRange());
 
 	// Check if logs exist to determine if traefik has been reloaded
 	// Only fetch when active to minimize network calls

--- a/apps/dokploy/components/dashboard/settings/web-server/terminal-modal.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/terminal-modal.tsx
@@ -32,7 +32,9 @@ export const TerminalModal = ({
 	serverId,
 	asButton = false,
 }: Props) => {
-	const [terminalKey, setTerminalKey] = useState<string>(getTerminalKey());
+	const [terminalKey, setTerminalKey] = useState<string>(() =>
+		getTerminalKey(),
+	);
 	const [isOpen, setIsOpen] = useState(false);
 	const isLocalServer = serverId === "local";
 


### PR DESCRIPTION
## What is this PR about?

Calling getTerminalKey() and getDefaultDateRange() directly in useState
re-runs them on every render. Wrap in an arrow function so they execute
only once during component initialization.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies the React `useState` lazy initializer pattern to two components, wrapping direct function calls (`getTerminalKey()` and `getDefaultDateRange()`) in arrow functions so they are only executed once during component initialization rather than on every render.

- In `terminal-modal.tsx`, `getTerminalKey()` (which calls `Date.now()`) was being evaluated on every render; it is now wrapped as `() => getTerminalKey()`.
- In `show-requests.tsx`, `getDefaultDateRange()` (which creates `new Date()` objects) was similarly evaluated on every render; it is now wrapped as `() => getDefaultDateRange()`.

Both changes are correct and follow React best practices. The fix prevents unnecessary function evaluations and avoids creating throwaway object allocations on each re-render. No logic changes are introduced — only the initialization timing is corrected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it applies a well-known React optimization with no behavioral changes.
- The changes are minimal, correct, and purely a performance micro-optimization. Lazy initializers in `useState` are idiomatic React; both wrapped functions are side-effect-free (aside from `Date.now()`, which is intentional and was already the existing behavior). No new logic is introduced and there is no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 43f9f54</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->