### PR TITLE
refactor: simplify createMount mutation by returning the promise dire…

### DIFF
--- a/apps/dokploy/server/api/routers/mount.ts
+++ b/apps/dokploy/server/api/routers/mount.ts
@@ -69,8 +69,7 @@ export const mountRouter = createTRPCRouter({
 	create: protectedProcedure
 		.input(apiCreateMount)
 		.mutation(async ({ input }) => {
-			await createMount(input);
-			return true;
+			return await createMount(input);
 		}),
 	remove: protectedProcedure
 		.input(apiRemoveMount)

--- a/packages/server/src/db/schema/mount.ts
+++ b/packages/server/src/db/schema/mount.ts
@@ -99,17 +99,15 @@ const createSchema = createInsertSchema(mounts, {
 	mountPath: z.string().min(1),
 	mountId: z.string().optional(),
 	filePath: z.string().optional(),
-	serviceType: z
-		.enum([
-			"application",
-			"postgres",
-			"mysql",
-			"mariadb",
-			"mongo",
-			"redis",
-			"compose",
-		])
-		.default("application"),
+	serviceType: z.enum([
+		"application",
+		"postgres",
+		"mysql",
+		"mariadb",
+		"mongo",
+		"redis",
+		"compose",
+	]),
 });
 
 export type ServiceType = NonNullable<


### PR DESCRIPTION
…ctly

Updated the createMount mutation to return the promise from createMount directly, enhancing readability. Additionally, adjusted the serviceType schema definition for clarity by removing the default value assignment.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3864 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two small refactoring changes to the mount system: it simplifies the `create` mutation to return the created `Mount` record directly (instead of discarding it and returning a hardcoded `true`), and removes the Zod-level `.default("application")` from the `serviceType` field in `createSchema`.

The router change is a straightforward and beneficial improvement — returning the full mount object is more useful to callers and makes `create` consistent with `remove`, `update`, and `one` mutations which already return their service-call results. All existing frontend components explicitly provide `serviceType` in their mutation calls, so removing the Zod default does not affect internal functionality.

Key points:
- The `create` mutation now returns the inserted `Mount` object instead of `true`. Any caller checking `result === true` (strict equality) would be affected, but tRPC mutation `onSuccess` callbacks do not typically check this.
- Removing `.default("application")` from the Zod schema makes `serviceType` explicitly required at the validation layer. This is a stricter and clearer API contract, but could be a minor breaking change for external API consumers that previously omitted `serviceType` and relied on the silent default.
- The DB column still has `.default("application")` (line 36 of `mount.ts`), so the database-level default is preserved — only the Zod input-validation default is removed.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — changes are simple refactors with no new logic introduced.
- Both changes are clean refactors. The mutation return-type change is strictly better (returns useful data). Removing the Zod default for `serviceType` is the correct design decision given all callers already provide it explicitly. The only residual concern is the possibility of external API consumers relying on the default, but this is low-risk for an open-source self-hosted project.
- No files require special attention.

<sub>Last reviewed commit: 36cf3a6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->