### PR TITLE
fix: update rsync command in web-server backup to exclude special fil…

### DIFF
--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -67,7 +67,7 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 			await execAsync(cleanupCommand);
 
 			await execAsync(
-				`rsync -a --ignore-errors ${BASE_PATH}/ ${tempDir}/filesystem/`,
+				`rsync -a --ignore-errors --no-specials --no-devices ${BASE_PATH}/ ${tempDir}/filesystem/`,
 			);
 
 			writeStream.write("Copied filesystem to temp directory\n");


### PR DESCRIPTION
…es and devices

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3853

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a backup failure by adding `--no-specials` and `--no-devices` to the `rsync` command used in the web server backup utility. The `-a` (archive) flag includes `-D`, which instructs rsync to attempt copying device and special files — this can cause failures when `BASE_PATH` contains sockets, FIFOs, or character/block device files (common in paths involving Docker or system directories). The new flags override that behavior so rsync skips those file types entirely.

**Change**: `rsync -a --ignore-errors` → `rsync -a --ignore-errors --no-specials --no-devices`

**Correctness**: Using `--no-specials --no-devices` alongside `-a` is the standard idiomatic rsync pattern for disabling device/special-file copying. This is valid in rsync 3.x and later.

**Interaction with `--ignore-errors`**: Both flags are complementary — `--no-specials --no-devices` prevents the class of errors from occurring in the first place, while `--ignore-errors` continues to guard against other I/O errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, correct fix to a real rsync failure scenario.
- The change is a single-line addition of two well-known rsync flags (`--no-specials`, `--no-devices`) that correctly override the device/special-file behavior introduced by the `-a` archive flag. This is the standard idiomatic fix for this class of rsync errors. No logic, security, or architectural concerns are introduced. The fix addresses the root cause of the issue rather than masking symptoms.
- No files require special attention.

<sub>Last reviewed commit: f1b2cc3</sub>

<!-- /greptile_comment -->