### PR TITLE
fix: update Docker network creation command to specify driver for sta…

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -53,7 +53,7 @@ Compose Type: ${composeType} ✅`;
 	
 		cd "${projectPath}";
 
-		${compose.isolatedDeployment ? `docker network inspect ${compose.appName} >/dev/null 2>&1 || docker network create --attachable ${compose.appName}` : ""}
+		${compose.isolatedDeployment ? `docker network inspect ${compose.appName} >/dev/null 2>&1 || docker network create ${compose.composeType === "stack" ? "--driver overlay" : ""} --attachable ${compose.appName}` : ""}
 		env -i PATH="$PATH" ${exportEnvCommand} docker ${command.split(" ").join(" ")} 2>&1 || { echo "Error: ❌ Docker command failed"; exit 1; }
 		${compose.isolatedDeployment ? `docker network connect ${compose.appName} $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1` : ""}
 	


### PR DESCRIPTION
…ck deployments

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3905 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two targeted fixes to `packages/server/src/utils/builders/compose.ts`:

**Primary fix (line 56):** Adds conditional `--driver overlay` flag to Docker network creation for Swarm stacks
- Root cause: `docker stack deploy` requires overlay networking, but the previous command defaulted to the bridge driver
- Fix: `--driver overlay` is now conditionally injected when `composeType === "stack"`, resulting in `docker network create --driver overlay --attachable <name>`
- Non-stack path: When `composeType !== "stack"`, the conditional injects empty string, producing a harmless double-space in the shell command that Bash ignores
- `--attachable` flag preserved: Still required for standalone containers (e.g., Traefik) to join the network

**Secondary fix (line 91):** Removes `--pull always` from docker-compose command
- Simplifies the compose command from `compose -p <app> -f <path> up -d --build --pull always --remove-orphans` to `compose -p <app> -f <path> up -d --build --remove-orphans`
- This is a minor optimization that relies on the default pull behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, targeted fixes that correctly address Docker Swarm stack compatibility issues without affecting non-stack deployments.
- The PR makes two focused changes: (1) The primary fix adds conditional overlay driver specification for Swarm stacks, directly addressing the incompatibility between non-overlay networks and `docker stack deploy`. (2) The secondary fix removes an optional `--pull always` flag that is harmless to remove. Both changes are minimal, logically sound, and do not introduce regressions. The overlay driver is required for Swarm stacks and is only applied when `composeType === "stack"`, so non-stack deployments using docker-compose are unaffected. The `--attachable` flag needed for Traefik compatibility is preserved in both paths.
- No files require special attention.

<sub>Last reviewed commit: 38b2045</sub>

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->