### PR TITLE
fix: prevent doubled /v1/ suffix in Azure OpenAI-compatible URLs

### DIFF
--- a/packages/server/src/utils/ai/select-ai-provider.ts
+++ b/packages/server/src/utils/ai/select-ai-provider.ts
@@ -30,6 +30,18 @@ export function selectAIProvider(config: { apiUrl: string; apiKey: string }) {
 				baseURL: config.apiUrl,
 			});
 		case "azure":
+			// Azure OpenAI-compatible endpoints already include /v1 in the path.
+			// Using createAzure with such URLs causes a doubled /v1//v1/ suffix.
+			if (config.apiUrl.includes("/v1")) {
+				return createOpenAICompatible({
+					name: "azure",
+					baseURL: config.apiUrl,
+					headers: {
+						"api-key": config.apiKey,
+						Authorization: `Bearer ${config.apiKey}`,
+					},
+				});
+			}
 			return createAzure({
 				apiKey: config.apiKey,
 				baseURL: config.apiUrl,


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3286

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Azure OpenAI-compatible endpoints that already contain `/v1` in their URL path would end up with a doubled `/v1//v1/` suffix when `createAzure` appended its own version segment. The fix detects the presence of `/v1` in the configured URL and, when found, routes through `createOpenAICompatible` (with both `api-key` and `Authorization` headers for broad compatibility) rather than `createAzure`.

**Key observations:**
- The overall approach is correct and aligns with how the related issue (#3286) describes the problem.
- The detection condition `config.apiUrl.includes("/v1")` uses a substring match, which is overly broad — it also matches version strings like `/v10`, `/v11`, `/v12`, etc. A boundary-aware check such as `config.apiUrl.includes("/v1/") || config.apiUrl.endsWith("/v1")` would be more precise and avoid false positives from other version segments.
- Sending both `api-key` and `Authorization: Bearer` headers simultaneously is intentional here, covering both Azure-native and OpenAI-compatible auth schemes in one branch.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with a minor improvement recommended for version-string detection precision.
- This PR correctly addresses the core issue of preventing doubled `/v1//v1/` suffixes in Azure OpenAI-compatible URLs. The fix is logic-sound and introduces no regressions for the standard `createAzure` path. The one identified concern is the overly broad substring match in the detection condition, which could incorrectly route URLs with `/v10`, `/v11`, etc., though such URLs are unlikely in typical Azure deployments. The suggested fix to use a boundary-aware check is straightforward and improves precision without functional impact.
- packages/server/src/utils/ai/select-ai-provider.ts — the version-string detection at line 35 should use a more precise boundary-aware check to avoid matching unintended version segments.

<sub>Last reviewed commit: 50182a8</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->