### PR TITLE
fix: add error handling for volume backup notification sending

### DIFF
--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -141,7 +141,10 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 				organizationId,
 			});
 		} catch (notificationError) {
-			console.error("Failed to send volume backup success notification", notificationError);
+			console.error(
+				"Failed to send volume backup success notification",
+				notificationError,
+			);
 		}
 	} catch (error) {
 		const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
@@ -175,7 +178,10 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 				errorMessage: error instanceof Error ? error.message : String(error),
 			});
 		} catch (notificationError) {
-			console.error("Failed to send volume backup error notification", notificationError);
+			console.error(
+				"Failed to send volume backup error notification",
+				notificationError,
+			);
 		}
 	}
 };


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3775

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where a failure in `sendVolumeBackupNotifications` (e.g., unreachable notification service) could corrupt the outcome of an otherwise-successful volume backup by cascading into the outer error handler — triggering `.tar` file cleanup and marking the deployment as `"error"`. Both notification calls are now wrapped in their own try-catch blocks that log the failure and swallow the error, correctly decoupling notification delivery from backup execution state.

**Key changes:**
- Success-path notification wrapped in try-catch so a notification failure no longer triggers the error cleanup branch
- Error-path notification wrapped in try-catch so a secondary notification failure doesn't surface above `runVolumeBackup`
- Both catch blocks log the failure via `console.error` for observability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes a minimal, targeted fix with no risk of regressions.
- The change is small and surgical: two notification calls are each wrapped in an isolated try-catch. The fix correctly addresses the root cause (a notification failure propagating into the backup's outer error handler), and the rest of the function's control flow is unchanged. No new logic, no new dependencies, and the behavior under all non-notification-failure paths is identical to before.
- No files require special attention.

<sub>Last reviewed commit: f961dc6</sub>

<!-- /greptile_comment -->