### PR TITLE
fix: use tasks. DNS prefix in Traefik service URLs to resolve VIP routing issue

### DIFF
--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -278,7 +278,7 @@ export const createServiceConfig = (
 	loadBalancer: HttpLoadBalancerService;
 } => ({
 	loadBalancer: {
-		servers: [{ url: `http://${appName}:${domain.port || 80}` }],
+		servers: [{ url: `http://tasks.${appName}:${domain.port || 80}` }],
 		passHostHeader: true,
 	},
 });


### PR DESCRIPTION
## Summary

- Fix 504 Gateway Timeout / 502 Bad Gateway errors caused by Traefik (standalone container) being unable to reach Docker Swarm services through VIP addresses on overlay networks
- Use `tasks.<service-name>` DNS prefix in generated Traefik dynamic configs, which resolves directly to task container IPs instead of the unreachable VIP

## Problem

Since Dokploy migrated Traefik from a Swarm service to a **standalone container** (`docker run`), it can no longer resolve Docker Swarm **VIP (Virtual IP)** addresses in overlay networks. Application services default to `vip` endpoint mode, so DNS resolution of `<service-name>` returns a VIP that standalone containers cannot route to.

This causes:
- `504 Gateway Timeout` on all application domains routed through Traefik
- Intermittent failures when Docker DNS returns both VIP and task IPs

The issue is particularly reproducible on:
- Single-node Docker Swarm setups
- Proxmox LXC containers (where overlay VIP support requires privileged mode)

## Root Cause

In `packages/server/src/utils/traefik/application.ts`, the `createServiceConfig` function generates:

```
http://<service-name>:<port>
```

This resolves to the Swarm VIP (`10.0.x.x`) which is **not routable from standalone containers**. However, `tasks.<service-name>` resolves directly to task container IPs, which ARE reachable.

## Fix

```diff
- servers: [{ url: `http://${appName}:${domain.port || 80}` }],
+ servers: [{ url: `http://tasks.${appName}:${domain.port || 80}` }],
```

The `tasks.` DNS prefix is a [Docker Swarm built-in](https://docs.docker.com/engine/network/drivers/overlay/#container-discovery) that always resolves to individual task IPs, bypassing the VIP entirely.

## Test plan

- [x] Verified on a single-node Docker Swarm with Dokploy v0.28.2
- [x] Before fix: `curl -H "Host: app.example.com" http://localhost` → `504 Gateway Timeout`
- [x] After fix: `curl -H "Host: app.example.com" http://localhost` → `307` (normal app redirect)
- [x] Confirmed `docker exec dokploy-traefik wget http://tasks.<service>:3000` succeeds while `wget http://<service>:3000` times out
- [ ] Deploy a new application and verify the generated YAML uses `tasks.` prefix automatically

Fixes #3480
Related: #3375, #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes 504/502 Gateway errors caused by Traefik (now running as a standalone `docker run` container) being unable to reach Docker Swarm services through VIP addresses on overlay networks. The fix applies the `tasks.` DNS prefix to service URLs in `createServiceConfig()`, so Traefik resolves directly to task container IPs instead of the unreachable Swarm VIP.

The core fix is correct and directly addresses the reported issue. The one-line change in `createServiceConfig` (in `application.ts` line 281) properly routes all new application domains through Traefik to their target services using Docker's built-in `tasks.` DNS prefix, which is the correct approach for standalone Traefik containers in a Swarm environment.

<h3>Confidence Score: 5/5</h3>

- The change is minimal, focused, and addresses the specific VIP routing failure described in the PR without side effects.
- The PR makes a single, well-scoped change to `createServiceConfig()` that directly fixes the documented problem. The fix uses Docker's standard `tasks.` DNS prefix, which is the correct and documented solution for standalone containers reaching Swarm services. No other code paths are modified, and the change is backward compatible for applications that have already been deployed (their configs will be regenerated on domain updates).
- No files require special attention. The change is correct and complete for the stated problem.

<sub>Last reviewed commit: 6d8ccb3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->