### PR TITLE
fix(server): fix MongoDB compose restore gzip filename mismatch

### DIFF
--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -69,6 +69,7 @@ export const restoreComposeBackup = async (
 			},
 			restoreType: composeType,
 			rcloneCommand,
+			backupFile: backupInput.backupFile,
 		});
 
 		emit("Starting restore...");

--- a/packages/server/src/utils/restore/utils.ts
+++ b/packages/server/src/utils/restore/utils.ts
@@ -81,15 +81,25 @@ const getMongoSpecificCommand = (
 	backupFile: string,
 ): string => {
 	const tempDir = "/tmp/dokploy-restore";
-	const fileName = backupFile.split("/").pop() || "backup.sql.gz";
-	const decompressedName = fileName.replace(".gz", "");
+	const fileName = backupFile
+		.split("/")
+		.filter((segment) => Boolean(segment))
+		.pop();
 	return `
 rm -rf ${tempDir} && \
 mkdir -p ${tempDir} && \
 ${rcloneCommand} ${tempDir} && \
 cd ${tempDir} && \
-gunzip -f "${fileName}" && \
-${restoreCommand} < "${decompressedName}" && \
+ARCHIVE_FILE="${fileName || ""}" && \
+if [ -z "$ARCHIVE_FILE" ] || [ ! -f "$ARCHIVE_FILE" ]; then \
+	ARCHIVE_FILE=$(find . -maxdepth 1 -type f -name "*.gz" | head -n 1); \
+fi && \
+if [ -z "$ARCHIVE_FILE" ] || [ ! -f "$ARCHIVE_FILE" ]; then \
+	echo "Mongo backup archive not found in ${tempDir}" >&2; exit 1; \
+fi && \
+DECOMPRESSED_FILE="\${ARCHIVE_FILE%.gz}" && \
+gunzip -f "$ARCHIVE_FILE" && \
+${restoreCommand} < "$DECOMPRESSED_FILE" && \
 rm -rf ${tempDir}
 	`;
 };


### PR DESCRIPTION
## What is this PR about?

Fix MongoDB restore failure for Docker Compose deployments where restore attempted to unzip `backup.sql.gz` even when the downloaded file had a timestamped name.

**Root cause**
Compose restore did not pass `backupFile` into `getRestoreCommand`, so Mongo restore used a fallback filename (`backup.sql.gz`) that often did not exist.

**Changes**
- Pass `backupInput.backupFile` from compose restore into `getRestoreCommand`.
- In Mongo restore command, fallback to detecting the downloaded `*.gz` file in `/tmp/dokploy-restore` when explicit filename is missing.
- Add clear failure if no archive is found.


## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3789

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes the root cause of MongoDB restore failures for Docker Compose deployments. The changes are:

1. **compose.ts**: Now passes `backupInput.backupFile` to `getRestoreCommand` (previously omitted), which was the direct cause of Mongo restore using an incorrect fallback filename.

2. **utils.ts**: Improves the shell script logic with better error handling:
   - Extracts just the filename from the full path
   - Checks if that file exists first
   - Falls back to searching for any `.gz` file in the temp directory
   - Returns a clear error message if no archive is found

The root-cause fix directly addresses the stated issue. The identical rclone copy pattern is already used in `mongo.ts` (which works in production), providing confidence that the fallback logic is sufficient.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. The root-cause fix is correct and directly addresses the stated issue. The improved error handling is logically sound and an improvement over the previous hardcoded fallback.
- The one-line fix in compose.ts correctly addresses the root cause where backupFile was not being passed to getRestoreCommand. The utils.ts improvements add robust error handling with proper shell script syntax. The code pattern is identical to mongo.ts which operates in production, providing confidence in the fallback logic. All changes are focused and targeted to the specific issue reported in #3789.
- No files require special attention

<sub>Last reviewed commit: b4079da</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->