### PR TITLE
refactor: replace authClient with api.organization.active for active …

### DIFF
--- a/apps/dokploy/components/dashboard/organization/handle-organization.tsx
+++ b/apps/dokploy/components/dashboard/organization/handle-organization.tsx
@@ -24,7 +24,6 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { authClient } from "@/lib/auth-client";
 import { api } from "@/utils/api";
 
 const organizationSchema = z.object({
@@ -55,8 +54,6 @@ export function AddOrganization({ organizationId }: Props) {
 	const { mutateAsync, isPending } = organizationId
 		? api.organization.update.useMutation()
 		: api.organization.create.useMutation();
-	const { refetch: refetchActiveOrganization } =
-		authClient.useActiveOrganization();
 
 	const form = useForm<OrganizationFormValues>({
 		resolver: zodResolver(organizationSchema),
@@ -89,7 +86,7 @@ export function AddOrganization({ organizationId }: Props) {
 				utils.organization.all.invalidate();
 				if (organizationId) {
 					utils.organization.one.invalidate({ organizationId });
-					refetchActiveOrganization();
+					utils.organization.active.invalidate();
 				}
 				setOpen(false);
 			})

--- a/apps/dokploy/components/dashboard/settings/git/github/add-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/github/add-github-provider.tsx
@@ -17,7 +17,8 @@ import { api } from "@/utils/api";
 
 export const AddGithubProvider = () => {
 	const [isOpen, setIsOpen] = useState(false);
-	const { data: activeOrganization } = authClient.useActiveOrganization();
+	const { data: activeOrganization } = api.organization.active.useQuery();
+
 	const { data: session } = authClient.useSession();
 	const { data } = api.user.get.useQuery();
 	const [manifest, setManifest] = useState("");
@@ -52,7 +53,7 @@ export const AddGithubProvider = () => {
 		);
 
 		setManifest(manifest);
-	}, [data?.id, activeOrganization?.id, session?.user?.id]);
+	}, [activeOrganization?.id, session?.user?.id]);
 
 	return (
 		<Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -131,11 +132,7 @@ export const AddGithubProvider = () => {
 										Unsure if you already have an app?
 									</a>
 									<Button
-										disabled={
-											(isOrganization && organizationName.length < 1) ||
-											!activeOrganization?.id ||
-											!session?.user?.id
-										}
+										disabled={isOrganization && organizationName.length < 1}
 										type="submit"
 										className="self-end"
 									>

--- a/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
@@ -55,7 +55,7 @@ export const AddInvitation = () => {
 		api.notification.getEmailProviders.useQuery();
 	const { mutateAsync: sendInvitation } = api.user.sendInvitation.useMutation();
 	const [error, setError] = useState<string | null>(null);
-	const { data: activeOrganization } = authClient.useActiveOrganization();
+	const { data: activeOrganization } = api.organization.active.useQuery();
 
 	const form = useForm<AddInvitation>({
 		defaultValues: {

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -557,8 +557,7 @@ function SidebarLogo() {
 	const { mutateAsync: setDefaultOrganization, isPending: isSettingDefault } =
 		api.organization.setDefault.useMutation();
 	const { isMobile } = useSidebar();
-	const { data: activeOrganization } = authClient.useActiveOrganization();
-	const _utils = api.useUtils();
+	const { data: activeOrganization } = api.organization.active.useQuery();
 
 	const { data: invitations, refetch: refetchInvitations } =
 		api.user.getInvitations.useQuery();

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -355,4 +355,13 @@ export const organizationRouter = createTRPCRouter({
 
 			return { success: true };
 		}),
+	active: protectedProcedure.query(async ({ ctx }) => {
+		if (!ctx.session.activeOrganizationId) {
+			return null;
+		}
+
+		return await db.query.organization.findFirst({
+			where: eq(organization.id, ctx.session.activeOrganizationId),
+		});
+	}),
 });


### PR DESCRIPTION
…organization queries

Updated components to use the new API method for fetching the active organization, improving consistency across the codebase. This change enhances maintainability and aligns with recent API updates.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)
 
closes #3876 https://github.com/Dokploy/dokploy/issues/3849

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors four components to replace `authClient.useActiveOrganization()` with a new `api.organization.active` tRPC endpoint, aligning active-organization data fetching with the rest of the codebase's tRPC patterns. The new endpoint is defined in `organization.ts` and the invalidation/refetch logic is updated accordingly.

Key observations:
- **Authorization gap in `active` endpoint** (`organization.ts`): Unlike the existing `one` endpoint, the new `active` endpoint does not verify that the current user is still a member of `activeOrganizationId` before returning the organization record. A revoked member whose session still holds the old `activeOrganizationId` could read that org's data.
- **Broken form guard in `add-github-provider.tsx`**: The button's `disabled` condition previously included `!activeOrganization?.id` to prevent submission while data is loading. That guard was removed, so submitting the form before `activeOrganization` has loaded will produce a GitHub app creation URL with `state=gh_init:undefined`, likely breaking the OAuth callback.
- The remaining changes (`handle-organization.tsx`, `add-invitation.tsx`, `side.tsx`) are clean, idiomatic replacements with no issues.

<h3>Confidence Score: 3/5</h3>

- This PR has two logic issues that should be addressed before merging: a missing membership check in the new `active` endpoint and a removed form guard that can produce malformed GitHub OAuth URLs.
- The refactoring is largely correct and well-structured, but two concrete regressions were introduced: (1) the `active` tRPC endpoint lacks the same membership verification found in every other org endpoint, creating a potential authorization bypass for revoked members with stale sessions; (2) the `!activeOrganization?.id` guard was removed from the GitHub provider button, meaning a user can submit the GitHub App creation form before the active organization has loaded, resulting in `state=gh_init:undefined` in the redirect URL and a broken OAuth flow.
- Pay close attention to `apps/dokploy/server/api/routers/organization.ts` (missing membership check) and `apps/dokploy/components/dashboard/settings/git/github/add-github-provider.tsx` (removed button guard).

<sub>Last reviewed commit: 9ac147a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->