### PR TITLE
fix: add docker login before rollback and fix execAsyncRemote argument order

### DIFF
--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -16,7 +16,7 @@ function shEscape(s: string | undefined): string {
 	return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 
-function safeDockerLoginCommand(
+export function safeDockerLoginCommand(
 	registry: string | undefined,
 	user: string | undefined,
 	pass: string | undefined,

--- a/packages/server/src/services/rollbacks.ts
+++ b/packages/server/src/services/rollbacks.ts
@@ -23,7 +23,7 @@ import { findDeploymentById } from "./deployment";
 import type { Mount } from "./mount";
 import type { Port } from "./port";
 import type { Project } from "./project";
-import type { Registry } from "./registry";
+import { type Registry, safeDockerLoginCommand } from "./registry";
 
 export const createRollback = async (
 	input: z.infer<typeof createRollbackSchema>,
@@ -175,10 +175,11 @@ const dockerLoginForRegistry = async (
 	registry: Registry,
 	serverId?: string | null,
 ) => {
-	const escapedRegistry = shEscape(registry.registryUrl);
-	const escapedUser = shEscape(registry.username);
-	const escapedPassword = shEscape(registry.password);
-	const loginCommand = `printf %s ${escapedPassword} | docker login ${escapedRegistry} -u ${escapedUser} --password-stdin`;
+	const loginCommand = safeDockerLoginCommand(
+		registry.registryUrl,
+		registry.username,
+		registry.password,
+	);
 
 	if (serverId) {
 		await execAsyncRemote(serverId, loginCommand);
@@ -186,11 +187,6 @@ const dockerLoginForRegistry = async (
 		await execAsync(loginCommand);
 	}
 };
-
-function shEscape(s: string | undefined): string {
-	if (!s) return "''";
-	return `'${s.replace(/'/g, `'\\''`)}'`;
-}
 
 const rollbackApplication = async (
 	appName: string,


### PR DESCRIPTION
## What is this PR about?

Fixes two bugs in `packages/server/src/services/rollbacks.ts`:

### 1. Rollback fails to pull images from private registries on fresh servers

When performing a rollback to an image stored in a private registry, Docker Swarm
fails with `No such image` if the Docker daemon has no cached registry credentials
(e.g. after backup/restore to a new server).

**Root cause:** The deploy path runs `docker login` via shell (in `getRegistryCommands()`)
before calling `service.update()`, which caches credentials in `~/.docker/config.json`.
The rollback path only passes `authconfig` via Dockerode API (`X-Registry-Auth` header),
which alone is not sufficient for Docker Swarm to reliably distribute credentials to nodes.

**Fix:** Added a `docker login` call in `rollbackApplication()` before
`service.update()` / `createService()`, using credentials from
`fullContext.rollbackRegistry`. This matches the existing deploy path behavior.

### 2. Swapped `execAsyncRemote` arguments in `deleteRollbackImage`

`execAsyncRemote(serverId, command)` was called as `execAsyncRemote(command, serverId)`.
Both parameters are `string`, so TypeScript doesn't catch this. This meant rollback
image cleanup on remote servers was silently broken.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related

Fixes #3861

Related: #3111, #1998

## Screenshots (if applicable)

N/A — backend-only change, no UI modifications.