### PR TITLE
fix: skip redirect middleware for preview deployments to prevent wild…

### DIFF
--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -152,16 +152,13 @@ export const createRouterConfig = async (
 	}
 
 	if ((entryPoint === "websecure" && https) || !https) {
-		// redirects
-		for (const redirect of redirects) {
-			let middlewareName = `redirect-${appName}-${redirect.uniqueConfigKey}`;
-			if (domain.domainType === "preview") {
-				middlewareName = `redirect-${appName.replace(
-					/^preview-(.+)-[^-]+$/,
-					"$1",
-				)}-${redirect.uniqueConfigKey}`;
+		// redirects - skip for preview deployments as wildcard subdomains
+		// should not inherit parent redirect rules (e.g., www-redirect)
+		if (domain.domainType !== "preview") {
+			for (const redirect of redirects) {
+				const middlewareName = `redirect-${appName}-${redirect.uniqueConfigKey}`;
+				routerConfig.middlewares?.push(middlewareName);
 			}
-			routerConfig.middlewares?.push(middlewareName);
 		}
 
 		// security


### PR DESCRIPTION
…card subdomain inheritance

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3819

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where preview deployment Traefik routers were inheriting the parent application's redirect middlewares (e.g., `www-redirect`) by remapping the middleware name to the parent app. Since preview deployments use unique wildcard subdomains, those redirect rules are domain-specific and don't apply — they would redirect users away from the preview URL to a production domain.

The fix simply skips the redirect middleware block entirely for `domainType === "preview"` domains. Key behaviours that remain unchanged:
- The global `redirect-to-https` middleware is still applied for preview deployments when `https` is enabled (line 150–152).
- The security/auth middleware remapping for preview deployments (lines 166–173) is untouched and continues to work correctly.

The change is minimal, targeted, well-commented, and correctly addresses the reported wildcard subdomain inheritance problem.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it correctly removes a narrow, well-scoped bug without introducing any regressions.
- The change is minimal (skipping redirect middleware for preview domains rather than incorrectly remapping to the parent app's middleware). HTTPS redirect and security/auth middleware for preview deployments are unaffected. The logic is straightforward and the fix is consistent with how security middleware is already handled differently for preview vs. non-preview domains.
- No files require special attention.

<sub>Last reviewed commit: 3430452</sub>

<!-- /greptile_comment -->