### PR TITLE
refactor: enhance volume backup path handling to ensure proper prefix…

### DIFF
--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -13,7 +13,10 @@ export const backupVolume = async (
 	const { VOLUME_BACKUPS_PATH, VOLUME_BACKUP_LOCK_PATH } = paths(!!serverId);
 	const destination = volumeBackup.destination;
 	const backupFileName = `${volumeName}-${new Date().toISOString()}.tar`;
-	const bucketDestination = `${normalizeS3Path(prefix)}${backupFileName}`;
+	const effectivePrefix = prefix
+		? normalizeS3Path(prefix)
+		: `${volumeBackup.appName}/`;
+	const bucketDestination = `${effectivePrefix}${backupFileName}`;
 	const rcloneFlags = getS3Credentials(volumeBackup.destination);
 	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeBackup.appName);

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -81,7 +81,9 @@ const cleanupOldVolumeBackups = async (
 
 	try {
 		const rcloneFlags = getS3Credentials(destination);
-		const normalizedPrefix = normalizeS3Path(prefix);
+		const normalizedPrefix = prefix
+			? normalizeS3Path(prefix)
+			: `${volumeBackup.appName}/`;
 		const backupFilesPath = `:s3:${destination.bucket}/${normalizedPrefix}`;
 		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" :s3:${destination.bucket}/${normalizedPrefix}`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;


### PR DESCRIPTION
… usage

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #2686

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where calling `normalizeS3Path(prefix)` with a `null` or `undefined` prefix would throw a `TypeError` at runtime (`.trim()` on null). The fix replaces the unconditional `normalizeS3Path(prefix)` call with a ternary that falls back to `${volumeBackup.appName}/` when `prefix` is falsy. The same fix is correctly applied in both changed files (`backup.ts` and `utils.ts`), keeping backup creation and cleanup paths in sync.

**Remaining edge case:** A whitespace-only prefix value (e.g., `"   "`) is still truthy, so it bypasses the fallback and `normalizeS3Path` trims it to `""`, resulting in files stored at the bucket root. Using `prefix?.trim() ?` instead of `prefix ?` would close this gap in both files.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; fixes the null/undefined crash bug and keeps backup paths in sync. A minor whitespace-only prefix edge case remains.
- The core fix is sound and addresses the reported issue (PR #2686) by preventing crashes when prefix is null/undefined. Both modified files are updated symmetrically, so backup creation and cleanup stay consistent. The only remaining gap is the whitespace-only prefix edge case, which is a minor concern that does not represent a regression from the previous code—the fix is a strict improvement. The fix itself is minimal and low-risk.
- Both backup.ts and utils.ts would benefit from the trim-first check (`prefix?.trim() ?`) to handle the whitespace edge case.

<sub>Last reviewed commit: 808001d</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->