### PR TITLE
feat: enhance Docker configuration with environment variables for API…

### DIFF
--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -2,8 +2,22 @@ import path from "node:path";
 import Docker from "dockerode";
 
 export const IS_CLOUD = process.env.IS_CLOUD === "true";
+export const DOCKER_API_VERSION = process.env.DOCKER_API_VERSION;
+export const DOCKER_HOST = process.env.DOCKER_HOST;
+export const DOCKER_PORT = process.env.DOCKER_PORT;
+
 export const CLEANUP_CRON_JOB = "50 23 * * *";
-export const docker = new Docker();
+export const docker = new Docker({
+	...(DOCKER_API_VERSION && {
+		version: DOCKER_API_VERSION,
+	}),
+	...(DOCKER_HOST && {
+		host: DOCKER_HOST,
+	}),
+	...(DOCKER_PORT && {
+		port: DOCKER_PORT,
+	}),
+});
 
 // When not set, use the legacy default so 2FA remains working for users who
 // enabled it before BETTER_AUTH_SECRET was introduced .


### PR DESCRIPTION
… version, host, and port

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3888

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds environment variable support for dockerode's `version`, `host`, and `port` options, allowing the Docker connection to be configured without code changes. The change is small and self-contained, but there is a significant naming collision issue with `DOCKER_HOST`.

- **`DOCKER_HOST` naming conflict**: `DOCKER_HOST` is a standard Docker environment variable that carries a full connection URI (e.g., `tcp://192.168.1.100:2375`). Both the Docker CLI and `docker-modem` (dockerode's internal transport layer) parse this variable natively with URI handling. Reusing the name but forwarding its value as a raw `host` string to dockerode bypasses that parsing and will silently break for any user who sets it in the standard format.
- **`DOCKER_PORT` type**: The port is passed as a raw string; it should be parsed to an integer (with a `NaN` guard) to guarantee well-defined behaviour.
- The `DOCKER_API_VERSION` addition looks correct and low-risk.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the `DOCKER_HOST` naming collision will silently break users who supply the value in standard Docker URI format.
- The `DOCKER_HOST` variable name reuses a well-known Docker convention for a different semantic purpose, which is a correctness issue that will affect users following standard Docker tooling conventions. The raw string port is a lower-severity style concern. Neither the checklist for local testing nor the CONTRIBUTING.md was confirmed followed by the author.
- packages/server/src/constants/index.ts — specifically the `DOCKER_HOST` variable naming and the raw string port value.

<sub>Last reviewed commit: 48a577e</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->