### PR TITLE
perf: reduce memory footprint for low memory self-hosted nodes  

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,17 @@ pnpm run dokploy:dev
 
 Go to http://localhost:3000 to see the development server
 
+### Environment Variables (Optional)
+
+These environment variables can be used to tune resource usage, especially on constrained (4GB) nodes:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MONITORING_WS_REFRESH_MS` | `1300` | WebSocket monitoring poll interval in milliseconds. Increase on low-memory nodes. |
+| `SCHEDULE_WORKER_COUNT` | `3` | Number of BullMQ workers for the schedules service. |
+| `SCHEDULE_WORKER_CONCURRENCY` | `100` | Max concurrent jobs per worker. |
+| `MAX_METRICS_LIMIT` | `2000` | Server-side cap for monitoring metrics queries. |
+
 > [!NOTE]
 > This project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /app
 
 # Set production
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--max-old-space-size=512"
 
 RUN apt-get update && apt-get install -y curl unzip zip apache2-utils iproute2 rsync git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.schedule
+++ b/Dockerfile.schedule
@@ -29,6 +29,7 @@ WORKDIR /app
 
 # Set production
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--max-old-space-size=256"
 
 # Copy only the necessary files
 COPY --from=build /prod/schedules/dist ./dist

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -29,6 +29,7 @@ WORKDIR /app
 
 # Set production
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--max-old-space-size=512"
 
 # Copy only the necessary files
 COPY --from=build /prod/api/dist ./dist

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-block-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-block-chart.tsx
@@ -80,8 +80,8 @@ interface CustomTooltipProps {
 		value?: number;
 		payload: {
 			time: string;
-			readMb: number;
-			writeMb: number;
+			readMb: string;
+			writeMb: string;
 		};
 	}[];
 }

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-network-chart.tsx
@@ -76,8 +76,8 @@ interface CustomTooltipProps {
 		value?: number;
 		payload: {
 			time: string;
-			inMB: number;
-			outMB: number;
+			inMB: string;
+			outMB: string;
 		};
 	}[];
 }

--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -15,22 +15,22 @@ const defaultData = {
 	},
 	memory: {
 		value: {
-			used: 0,
-			total: 0,
+			used: "0",
+			total: "0",
 		},
 		time: "",
 	},
 	block: {
 		value: {
-			readMb: 0,
-			writeMb: 0,
+			readMb: "0",
+			writeMb: "0",
 		},
 		time: "",
 	},
 	network: {
 		value: {
-			inputMb: 0,
-			outputMb: 0,
+			inputMb: "0",
+			outputMb: "0",
 		},
 		time: "",
 	},
@@ -51,22 +51,22 @@ export interface DockerStats {
 	};
 	memory: {
 		value: {
-			used: number;
-			total: number;
+			used: string;
+			total: string;
 		};
 		time: string;
 	};
 	block: {
 		value: {
-			readMb: number;
-			writeMb: number;
+			readMb: string;
+			writeMb: string;
 		};
 		time: string;
 	};
 	network: {
 		value: {
-			inputMb: number;
-			outputMb: number;
+			inputMb: string;
+			outputMb: string;
 		};
 		time: string;
 	};

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -8,7 +8,121 @@ import {
 	recordAdvancedStats,
 	validateRequest,
 } from "@dokploy/server";
-import { WebSocketServer } from "ws";
+import { type WebSocket, WebSocketServer } from "ws";
+
+const REFRESH_MS = Number(process.env.MONITORING_WS_REFRESH_MS) || 1300;
+
+interface Poller {
+	clients: Set<WebSocket>;
+	running: boolean;
+	appType: "application" | "stack" | "docker-compose";
+}
+
+const pollers = new Map<string, Poller>();
+
+async function runPollerLoop(appName: string) {
+	const poller = pollers.get(appName);
+	if (!poller) return;
+
+	while (poller.running && poller.clients.size > 0) {
+		try {
+			let data: unknown;
+
+			if (appName === "dokploy") {
+				const stat = await getHostSystemStats();
+				await recordAdvancedStats(stat, appName);
+				data = await getLastAdvancedStatsFile(appName);
+			} else {
+				const filter = {
+					status: ["running"],
+					...(poller.appType === "application" && {
+						label: [`com.docker.swarm.service.name=${appName}`],
+					}),
+					...(poller.appType === "stack" && {
+						label: [`com.docker.swarm.task.name=${appName}`],
+					}),
+					...(poller.appType === "docker-compose" && {
+						name: [appName],
+					}),
+				};
+
+				const containers = await docker.listContainers({
+					filters: JSON.stringify(filter),
+				});
+
+				const container = containers[0];
+				if (!container || container?.State !== "running") {
+					for (const client of poller.clients) {
+						client.close(4000, "Container not running");
+					}
+					break;
+				}
+
+				const { stdout, stderr } = await execAsync(
+					`docker stats ${container.Id} --no-stream --format '{"BlockIO":"{{.BlockIO}}","CPUPerc":"{{.CPUPerc}}","Container":"{{.Container}}","ID":"{{.ID}}","MemPerc":"{{.MemPerc}}","MemUsage":"{{.MemUsage}}","Name":"{{.Name}}","NetIO":"{{.NetIO}}"}'`,
+				);
+				if (stderr) {
+					console.error("Docker stats error:", stderr);
+					await delay(REFRESH_MS);
+					continue;
+				}
+
+				const stat = JSON.parse(stdout);
+				await recordAdvancedStats(stat, appName);
+				data = await getLastAdvancedStatsFile(appName);
+			}
+
+			const message = JSON.stringify({ data });
+			for (const client of poller.clients) {
+				if (client.readyState === client.OPEN) {
+					client.send(message);
+				}
+			}
+		} catch (error) {
+			const msg = `Error: ${(error as Error).message}`;
+			for (const client of poller.clients) {
+				client.close(4000, msg);
+			}
+			break;
+		}
+
+		await delay(REFRESH_MS);
+	}
+
+	pollers.delete(appName);
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function addClientToPoller(
+	appName: string,
+	appType: "application" | "stack" | "docker-compose",
+	ws: WebSocket,
+) {
+	let poller = pollers.get(appName);
+
+	if (poller) {
+		poller.clients.add(ws);
+	} else {
+		poller = {
+			clients: new Set([ws]),
+			running: true,
+			appType,
+		};
+		pollers.set(appName, poller);
+		runPollerLoop(appName);
+	}
+
+	ws.on("close", () => {
+		if (!poller) return;
+		poller.clients.delete(ws);
+		if (poller.clients.size === 0) {
+			poller.running = false;
+		}
+	});
+}
 
 export const setupDockerStatsMonitoringSocketServer = (
 	server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>,
@@ -55,70 +169,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 			ws.close();
 			return;
 		}
-		const intervalId = setInterval(async () => {
-			try {
-				// Special case: when monitoring "dokploy", get host system stats instead of container stats
-				if (appName === "dokploy") {
-					const stat = await getHostSystemStats();
 
-					await recordAdvancedStats(stat, appName);
-					const data = await getLastAdvancedStatsFile(appName);
-
-					ws.send(
-						JSON.stringify({
-							data,
-						}),
-					);
-					return;
-				}
-
-				const filter = {
-					status: ["running"],
-					...(appType === "application" && {
-						label: [`com.docker.swarm.service.name=${appName}`],
-					}),
-					...(appType === "stack" && {
-						label: [`com.docker.swarm.task.name=${appName}`],
-					}),
-					...(appType === "docker-compose" && {
-						name: [appName],
-					}),
-				};
-
-				const containers = await docker.listContainers({
-					filters: JSON.stringify(filter),
-				});
-
-				const container = containers[0];
-				if (!container || container?.State !== "running") {
-					ws.close(4000, "Container not running");
-					return;
-				}
-				const { stdout, stderr } = await execAsync(
-					`docker stats ${container.Id} --no-stream --format \'{"BlockIO":"{{.BlockIO}}","CPUPerc":"{{.CPUPerc}}","Container":"{{.Container}}","ID":"{{.ID}}","MemPerc":"{{.MemPerc}}","MemUsage":"{{.MemUsage}}","Name":"{{.Name}}","NetIO":"{{.NetIO}}"}\'`,
-				);
-				if (stderr) {
-					console.error("Docker stats error:", stderr);
-					return;
-				}
-				const stat = JSON.parse(stdout);
-
-				await recordAdvancedStats(stat, appName);
-				const data = await getLastAdvancedStatsFile(appName);
-
-				ws.send(
-					JSON.stringify({
-						data,
-					}),
-				);
-			} catch (error) {
-				// @ts-ignore
-				ws.close(4000, `Error: ${error.message}`);
-			}
-		}, 1300);
-
-		ws.on("close", () => {
-			clearInterval(intervalId);
-		});
+		addClientToPoller(appName, appType, ws);
 	});
 };

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -10,7 +10,10 @@ import {
 } from "@dokploy/server";
 import { type WebSocket, WebSocketServer } from "ws";
 
-const REFRESH_MS = Math.max(500, Number(process.env.MONITORING_WS_REFRESH_MS) || 1300);
+const REFRESH_MS = Math.max(
+	500,
+	Number(process.env.MONITORING_WS_REFRESH_MS) || 1300,
+);
 
 interface Poller {
 	clients: Set<WebSocket>;

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -10,7 +10,7 @@ import {
 } from "@dokploy/server";
 import { type WebSocket, WebSocketServer } from "ws";
 
-const REFRESH_MS = Number(process.env.MONITORING_WS_REFRESH_MS) || 1300;
+const REFRESH_MS = Math.max(500, Number(process.env.MONITORING_WS_REFRESH_MS) || 1300);
 
 interface Poller {
 	clients: Set<WebSocket>;
@@ -116,10 +116,11 @@ function addClientToPoller(
 	}
 
 	ws.on("close", () => {
-		if (!poller) return;
-		poller.clients.delete(ws);
-		if (poller.clients.size === 0) {
-			poller.running = false;
+		const p = pollers.get(appName);
+		if (!p) return;
+		p.clients.delete(ws);
+		if (p.clients.size === 0) {
+			p.running = false;
 		}
 	});
 }

--- a/apps/monitoring/README.md
+++ b/apps/monitoring/README.md
@@ -49,11 +49,37 @@ go mod download
 go run main.go
 ```
 
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `METRICS_CONFIG` | — | JSON configuration (see above) |
+| `MAX_METRICS_LIMIT` | `2000` | Server-side cap for metrics queries. Applies when `limit=all` or when a requested limit exceeds this value. |
+
 ## Endpoints
 
 - `GET /health` - Check service health status (no authentication required)
-- `GET /metrics?limit=<number|all>` - Get server metrics (default limit: 50)
-- `GET /metrics/containers?limit=<number|all>&appName=<name>` - Get container metrics for a specific application (default limit: 50)
+- `GET /metrics?limit=<number|all>&before=<RFC3339Nano>` - Get server metrics (default limit: 50). Returns `X-Total-Count` header with total row count.
+- `GET /metrics/containers?limit=<number|all>&appName=<name>&before=<RFC3339Nano>` - Get container metrics for a specific application (default limit: 50). Returns `X-Total-Count` header.
+
+### Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `limit` | Number of records to return, or `all` (capped at `MAX_METRICS_LIMIT`). Default: `50`. |
+| `before` | RFC3339Nano timestamp cursor for pagination. Returns records older than this timestamp. |
+| `appName` | (containers only) Filter by application/container name. |
+
+### Pagination
+
+Use the `before` parameter to paginate through historical data. Take the oldest `timestamp` from the current response and pass it as `before` in the next request.
+
+```
+GET /metrics?limit=50
+GET /metrics?limit=50&before=2025-01-19T21:44:54.232164Z
+```
+
+> **Note:** `limit=all` is deprecated and capped at `MAX_METRICS_LIMIT` (default 2000). Use pagination with `before` for large datasets.
 
 ## Features
 

--- a/apps/monitoring/database/containers.go
+++ b/apps/monitoring/database/containers.go
@@ -53,13 +53,13 @@ func (db *DB) GetLastNContainerMetrics(containerName string, limit int) ([]Conta
 
 	query := `
 		WITH recent_metrics AS (
-			SELECT metrics_json
+			SELECT timestamp, metrics_json
 			FROM container_metrics
 			WHERE container_name = ?
 			ORDER BY timestamp DESC
 			LIMIT ?
 		)
-		SELECT metrics_json FROM recent_metrics ORDER BY json_extract(metrics_json, '$.timestamp') ASC
+		SELECT metrics_json FROM recent_metrics ORDER BY timestamp ASC
 	`
 	rows, err := db.Query(query, containerName, limit)
 	if err != nil {
@@ -89,13 +89,13 @@ func (db *DB) GetContainerMetricsBefore(containerName string, cursor time.Time, 
 
 	query := `
 		WITH before_metrics AS (
-			SELECT metrics_json
+			SELECT timestamp, metrics_json
 			FROM container_metrics
 			WHERE container_name = ? AND timestamp < ?
 			ORDER BY timestamp DESC
 			LIMIT ?
 		)
-		SELECT metrics_json FROM before_metrics ORDER BY json_extract(metrics_json, '$.timestamp') ASC
+		SELECT metrics_json FROM before_metrics ORDER BY timestamp ASC
 	`
 	rows, err := db.Query(query, containerName, cursor.UTC().Format(time.RFC3339Nano), limit)
 	if err != nil {
@@ -132,12 +132,12 @@ func (db *DB) GetAllMetricsContainer(containerName string) ([]ContainerMetric, e
 
 	query := `
 		WITH recent_metrics AS (
-			SELECT metrics_json
+			SELECT timestamp, metrics_json
 			FROM container_metrics
 			WHERE container_name = ?
 			ORDER BY timestamp DESC
 		)
-		SELECT metrics_json FROM recent_metrics ORDER BY json_extract(metrics_json, '$.timestamp') ASC
+		SELECT metrics_json FROM recent_metrics ORDER BY timestamp ASC
 	`
 	rows, err := db.Query(query, containerName)
 	if err != nil {

--- a/apps/monitoring/database/containers.go
+++ b/apps/monitoring/database/containers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 func (db *DB) InitContainerMetricsTable() error {
@@ -81,6 +82,49 @@ func (db *DB) GetLastNContainerMetrics(containerName string, limit int) ([]Conta
 		metrics = append(metrics, metric)
 	}
 	return metrics, nil
+}
+
+func (db *DB) GetContainerMetricsBefore(containerName string, cursor time.Time, limit int) ([]ContainerMetric, error) {
+	containerName = strings.TrimPrefix(containerName, "/")
+
+	query := `
+		WITH before_metrics AS (
+			SELECT metrics_json
+			FROM container_metrics
+			WHERE container_name = ? AND timestamp < ?
+			ORDER BY timestamp DESC
+			LIMIT ?
+		)
+		SELECT metrics_json FROM before_metrics ORDER BY json_extract(metrics_json, '$.timestamp') ASC
+	`
+	rows, err := db.Query(query, containerName, cursor.UTC().Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var metrics []ContainerMetric
+	for rows.Next() {
+		var metricsJSON string
+		err := rows.Scan(&metricsJSON)
+		if err != nil {
+			return nil, err
+		}
+
+		var metric ContainerMetric
+		if err := json.Unmarshal([]byte(metricsJSON), &metric); err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, metric)
+	}
+	return metrics, nil
+}
+
+func (db *DB) GetContainerMetricsCount(containerName string) (int, error) {
+	containerName = strings.TrimPrefix(containerName, "/")
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM container_metrics WHERE container_name = ?`, containerName).Scan(&count)
+	return count, err
 }
 
 func (db *DB) GetAllMetricsContainer(containerName string) ([]ContainerMetric, error) {

--- a/apps/monitoring/database/server.go
+++ b/apps/monitoring/database/server.go
@@ -91,6 +91,41 @@ func (db *DB) GetLastNMetrics(n int) ([]ServerMetric, error) {
 	return metrics, nil
 }
 
+func (db *DB) GetMetricsBefore(cursor time.Time, limit int) ([]ServerMetric, error) {
+	rows, err := db.Query(`
+		WITH before_metrics AS (
+			SELECT timestamp, cpu, cpu_model, cpu_cores, cpu_physical_cores, cpu_speed, os, distro, kernel, arch, mem_used, mem_used_gb, mem_total, uptime, disk_used, total_disk, network_in, network_out
+			FROM server_metrics
+			WHERE timestamp < ?
+			ORDER BY timestamp DESC
+			LIMIT ?
+		)
+		SELECT * FROM before_metrics
+		ORDER BY timestamp ASC
+	`, cursor.UTC().Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var metrics []ServerMetric
+	for rows.Next() {
+		var m ServerMetric
+		err := rows.Scan(&m.Timestamp, &m.CPU, &m.CPUModel, &m.CPUCores, &m.CPUPhysicalCores, &m.CPUSpeed, &m.OS, &m.Distro, &m.Kernel, &m.Arch, &m.MemUsed, &m.MemUsedGB, &m.MemTotal, &m.Uptime, &m.DiskUsed, &m.TotalDisk, &m.NetworkIn, &m.NetworkOut)
+		if err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, m)
+	}
+	return metrics, nil
+}
+
+func (db *DB) GetMetricsCount() (int, error) {
+	var count int
+	err := db.QueryRow(`SELECT COUNT(*) FROM server_metrics`).Scan(&count)
+	return count, err
+}
+
 func (db *DB) GetAllMetrics() ([]ServerMetric, error) {
 	rows, err := db.Query(`
 		SELECT timestamp, cpu, cpu_model, cpu_cores, cpu_physical_cores, cpu_speed, os, distro, kernel, arch, mem_used, mem_used_gb, mem_total, uptime, disk_used, total_disk, network_in, network_out

--- a/apps/monitoring/main.go
+++ b/apps/monitoring/main.go
@@ -16,6 +16,16 @@ import (
 	"github.com/mauriciogm/dokploy/apps/monitoring/monitoring"
 )
 
+var maxMetricsLimit = 2000
+
+func init() {
+	if v := os.Getenv("MAX_METRICS_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxMetricsLimit = n
+		}
+	}
+}
+
 func main() {
 	godotenv.Load()
 
@@ -64,33 +74,56 @@ func main() {
 
 	app.Get("/metrics", func(c *fiber.Ctx) error {
 		limit := c.Query("limit", "50")
+		before := c.Query("before", "")
 
 		var metrics []monitoring.SystemMetrics
-		if limit == "all" {
-			dbMetrics, err := db.GetAllMetrics()
-			if err != nil {
-				return c.Status(500).JSON(fiber.Map{
-					"error": "Failed to fetch metrics",
+		var dbMetrics []database.ServerMetric
+		var queryErr error
+
+		if before != "" {
+			cursor, parseErr := time.Parse(time.RFC3339Nano, before)
+			if parseErr != nil {
+				return c.Status(400).JSON(fiber.Map{
+					"error": "Invalid 'before' timestamp format. Use RFC3339Nano.",
 				})
 			}
-			for _, m := range dbMetrics {
-				metrics = append(metrics, monitoring.ConvertToSystemMetrics(m))
+			n := 50
+			if limit != "all" {
+				if parsed, err := strconv.Atoi(limit); err == nil {
+					n = parsed
+				}
 			}
+			if n > maxMetricsLimit {
+				n = maxMetricsLimit
+			}
+			dbMetrics, queryErr = db.GetMetricsBefore(cursor, n)
+		} else if limit == "all" {
+			log.Printf("DEPRECATION WARNING: limit=all is deprecated. Results capped at %d. Use pagination with 'before' parameter.", maxMetricsLimit)
+			dbMetrics, queryErr = db.GetLastNMetrics(maxMetricsLimit)
 		} else {
 			n, err := strconv.Atoi(limit)
 			if err != nil {
 				n = 50
 			}
-			dbMetrics, err := db.GetLastNMetrics(n)
-			if err != nil {
-				return c.Status(500).JSON(fiber.Map{
-					"error": "Failed to fetch metrics",
-				})
+			if n > maxMetricsLimit {
+				n = maxMetricsLimit
 			}
-			for _, m := range dbMetrics {
-				metrics = append(metrics, monitoring.ConvertToSystemMetrics(m))
-			}
+			dbMetrics, queryErr = db.GetLastNMetrics(n)
 		}
+
+		if queryErr != nil {
+			return c.Status(500).JSON(fiber.Map{
+				"error": "Failed to fetch metrics",
+			})
+		}
+
+		for _, m := range dbMetrics {
+			metrics = append(metrics, monitoring.ConvertToSystemMetrics(m))
+		}
+
+		// Report total count so clients know if results were truncated
+		totalCount, _ := db.GetMetricsCount()
+		c.Set("X-Total-Count", strconv.Itoa(totalCount))
 
 		return c.JSON(metrics)
 	})
@@ -107,6 +140,7 @@ func main() {
 	app.Get("/metrics/containers", func(c *fiber.Ctx) error {
 		limit := c.Query("limit", "50")
 		appName := c.Query("appName", "")
+		before := c.Query("before", "")
 
 		if appName == "" {
 			return c.JSON([]database.ContainerMetric{})
@@ -115,12 +149,33 @@ func main() {
 		var metrics []database.ContainerMetric
 		var err error
 
-		if limit == "all" {
-			metrics, err = db.GetAllMetricsContainer(appName)
+		if before != "" {
+			cursor, parseErr := time.Parse(time.RFC3339Nano, before)
+			if parseErr != nil {
+				return c.Status(400).JSON(fiber.Map{
+					"error": "Invalid 'before' timestamp format. Use RFC3339Nano.",
+				})
+			}
+			n := 50
+			if limit != "all" {
+				if parsed, pErr := strconv.Atoi(limit); pErr == nil {
+					n = parsed
+				}
+			}
+			if n > maxMetricsLimit {
+				n = maxMetricsLimit
+			}
+			metrics, err = db.GetContainerMetricsBefore(appName, cursor, n)
+		} else if limit == "all" {
+			log.Printf("DEPRECATION WARNING: limit=all is deprecated for container metrics. Results capped at %d.", maxMetricsLimit)
+			metrics, err = db.GetLastNContainerMetrics(appName, maxMetricsLimit)
 		} else {
 			limitNum, parseErr := strconv.Atoi(limit)
 			if parseErr != nil {
 				limitNum = 50
+			}
+			if limitNum > maxMetricsLimit {
+				limitNum = maxMetricsLimit
 			}
 			metrics, err = db.GetLastNContainerMetrics(appName, limitNum)
 		}
@@ -130,6 +185,9 @@ func main() {
 				"error": "Error getting container metrics: " + err.Error(),
 			})
 		}
+
+		totalCount, _ := db.GetContainerMetricsCount(appName)
+		c.Set("X-Total-Count", strconv.Itoa(totalCount))
 
 		return c.JSON(metrics)
 	})

--- a/apps/monitoring/main.go
+++ b/apps/monitoring/main.go
@@ -122,7 +122,10 @@ func main() {
 		}
 
 		// Report total count so clients know if results were truncated
-		totalCount, _ := db.GetMetricsCount()
+		totalCount, countErr := db.GetMetricsCount()
+		if countErr != nil {
+			log.Printf("Error getting metrics count: %v", countErr)
+		}
 		c.Set("X-Total-Count", strconv.Itoa(totalCount))
 
 		return c.JSON(metrics)
@@ -186,7 +189,10 @@ func main() {
 			})
 		}
 
-		totalCount, _ := db.GetContainerMetricsCount(appName)
+		totalCount, countErr := db.GetContainerMetricsCount(appName)
+		if countErr != nil {
+			log.Printf("Error getting container metrics count: %v", countErr)
+		}
 		c.Set("X-Total-Count", strconv.Itoa(totalCount))
 
 		return c.JSON(metrics)

--- a/apps/schedules/src/index.ts
+++ b/apps/schedules/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "./queue.js";
 import { jobQueueSchema } from "./schema.js";
 import { initializeJobs } from "./utils.js";
-import { firstWorker, secondWorker, thirdWorker } from "./workers.js";
+import { workers } from "./workers.js";
 
 const app = new Hono();
 
@@ -89,9 +89,7 @@ app.get("/health", async (c) => {
 
 export const gracefulShutdown = async (signal: string) => {
 	logger.warn(`Received ${signal}, closing server...`);
-	await firstWorker.close();
-	await secondWorker.close();
-	await thirdWorker.close();
+	await Promise.all(workers.map((w) => w.close()));
 	process.exit(0);
 };
 

--- a/apps/schedules/src/workers.ts
+++ b/apps/schedules/src/workers.ts
@@ -3,43 +3,25 @@ import { logger } from "./logger.js";
 import type { QueueJob } from "./schema.js";
 import { runJobs } from "./utils.js";
 
-export const firstWorker = new Worker(
-	"backupQueue",
-	async (job: Job<QueueJob>) => {
-		logger.info({ data: job.data }, "Running job first worker");
-		await runJobs(job.data);
-	},
-	{
-		concurrency: 100,
-		connection: {
-			url: process.env.REDIS_URL!,
-		},
-	},
-);
-export const secondWorker = new Worker(
-	"backupQueue",
-	async (job: Job<QueueJob>) => {
-		logger.info({ data: job.data }, "Running job second worker");
-		await runJobs(job.data);
-	},
-	{
-		concurrency: 100,
-		connection: {
-			url: process.env.REDIS_URL!,
-		},
-	},
-);
+const workerCount = Number(process.env.SCHEDULE_WORKER_COUNT) || 3;
+const workerConcurrency =
+	Number(process.env.SCHEDULE_WORKER_CONCURRENCY) || 100;
 
-export const thirdWorker = new Worker(
-	"backupQueue",
-	async (job: Job<QueueJob>) => {
-		logger.info({ data: job.data }, "Running job third worker");
-		await runJobs(job.data);
-	},
-	{
-		concurrency: 100,
-		connection: {
-			url: process.env.REDIS_URL!,
+export const workers: Worker[] = [];
+
+for (let i = 0; i < workerCount; i++) {
+	const worker = new Worker(
+		"backupQueue",
+		async (job: Job<QueueJob>) => {
+			logger.info({ data: job.data }, `Running job worker-${i}`);
+			await runJobs(job.data);
 		},
-	},
-);
+		{
+			concurrency: workerConcurrency,
+			connection: {
+				url: process.env.REDIS_URL!,
+			},
+		},
+	);
+	workers.push(worker);
+}

--- a/apps/schedules/src/workers.ts
+++ b/apps/schedules/src/workers.ts
@@ -4,8 +4,10 @@ import type { QueueJob } from "./schema.js";
 import { runJobs } from "./utils.js";
 
 const workerCount = Math.max(1, Number(process.env.SCHEDULE_WORKER_COUNT) || 3);
-const workerConcurrency =
-	Math.max(1, Number(process.env.SCHEDULE_WORKER_CONCURRENCY) || 100);
+const workerConcurrency = Math.max(
+	1,
+	Number(process.env.SCHEDULE_WORKER_CONCURRENCY) || 100,
+);
 
 export const workers: Worker[] = [];
 

--- a/apps/schedules/src/workers.ts
+++ b/apps/schedules/src/workers.ts
@@ -3,9 +3,9 @@ import { logger } from "./logger.js";
 import type { QueueJob } from "./schema.js";
 import { runJobs } from "./utils.js";
 
-const workerCount = Number(process.env.SCHEDULE_WORKER_COUNT) || 3;
+const workerCount = Math.max(1, Number(process.env.SCHEDULE_WORKER_COUNT) || 3);
 const workerConcurrency =
-	Number(process.env.SCHEDULE_WORKER_CONCURRENCY) || 100;
+	Math.max(1, Number(process.env.SCHEDULE_WORKER_CONCURRENCY) || 100);
 
 export const workers: Worker[] = [];
 

--- a/packages/server/src/monitoring/utils.ts
+++ b/packages/server/src/monitoring/utils.ts
@@ -169,7 +169,9 @@ async function flushToDisk() {
 		const buf = statsCache.get(key);
 		if (!buf) continue;
 
-		const [appName, statType] = key.split("/");
+		const lastSlash = key.lastIndexOf("/");
+		const appName = key.substring(0, lastSlash);
+		const statType = key.substring(lastSlash + 1);
 		const dirPath = `${MONITORING_PATH}/${appName}`;
 		try {
 			await promises.mkdir(dirPath, { recursive: true });
@@ -193,10 +195,14 @@ function ensureFlushTimer() {
 // Flush on process exit
 process.on("beforeExit", () => flushToDisk());
 process.on("SIGTERM", () => {
-	flushToDisk().then(() => process.exit(0));
+	flushToDisk()
+		.catch((err) => console.error("Flush failed on SIGTERM:", err))
+		.finally(() => process.exit(0));
 });
 process.on("SIGINT", () => {
-	flushToDisk().then(() => process.exit(0));
+	flushToDisk()
+		.catch((err) => console.error("Flush failed on SIGINT:", err))
+		.finally(() => process.exit(0));
 });
 
 export const recordAdvancedStats = async (

--- a/packages/server/src/monitoring/utils.ts
+++ b/packages/server/src/monitoring/utils.ts
@@ -12,33 +12,204 @@ export interface Container {
 	Name: string;
 	NetIO: string;
 }
+
+type StatType = "cpu" | "memory" | "disk" | "network" | "block";
+
+export interface MemoryStatValue {
+	used: string;
+	total: string;
+}
+
+export interface BlockStatValue {
+	readMb: string;
+	writeMb: string;
+}
+
+export interface NetworkStatValue {
+	inputMb: string;
+	outputMb: string;
+}
+
+export interface DiskStatValue {
+	diskTotal: number;
+	diskUsedPercentage: number;
+	diskUsage: number;
+	diskFree: number;
+}
+
+export type StatValue =
+	| string
+	| MemoryStatValue
+	| BlockStatValue
+	| NetworkStatValue
+	| DiskStatValue;
+
+export interface StatTypeMap {
+	cpu: string;
+	memory: MemoryStatValue;
+	block: BlockStatValue;
+	network: NetworkStatValue;
+	disk: DiskStatValue;
+}
+
+const MAX_ENTRIES = 288;
+const FLUSH_INTERVAL_MS = 30_000;
+
+// Cached OSUtils instances
+const osutils = new OSUtils();
+const osutilsWithDisk = new OSUtils({ disk: { includeStats: true } });
+
+// In-memory ring buffer
+export interface StatsEntry<T = StatValue> {
+	value: T;
+	time: string;
+}
+
+class RingBuffer<T = StatValue> {
+	private buffer: StatsEntry<T>[];
+	private head = 0;
+	private count = 0;
+
+	constructor(private capacity: number) {
+		this.buffer = new Array(capacity);
+	}
+
+	push(entry: StatsEntry<T>) {
+		this.buffer[this.head] = entry;
+		this.head = (this.head + 1) % this.capacity;
+		if (this.count < this.capacity) {
+			this.count++;
+		}
+	}
+
+	toArray(): StatsEntry<T>[] {
+		if (this.count === 0) return [];
+		if (this.count < this.capacity) {
+			return this.buffer.slice(0, this.count);
+		}
+		// Wrap around: from head to end, then start to head
+		return [
+			...this.buffer.slice(this.head),
+			...this.buffer.slice(0, this.head),
+		];
+	}
+
+	last(): StatsEntry<T> | null {
+		if (this.count === 0) return null;
+		const idx = (this.head - 1 + this.capacity) % this.capacity;
+		return this.buffer[idx]!;
+	}
+
+	get length() {
+		return this.count;
+	}
+}
+
+const statsCache = new Map<string, RingBuffer>();
+const dirtyKeys = new Set<string>();
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+function getCacheKey(appName: string, statType: StatType): string {
+	return `${appName}/${statType}`;
+}
+
+function getOrCreateBuffer(key: string): RingBuffer {
+	let buf = statsCache.get(key);
+	if (!buf) {
+		buf = new RingBuffer(MAX_ENTRIES);
+		statsCache.set(key, buf);
+	}
+	return buf;
+}
+
+async function loadFromDisk(
+	appName: string,
+	statType: StatType,
+): Promise<RingBuffer> {
+	const key = getCacheKey(appName, statType);
+	const existing = statsCache.get(key);
+	if (existing && existing.length > 0) return existing;
+
+	const buf = getOrCreateBuffer(key);
+	try {
+		const { MONITORING_PATH } = paths();
+		const filePath = `${MONITORING_PATH}/${appName}/${statType}.json`;
+		const data = await promises.readFile(filePath, "utf-8");
+		const entries: StatsEntry[] = JSON.parse(data);
+		for (const entry of entries) {
+			buf.push(entry);
+		}
+	} catch {
+		// File doesn't exist yet
+	}
+	return buf;
+}
+
+async function flushToDisk() {
+	if (dirtyKeys.size === 0) return;
+
+	const { MONITORING_PATH } = paths();
+	const keysToFlush = [...dirtyKeys];
+	dirtyKeys.clear();
+
+	for (const key of keysToFlush) {
+		const buf = statsCache.get(key);
+		if (!buf) continue;
+
+		const [appName, statType] = key.split("/");
+		const dirPath = `${MONITORING_PATH}/${appName}`;
+		try {
+			await promises.mkdir(dirPath, { recursive: true });
+			await promises.writeFile(
+				`${dirPath}/${statType}.json`,
+				JSON.stringify(buf.toArray()),
+			);
+		} catch (err) {
+			console.error(`Failed to flush stats for ${key}:`, err);
+		}
+	}
+}
+
+function ensureFlushTimer() {
+	if (flushTimer) return;
+	flushTimer = setInterval(flushToDisk, FLUSH_INTERVAL_MS);
+	// Don't prevent process exit
+	if (flushTimer.unref) flushTimer.unref();
+}
+
+// Flush on process exit
+process.on("beforeExit", () => flushToDisk());
+process.on("SIGTERM", () => {
+	flushToDisk().then(() => process.exit(0));
+});
+
 export const recordAdvancedStats = async (
 	stats: Container,
 	appName: string,
 ) => {
-	const { MONITORING_PATH } = paths();
-	const path = `${MONITORING_PATH}/${appName}`;
+	ensureFlushTimer();
 
-	await promises.mkdir(path, { recursive: true });
+	const memParts = stats.MemUsage.split(" ");
+	const blockParts = stats.BlockIO.split(" ");
+	const netParts = stats.NetIO.split(" ");
 
 	await updateStatsFile(appName, "cpu", stats.CPUPerc);
 	await updateStatsFile(appName, "memory", {
-		used: stats.MemUsage.split(" ")[0],
-		total: stats.MemUsage.split(" ")[2],
+		used: memParts[0] ?? "0",
+		total: memParts[2] ?? "0",
 	});
 
 	await updateStatsFile(appName, "block", {
-		readMb: stats.BlockIO.split(" ")[0],
-		writeMb: stats.BlockIO.split(" ")[2],
+		readMb: blockParts[0] ?? "0",
+		writeMb: blockParts[2] ?? "0",
 	});
 
 	await updateStatsFile(appName, "network", {
-		inputMb: stats.NetIO.split(" ")[0],
-		outputMb: stats.NetIO.split(" ")[2],
+		inputMb: netParts[0] ?? "0",
+		outputMb: netParts[2] ?? "0",
 	});
 
 	if (appName === "dokploy") {
-		const osutils = new OSUtils();
 		const diskResult = await osutils.disk.usageByMountPoint("/");
 
 		if (diskResult.success && diskResult.data) {
@@ -58,23 +229,13 @@ export const recordAdvancedStats = async (
 	}
 };
 
-/**
- * Get host system statistics using node-os-utils
- * This is used when monitoring "dokploy" to show host stats instead of container stats
- */
 export const getHostSystemStats = async (): Promise<Container> => {
-	const osutils = new OSUtils({
-		disk: {
-			includeStats: true, // Enable disk I/O statistics
-		},
-	});
-
 	// Get CPU usage
-	const cpuResult = await osutils.cpu.usage();
+	const cpuResult = await osutilsWithDisk.cpu.usage();
 	const cpuUsage = cpuResult.success ? cpuResult.data : 0;
 
 	// Get memory info
-	const memResult = await osutils.memory.info();
+	const memResult = await osutilsWithDisk.memory.info();
 	let memUsedGB = 0;
 	let memTotalGB = 0;
 	let memUsedPercent = 0;
@@ -87,7 +248,7 @@ export const getHostSystemStats = async (): Promise<Container> => {
 	// Get network stats from network.overview()
 	let netInputBytes = 0;
 	let netOutputBytes = 0;
-	const networkOverview = await osutils.network.overview();
+	const networkOverview = await osutilsWithDisk.network.overview();
 	if (networkOverview.success) {
 		netInputBytes = networkOverview.data.totalRxBytes.toBytes();
 		netOutputBytes = networkOverview.data.totalTxBytes.toBytes();
@@ -96,25 +257,21 @@ export const getHostSystemStats = async (): Promise<Container> => {
 	// Get Block I/O from disk.stats()
 	let blockReadBytes = 0;
 	let blockWriteBytes = 0;
-	const diskStats = await osutils.disk.stats();
+	const diskStats = await osutilsWithDisk.disk.stats();
 	if (diskStats.success && diskStats.data.length > 0) {
-		// Filter out virtual devices (loop, ram, sr, etc.) - only include real disk devices
 		const excludePatterns = [/^loop/, /^ram/, /^sr\d+$/, /^fd\d+$/];
 		for (const stat of diskStats.data) {
-			// Skip virtual devices
 			if (
 				stat.device &&
 				excludePatterns.some((pattern) => pattern.test(stat.device))
 			) {
 				continue;
 			}
-			// readBytes and writeBytes are DataSize objects with .toBytes() method
 			blockReadBytes += stat.readBytes.toBytes();
 			blockWriteBytes += stat.writeBytes.toBytes();
 		}
 	}
 
-	// Format values similar to docker stats
 	const formatBytes = (bytes: number): string => {
 		if (bytes >= 1024 * 1024 * 1024) {
 			return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GiB`;
@@ -128,20 +285,16 @@ export const getHostSystemStats = async (): Promise<Container> => {
 		return `${bytes}B`;
 	};
 
-	// Format memory usage similar to docker stats format: "used / total"
 	const memUsedFormatted = `${memUsedGB.toFixed(2)}GiB`;
 	const memTotalFormatted = `${memTotalGB.toFixed(2)}GiB`;
 	const memUsageFormatted = `${memUsedFormatted} / ${memTotalFormatted}`;
 
-	// Format network I/O
 	const netInputMb = netInputBytes / (1024 * 1024);
 	const netOutputMb = netOutputBytes / (1024 * 1024);
 	const netIOFormatted = `${netInputMb.toFixed(2)}MB / ${netOutputMb.toFixed(2)}MB`;
 
-	// Format Block I/O
 	const blockIOFormatted = `${formatBytes(blockReadBytes)} / ${formatBytes(blockWriteBytes)}`;
 
-	// Create a stat object compatible with recordAdvancedStats
 	return {
 		CPUPerc: `${cpuUsage.toFixed(2)}%`,
 		MemPerc: `${memUsedPercent.toFixed(2)}%`,
@@ -164,53 +317,52 @@ export const getAdvancedStats = async (appName: string) => {
 	};
 };
 
-export const readStatsFile = async (
+export const readStatsFile = async <T extends StatType>(
 	appName: string,
-	statType: "cpu" | "memory" | "disk" | "network" | "block",
-) => {
-	try {
-		const { MONITORING_PATH } = paths();
-		const filePath = `${MONITORING_PATH}/${appName}/${statType}.json`;
-		const data = await promises.readFile(filePath, "utf-8");
-		return JSON.parse(data);
-	} catch {
-		return [];
+	statType: T,
+): Promise<StatsEntry<StatTypeMap[T]>[]> => {
+	const key = getCacheKey(appName, statType);
+	const cached = statsCache.get(key);
+	if (cached && cached.length > 0) {
+		return cached.toArray() as StatsEntry<StatTypeMap[T]>[];
 	}
+
+	// Cold start: load from disk
+	const buf = await loadFromDisk(appName, statType);
+	return buf.toArray() as StatsEntry<StatTypeMap[T]>[];
 };
 
 export const updateStatsFile = async (
 	appName: string,
-	statType: "cpu" | "memory" | "disk" | "network" | "block",
-	value: number | string | unknown,
+	statType: StatType,
+	value: StatValue,
 ) => {
-	const { MONITORING_PATH } = paths();
-	const stats = await readStatsFile(appName, statType);
-	stats.push({ value, time: new Date() });
+	const key = getCacheKey(appName, statType);
+	const buf = getOrCreateBuffer(key);
 
-	if (stats.length > 288) {
-		stats.shift();
+	// Ensure buffer is loaded from disk on first write
+	if (buf.length === 0) {
+		await loadFromDisk(appName, statType);
 	}
 
-	const content = JSON.stringify(stats);
-	await promises.writeFile(
-		`${MONITORING_PATH}/${appName}/${statType}.json`,
-		content,
-	);
+	const finalBuf = getOrCreateBuffer(key);
+	finalBuf.push({ value, time: new Date().toISOString() });
+	dirtyKeys.add(key);
 };
 
-export const readLastValueStatsFile = async (
+export const readLastValueStatsFile = async <T extends StatType>(
 	appName: string,
-	statType: "cpu" | "memory" | "disk" | "network" | "block",
-) => {
-	try {
-		const { MONITORING_PATH } = paths();
-		const filePath = `${MONITORING_PATH}/${appName}/${statType}.json`;
-		const data = await promises.readFile(filePath, "utf-8");
-		const stats = JSON.parse(data);
-		return stats[stats.length - 1] || null;
-	} catch {
-		return null;
+	statType: T,
+): Promise<StatsEntry<StatTypeMap[T]> | null> => {
+	const key = getCacheKey(appName, statType);
+	const cached = statsCache.get(key);
+	if (cached && cached.length > 0) {
+		return cached.last() as StatsEntry<StatTypeMap[T]> | null;
 	}
+
+	// Cold start: load from disk
+	const buf = await loadFromDisk(appName, statType);
+	return buf.last() as StatsEntry<StatTypeMap[T]> | null;
 };
 
 export const getLastAdvancedStatsFile = async (appName: string) => {

--- a/packages/server/src/monitoring/utils.ts
+++ b/packages/server/src/monitoring/utils.ts
@@ -107,6 +107,7 @@ class RingBuffer<T = StatValue> {
 
 const statsCache = new Map<string, RingBuffer>();
 const dirtyKeys = new Set<string>();
+const loadingPromises = new Map<string, Promise<RingBuffer>>();
 let flushTimer: ReturnType<typeof setInterval> | null = null;
 
 function getCacheKey(appName: string, statType: StatType): string {
@@ -130,19 +131,31 @@ async function loadFromDisk(
 	const existing = statsCache.get(key);
 	if (existing && existing.length > 0) return existing;
 
-	const buf = getOrCreateBuffer(key);
-	try {
-		const { MONITORING_PATH } = paths();
-		const filePath = `${MONITORING_PATH}/${appName}/${statType}.json`;
-		const data = await promises.readFile(filePath, "utf-8");
-		const entries: StatsEntry[] = JSON.parse(data);
-		for (const entry of entries) {
-			buf.push(entry);
+	const inflight = loadingPromises.get(key);
+	if (inflight) return inflight;
+
+	const promise = (async () => {
+		const buf = getOrCreateBuffer(key);
+		try {
+			const { MONITORING_PATH } = paths();
+			const filePath = `${MONITORING_PATH}/${appName}/${statType}.json`;
+			const data = await promises.readFile(filePath, "utf-8");
+			const entries: StatsEntry[] = JSON.parse(data);
+			for (const entry of entries) {
+				buf.push(entry);
+			}
+		} catch {
+			// File doesn't exist yet
 		}
-	} catch {
-		// File doesn't exist yet
+		return buf;
+	})();
+
+	loadingPromises.set(key, promise);
+	try {
+		return await promise;
+	} finally {
+		loadingPromises.delete(key);
 	}
-	return buf;
 }
 
 async function flushToDisk() {
@@ -180,6 +193,9 @@ function ensureFlushTimer() {
 // Flush on process exit
 process.on("beforeExit", () => flushToDisk());
 process.on("SIGTERM", () => {
+	flushToDisk().then(() => process.exit(0));
+});
+process.on("SIGINT", () => {
 	flushToDisk().then(() => process.exit(0));
 });
 
@@ -338,15 +354,14 @@ export const updateStatsFile = async (
 	value: StatValue,
 ) => {
 	const key = getCacheKey(appName, statType);
-	const buf = getOrCreateBuffer(key);
+	let buf = getOrCreateBuffer(key);
 
 	// Ensure buffer is loaded from disk on first write
 	if (buf.length === 0) {
-		await loadFromDisk(appName, statType);
+		buf = await loadFromDisk(appName, statType);
 	}
 
-	const finalBuf = getOrCreateBuffer(key);
-	finalBuf.push({ value, time: new Date().toISOString() });
+	buf.push({ value, time: new Date().toISOString() });
 	dirtyKeys.add(key);
 };
 

--- a/packages/server/src/setup/monitoring-setup.ts
+++ b/packages/server/src/setup/monitoring-setup.ts
@@ -26,10 +26,8 @@ export const setupMonitoring = async (serverId: string) => {
 		Env: [`METRICS_CONFIG=${JSON.stringify(server?.metricsConfig)}`],
 		Image: imageName,
 		HostConfig: {
-			// Memory: 100 * 1024 * 1024, // 100MB en bytes
-			// PidMode: "host",
-			// CapAdd: ["NET_ADMIN", "SYS_ADMIN"],
-			// Privileged: true,
+			Memory: 150 * 1024 * 1024, // 150MB hard limit
+			MemoryReservation: 64 * 1024 * 1024, // 64MB soft limit
 			RestartPolicy: {
 				Name: "always",
 			},
@@ -102,10 +100,8 @@ export const setupWebMonitoring = async () => {
 		Env: [`METRICS_CONFIG=${JSON.stringify(webServerSettings?.metricsConfig)}`],
 		Image: imageName,
 		HostConfig: {
-			// Memory: 100 * 1024 * 1024, // 100MB en bytes
-			// PidMode: "host",
-			// CapAdd: ["NET_ADMIN", "SYS_ADMIN"],
-			// Privileged: true,
+			Memory: 150 * 1024 * 1024, // 150MB hard limit
+			MemoryReservation: 64 * 1024 * 1024, // 64MB soft limit
 			RestartPolicy: {
 				Name: "always",
 			},


### PR DESCRIPTION
## What is this PR about?

Reduces Dokploy's memory footprint so single-node 4GB installs run stable without OOM.

Key changes:

  - Replace `setInterval` with non-overlapping `setTimeout` loop in WebSocket monitoring, share a single poller per `appName` across multiple clients instead of N independent `docker stats` calls
  - Replace per-tick JSON file I/O with in-memory ring buffer (flushed to disk every 30s), cache `OSUtils` instances at module scope
  - Make schedule workers configurable via `SCHEDULE_WORKER_COUNT` and `SCHEDULE_WORKER_CONCURRENCY` env vars (defaults unchanged: 3 workers, 100 concurrency)
  - Add `NODE_OPTIONS --max-old-space-size` limits (512MB main/API, 256MB schedules) and Docker memory limits (150MB hard / 64MB soft) on monitoring container
  - Cap `limit=all` metrics queries at `MAX_METRICS_LIMIT` (default 2000), add cursor-based pagination via `before` query param, return `X-Total-Count` header
  - Fix type mismatches in monitoring UI components (`number` → `string` for block/network stat values)

Hardening fixes:

  - Prevent race condition in `loadFromDisk` via per-key promise deduplication
  - Remove redundant double-buffer in `updateStatsFile`
  - Add `SIGINT` handler to flush dirty buffers on Ctrl+C
  - Fix stale closure in WebSocket close handler (look up poller from map instead of captured variable)
  - Add lower-bound validation for `MONITORING_WS_REFRESH_MS` (min 500ms), `SCHEDULE_WORKER_COUNT` (min 1), `SCHEDULE_WORKER_CONCURRENCY` (min 1)
  - Log errors from `GetMetricsCount`/`GetContainerMetricsCount` instead of discarding
  - Use consistent `ORDER BY timestamp` in container metric CTEs instead of `json_extract`

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3909

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces Dokploy's memory footprint for constrained 4 GB single-node deployments through several complementary changes: replacing per-client `setInterval` WebSocket pollers with a shared `setTimeout` loop per `appName`, swapping per-tick JSON file I/O for an in-memory ring buffer with a 30s flush, making BullMQ worker count/concurrency configurable, adding `NODE_OPTIONS` heap limits to Dockerfiles, activating Docker memory limits on the monitoring container, and adding cursor-based pagination to the monitoring API.

Key issues found during review:

- **Race condition in `loadFromDisk` not fixed** (`packages/server/src/monitoring/utils.ts` lines 125–146): The PR claims per-key promise deduplication was added, but it is absent. Concurrent callers that observe an empty buffer will each independently read the file and push all entries into the same `RingBuffer`, producing duplicate data points on cold start.
- **`SIGTERM` handler can hang the process** (`utils.ts` line 182): `flushToDisk().then(() => process.exit(0))` has no `.catch()` — if the flush throws, the process never exits. The claimed `SIGINT` handler was also never added.
- **Negative `SCHEDULE_WORKER_COUNT` creates zero workers** (`apps/schedules/src/workers.ts` line 6): Negative numbers are truthy in JS, so the `|| 3` fallback does not fire. A user setting `SCHEDULE_WORKER_COUNT=-1` silently starves the entire job queue.
- **`flushToDisk` key split is fragile** (`utils.ts` line 159): `key.split("/")[0]` is used as `appName`, but the cache key format is `appName/statType`. If `appName` contains a `/`, the split produces wrong segments and writes data to the wrong path.
- **Count query errors silently discarded** (`apps/monitoring/main.go` lines 125, 189): Despite the PR description claiming errors would be logged, both `GetMetricsCount` and `GetContainerMetricsCount` errors are still swallowed with `_`, returning a misleading `X-Total-Count: 0` to clients.
- **`MONITORING_WS_REFRESH_MS` lower-bound is missing** (`apps/dokploy/server/wss/docker-stats.ts` line 13): A negative env-var value bypasses the `|| 1300` default (negative is truthy), making the delay `0 ms` effectively and spinning the poller at full speed.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — the unimplemented race-condition fix in `loadFromDisk` and the missing process-exit safety net on `SIGTERM` are correctness issues that directly undermine the stated goals of this PR.
- Several features described in the PR description were not actually implemented: promise deduplication in `loadFromDisk`, `SIGINT` handler, lower-bound validations for env vars, and error logging for count queries. The unfixed race condition in `loadFromDisk` means the ring buffer can be seeded with duplicate historical entries on cold start. The `SIGTERM` handler missing `.catch()` risks hanging the Node.js process on deployment restarts. The negative-worker-count bug can silently disable the entire job scheduler. The underlying architecture (shared poller, ring buffer, cursor pagination) is sound, but these implementation gaps need to be closed before the PR is safe to merge.
- `packages/server/src/monitoring/utils.ts` (race condition, missing signal handlers) and `apps/schedules/src/workers.ts` (missing lower-bound validation) need the most attention.

<sub>Last reviewed commit: 3003f7a</sub>

> Greptile also left **6 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->