### PR TITLE
feat: add enableSubmodules and update watchPaths in application schema

### DIFF
--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -365,12 +365,13 @@ const createSchema = createInsertSchema(applications, {
 	previewPath: z.string().optional(),
 	previewCertificateType: z.enum(["letsencrypt", "none", "custom"]).optional(),
 	previewRequireCollaboratorPermissions: z.boolean().optional(),
-	watchPaths: z.array(z.string()).optional(),
+	watchPaths: z.array(z.string()).optional().optional(),
 	previewLabels: z.array(z.string()).optional(),
 	cleanCache: z.boolean().optional(),
 	stopGracePeriodSwarm: z.bigint().nullable(),
 	endpointSpecSwarm: EndpointSpecSwarmSchema.nullable(),
 	ulimitsSwarm: UlimitsSwarmSchema.nullable(),
+	enableSubmodules: z.boolean().optional(),
 });
 
 export const apiCreateApplication = createSchema.pick({
@@ -433,13 +434,13 @@ export const apiSaveGithubProvider = createSchema
 		owner: true,
 		buildPath: true,
 		githubId: true,
-		watchPaths: true,
-		enableSubmodules: true,
 	})
 	.required()
 	.extend({
 		triggerType: z.enum(["push", "tag"]).default("push"),
-	});
+	})
+	.required()
+	.merge(createSchema.pick({ enableSubmodules: true, watchPaths: true }));
 
 export const apiSaveGitlabProvider = createSchema
 	.pick({
@@ -451,10 +452,9 @@ export const apiSaveGitlabProvider = createSchema
 		gitlabId: true,
 		gitlabProjectId: true,
 		gitlabPathNamespace: true,
-		watchPaths: true,
-		enableSubmodules: true,
 	})
-	.required();
+	.required()
+	.merge(createSchema.pick({ enableSubmodules: true, watchPaths: true }));
 
 export const apiSaveBitbucketProvider = createSchema
 	.pick({
@@ -465,10 +465,9 @@ export const apiSaveBitbucketProvider = createSchema
 		bitbucketRepositorySlug: true,
 		bitbucketId: true,
 		applicationId: true,
-		watchPaths: true,
-		enableSubmodules: true,
 	})
-	.required();
+	.required()
+	.merge(createSchema.pick({ enableSubmodules: true, watchPaths: true }));
 
 export const apiSaveGiteaProvider = createSchema
 	.pick({
@@ -478,10 +477,9 @@ export const apiSaveGiteaProvider = createSchema
 		giteaOwner: true,
 		giteaRepository: true,
 		giteaId: true,
-		watchPaths: true,
-		enableSubmodules: true,
 	})
-	.required();
+	.required()
+	.merge(createSchema.pick({ enableSubmodules: true, watchPaths: true }));
 
 export const apiSaveDockerProvider = createSchema
 	.pick({
@@ -506,6 +504,7 @@ export const apiSaveGitProvider = createSchema
 	.merge(
 		createSchema.pick({
 			customGitSSHKeyId: true,
+			enableSubmodules: true,
 		}),
 	);
 


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3850

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `enableSubmodules` to the application schema and makes `watchPaths` and `enableSubmodules` optional across provider schemas through `.merge()`. However, the changes introduced three issues:

1. **Redundant `.optional()` (line 368)**: The `watchPaths` field calls `.optional()` twice, which is idempotent but unintended.

2. **Conflicting `.required()` calls (lines 438–442)**: `apiSaveGithubProvider` calls `.required()` twice — after `.pick()` and after `.extend()`. This second call overrides the intent of `triggerType`'s default value, making it nominally required despite the default.

3. **Field duplication in `apiSaveGitProvider` (lines 494–509)**: The schema has `enableSubmodules` in both the initial `.pick()` (required) and the `.merge()` (optional). In Zod, `.merge()` overwrites, so the optional version wins, defeating the `.required()` constraint. Additionally, `watchPaths` is inconsistently kept required here while it was moved to optional in all other provider schemas, suggesting incomplete refactoring.

<h3>Confidence Score: 2/5</h3>

- This PR has logic bugs that would cause incorrect validation behavior at runtime, particularly in the `apiSaveGitProvider` schema where `.merge()` silently overrides field requirements.
- All three issues are verified in the code and would affect runtime behavior: (1) the style redundancy is harmless but unintended; (2) the conflicting `.required()` calls in `apiSaveGithubProvider` alter field optionality contrary to the default's intent; (3) the field duplication in `apiSaveGitProvider` causes Zod to silently override the required constraint with an optional one, and the inconsistent treatment of `watchPaths` versus other providers suggests incomplete refactoring. The second and third issues are logic bugs that should be fixed before merge.
- packages/server/src/db/schema/application.ts — specifically lines 368, 438–443, and 494–509 where the three issues are located.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   `enableSubmodules` appears in both the initial `.pick()` (line 501) and the subsequent `.merge()` (line 507). In Zod, `.merge()` overwrites fields from the base schema, so the optional version from the merge re-introduces `enableSubmodules` as optional, silently defeating the `.required()` call on line 503.

   Additionally, `watchPaths` remains in the initial `.pick()` (line 500) and is made required, which diverges from all other provider schemas (GitHub, GitLab, Bitbucket, Gitea) where both fields are in the optional `.merge()` block. This suggests the refactoring was incomplete for this provider.

   To align with other providers and fix the duplication, move both optional fields to the `.merge()` block:

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: d1c4ac2</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->