### PR TITLE
feat(docker): enhance Docker provider with registry browser for image and tag selection

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -280,9 +280,9 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 											role="combobox"
 											aria-expanded={imageOpen}
 											className={cn(
-											"w-full justify-between font-normal",
-											imageError && "border-destructive",
-										)}
+												"w-full justify-between font-normal",
+												imageError && "border-destructive",
+											)}
 										>
 											{derivedImage || "Select an image..."}
 											{imagesLoading ? (
@@ -324,7 +324,9 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 									</PopoverContent>
 								</Popover>
 								{imageError && (
-									<p className="text-sm font-medium text-destructive mt-1">{imageError}</p>
+									<p className="text-sm font-medium text-destructive mt-1">
+										{imageError}
+									</p>
 								)}
 							</div>
 
@@ -337,9 +339,9 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 											role="combobox"
 											aria-expanded={tagOpen}
 											className={cn(
-											"w-full justify-between font-normal",
-											tagError && "border-destructive",
-										)}
+												"w-full justify-between font-normal",
+												tagError && "border-destructive",
+											)}
 											disabled={!derivedImage}
 										>
 											{derivedTag || "Select a tag..."}
@@ -379,7 +381,9 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 									</PopoverContent>
 								</Popover>
 								{tagError && (
-									<p className="text-sm font-medium text-destructive mt-1">{tagError}</p>
+									<p className="text-sm font-medium text-destructive mt-1">
+										{tagError}
+									</p>
 								)}
 							</div>
 						</div>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -84,7 +84,7 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 
 	const derivedRegistryId = userOverride
 		? selectedRegistryId
-		: data?.registryId ?? "";
+		: (data?.registryId ?? "");
 
 	const derivedImage = (() => {
 		if (userOverride) return selectedImage;

--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -38,9 +38,7 @@ import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 
 const DockerProviderSchema = z.object({
-	dockerImage: z.string().min(1, {
-		message: "Docker image is required",
-	}),
+	dockerImage: z.string().optional(),
 	username: z.string().optional(),
 	password: z.string().optional(),
 	registryURL: z.string().optional(),
@@ -66,10 +64,13 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 		resolver: zodResolver(DockerProviderSchema),
 	});
 
+	const NO_REGISTRY = "none";
 	const [userOverride, setUserOverride] = useState(false);
 	const [selectedRegistryId, setSelectedRegistryId] = useState<string>("");
 	const [selectedImage, setSelectedImage] = useState<string>("");
 	const [selectedTag, setSelectedTag] = useState<string>("");
+	const [imageError, setImageError] = useState<string>("");
+	const [tagError, setTagError] = useState<string>("");
 
 	useEffect(() => {
 		if (data) {
@@ -113,7 +114,30 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 	const [imageOpen, setImageOpen] = useState(false);
 	const [tagOpen, setTagOpen] = useState(false);
 
-	const { data: registries } = api.registry.all.useQuery();
+	const { data: registries, isLoading: registriesLoading } =
+		api.registry.all.useQuery();
+
+	const selectedRegistry = registries?.find(
+		(r) => r.registryId === derivedRegistryId,
+	);
+
+	// Strip imagePrefix from catalog names for display/storage.
+	// The registry API returns full paths (e.g. "docker/empty") but we store
+	// only the base name so populateFormFromRegistry can add the prefix back once.
+	const stripPrefix = (imageName: string) => {
+		const prefix = selectedRegistry?.imagePrefix;
+		if (prefix && imageName.startsWith(`${prefix}/`)) {
+			return imageName.substring(prefix.length + 1);
+		}
+		return imageName;
+	};
+
+	// Reconstruct full registry path (prefix + base name) for API calls
+	const fullImageName = (() => {
+		if (!derivedImage) return "";
+		const prefix = selectedRegistry?.imagePrefix;
+		return prefix ? `${prefix}/${derivedImage}` : derivedImage;
+	})();
 
 	const { data: images, isLoading: imagesLoading } =
 		api.registry.getImages.useQuery(
@@ -123,13 +147,9 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 
 	const { data: tags, isLoading: tagsLoading } =
 		api.registry.getImageTags.useQuery(
-			{ registryId: derivedRegistryId, imageName: derivedImage },
+			{ registryId: derivedRegistryId, imageName: fullImageName },
 			{ enabled: !!derivedRegistryId && !!derivedImage },
 		);
-
-	const selectedRegistry = registries?.find(
-		(r) => r.registryId === derivedRegistryId,
-	);
 
 	const populateFormFromRegistry = (
 		reg: typeof selectedRegistry,
@@ -149,10 +169,12 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 
 	const handleRegistryChange = (value: string) => {
 		setUserOverride(true);
-		setSelectedRegistryId(value === "none" ? "" : value);
+		setSelectedRegistryId(value === NO_REGISTRY ? "" : value);
 		setSelectedImage("");
 		setSelectedTag("");
-		if (value === "none") {
+		setImageError("");
+		setTagError("");
+		if (value === NO_REGISTRY) {
 			form.setValue("dockerImage", "");
 			form.setValue("username", "");
 			form.setValue("password", "");
@@ -165,18 +187,36 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 		setSelectedImage(image);
 		setSelectedTag("");
 		setImageOpen(false);
+		setImageError("");
+		setTagError("");
 	};
 
 	const handleTagSelect = (tag: string) => {
 		setUserOverride(true);
 		setSelectedTag(tag);
 		setTagOpen(false);
+		setTagError("");
 		populateFormFromRegistry(selectedRegistry, derivedImage, tag);
 	};
 
 	const onSubmit = async (values: DockerProvider) => {
+		if (derivedRegistryId) {
+			let hasError = false;
+			if (!derivedImage) {
+				setImageError("Image is required");
+				hasError = true;
+			}
+			if (!derivedTag) {
+				setTagError("Tag is required");
+				hasError = true;
+			}
+			if (hasError) return;
+		} else if (!values.dockerImage) {
+			form.setError("dockerImage", { message: "Docker image is required" });
+			return;
+		}
 		await mutateAsync({
-			dockerImage: values.dockerImage,
+			dockerImage: values.dockerImage ?? "",
 			password: values.password || null,
 			applicationId,
 			username: values.username || null,
@@ -202,14 +242,24 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 					<div>
 						<FormLabel>Browse from Registry</FormLabel>
 						<Select
-							value={derivedRegistryId || "none"}
+							value={derivedRegistryId || NO_REGISTRY}
 							onValueChange={handleRegistryChange}
+							disabled={registriesLoading}
 						>
 							<SelectTrigger>
-								<SelectValue placeholder="Select a registry" />
+								{registriesLoading ? (
+									<div className="flex items-center gap-2">
+										<Loader2 className="h-4 w-4 animate-spin" />
+										<span className="text-muted-foreground">
+											Loading registries...
+										</span>
+									</div>
+								) : (
+									<SelectValue placeholder="Select a registry" />
+								)}
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="none">None (manual input)</SelectItem>
+								<SelectItem value={NO_REGISTRY}>None (manual input)</SelectItem>
 								{registries?.map((reg) => (
 									<SelectItem key={reg.registryId} value={reg.registryId}>
 										{reg.registryName}
@@ -229,7 +279,10 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 											variant="outline"
 											role="combobox"
 											aria-expanded={imageOpen}
-											className="w-full justify-between font-normal"
+											className={cn(
+											"w-full justify-between font-normal",
+											imageError && "border-destructive",
+										)}
 										>
 											{derivedImage || "Select an image..."}
 											{imagesLoading ? (
@@ -245,28 +298,34 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 											<CommandList>
 												<CommandEmpty>No images found.</CommandEmpty>
 												<CommandGroup>
-													{images?.map((image) => (
-														<CommandItem
-															key={image}
-															value={image}
-															onSelect={() => handleImageSelect(image)}
-														>
-															<Check
-																className={cn(
-																	"mr-2 h-4 w-4",
-																	derivedImage === image
-																		? "opacity-100"
-																		: "opacity-0",
-																)}
-															/>
-															{image}
-														</CommandItem>
-													))}
+													{images?.map((image) => {
+														const baseName = stripPrefix(image);
+														return (
+															<CommandItem
+																key={image}
+																value={baseName}
+																onSelect={() => handleImageSelect(baseName)}
+															>
+																<Check
+																	className={cn(
+																		"mr-2 h-4 w-4",
+																		derivedImage === baseName
+																			? "opacity-100"
+																			: "opacity-0",
+																	)}
+																/>
+																{baseName}
+															</CommandItem>
+														);
+													})}
 												</CommandGroup>
 											</CommandList>
 										</Command>
 									</PopoverContent>
 								</Popover>
+								{imageError && (
+									<p className="text-sm font-medium text-destructive mt-1">{imageError}</p>
+								)}
 							</div>
 
 							<div>
@@ -277,7 +336,10 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 											variant="outline"
 											role="combobox"
 											aria-expanded={tagOpen}
-											className="w-full justify-between font-normal"
+											className={cn(
+											"w-full justify-between font-normal",
+											tagError && "border-destructive",
+										)}
 											disabled={!derivedImage}
 										>
 											{derivedTag || "Select a tag..."}
@@ -316,6 +378,9 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 										</Command>
 									</PopoverContent>
 								</Popover>
+								{tagError && (
+									<p className="text-sm font-medium text-destructive mt-1">{tagError}</p>
+								)}
 							</div>
 						</div>
 					)}

--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -1,9 +1,18 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { useEffect } from "react";
+import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
 import {
 	Form,
 	FormControl,
@@ -13,6 +22,19 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 
 const DockerProviderSchema = z.object({
@@ -44,6 +66,11 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 		resolver: zodResolver(DockerProviderSchema),
 	});
 
+	const [userOverride, setUserOverride] = useState(false);
+	const [selectedRegistryId, setSelectedRegistryId] = useState<string>("");
+	const [selectedImage, setSelectedImage] = useState<string>("");
+	const [selectedTag, setSelectedTag] = useState<string>("");
+
 	useEffect(() => {
 		if (data) {
 			form.reset({
@@ -55,6 +82,98 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 		}
 	}, [form.reset, data?.applicationId, form]);
 
+	const derivedRegistryId = userOverride
+		? selectedRegistryId
+		: data?.registryId ?? "";
+
+	const derivedImage = (() => {
+		if (userOverride) return selectedImage;
+		if (!data?.registryId || !data?.dockerImage) return "";
+		const dockerImage = data.dockerImage;
+		const tagSep = dockerImage.lastIndexOf(":");
+		if (tagSep === -1) return dockerImage;
+		let beforeTag = dockerImage.substring(0, tagSep);
+		const regUrl = (data.registryUrl || "").replace(/\/+$/, "");
+		if (regUrl && beforeTag.startsWith(`${regUrl}/`)) {
+			beforeTag = beforeTag.substring(regUrl.length + 1);
+		}
+		const prefix = data.registry?.imagePrefix;
+		if (prefix && beforeTag.startsWith(`${prefix}/`)) {
+			beforeTag = beforeTag.substring(prefix.length + 1);
+		}
+		return beforeTag;
+	})();
+
+	const derivedTag = (() => {
+		if (userOverride) return selectedTag;
+		if (!data?.registryId || !data?.dockerImage) return "";
+		const tagSep = data.dockerImage.lastIndexOf(":");
+		return tagSep !== -1 ? data.dockerImage.substring(tagSep + 1) : "";
+	})();
+	const [imageOpen, setImageOpen] = useState(false);
+	const [tagOpen, setTagOpen] = useState(false);
+
+	const { data: registries } = api.registry.all.useQuery();
+
+	const { data: images, isLoading: imagesLoading } =
+		api.registry.getImages.useQuery(
+			{ registryId: derivedRegistryId },
+			{ enabled: !!derivedRegistryId },
+		);
+
+	const { data: tags, isLoading: tagsLoading } =
+		api.registry.getImageTags.useQuery(
+			{ registryId: derivedRegistryId, imageName: derivedImage },
+			{ enabled: !!derivedRegistryId && !!derivedImage },
+		);
+
+	const selectedRegistry = registries?.find(
+		(r) => r.registryId === derivedRegistryId,
+	);
+
+	const populateFormFromRegistry = (
+		reg: typeof selectedRegistry,
+		image: string,
+		tag: string,
+	) => {
+		if (!reg) return;
+		const registryUrl = reg.registryUrl.replace(/\/+$/, "");
+		const prefix = reg.imagePrefix;
+		const imagePath = prefix ? `${prefix}/${image}` : image;
+		const fullImage = `${registryUrl}/${imagePath}:${tag}`;
+		form.setValue("dockerImage", fullImage);
+		form.setValue("username", reg.username);
+		form.setValue("password", reg.password);
+		form.setValue("registryURL", reg.registryUrl);
+	};
+
+	const handleRegistryChange = (value: string) => {
+		setUserOverride(true);
+		setSelectedRegistryId(value === "none" ? "" : value);
+		setSelectedImage("");
+		setSelectedTag("");
+		if (value === "none") {
+			form.setValue("dockerImage", "");
+			form.setValue("username", "");
+			form.setValue("password", "");
+			form.setValue("registryURL", "");
+		}
+	};
+
+	const handleImageSelect = (image: string) => {
+		setUserOverride(true);
+		setSelectedImage(image);
+		setSelectedTag("");
+		setImageOpen(false);
+	};
+
+	const handleTagSelect = (tag: string) => {
+		setUserOverride(true);
+		setSelectedTag(tag);
+		setTagOpen(false);
+		populateFormFromRegistry(selectedRegistry, derivedImage, tag);
+	};
+
 	const onSubmit = async (values: DockerProvider) => {
 		await mutateAsync({
 			dockerImage: values.dockerImage,
@@ -62,6 +181,7 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 			applicationId,
 			username: values.username || null,
 			registryUrl: values.registryURL || null,
+			registryId: derivedRegistryId || null,
 		})
 			.then(async () => {
 				toast.success("Docker Provider Saved");
@@ -78,75 +198,200 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 				onSubmit={form.handleSubmit(onSubmit)}
 				className="flex flex-col gap-4"
 			>
-				<div className="grid md:grid-cols-2 gap-4 ">
-					<div className="space-y-4">
-						<FormField
-							control={form.control}
-							name="dockerImage"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Docker Image</FormLabel>
-									<FormControl>
-										<Input placeholder="node:16" {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+				<div className="space-y-4">
+					<div>
+						<FormLabel>Browse from Registry</FormLabel>
+						<Select
+							value={derivedRegistryId || "none"}
+							onValueChange={handleRegistryChange}
+						>
+							<SelectTrigger>
+								<SelectValue placeholder="Select a registry" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="none">None (manual input)</SelectItem>
+								{registries?.map((reg) => (
+									<SelectItem key={reg.registryId} value={reg.registryId}>
+										{reg.registryName}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</div>
-					<FormField
-						control={form.control}
-						name="registryURL"
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>Registry URL</FormLabel>
-								<FormControl>
-									<Input placeholder="Registry URL" {...field} />
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-					<div className="space-y-4">
-						<FormField
-							control={form.control}
-							name="username"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Username</FormLabel>
-									<FormControl>
-										<Input
-											placeholder="Username"
-											autoComplete="username"
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-					</div>
-					<div className="space-y-4">
-						<FormField
-							control={form.control}
-							name="password"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Password</FormLabel>
-									<FormControl>
-										<Input
-											placeholder="Password"
-											autoComplete="one-time-code"
-											{...field}
-											type="password"
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-					</div>
+
+					{derivedRegistryId && (
+						<div className="grid md:grid-cols-2 gap-4">
+							<div>
+								<FormLabel>Image</FormLabel>
+								<Popover open={imageOpen} onOpenChange={setImageOpen}>
+									<PopoverTrigger asChild>
+										<Button
+											variant="outline"
+											role="combobox"
+											aria-expanded={imageOpen}
+											className="w-full justify-between font-normal"
+										>
+											{derivedImage || "Select an image..."}
+											{imagesLoading ? (
+												<Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin" />
+											) : (
+												<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+											)}
+										</Button>
+									</PopoverTrigger>
+									<PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+										<Command>
+											<CommandInput placeholder="Search images..." />
+											<CommandList>
+												<CommandEmpty>No images found.</CommandEmpty>
+												<CommandGroup>
+													{images?.map((image) => (
+														<CommandItem
+															key={image}
+															value={image}
+															onSelect={() => handleImageSelect(image)}
+														>
+															<Check
+																className={cn(
+																	"mr-2 h-4 w-4",
+																	derivedImage === image
+																		? "opacity-100"
+																		: "opacity-0",
+																)}
+															/>
+															{image}
+														</CommandItem>
+													))}
+												</CommandGroup>
+											</CommandList>
+										</Command>
+									</PopoverContent>
+								</Popover>
+							</div>
+
+							<div>
+								<FormLabel>Tag</FormLabel>
+								<Popover open={tagOpen} onOpenChange={setTagOpen}>
+									<PopoverTrigger asChild>
+										<Button
+											variant="outline"
+											role="combobox"
+											aria-expanded={tagOpen}
+											className="w-full justify-between font-normal"
+											disabled={!derivedImage}
+										>
+											{derivedTag || "Select a tag..."}
+											{tagsLoading ? (
+												<Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin" />
+											) : (
+												<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+											)}
+										</Button>
+									</PopoverTrigger>
+									<PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+										<Command>
+											<CommandInput placeholder="Search tags..." />
+											<CommandList>
+												<CommandEmpty>No tags found.</CommandEmpty>
+												<CommandGroup>
+													{tags?.map((tag) => (
+														<CommandItem
+															key={tag}
+															value={tag}
+															onSelect={() => handleTagSelect(tag)}
+														>
+															<Check
+																className={cn(
+																	"mr-2 h-4 w-4",
+																	derivedTag === tag
+																		? "opacity-100"
+																		: "opacity-0",
+																)}
+															/>
+															{tag}
+														</CommandItem>
+													))}
+												</CommandGroup>
+											</CommandList>
+										</Command>
+									</PopoverContent>
+								</Popover>
+							</div>
+						</div>
+					)}
 				</div>
+
+				{!derivedRegistryId && (
+					<div className="grid md:grid-cols-2 gap-4 ">
+						<div className="space-y-4">
+							<FormField
+								control={form.control}
+								name="dockerImage"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Docker Image</FormLabel>
+										<FormControl>
+											<Input placeholder="node:16" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<FormField
+							control={form.control}
+							name="registryURL"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Registry URL</FormLabel>
+									<FormControl>
+										<Input placeholder="Registry URL" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<div className="space-y-4">
+							<FormField
+								control={form.control}
+								name="username"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Username</FormLabel>
+										<FormControl>
+											<Input
+												placeholder="Username"
+												autoComplete="username"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<div className="space-y-4">
+							<FormField
+								control={form.control}
+								name="password"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Password</FormLabel>
+										<FormControl>
+											<Input
+												placeholder="Password"
+												autoComplete="one-time-code"
+												{...field}
+												type="password"
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+					</div>
+				)}
 
 				<div className="flex flex-row justify-end">
 					<Button

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -539,6 +539,7 @@ export const applicationRouter = createTRPCRouter({
 				sourceType: "docker",
 				applicationStatus: "idle",
 				registryUrl: input.registryUrl,
+				registryId: input.registryId ?? null,
 			});
 
 			return true;

--- a/apps/dokploy/server/api/routers/registry.ts
+++ b/apps/dokploy/server/api/routers/registry.ts
@@ -2,7 +2,10 @@ import {
 	createRegistry,
 	execAsyncRemote,
 	execFileAsync,
+	fetchRegistryImages,
+	fetchRegistryImageTags,
 	findRegistryById,
+	findRegistryByIdWithPassword,
 	IS_CLOUD,
 	removeRegistry,
 	updateRegistry,
@@ -10,6 +13,7 @@ import {
 import { db } from "@dokploy/server/db";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
+import { z } from "zod";
 import {
 	apiCreateRegistry,
 	apiFindOneRegistry,
@@ -121,6 +125,43 @@ export const registryRouter = createTRPCRouter({
 					cause: error,
 				});
 			}
+		}),
+	getImages: protectedProcedure
+		.input(apiFindOneRegistry)
+		.query(async ({ input, ctx }) => {
+			const reg = await findRegistryByIdWithPassword(input.registryId);
+			if (reg.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to access this registry",
+				});
+			}
+			return await fetchRegistryImages(
+				reg.registryUrl,
+				reg.username,
+				reg.password,
+			);
+		}),
+	getImageTags: protectedProcedure
+		.input(
+			apiFindOneRegistry.extend({
+				imageName: z.string().min(1),
+			}),
+		)
+		.query(async ({ input, ctx }) => {
+			const reg = await findRegistryByIdWithPassword(input.registryId);
+			if (reg.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You are not allowed to access this registry",
+				});
+			}
+			return await fetchRegistryImageTags(
+				reg.registryUrl,
+				reg.username,
+				reg.password,
+				input.imageName,
+			);
 		}),
 	testRegistryById: protectedProcedure
 		.input(apiTestRegistryById)

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -491,7 +491,10 @@ export const apiSaveDockerProvider = createSchema
 		password: true,
 		registryUrl: true,
 	})
-	.required();
+	.required()
+	.extend({
+		registryId: z.string().nullable().optional(),
+	});
 
 export const apiSaveGitProvider = createSchema
 	.pick({

--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -191,7 +191,9 @@ async function buildRegistryApiUrl(registryUrl: string): Promise<string> {
 	}
 	// Try HTTPS first, fall back to HTTP for self-hosted registries
 	try {
-		await fetch(`https://${trimmed}/v2/`, { signal: AbortSignal.timeout(3000) });
+		await fetch(`https://${trimmed}/v2/`, {
+			signal: AbortSignal.timeout(3000),
+		});
 		return `https://${trimmed}`;
 	} catch {
 		return `http://${trimmed}`;

--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -203,7 +203,7 @@ async function buildRegistryApiUrl(registryUrl: string): Promise<string> {
 function parseNextLinkHeader(header: string | null): string | null {
 	if (!header) return null;
 	const match = header.match(/<([^>]+)>;\s*rel="next"/);
-	return match ? match[1] : null;
+	return match?.[1] ?? null;
 }
 
 export const fetchRegistryImages = async (

--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -184,12 +184,24 @@ export const findRegistryByIdWithPassword = async (registryId: string) => {
 	return registryResponse;
 };
 
-function buildRegistryApiUrl(registryUrl: string): string {
+async function buildRegistryApiUrl(registryUrl: string): Promise<string> {
 	const trimmed = registryUrl.replace(/\/+$/, "");
 	if (/^https?:\/\//i.test(trimmed)) {
 		return trimmed;
 	}
-	return `http://${trimmed}`;
+	// Try HTTPS first, fall back to HTTP for self-hosted registries
+	try {
+		await fetch(`https://${trimmed}/v2/`, { signal: AbortSignal.timeout(3000) });
+		return `https://${trimmed}`;
+	} catch {
+		return `http://${trimmed}`;
+	}
+}
+
+function parseNextLinkHeader(header: string | null): string | null {
+	if (!header) return null;
+	const match = header.match(/<([^>]+)>;\s*rel="next"/);
+	return match ? match[1] : null;
 }
 
 export const fetchRegistryImages = async (
@@ -197,24 +209,54 @@ export const fetchRegistryImages = async (
 	username: string,
 	password: string,
 ): Promise<string[]> => {
-	const baseUrl = buildRegistryApiUrl(registryUrl);
+	const baseUrl = await buildRegistryApiUrl(registryUrl);
 	const auth = Buffer.from(`${username}:${password}`).toString("base64");
+	const headers = { Authorization: `Basic ${auth}` };
 
-	const response = await fetch(`${baseUrl}/v2/_catalog`, {
-		headers: {
-			Authorization: `Basic ${auth}`,
-		},
-	});
+	const repositories: string[] = [];
+	let url: string | null = `${baseUrl}/v2/_catalog?n=100`;
 
-	if (!response.ok) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Failed to fetch images from registry: ${response.statusText}`,
-		});
+	while (url) {
+		let response: Response;
+		try {
+			response = await fetch(url, { headers });
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Could not connect to registry: ${message}`,
+			});
+		}
+
+		if (!response.ok) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Failed to fetch images from registry: ${response.statusText}`,
+			});
+		}
+
+		const data = (await response.json()) as { repositories?: string[] };
+		repositories.push(...(data.repositories ?? []));
+		url = parseNextLinkHeader(response.headers.get("Link"));
 	}
 
-	const data = (await response.json()) as { repositories?: string[] };
-	return data.repositories ?? [];
+	// Filter out repositories with no tags (e.g. after manifest deletion)
+	const results = await Promise.all(
+		repositories.map(async (repo) => {
+			try {
+				const tags = await fetchRegistryImageTags(
+					registryUrl,
+					username,
+					password,
+					repo,
+				);
+				return tags.length > 0 ? repo : null;
+			} catch {
+				return null;
+			}
+		}),
+	);
+	return results.filter((r): r is string => r !== null);
 };
 
 export const fetchRegistryImageTags = async (
@@ -223,22 +265,36 @@ export const fetchRegistryImageTags = async (
 	password: string,
 	imageName: string,
 ): Promise<string[]> => {
-	const baseUrl = buildRegistryApiUrl(registryUrl);
+	const baseUrl = await buildRegistryApiUrl(registryUrl);
 	const auth = Buffer.from(`${username}:${password}`).toString("base64");
+	const headers = { Authorization: `Basic ${auth}` };
 
-	const response = await fetch(`${baseUrl}/v2/${imageName}/tags/list`, {
-		headers: {
-			Authorization: `Basic ${auth}`,
-		},
-	});
+	const allTags: string[] = [];
+	let url: string | null = `${baseUrl}/v2/${imageName}/tags/list?n=100`;
 
-	if (!response.ok) {
-		throw new TRPCError({
-			code: "BAD_REQUEST",
-			message: `Failed to fetch tags for image "${imageName}": ${response.statusText}`,
-		});
+	while (url) {
+		let response: Response;
+		try {
+			response = await fetch(url, { headers });
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Could not connect to registry: ${message}`,
+			});
+		}
+
+		if (!response.ok) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Failed to fetch tags for image "${imageName}": ${response.statusText}`,
+			});
+		}
+
+		const data = (await response.json()) as { tags?: string[] };
+		allTags.push(...(data.tags ?? []));
+		url = parseNextLinkHeader(response.headers.get("Link"));
 	}
 
-	const data = (await response.json()) as { tags?: string[] };
-	return data.tags ?? [];
+	return allTags;
 };

--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -170,3 +170,75 @@ export const findAllRegistryByOrganizationId = async (
 	});
 	return registryResponse;
 };
+
+export const findRegistryByIdWithPassword = async (registryId: string) => {
+	const registryResponse = await db.query.registry.findFirst({
+		where: eq(registry.registryId, registryId),
+	});
+	if (!registryResponse) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Registry not found",
+		});
+	}
+	return registryResponse;
+};
+
+function buildRegistryApiUrl(registryUrl: string): string {
+	const trimmed = registryUrl.replace(/\/+$/, "");
+	if (/^https?:\/\//i.test(trimmed)) {
+		return trimmed;
+	}
+	return `http://${trimmed}`;
+}
+
+export const fetchRegistryImages = async (
+	registryUrl: string,
+	username: string,
+	password: string,
+): Promise<string[]> => {
+	const baseUrl = buildRegistryApiUrl(registryUrl);
+	const auth = Buffer.from(`${username}:${password}`).toString("base64");
+
+	const response = await fetch(`${baseUrl}/v2/_catalog`, {
+		headers: {
+			Authorization: `Basic ${auth}`,
+		},
+	});
+
+	if (!response.ok) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Failed to fetch images from registry: ${response.statusText}`,
+		});
+	}
+
+	const data = (await response.json()) as { repositories?: string[] };
+	return data.repositories ?? [];
+};
+
+export const fetchRegistryImageTags = async (
+	registryUrl: string,
+	username: string,
+	password: string,
+	imageName: string,
+): Promise<string[]> => {
+	const baseUrl = buildRegistryApiUrl(registryUrl);
+	const auth = Buffer.from(`${username}:${password}`).toString("base64");
+
+	const response = await fetch(`${baseUrl}/v2/${imageName}/tags/list`, {
+		headers: {
+			Authorization: `Basic ${auth}`,
+		},
+	});
+
+	if (!response.ok) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Failed to fetch tags for image "${imageName}": ${response.statusText}`,
+		});
+	}
+
+	const data = (await response.json()) as { tags?: string[] };
+	return data.tags ?? [];
+};


### PR DESCRIPTION
## Summary

This PR enhances the Docker provider configuration in application general settings by adding a **registry browser** directly within the Docker tab. Users can now select a registry they've already added to the system and browse available images and tags instead of manually typing the full image path and credentials.

- Registry selector dropdown that lists all registries added to the system
- Searchable image combobox fetching the image catalog from the selected registry via Docker Registry API v2
- Searchable tag combobox fetching available tags for the selected image
- Auto-populates Docker image path, username, password, and registry URL on tag selection
- Falls back to the existing manual input form when no registry is selected
- Persists the linked `registryId` alongside the Docker provider configuration

## Changes Made

### Database Schema
- Extended `apiSaveDockerProvider` validation schema with an optional `registryId` field (`packages/server/src/db/schema/application.ts`)

### Backend Implementation
- **Registry Service** (`packages/server/src/services/registry.ts`):
  - `findRegistryByIdWithPassword()`: Retrieves a registry record including credentials
  - `fetchRegistryImages()`: Fetches the image catalog via `/v2/_catalog` endpoint
  - `fetchRegistryImageTags()`: Fetches tags for a specific image via `/v2/{image}/tags/list` endpoint

- **tRPC Registry Router** (`apps/dokploy/server/api/routers/registry.ts`):
  - `getImages`: Protected query — returns image list from a registry
  - `getImageTags`: Protected query — returns tag list for a given image

- **Application Router** (`apps/dokploy/server/api/routers/application.ts`):
  - Updated `saveDockerProvider` to persist `registryId` when provided

### Frontend Implementation
- **Docker Provider Component** (`apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx`):
  - Added "Browse from Registry" section at the top of the Docker provider form
  - Cascading selectors: Registry → Image (combobox with search) → Tag (combobox with search)
  - Loading spinners during image/tag fetch
  - Selecting a tag auto-fills all form fields (image path, credentials, registry URL)
  - Manual input fields remain visible and functional when no registry is selected
  - Existing saved registry configuration is correctly derived and pre-selected on form load

## Screenshots

### Docker Provider - Registry Browser
<img width="2346" height="814" alt="CleanShot 2026-03-06 at 01 06 15@2x" src="https://github.com/user-attachments/assets/21098926-82cb-402a-83ea-7f0ee344e42a" />

### Image Selection
<img width="2342" height="818" alt="CleanShot 2026-03-06 at 01 06 22@2x" src="https://github.com/user-attachments/assets/0a0b81b8-20b7-4822-8353-509242ac5711" />

### Manual Input (No Registry Selected)
<img width="2336" height="1010" alt="CleanShot 2026-03-06 at 01 06 05@2x" src="https://github.com/user-attachments/assets/cb5b78fc-ff8b-4e54-9b29-3e9187f8826b" />

## Test Plan

- [x] Registry dropdown lists all registries added to the system
- [x] Selecting a registry fetches and displays images from that registry
- [x] Selecting an image fetches and displays available tags
- [x] Selecting a tag auto-populates Docker image, username, password, and registry URL fields
- [x] Saving persists `registryId` alongside the Docker provider config
- [x] Existing saved configurations are correctly pre-selected when reopening the form
- [x] Manual input form is shown when "None (manual input)" is selected
- [x] Authentication with private registries works correctly

## Breaking Changes

None. Existing Docker provider configurations continue to work without modification. The registry browser is purely additive.

## Related Issues

Closes #2204