### PR TITLE
refactor: streamline deployment cleanup by consolidating removeLastTe…

### DIFF
--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -117,12 +117,12 @@ export const createDeployment = async (
 	>,
 ) => {
 	const application = await findApplicationById(deployment.applicationId);
+	await removeLastTenDeployments(
+		deployment.applicationId,
+		"application",
+		application.serverId,
+	);
 	try {
-		await removeLastTenDeployments(
-			deployment.applicationId,
-			"application",
-			application.serverId,
-		);
 		const serverId = application.buildServerId || application.serverId;
 
 		const { LOGS_PATH } = paths(!!serverId);
@@ -200,13 +200,12 @@ export const createDeploymentPreview = async (
 	const previewDeployment = await findPreviewDeploymentById(
 		deployment.previewDeploymentId,
 	);
+	await removeLastTenDeployments(
+		deployment.previewDeploymentId,
+		"previewDeployment",
+		previewDeployment?.application?.serverId,
+	);
 	try {
-		await removeLastTenDeployments(
-			deployment.previewDeploymentId,
-			"previewDeployment",
-			previewDeployment?.application?.serverId,
-		);
-
 		const appName = `${previewDeployment.appName}`;
 		const { LOGS_PATH } = paths(!!previewDeployment?.application?.serverId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");
@@ -281,12 +280,12 @@ export const createDeploymentCompose = async (
 	>,
 ) => {
 	const compose = await findComposeById(deployment.composeId);
+	await removeLastTenDeployments(
+		deployment.composeId,
+		"compose",
+		compose.serverId,
+	);
 	try {
-		await removeLastTenDeployments(
-			deployment.composeId,
-			"compose",
-			compose.serverId,
-		);
 		const { LOGS_PATH } = paths(!!compose.serverId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");
 		const fileName = `${compose.appName}-${formattedDateTime}.log`;
@@ -369,8 +368,8 @@ export const createDeploymentBackup = async (
 	} else if (backup.backupType === "compose") {
 		serverId = backup.compose?.serverId;
 	}
+	await removeLastTenDeployments(deployment.backupId, "backup", serverId);
 	try {
-		await removeLastTenDeployments(deployment.backupId, "backup", serverId);
 		const { LOGS_PATH } = paths(!!serverId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");
 		const fileName = `${backup.appName}-${formattedDateTime}.log`;
@@ -439,12 +438,12 @@ export const createDeploymentSchedule = async (
 ) => {
 	const schedule = await findScheduleById(deployment.scheduleId);
 
+	const serverId =
+		schedule.application?.serverId ||
+		schedule.compose?.serverId ||
+		schedule.server?.serverId;
+	await removeLastTenDeployments(deployment.scheduleId, "schedule", serverId);
 	try {
-		const serverId =
-			schedule.application?.serverId ||
-			schedule.compose?.serverId ||
-			schedule.server?.serverId;
-		await removeLastTenDeployments(deployment.scheduleId, "schedule", serverId);
 		const { SCHEDULES_PATH } = paths(!!serverId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");
 		const fileName = `${schedule.appName}-${formattedDateTime}.log`;
@@ -515,14 +514,14 @@ export const createDeploymentVolumeBackup = async (
 ) => {
 	const volumeBackup = await findVolumeBackupById(deployment.volumeBackupId);
 
+	const serverId =
+		volumeBackup.application?.serverId || volumeBackup.compose?.serverId;
+	await removeLastTenDeployments(
+		deployment.volumeBackupId,
+		"volumeBackup",
+		serverId,
+	);
 	try {
-		const serverId =
-			volumeBackup.application?.serverId || volumeBackup.compose?.serverId;
-		await removeLastTenDeployments(
-			deployment.volumeBackupId,
-			"volumeBackup",
-			serverId,
-		);
 		const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");
 		const fileName = `${volumeBackup.appName}-${formattedDateTime}.log`;
@@ -601,24 +600,23 @@ export const removeDeployment = async (deploymentId: string) => {
 			.then((result) => result[0]);
 
 		if (!deployment) {
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: "Deployment not found",
-			});
+			return null;
 		}
-		const command = `
-			rm -f ${deployment.logPath};
-		`;
-		if (deployment.serverId) {
-			await execAsyncRemote(deployment.serverId, command);
-		} else {
-			await execAsync(command);
+
+		const logPath = path.join(deployment.logPath);
+		if (logPath && logPath !== ".") {
+			const command = `rm -f ${logPath};`;
+			if (deployment.serverId) {
+				await execAsyncRemote(deployment.serverId, command);
+			} else {
+				await execAsync(command);
+			}
 		}
 
 		return deployment;
 	} catch (error) {
 		const message =
-			error instanceof Error ? error.message : "Error creating the deployment";
+			error instanceof Error ? error.message : "Error removing the deployment";
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message,
@@ -686,34 +684,49 @@ const removeLastTenDeployments = async (
 		if (serverId) {
 			let command = "";
 			for (const oldDeployment of deploymentsToDelete) {
-				const logPath = path.join(oldDeployment.logPath);
-				if (oldDeployment.rollbackId) {
-					await removeRollbackById(oldDeployment.rollbackId);
-				}
+				try {
+					const logPath = path.join(oldDeployment.logPath);
+					if (oldDeployment.rollbackId) {
+						await removeRollbackById(oldDeployment.rollbackId);
+					}
 
-				if (logPath !== ".") {
-					command += `
-					rm -rf ${logPath};
-					`;
+					if (logPath && logPath !== ".") {
+						command += `rm -rf ${logPath};`;
+					}
+					await removeDeployment(oldDeployment.deploymentId);
+				} catch (err) {
+					console.error(
+						`Failed to remove deployment ${oldDeployment.deploymentId} during cleanup:`,
+						err,
+					);
 				}
-				await removeDeployment(oldDeployment.deploymentId);
 			}
 
-			await execAsyncRemote(serverId, command);
+			if (command) {
+				await execAsyncRemote(serverId, command);
+			}
 		} else {
 			for (const oldDeployment of deploymentsToDelete) {
-				if (oldDeployment.rollbackId) {
-					await removeRollbackById(oldDeployment.rollbackId);
+				try {
+					if (oldDeployment.rollbackId) {
+						await removeRollbackById(oldDeployment.rollbackId);
+					}
+					const logPath = path.join(oldDeployment.logPath);
+					if (
+						logPath &&
+						logPath !== "." &&
+						existsSync(logPath) &&
+						!oldDeployment.errorMessage
+					) {
+						await fsPromises.unlink(logPath);
+					}
+					await removeDeployment(oldDeployment.deploymentId);
+				} catch (err) {
+					console.error(
+						`Failed to remove deployment ${oldDeployment.deploymentId} during cleanup:`,
+						err,
+					);
 				}
-				const logPath = path.join(oldDeployment.logPath);
-				if (
-					existsSync(logPath) &&
-					!oldDeployment.errorMessage &&
-					logPath !== "."
-				) {
-					await fsPromises.unlink(logPath);
-				}
-				await removeDeployment(oldDeployment.deploymentId);
 			}
 		}
 	}


### PR DESCRIPTION
…nDeployments calls

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3752 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors deployment cleanup by moving `removeLastTenDeployments` calls outside the `try/catch` blocks in all six `createDeployment*` functions, and extends `removeDeployment` to also delete the associated log file locally via `execAsync` and remotely via `execAsyncRemote`.

**Key issues found:**

- **Double file deletion (remote):** In `removeLastTenDeployments`, the `serverId` branch accumulates `rm -rf` shell commands in a loop (building them from `removeDeployment` calls inside the loop), then executes the batch via `execAsyncRemote` after the loop. But `removeDeployment` itself also runs `execAsyncRemote(deployment.serverId, 'rm -f logPath')` for each deployment. Every log file is deleted twice over SSH — once per item inside the loop, and once more in the batch call after it (lines 686–707).

- **Double file deletion (local):** The `else` branch calls `fsPromises.unlink(logPath)` explicitly at line 721 and then calls `removeDeployment`, which also runs `execAsync('rm -f logPath')` at line 612. The file removal is redundant (though `rm -f` silently succeeds if the file is already gone) (lines 709–730).

- **Cleanup error skips error-deployment creation:** Moving `removeLastTenDeployments` outside the `try/catch` means if the cleanup call itself throws (e.g., the DB query inside it fails or `execAsyncRemote` throws), the `catch` block that writes an error deployment record and updates application status to `"error"` is bypassed entirely. This applies to all six `createDeployment*` functions (lines 120–124 and similar across all deployment functions).

<h3>Confidence Score: 2/5</h3>

- This PR introduces double-deletion regressions and a critical flow-control bug that could silently swallow deployment-creation errors.
- The refactoring introduces three concrete bugs: (1) redundant double deletion of log files both remotely and locally, increasing resource usage and SSH calls unnecessarily; (2) a critical flow-control regression where cleanup-phase errors bypass the error-deployment creation and status-update logic, potentially leaving deployments in an inconsistent state without proper error records. These are not speculative issues—they are directly observable from the code structure.
- packages/server/src/services/deployment.ts — specifically the `removeLastTenDeployments` function (lines 669–733) and the placement of `removeLastTenDeployments` calls outside `try/catch` in all six `createDeployment*` functions.

<sub>Last reviewed commit: b87f8cc</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->