### PR TITLE
refactor: update Gitea and GitLab URL handling to prioritize internal…

### DIFF
--- a/packages/server/src/utils/providers/gitea.ts
+++ b/packages/server/src/utils/providers/gitea.ts
@@ -211,7 +211,10 @@ export const testGiteaConnection = async (input: { giteaId: string }) => {
 			});
 		}
 
-		const baseUrl = (provider.giteaInternalUrl || provider.giteaUrl).replace(/\/+$/, "");
+		const baseUrl = (provider.giteaInternalUrl || provider.giteaUrl).replace(
+			/\/+$/,
+			"",
+		);
 
 		// Use /user/repos to get authenticated user's repositories with pagination
 		let allRepos = 0;
@@ -268,7 +271,9 @@ export const getGiteaRepositories = async (giteaId?: string) => {
 	await refreshGiteaToken(giteaId);
 	const giteaProvider = await findGiteaById(giteaId);
 
-	const baseUrl = (giteaProvider.giteaInternalUrl || giteaProvider.giteaUrl).replace(/\/+$/, "");
+	const baseUrl = (
+		giteaProvider.giteaInternalUrl || giteaProvider.giteaUrl
+	).replace(/\/+$/, "");
 
 	// Use /user/repos to get authenticated user's repositories with pagination
 	let allRepositories: any[] = [];
@@ -333,7 +338,9 @@ export const getGiteaBranches = async (input: {
 
 	const giteaProvider = await findGiteaById(input.giteaId);
 
-	const baseUrl = (giteaProvider.giteaInternalUrl || giteaProvider.giteaUrl).replace(/\/+$/, "");
+	const baseUrl = (
+		giteaProvider.giteaInternalUrl || giteaProvider.giteaUrl
+	).replace(/\/+$/, "");
 
 	// Handle pagination for branches
 	let allBranches: any[] = [];

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -214,7 +214,9 @@ export const getGitlabBranches = async (input: {
 	const allBranches = [];
 	let page = 1;
 	const perPage = 100; // GitLab's max per page is 100
-	const baseUrl = (gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl).replace(/\/+$/, "");
+	const baseUrl = (
+		gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl
+	).replace(/\/+$/, "");
 
 	while (true) {
 		const branchesResponse = await fetch(
@@ -293,7 +295,9 @@ export const validateGitlabProvider = async (gitlabProvider: Gitlab) => {
 		const allProjects = [];
 		let page = 1;
 		const perPage = 100; // GitLab's max per page is 100
-		const baseUrl = (gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl).replace(/\/+$/, "");
+		const baseUrl = (
+			gitlabProvider.gitlabInternalUrl || gitlabProvider.gitlabUrl
+		).replace(/\/+$/, "");
 
 		while (true) {
 			const response = await fetch(


### PR DESCRIPTION
… URLs if available

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3900 #3848

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the "prioritize internal URL" pattern — already applied to token refresh functions — to the remaining provider API call sites in `gitea.ts` and `gitlab.ts`. Specifically, `testGiteaConnection`, `getGiteaRepositories`, `getGiteaBranches`, `getGitlabBranches`, and `validateGitlabProvider` now resolve the base URL as `(internalUrl || externalUrl)` before making HTTP requests to the provider API.

**Key observations:**
- The fallback logic `(internalUrl || externalUrl)` is correct: both fields are defined as nullable `text` columns in the DB schema, so null/undefined/empty-string values all correctly fall through to the external URL.
- The token-refresh functions (`refreshGiteaToken`, `refreshGitlabToken`) already used this same pattern — this PR brings the remaining call sites into alignment.
- The git clone helper functions (`cloneGiteaRepository`, `getGitlabRepoClone`/`getGitlabCloneUrl`) still use the external URL. This is likely intentional since git clone commands can be dispatched to remote worker machines where the internal URL would not be reachable, but it does create an asymmetry that is worth clarifying with a comment.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are a small, consistent refactor with a correct fallback pattern and no new error paths.
- The `(internalUrl || externalUrl)` pattern is logically correct for all nullable field cases. The changes are confined to URL resolution and don't alter any business logic. The only open question is whether the git clone helpers should also be updated, which appears to be an intentional design decision rather than a bug.
- No files require special attention, though reviewers may want to confirm the intentional omission of internal URL handling in `cloneGiteaRepository` and `getGitlabRepoClone`/`getGitlabCloneUrl`.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/server/src/utils/providers/gitea.ts`, line 172-177 ([link](https://github.com/dokploy/dokploy/blob/28cc361c473bfada32505207c9917b3d52223b40/packages/server/src/utils/providers/gitea.ts#L172-L177)) 

   **Clone URL still uses external URL**

   `cloneGiteaRepository` still uses `giteaProvider.giteaUrl` to build the git clone URL, while all API calls in this PR now prefer `giteaInternalUrl`. If a user configures an internal URL specifically to enable server-side communication with a locally-hosted Gitea instance, the clone step will still reach out over the external URL.

   This may be intentional (since the shell `git clone` command can be dispatched to remote workers where the internal URL may not be reachable), but it's worth confirming the design intent. If the clone always runs on the same host as Dokploy, `giteaInternalUrl` should be used here as well for consistency.


2. `packages/server/src/utils/providers/gitlab.ts`, line 93-100 ([link](https://github.com/dokploy/dokploy/blob/28cc361c473bfada32505207c9917b3d52223b40/packages/server/src/utils/providers/gitlab.ts#L93-L100)) 

   **Clone URL helpers still use external URL**

   `getGitlabRepoClone` (line 93) and `getGitlabCloneUrl` (line 98) both derive the clone URL from `gitlab?.gitlabUrl`, not `gitlabInternalUrl`. For the same reasons as in `gitea.ts`, this is inconsistent with the PR's goal of prioritizing internal URLs.

   Same caveat applies — if `git clone` is executed on remote workers, the internal URL would not be reachable. If the intent is to limit the internal URL to direct Node.js HTTP calls only (i.e., API listing/validation), these functions are correctly left unchanged. Either way, a brief code comment clarifying the reasoning would help future readers.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 28cc361</sub>

<!-- /greptile_comment -->