### PR TITLE
feat: include backup file in restoreComposeBackup function for improv…

### DIFF
--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -69,6 +69,7 @@ export const restoreComposeBackup = async (
 			},
 			restoreType: composeType,
 			rcloneCommand,
+			backupFile: backupInput.backupFile,
 		});
 
 		emit("Starting restore...");


### PR DESCRIPTION
…ed restore process

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3789 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where MongoDB database restores triggered through a compose setup would silently use the wrong filename during the restore process. The root cause was that `backupFile` was not being forwarded to `getRestoreCommand`, so `getMongoSpecificCommand` would fall back to the hardcoded string `"backup.sql.gz"` for every restore, causing the operation to fail.

- **Fix**: Passes `backupFile: backupInput.backupFile` to `getRestoreCommand` in `compose.ts`, matching the pattern already established in `mongo.ts`.
- **Impact**: Only MongoDB restores via compose were affected; postgres, mariadb, and mysql restore commands do not use `backupFile` internally.
- **Minor pre-existing note**: The generic catch block in `compose.ts` uses the message `"Error restoring mongo backup"` for all database types (lines 91 & 95), which is misleading for non-mongo failures — but this is a pre-existing issue not introduced by this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, targeted one-line fix with no side effects on other database types.
- The change is a single-line addition that forwards an already-available value (`backupInput.backupFile`) to `getRestoreCommand`, which already accepts it as an optional parameter. The fix is consistent with how `mongo.ts` handles the same flow, and there is no risk of regression for non-mongo database types since `backupFile` is only consumed in the mongo-specific code path inside `getRestoreCommand`.
- No files require special attention.

<sub>Last reviewed commit: 4882bd2</sub>

<!-- /greptile_comment -->