### PR TITLE
fix: Replace tooltip trigger button for help icon (provider compose ui)

### DIFF
--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
@@ -410,7 +410,7 @@ export const SaveGiteaProviderCompose = ({ composeId }: Props) => {
 										<TooltipProvider>
 											<Tooltip>
 												<TooltipTrigger asChild>
-												    <HelpCircle className="size-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer" />
+													<HelpCircle className="size-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer" />
 												</TooltipTrigger>
 												<TooltipContent>
 													<p>


### PR DESCRIPTION
This is only in one provider but can be extened to other providers

## What is this PR about?

Prevents <button type=""> from defaulting to trigger a form submit action on click

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x. doing it now] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [nope, there are other providers that need to be done] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real bug where `<TooltipTrigger>` without `asChild` would default to `type="submit"` inside a form, causing unintended form submissions when the help icon is clicked. The fix replaces the div-based trigger with a proper `<button type="button">` and adds `asChild` to the trigger.

**Critical issues found:**
- **Missing import**: `HelpCircle` from `lucide-react` is used on line 417 but not imported. The lucide-react import on line 2 must be updated to include `HelpCircle`.
- **Indentation**: The new `<button>` block uses mixed spaces and tabs, breaking the file's tab-based indentation consistency.
- EDIT @naturedamends : DONE

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — missing `HelpCircle` import will cause a build failure.
- The PR introduces a build-breaking error: `HelpCircle` is used on line 417 but not imported from lucide-react. Additionally, the new button block uses inconsistent indentation (mixed spaces and tabs). Both issues must be resolved before merging.
- apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx (missing import and indentation)

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx`, line 2 ([link](https://github.com/dokploy/dokploy/blob/453a7b12b6c91e6bd988493aa9b1698451725c55/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx#L2)) 

   `HelpCircle` is used on line 417 but is never imported in this file. The existing lucide-react import on line 2 only includes `{ CheckIcon, ChevronsUpDown, Plus, X }`. This will cause a build error.

   Update the import to include `HelpCircle`:

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 453a7b1</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Rule from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->