### PR TITLE
feat(backups): support FTP/SFTP/GDrive/OneDrive rclone destinations

### DIFF
--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -1,4 +1,9 @@
-import { normalizeS3Path } from "@dokploy/server/utils/backups/utils";
+import {
+	getRcloneDestination,
+	getRclonePrefixPath,
+	getS3Credentials,
+	normalizeS3Path,
+} from "@dokploy/server/utils/backups/utils";
 import { describe, expect, test } from "vitest";
 
 describe("normalizeS3Path", () => {
@@ -57,5 +62,63 @@ describe("normalizeS3Path", () => {
 		expect(normalizeS3Path("instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("/instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("instance-backups")).toBe("instance-backups/");
+	});
+});
+
+describe("rclone destination provider mapping", () => {
+	const baseDestination = {
+		destinationId: "dest_1",
+		name: "test",
+		organizationId: "org_1",
+		createdAt: new Date(),
+		accessKey: "key",
+		secretAccessKey: "secret",
+		bucket: "bucket-root",
+		region: "us-east-1",
+		endpoint: "endpoint",
+		provider: "AWS",
+	};
+
+	test("should keep S3 behavior by default", () => {
+		const flags = getS3Credentials(baseDestination);
+		expect(flags.some((flag) => flag.includes("--s3-access-key-id"))).toBe(true);
+		expect(getRcloneDestination(baseDestination, "prefix/file.sql.gz")).toBe(
+			":s3:bucket-root/prefix/file.sql.gz",
+		);
+		expect(getRclonePrefixPath(baseDestination, "prefix")).toBe(
+			":s3:bucket-root/prefix/",
+		);
+	});
+
+	test("should generate ftp credentials and destination", () => {
+		const ftp = {
+			...baseDestination,
+			provider: "FTP",
+			bucket: "remote-root",
+			endpoint: "ftp.example.com",
+		};
+		const flags = getS3Credentials(ftp);
+		expect(flags.some((flag) => flag.includes("--ftp-host"))).toBe(true);
+		expect(getRcloneDestination(ftp, "prefix/file.sql.gz")).toBe(
+			":ftp:remote-root/prefix/file.sql.gz",
+		);
+		expect(getRclonePrefixPath(ftp, "prefix")).toBe(":ftp:remote-root/prefix/");
+	});
+
+	test("should generate sftp credentials and destination", () => {
+		const sftp = {
+			...baseDestination,
+			provider: "SFTP",
+			bucket: "remote-root",
+			endpoint: "sftp.example.com",
+		};
+		const flags = getS3Credentials(sftp);
+		expect(flags.some((flag) => flag.includes("--sftp-host"))).toBe(true);
+		expect(getRcloneDestination(sftp, "prefix/file.sql.gz")).toBe(
+			":sftp:remote-root/prefix/file.sql.gz",
+		);
+		expect(getRclonePrefixPath(sftp, "prefix")).toBe(
+			":sftp:remote-root/prefix/",
+		);
 	});
 });

--- a/apps/dokploy/components/dashboard/settings/destination/constants.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/constants.ts
@@ -3,6 +3,22 @@ export const S3_PROVIDERS: Array<{
 	name: string;
 }> = [
 	{
+		key: "FTP",
+		name: "FTP (Rclone)",
+	},
+	{
+		key: "SFTP",
+		name: "SFTP (Rclone)",
+	},
+	{
+		key: "GDrive",
+		name: "Google Drive (Rclone)",
+	},
+	{
+		key: "OneDrive",
+		name: "OneDrive (Rclone)",
+	},
+	{
 		key: "AWS",
 		name: "Amazon Web Services (AWS) S3",
 	},

--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -92,6 +92,36 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		},
 		resolver: zodResolver(addDestination),
 	});
+	const selectedProvider = form.watch("provider");
+	const normalizedProvider = selectedProvider.toLowerCase();
+	const isFtp = normalizedProvider === "ftp" || normalizedProvider === "sftp";
+	const isDrive =
+		normalizedProvider === "gdrive" || normalizedProvider === "onedrive";
+	const accessKeyLabel = isFtp
+		? "Username"
+		: isDrive
+			? "Client ID"
+			: "Access Key Id";
+	const secretLabel = isFtp
+		? "Password"
+		: isDrive
+			? "Client Secret"
+			: "Secret Access Key";
+	const bucketLabel = isFtp
+		? "Remote Root Path"
+		: isDrive
+			? "Remote Folder"
+			: "Bucket";
+	const endpointLabel = isFtp
+		? "Host"
+		: isDrive
+			? "OAuth Token JSON"
+			: "Endpoint";
+	const endpointPlaceholder = isFtp
+		? "storage.example.com"
+		: isDrive
+			? '{"access_token":"...","refresh_token":"..."}'
+			: "https://s3.example.com";
 	useEffect(() => {
 		if (destination) {
 			form.reset({
@@ -168,8 +198,6 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		const endpoint = form.getValues("endpoint");
 		const region = form.getValues("region");
 
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
-
 		await testConnection({
 			provider,
 			accessKey,
@@ -185,7 +213,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 			})
 			.catch((e) => {
 				toast.error("Error connecting to provider", {
-					description: `${e.message}\n\nTry manually: rclone ls ${connectionString}`,
+					description: e.message,
 				});
 			});
 	};
@@ -261,7 +289,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 											>
 												<FormControl>
 													<SelectTrigger>
-														<SelectValue placeholder="Select a S3 Provider" />
+														<SelectValue placeholder="Select a Provider" />
 													</SelectTrigger>
 												</FormControl>
 												<SelectContent>
@@ -288,7 +316,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => {
 								return (
 									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
+										<FormLabel>{accessKeyLabel}</FormLabel>
 										<FormControl>
 											<Input placeholder={"xcas41dasde"} {...field} />
 										</FormControl>
@@ -303,7 +331,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
+										<FormLabel>{secretLabel}</FormLabel>
 									</div>
 									<FormControl>
 										<Input placeholder={"asd123asdasw"} {...field} />
@@ -318,7 +346,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
+										<FormLabel>{bucketLabel}</FormLabel>
 									</div>
 									<FormControl>
 										<Input placeholder={"dokploy-bucket"} {...field} />
@@ -327,32 +355,31 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 								</FormItem>
 							)}
 						/>
-						<FormField
-							control={form.control}
-							name="region"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"us-east-1"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+						{!isFtp && !isDrive && (
+							<FormField
+								control={form.control}
+								name="region"
+								render={({ field }) => (
+									<FormItem>
+										<div className="space-y-0.5">
+											<FormLabel>Region</FormLabel>
+										</div>
+										<FormControl>
+											<Input placeholder={"us-east-1"} {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						)}
 						<FormField
 							control={form.control}
 							name="endpoint"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
+									<FormLabel>{endpointLabel}</FormLabel>
 									<FormControl>
-										<Input
-											placeholder={"https://us.bucket.aws/s3"}
-											{...field}
-										/>
+										<Input placeholder={endpointPlaceholder} {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>

--- a/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
@@ -23,11 +23,11 @@ export const ShowDestinations = () => {
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
 							<Database className="size-6 text-muted-foreground self-center" />
-							S3 Destinations
+							Backup Destinations
 						</CardTitle>
 						<CardDescription>
-							Add your providers like AWS S3, Cloudflare R2, Wasabi,
-							DigitalOcean Spaces etc.
+							Add providers like AWS S3, Cloudflare R2, FTP, SFTP, Google
+							Drive, and OneDrive.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-2 py-8 border-t">

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -3,6 +3,8 @@ import {
 	execAsync,
 	execAsyncRemote,
 	findDestinationById,
+	getRcloneDestination,
+	getS3Credentials,
 	IS_CLOUD,
 	removeDestinationById,
 	updateDestinationById,
@@ -43,26 +45,16 @@ export const destinationRouter = createTRPCRouter({
 	testConnection: adminProcedure
 		.input(apiCreateDestination)
 		.mutation(async ({ input }) => {
-			const { secretAccessKey, bucket, region, endpoint, accessKey, provider } =
-				input;
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
-				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+				const destinationLike = {
+					...input,
+					createdAt: new Date(),
+					destinationId: "test-connection",
+					organizationId: "test-connection",
+				};
+				const rcloneFlags = getS3Credentials(destinationLike);
+				const rcloneDestination = getRcloneDestination(destinationLike, "");
+				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}" --retries 1 --low-level-retries 1 --timeout 10s --contimeout 5s`;
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
@@ -82,7 +74,7 @@ export const destinationRouter = createTRPCRouter({
 					message:
 						error instanceof Error
 							? error?.message
-							: "Error connecting to bucket",
+							: "Error connecting to destination",
 					cause: error,
 				});
 			}

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -8,7 +8,12 @@ import { findEnvironmentById } from "@dokploy/server/services/environment";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupCommand,
+	getRcloneDestination,
+	getS3Credentials,
+	normalizeS3Path,
+} from "./utils";
 
 export const runComposeBackup = async (
 	compose: Compose,
@@ -30,7 +35,10 @@ export const runComposeBackup = async (
 
 	try {
 		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -10,7 +10,8 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import { getRclonePrefixPath, getS3Credentials, scheduleBackup } from "./utils";
+import { normalizeS3Path } from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -131,7 +132,11 @@ export const keepLatestNBackups = async (
 	try {
 		const rcloneFlags = getS3Credentials(backup.destination);
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${backup.destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupPrefix = `${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = getRclonePrefixPath(
+			backup.destination,
+			backupPrefix,
+		);
 
 		// --include "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
 		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".sql.gz"}" ${backupFilesPath}`;

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -8,7 +8,12 @@ import type { Mariadb } from "@dokploy/server/services/mariadb";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupCommand,
+	getRcloneDestination,
+	getS3Credentials,
+	normalizeS3Path,
+} from "./utils";
 
 export const runMariadbBackup = async (
 	mariadb: Mariadb,
@@ -28,7 +33,10 @@ export const runMariadbBackup = async (
 	});
 	try {
 		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -8,7 +8,12 @@ import type { Mongo } from "@dokploy/server/services/mongo";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupCommand,
+	getRcloneDestination,
+	getS3Credentials,
+	normalizeS3Path,
+} from "./utils";
 
 export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 	const { environmentId, name, appName } = mongo;
@@ -25,7 +30,10 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 	});
 	try {
 		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -8,7 +8,12 @@ import type { MySql } from "@dokploy/server/services/mysql";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupCommand,
+	getRcloneDestination,
+	getS3Credentials,
+	normalizeS3Path,
+} from "./utils";
 
 export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	const { environmentId, name, appName } = mysql;
@@ -26,7 +31,10 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 
 	try {
 		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -8,7 +8,12 @@ import type { Postgres } from "@dokploy/server/services/postgres";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupCommand,
+	getRcloneDestination,
+	getS3Credentials,
+	normalizeS3Path,
+} from "./utils";
 
 export const runPostgresBackup = async (
 	postgres: Postgres,
@@ -29,7 +34,10 @@ export const runPostgresBackup = async (
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
 		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -58,23 +58,110 @@ export const normalizeS3Path = (prefix: string) => {
 	return normalizedPrefix ? `${normalizedPrefix}/` : "";
 };
 
+const normalizeProvider = (provider: string | null) =>
+	(provider || "").trim().toLowerCase();
+
+const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
+
+type RcloneProviderKind = "s3" | "ftp" | "sftp" | "gdrive" | "onedrive";
+
+const getRcloneProviderKind = (destination: Destination): RcloneProviderKind => {
+	const provider = normalizeProvider(destination.provider);
+	if (provider === "ftp") return "ftp";
+	if (provider === "sftp") return "sftp";
+	if (provider === "gdrive" || provider === "google drive" || provider === "drive") {
+		return "gdrive";
+	}
+	if (provider === "onedrive" || provider === "one drive") return "onedrive";
+	return "s3";
+};
+
 export const getS3Credentials = (destination: Destination) => {
+	const providerKind = getRcloneProviderKind(destination);
 	const { accessKey, secretAccessKey, region, endpoint, provider } =
 		destination;
+	if (providerKind === "ftp") {
+		return [
+			`--ftp-host=${shellQuote(endpoint)}`,
+			`--ftp-user=${shellQuote(accessKey)}`,
+			`--ftp-pass=${shellQuote(secretAccessKey)}`,
+		];
+	}
+	if (providerKind === "sftp") {
+		return [
+			`--sftp-host=${shellQuote(endpoint)}`,
+			`--sftp-user=${shellQuote(accessKey)}`,
+			`--sftp-pass=${shellQuote(secretAccessKey)}`,
+		];
+	}
+	if (providerKind === "gdrive") {
+		const flags = [
+			`--drive-client-id=${shellQuote(accessKey)}`,
+			`--drive-client-secret=${shellQuote(secretAccessKey)}`,
+		];
+		if (endpoint) {
+			flags.push(`--drive-token=${shellQuote(endpoint)}`);
+		}
+		return flags;
+	}
+	if (providerKind === "onedrive") {
+		const flags = [
+			`--onedrive-client-id=${shellQuote(accessKey)}`,
+			`--onedrive-client-secret=${shellQuote(secretAccessKey)}`,
+		];
+		if (endpoint) {
+			flags.push(`--onedrive-token=${shellQuote(endpoint)}`);
+		}
+		return flags;
+	}
+
 	const rcloneFlags = [
-		`--s3-access-key-id="${accessKey}"`,
-		`--s3-secret-access-key="${secretAccessKey}"`,
-		`--s3-region="${region}"`,
-		`--s3-endpoint="${endpoint}"`,
+		`--s3-access-key-id=${shellQuote(accessKey)}`,
+		`--s3-secret-access-key=${shellQuote(secretAccessKey)}`,
+		`--s3-region=${shellQuote(region)}`,
+		`--s3-endpoint=${shellQuote(endpoint)}`,
 		"--s3-no-check-bucket",
 		"--s3-force-path-style",
 	];
 
 	if (provider) {
-		rcloneFlags.unshift(`--s3-provider="${provider}"`);
+		rcloneFlags.unshift(`--s3-provider=${shellQuote(provider)}`);
 	}
-
 	return rcloneFlags;
+};
+
+export const getRcloneRemoteType = (destination: Destination) => {
+	const providerKind = getRcloneProviderKind(destination);
+	if (providerKind === "ftp") return "ftp";
+	if (providerKind === "sftp") return "sftp";
+	if (providerKind === "gdrive") return "drive";
+	if (providerKind === "onedrive") return "onedrive";
+	return "s3";
+};
+
+export const getRcloneDestination = (
+	destination: Destination,
+	objectPath: string,
+) => {
+	const remoteType = getRcloneRemoteType(destination);
+	if (remoteType === "s3") {
+		return `:s3:${destination.bucket}/${objectPath}`;
+	}
+	const rootPrefix = normalizeS3Path(destination.bucket || "");
+	return `:${remoteType}:${rootPrefix}${objectPath}`;
+};
+
+export const getRclonePrefixPath = (
+	destination: Destination,
+	prefix: string,
+) => {
+	const remoteType = getRcloneRemoteType(destination);
+	const normalizedPrefix = normalizeS3Path(prefix);
+	if (remoteType === "s3") {
+		return `:s3:${destination.bucket}/${normalizedPrefix}`;
+	}
+	const rootPrefix = normalizeS3Path(destination.bucket || "");
+	return `:${remoteType}:${rootPrefix}${normalizedPrefix}`;
 };
 
 export const getPostgresBackupCommand = (

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -10,7 +10,7 @@ import {
 } from "@dokploy/server/services/deployment";
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { execAsync } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path } from "./utils";
+import { getRcloneDestination, getS3Credentials, normalizeS3Path } from "./utils";
 
 export const runWebServerBackup = async (backup: BackupSchedule) => {
 	if (IS_CLOUD) {
@@ -31,7 +31,8 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const objectPath = `${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const destinationPath = getRcloneDestination(destination, objectPath);
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -79,10 +80,10 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 
 			writeStream.write("Zipped database and filesystem\n");
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${tempDir}/${backupFileName}" "${s3Path}"`;
-			writeStream.write("Running command to upload backup to S3\n");
+			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${tempDir}/${backupFileName}" "${destinationPath}"`;
+			writeStream.write("Running command to upload backup to destination\n");
 			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			writeStream.write("Uploaded backup to destination ✅\n");
 			writeStream.end();
 			await updateDeploymentStatus(deployment.deploymentId, "done");
 			return true;


### PR DESCRIPTION
/claim #416

This PR adds a focused, incremental implementation to support additional rclone destination types while keeping existing S3 behavior intact.

What changed:
- Backend backup/rclone pathing
  - generalized destination + prefix path building for non-S3 providers
  - added provider mapping in backup utils for:
    - S3 (existing behavior)
    - FTP
    - SFTP
    - Google Drive (drive)
    - OneDrive
- Backup flows updated (database/compose/web-server/retention)
  - all upload and retention commands now use provider-aware destination builders
- Destination test connection
  - switched from hardcoded S3-only command generation to provider-aware rclone command generation
- UI updates for destination setup
  - provider list now includes FTP/SFTP/GDrive/OneDrive entries
  - destination screen copy updated from S3-only wording
  - form labels adapt per provider (e.g. username/password for FTP/SFTP, client ID/secret + token for drive providers)
- Tests
  - added utility coverage for provider mapping + destination path generation in `apps/dokploy/__test__/utils/backups.test.ts`

Why this approach:
- keeps the existing destination model and S3 flows stable
- unblocks multi-destination support without introducing a large schema migration
- enables incremental extension for additional rclone providers using the same mapping pattern

Validation notes:
- Added/updated tests in `apps/dokploy/__test__/utils/backups.test.ts`
- Could not execute vitest in this environment because workspace dependencies are not installed (`node_modules` missing) and repository requires Node `^24.4.0` while current environment is Node `22.x`.

I can follow up with a second PR for richer provider-specific UX (advanced fields / token refresh workflows) if this incremental backend-compatible approach looks good.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for FTP, SFTP, Google Drive, and OneDrive as rclone backup destinations alongside existing S3. The implementation is well-structured:

**Strengths:**
- Provider-aware helpers (`getRcloneDestination`, `getRclonePrefixPath`, `getS3Credentials`) cleanly abstract destination paths and credential handling
- Existing S3 flows remain stable and intact
- New providers are integrated uniformly across all backup types (postgres, mysql, mariadb, mongo, compose, web-server) and test-connection endpoint
- Tests added for provider mapping and path generation
- PR approach is incremental and unblocks multi-destination support without requiring schema migration

**Approach is sound:**
The generalized helpers are reused across all backup modules, reducing duplication and making future provider additions straightforward. The pattern is consistent and maintainable.

No blocking issues identified.

<h3>Confidence Score: 4/5</h3>

- The PR implements new provider support through clean, well-structured helpers while preserving existing S3 behavior. The approach is incremental and maintainable.
- The implementation follows a solid pattern: provider-aware helpers are reused consistently across all backup modules and endpoints. Existing S3 flows remain stable. Tests verify the provider mapping and path generation logic. The code is clear and the incremental approach reduces risk by not requiring schema changes. The only additional assurance would be runtime validation of the new FTP/SFTP/GDrive/OneDrive flows in a test environment, which is standard practice for new provider integrations.
- No files require special attention. The changes are well-distributed and follow consistent patterns.

<sub>Last reviewed commit: 0bb0682</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->