### PR TITLE
fix: fixes excessive alias count error

### DIFF
--- a/apps/dokploy/__test__/compose/compose.test.ts
+++ b/apps/dokploy/__test__/compose/compose.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllProperties } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile1 = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/config/config-root.test.ts
+++ b/apps/dokploy/__test__/compose/config/config-root.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToConfigsRoot, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/config/config-service.test.ts
+++ b/apps/dokploy/__test__/compose/config/config-service.test.ts
@@ -3,8 +3,8 @@ import {
 	addSuffixToConfigsInServices,
 	generateRandomHash,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/config/config.test.ts
+++ b/apps/dokploy/__test__/compose/config/config.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllConfigs, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
+++ b/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
@@ -1,7 +1,7 @@
 import type { Domain } from "@dokploy/server";
 import { createDomainLabels } from "@dokploy/server";
+import { parse, stringify } from "@dokploy/server/utils/yaml";
 import { describe, expect, it } from "vitest";
-import { parse, stringify } from "yaml";
 
 /**
  * Regression tests for Traefik Host rule label format.

--- a/apps/dokploy/__test__/compose/network/network-root.test.ts
+++ b/apps/dokploy/__test__/compose/network/network-root.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToNetworksRoot, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/network/network-service.test.ts
+++ b/apps/dokploy/__test__/compose/network/network-service.test.ts
@@ -3,8 +3,8 @@ import {
 	addSuffixToServiceNetworks,
 	generateRandomHash,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/network/network.test.ts
+++ b/apps/dokploy/__test__/compose/network/network.test.ts
@@ -5,8 +5,8 @@ import {
 	addSuffixToServiceNetworks,
 	generateRandomHash,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFileCombined = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/secrets/secret-root.test.ts
+++ b/apps/dokploy/__test__/compose/secrets/secret-root.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToSecretsRoot, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/secrets/secret-services.test.ts
+++ b/apps/dokploy/__test__/compose/secrets/secret-services.test.ts
@@ -3,8 +3,8 @@ import {
 	addSuffixToSecretsInServices,
 	generateRandomHash,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFileSecretsServices = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/secrets/secret.test.ts
+++ b/apps/dokploy/__test__/compose/secrets/secret.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllSecrets } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFileCombinedSecrets = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/service/service-container-name.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-container-name.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/service/service-depends-on.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-depends-on.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/service/service-extends.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-extends.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/service/service-links.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-links.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/service/service-names.test.ts
+++ b/apps/dokploy/__test__/compose/service/service-names.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/service/service.test.ts
+++ b/apps/dokploy/__test__/compose/service/service.test.ts
@@ -3,8 +3,8 @@ import {
 	addSuffixToAllServiceNames,
 	addSuffixToServiceNames,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFileCombinedAllCases = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/service/sevice-volumes-from.test.ts
+++ b/apps/dokploy/__test__/compose/service/sevice-volumes-from.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToServiceNames, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/volume/volume-2.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-2.test.ts
@@ -4,8 +4,8 @@ import {
 	addSuffixToVolumesRoot,
 	generateRandomHash,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile = `
 services:

--- a/apps/dokploy/__test__/compose/volume/volume-root.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-root.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToVolumesRoot, generateRandomHash } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFile = `
 version: "3.8"

--- a/apps/dokploy/__test__/compose/volume/volume-services.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-services.test.ts
@@ -3,8 +3,8 @@ import {
 	addSuffixToVolumesInServices,
 	generateRandomHash,
 } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 test("Generate random hash with 8 characters", () => {
 	const hash = generateRandomHash();

--- a/apps/dokploy/__test__/compose/volume/volume.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume.test.ts
@@ -1,7 +1,7 @@
 import type { ComposeSpecification } from "@dokploy/server";
 import { addSuffixToAllVolumes } from "@dokploy/server";
+import { parse } from "@dokploy/server/utils/yaml";
 import { expect, test } from "vitest";
-import { parse } from "yaml";
 
 const composeFileTypeVolume = `
 version: "3.8"

--- a/apps/dokploy/components/dashboard/application/advanced/traefik/update-traefik-config.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/traefik/update-traefik-config.tsx
@@ -1,8 +1,8 @@
+import { parse, stringify, YAMLParseError } from "@dokploy/server/utils/yaml";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { parse, stringify, YAMLParseError } from "yaml";
 import { z } from "zod";
 import { AlertBlock } from "@/components/shared/alert-block";
 import { CodeEditor } from "@/components/shared/code-editor";

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -41,12 +41,12 @@ import {
 	fetchTemplatesList,
 } from "@dokploy/server/templates/github";
 import { processTemplate } from "@dokploy/server/templates/processors";
+import { stringify } from "@dokploy/server/utils/yaml";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
 import _ from "lodash";
 import { nanoid } from "nanoid";
 import { parse } from "toml";
-import { stringify } from "yaml";
 import { z } from "zod";
 import { slugify } from "@/lib/slug";
 import {

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -46,11 +46,11 @@ import {
 	writeTraefikSetup,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import { parse, stringify } from "@dokploy/server/utils/yaml";
 import { generateOpenApiDocument } from "@dokploy/trpc-openapi";
 import { TRPCError } from "@trpc/server";
 import { eq, sql } from "drizzle-orm";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { parse, stringify } from "yaml";
 import { z } from "zod";
 import {
 	apiAssignDomain,

--- a/packages/server/src/services/certificate.ts
+++ b/packages/server/src/services/certificate.ts
@@ -7,9 +7,9 @@ import {
 	certificates,
 } from "@dokploy/server/db/schema";
 import { removeDirectoryIfExistsContent } from "@dokploy/server/utils/filesystem/directory";
+import { stringify } from "@dokploy/server/utils/yaml";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
-import { stringify } from "yaml";
 import type { z } from "zod";
 import { encodeBase64 } from "../utils/docker/utils";
 import { execAsyncRemote } from "../utils/process/execAsync";

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -7,8 +7,8 @@ import {
 	writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { stringify } from "@dokploy/server/utils/yaml";
 import type { ContainerCreateOptions, CreateServiceOptions } from "dockerode";
-import { stringify } from "yaml";
 import { paths } from "../constants";
 import { getRemoteDocker } from "../utils/servers/remote-docker";
 import type { FileConfig } from "../utils/traefik/file-types";

--- a/packages/server/src/utils/docker/collision.ts
+++ b/packages/server/src/utils/docker/collision.ts
@@ -1,6 +1,6 @@
 import { findComposeById } from "@dokploy/server/services/compose";
-import { stringify } from "yaml";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { stringify } from "../yaml";
 import { addAppNameToAllServiceNames } from "./collision/root-network";
 import { generateRandomHash } from "./compose";
 import { addSuffixToAllVolumes } from "./compose/volume";

--- a/packages/server/src/utils/docker/compose.ts
+++ b/packages/server/src/utils/docker/compose.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { findComposeById } from "@dokploy/server/services/compose";
-import { parse, stringify } from "yaml";
+import { parse, stringify } from "../yaml";
 import { addSuffixToAllConfigs } from "./compose/configs";
 import { addSuffixToAllNetworks } from "./compose/network";
 import { addSuffixToAllSecrets } from "./compose/secrets";

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
-import { parse, stringify } from "yaml";
 import { execAsyncRemote } from "../process/execAsync";
 import { cloneBitbucketRepository } from "../providers/bitbucket";
 import { cloneGitRepository } from "../providers/git";
@@ -11,6 +10,7 @@ import { cloneGiteaRepository } from "../providers/gitea";
 import { cloneGithubRepository } from "../providers/github";
 import { cloneGitlabRepository } from "../providers/gitlab";
 import { getCreateComposeFileCommand } from "../providers/raw";
+import { parse, stringify } from "../yaml";
 import { randomizeDeployableSpecificationFile } from "./collision";
 import { randomizeSpecificationFile } from "./compose";
 import type {

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { paths } from "@dokploy/server/constants";
 import type { Domain } from "@dokploy/server/services/domain";
-import { parse, stringify } from "yaml";
 import { encodeBase64 } from "../docker/utils";
 import { execAsyncRemote } from "../process/execAsync";
+import { parse, stringify } from "../yaml";
 import type { FileConfig, HttpLoadBalancerService } from "./file-types";
 
 export const createTraefikConfig = (appName: string) => {

--- a/packages/server/src/utils/traefik/middleware.ts
+++ b/packages/server/src/utils/traefik/middleware.ts
@@ -2,9 +2,9 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import type { Domain } from "@dokploy/server/services/domain";
-import { parse, stringify } from "yaml";
 import type { ApplicationNested } from "../builders";
 import { execAsyncRemote } from "../process/execAsync";
+import { parse, stringify } from "../yaml";
 import { writeTraefikConfigRemote } from "./application";
 import type { FileConfig } from "./file-types";
 

--- a/packages/server/src/utils/traefik/web-server.ts
+++ b/packages/server/src/utils/traefik/web-server.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import type { webServerSettings } from "@dokploy/server/db/schema/web-server-settings";
-import { parse, stringify } from "yaml";
+import { parse, stringify } from "../yaml";
 import {
 	loadOrCreateConfig,
 	removeTraefikConfig,

--- a/packages/server/src/utils/yaml/index.ts
+++ b/packages/server/src/utils/yaml/index.ts
@@ -1,0 +1,11 @@
+import * as yaml from "yaml";
+
+export { stringify, YAMLParseError } from "yaml";
+
+export const parse = (
+	src: string,
+	options?: yaml.ParseOptions &
+		yaml.DocumentOptions &
+		yaml.SchemaOptions &
+		yaml.ToJSOptions,
+): any => yaml.parse(src, { maxAliasCount: 10000, ...options });


### PR DESCRIPTION
## What is this PR about?
- Adds our own parse method with identical signature, which then forwards calls to yaml.parse with option ` {maxAliasCount: 10000}` (overridable) applied -> fixes https://github.com/Dokploy/dokploy/issues/3924
- ensure our own parse method is used everywhere (also in tests)
- added test case for compose file with many (+200) aliases

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3924

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `ReferenceError: Excessive alias count indicates a resource exhaustion attack` error by introducing a thin wrapper around `yaml.parse` that raises `maxAliasCount` from the default 100 to 10,000 (overridable). All 34 changed files migrate their `yaml` imports to the new wrapper, and a regression test with 205 alias references is added to confirm the fix.

**Key changes:**
- `packages/server/src/utils/yaml/index.ts`: New wrapper that re-exports `stringify` and `YAMLParseError` directly from `yaml` while overriding `maxAliasCount` to 10,000 for `parse`
- All test files and server-side utilities consistently swapped `from "yaml"` for `from "@dokploy/server/utils/yaml"` or the relative `../yaml` path — no direct `yaml` imports remain outside the wrapper itself
- A new test case validates parsing with 205 aliases without throwing

**Issues found:**
- The wrapper only implements one of the two `yaml.parse` overloads — the reviver-function variant (`parse(src, (key, value) => ...)`) is silently swallowed as an options object. Not a current bug, but the API is not fully equivalent to the original.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the fix is correct and well-tested, with one minor signature gap in the yaml wrapper.
- The core change is a focused, low-risk fix — raising the YAML alias limit via a thin wrapper. All call sites have been migrated consistently, including tests. The only concern is the missing reviver-function overload in the wrapper, which is not used anywhere in the codebase today but makes the stated "identical signature" claim inaccurate and could become a silent bug if someone adds a reviver call in the future.
- packages/server/src/utils/yaml/index.ts — the parse wrapper is missing the reviver-function overload.

<sub>Last reviewed commit: 08a172c</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->