### PR TITLE
feat: add wildcard domain support with DNS challenge

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -1,5 +1,5 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { DatabaseZap, Dices, RefreshCw } from "lucide-react";
+import { AlertTriangle, DatabaseZap, Dices, RefreshCw } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -210,6 +210,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 	const domainType = form.watch("domainType");
 	const host = form.watch("host");
 	const isTraefikMeDomain = host?.includes("traefik.me") || false;
+	const isWildcardHost = host?.startsWith("*.") || false;
 
 	useEffect(() => {
 		if (data) {
@@ -555,6 +556,14 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 									)}
 								/>
 
+								{isWildcardHost && (
+									<AlertBlock type="info">
+										<strong>Wildcard Domain:</strong> This domain will match all
+										subdomains (e.g., <code>app.{host?.slice(2)}</code>,{" "}
+										<code>api.{host?.slice(2)}</code>).
+									</AlertBlock>
+								)}
+
 								<FormField
 									control={form.control}
 									name="path"
@@ -696,6 +705,27 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 												);
 											}}
 										/>
+
+										{isWildcardHost && certificateType === "letsencrypt" && (
+											<AlertBlock type="warning">
+												<div className="flex items-start gap-2">
+													<AlertTriangle className="size-4 mt-0.5 shrink-0" />
+													<div>
+														<strong>DNS Challenge Required:</strong> Wildcard SSL
+														certificates require DNS challenge validation.
+														Make sure you have configured your DNS provider
+														credentials in{" "}
+														<Link
+															href="/dashboard/settings/server"
+															className="text-primary underline"
+														>
+															Settings → Web Server → Traefik Environment
+														</Link>{" "}
+														(e.g., <code>CF_DNS_API_TOKEN</code> for Cloudflare).
+													</div>
+												</div>
+											</AlertBlock>
+										)}
 
 										{certificateType === "custom" && (
 											<FormField

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -740,7 +740,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 														Make sure you have configured your DNS provider
 														credentials in{" "}
 														<Link
-															href="/dashboard/settings/server"
+															href="/dashboard/settings/server?traefikEnv=true"
 															className="text-primary underline"
 														>
 															Settings → Web Server → Traefik Environment

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -745,7 +745,6 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 														>
 															Settings → Web Server → Traefik Environment
 														</Link>{" "}
-														(e.g., <code>CF_DNS_API_TOKEN</code> for Cloudflare).
 													</div>
 												</div>
 											</AlertBlock>

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -92,6 +92,30 @@ export const domain = z
 			});
 		}
 
+		if (input.host.startsWith("*.")) {
+			const baseDomain = input.host.slice(2);
+			if (!baseDomain || baseDomain.includes("*")) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["host"],
+					message:
+						"Invalid wildcard domain format. Use *.example.com",
+				});
+			}
+
+			if (
+				input.https &&
+				input.certificateType === "none"
+			) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["certificateType"],
+					message:
+						"Wildcard domains require Let's Encrypt (DNS Challenge) or a Custom certificate resolver for HTTPS",
+				});
+			}
+		}
+
 		// Validate stripPath requires a valid path
 		if (input.stripPath && (!input.path || input.path === "/")) {
 			ctx.addIssue({

--- a/apps/dokploy/components/dashboard/settings/web-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server.tsx
@@ -1,4 +1,5 @@
 import { ServerIcon } from "lucide-react";
+import { useRouter } from "next/router";
 import {
 	Card,
 	CardContent,
@@ -12,8 +13,27 @@ import { ShowStorageActions } from "./servers/actions/show-storage-actions";
 import { ShowTraefikActions } from "./servers/actions/show-traefik-actions";
 import { ToggleDockerCleanup } from "./servers/actions/toggle-docker-cleanup";
 import { UpdateServer } from "./web-server/update-server";
+import { EditTraefikEnv } from "./web-server/edit-traefik-env";
 
 export const WebServer = () => {
+	const router = useRouter();
+	const showTraefikEnv = router.query.traefikEnv === "true";
+
+	const handleTraefikEnvClose = (open: boolean) => {
+		if (!open && showTraefikEnv) {
+			const query = { ...router.query };
+			delete query.traefikEnv;
+			router.replace(
+				{
+					pathname: router.pathname,
+					query,
+				},
+				undefined,
+				{ shallow: true },
+			);
+		}
+	};
+
 	const { data: webServerSettings } =
 		api.settings.getWebServerSettings.useQuery();
 
@@ -21,7 +41,14 @@ export const WebServer = () => {
 
 	return (
 		<div className="w-full">
-			{/* <Card className={cn("rounded-lg w-full bg-transparent p-0", className)}></Card> */}
+			{showTraefikEnv && (
+				<EditTraefikEnv
+					autoOpen
+					showDnsGuide
+					onOpenChange={handleTraefikEnvClose}
+				/>
+			)}
+
 			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
@@ -31,14 +58,6 @@ export const WebServer = () => {
 						</CardTitle>
 						<CardDescription>Reload or clean the web server.</CardDescription>
 					</CardHeader>
-					{/* <CardHeader>
-						<CardTitle className="text-xl">
-							Web Server
-						</CardTitle>
-						<CardDescription>
-							Reload or clean the web server.
-						</CardDescription>
-					</CardHeader> */}
 					<CardContent className="space-y-6 py-6 border-t">
 						<div className="grid md:grid-cols-2 gap-4">
 							<ShowDokployActions />

--- a/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
@@ -106,10 +106,24 @@ export const EditTraefikEnv = ({ children, serverId }: Props) => {
 				<DialogHeader>
 					<DialogTitle>Update Traefik Environment</DialogTitle>
 					<DialogDescription>
-						Update the traefik environment variables
+						Update the traefik environment variables. For wildcard
+						SSL certificates, configure your DNS provider credentials
+						below.
 					</DialogDescription>
 				</DialogHeader>
 				{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
+
+				<AlertBlock type="info">
+					<strong>DNS Challenge for Wildcard Certificates:</strong>{" "}
+					To use wildcard domains (e.g., *.example.com) with HTTPS,
+					add your DNS provider API credentials here. Common providers:
+					<ul className="mt-1 ml-4 list-disc text-xs space-y-0.5">
+						<li><strong>Cloudflare:</strong> <code>CF_DNS_API_TOKEN=your_token</code></li>
+						<li><strong>Route53:</strong> <code>AWS_ACCESS_KEY_ID</code> + <code>AWS_SECRET_ACCESS_KEY</code></li>
+						<li><strong>DigitalOcean:</strong> <code>DO_AUTH_TOKEN=your_token</code></li>
+						<li><strong>Hetzner:</strong> <code>HETZNER_API_KEY=your_key</code></li>
+					</ul>
+				</AlertBlock>
 
 				<Form {...form}>
 					<form
@@ -128,13 +142,9 @@ export const EditTraefikEnv = ({ children, serverId }: Props) => {
 											<CodeEditor
 												language="properties"
 												wrapperClassName="h-[35rem] font-mono"
-												placeholder={`TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=test@localhost.com
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_STORAGE=/etc/dokploy/traefik/dynamic/acme.json
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_HTTP_CHALLENGE=true
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_HTTP_CHALLENGE_PRETTY=true
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_HTTP_CHALLENGE_ENTRYPOINT=web
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_HTTP_CHALLENGE_DNS_CHALLENGE=true
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_HTTP_CHALLENGE_DNS_PROVIDER=cloudflare
+												placeholder={`# DNS Challenge credentials for wildcard certificates
+CF_DNS_API_TOKEN=your_cloudflare_api_token
+CF_API_EMAIL=your_cloudflare_email
                                                     `}
 												{...field}
 											/>

--- a/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
@@ -51,9 +51,7 @@ export const EditTraefikEnv = ({
 	const [canEdit, setCanEdit] = useState(true);
 
 	useEffect(() => {
-		if (autoOpen) {
-			setIsOpen(true);
-		}
+		setIsOpen(autoOpen);
 	}, [autoOpen]);
 
 	const handleOpenChange = (open: boolean) => {
@@ -165,10 +163,16 @@ export const EditTraefikEnv = ({
 											<CodeEditor
 												language="properties"
 												wrapperClassName="h-[35rem] font-mono"
-												placeholder={`# DNS Challenge credentials for wildcard certificates
+												placeholder={
+													showDnsGuide
+														? `# DNS Challenge credentials for wildcard certificates
 CF_DNS_API_TOKEN=your_cloudflare_api_token
-CF_API_EMAIL=your_cloudflare_email
-                                                    `}
+CF_API_EMAIL=your_cloudflare_email`
+														: `TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=test@localhost.com
+TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_STORAGE=/etc/dokploy/traefik/dynamic/acme.json
+TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_HTTPCHALLENGE=true
+TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_HTTPCHALLENGE_ENTRYPOINT=web`
+												}
 												{...field}
 											/>
 										</FormControl>

--- a/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
@@ -1,4 +1,5 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -38,7 +39,32 @@ interface Props {
 }
 
 export const EditTraefikEnv = ({ children, serverId }: Props) => {
+	const router = useRouter();
+	const isOpenedViaWildcard = router.query.traefikEnv === "true";
+	const [isOpen, setIsOpen] = useState(false);
 	const [canEdit, setCanEdit] = useState(true);
+
+	useEffect(() => {
+		if (isOpenedViaWildcard) {
+			setIsOpen(true);
+		}
+	}, [isOpenedViaWildcard]);
+
+	const handleOpenChange = (open: boolean) => {
+		setIsOpen(open);
+		if (!open && isOpenedViaWildcard) {
+			const query = { ...router.query };
+			delete query.traefikEnv;
+			router.replace(
+				{
+					pathname: router.pathname,
+					query,
+				},
+				undefined,
+				{ shallow: true },
+			);
+		}
+	};
 
 	const { data } = api.settings.readTraefikEnv.useQuery({
 		serverId,
@@ -100,7 +126,7 @@ export const EditTraefikEnv = ({ children, serverId }: Props) => {
 	}, [form, onSubmit, isPending, canEdit]);
 
 	return (
-		<Dialog>
+		<Dialog open={isOpen} onOpenChange={handleOpenChange}>
 			<DialogTrigger asChild>{children}</DialogTrigger>
 			<DialogContent className="sm:max-w-4xl">
 				<DialogHeader>
@@ -113,17 +139,19 @@ export const EditTraefikEnv = ({ children, serverId }: Props) => {
 				</DialogHeader>
 				{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
 
-				<AlertBlock type="info">
-					<strong>DNS Challenge for Wildcard Certificates:</strong>{" "}
-					To use wildcard domains (e.g., *.example.com) with HTTPS,
-					add your DNS provider API credentials here. Common providers:
-					<ul className="mt-1 ml-4 list-disc text-xs space-y-0.5">
-						<li><strong>Cloudflare:</strong> <code>CF_DNS_API_TOKEN=your_token</code></li>
-						<li><strong>Route53:</strong> <code>AWS_ACCESS_KEY_ID</code> + <code>AWS_SECRET_ACCESS_KEY</code></li>
-						<li><strong>DigitalOcean:</strong> <code>DO_AUTH_TOKEN=your_token</code></li>
-						<li><strong>Hetzner:</strong> <code>HETZNER_API_KEY=your_key</code></li>
-					</ul>
-				</AlertBlock>
+				{isOpenedViaWildcard && (
+					<AlertBlock type="info">
+						<strong>DNS Challenge for Wildcard Certificates:</strong>{" "}
+						To use wildcard domains (e.g., *.example.com) with HTTPS,
+						add your DNS provider API credentials here. Common providers:
+						<ul className="mt-1 ml-4 list-disc text-xs space-y-0.5">
+							<li><strong>Cloudflare:</strong> <code>CF_DNS_API_TOKEN=your_token</code></li>
+							<li><strong>Route53:</strong> <code>AWS_ACCESS_KEY_ID</code> + <code>AWS_SECRET_ACCESS_KEY</code></li>
+							<li><strong>DigitalOcean:</strong> <code>DO_AUTH_TOKEN=your_token</code></li>
+							<li><strong>Hetzner:</strong> <code>HETZNER_API_KEY=your_key</code></li>
+						</ul>
+					</AlertBlock>
+				)}
 
 				<Form {...form}>
 					<form

--- a/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx
@@ -1,5 +1,4 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -36,34 +35,30 @@ type Schema = z.infer<typeof schema>;
 interface Props {
 	children?: React.ReactNode;
 	serverId?: string;
+	autoOpen?: boolean;
+	showDnsGuide?: boolean;
+	onOpenChange?: (open: boolean) => void;
 }
 
-export const EditTraefikEnv = ({ children, serverId }: Props) => {
-	const router = useRouter();
-	const isOpenedViaWildcard = router.query.traefikEnv === "true";
-	const [isOpen, setIsOpen] = useState(false);
+export const EditTraefikEnv = ({
+	children,
+	serverId,
+	autoOpen = false,
+	showDnsGuide = false,
+	onOpenChange: onOpenChangeProp,
+}: Props) => {
+	const [isOpen, setIsOpen] = useState(autoOpen);
 	const [canEdit, setCanEdit] = useState(true);
 
 	useEffect(() => {
-		if (isOpenedViaWildcard) {
+		if (autoOpen) {
 			setIsOpen(true);
 		}
-	}, [isOpenedViaWildcard]);
+	}, [autoOpen]);
 
 	const handleOpenChange = (open: boolean) => {
 		setIsOpen(open);
-		if (!open && isOpenedViaWildcard) {
-			const query = { ...router.query };
-			delete query.traefikEnv;
-			router.replace(
-				{
-					pathname: router.pathname,
-					query,
-				},
-				undefined,
-				{ shallow: true },
-			);
-		}
+		onOpenChangeProp?.(open);
 	};
 
 	const { data } = api.settings.readTraefikEnv.useQuery({
@@ -127,7 +122,7 @@ export const EditTraefikEnv = ({ children, serverId }: Props) => {
 
 	return (
 		<Dialog open={isOpen} onOpenChange={handleOpenChange}>
-			<DialogTrigger asChild>{children}</DialogTrigger>
+			{children && <DialogTrigger asChild>{children}</DialogTrigger>}
 			<DialogContent className="sm:max-w-4xl">
 				<DialogHeader>
 					<DialogTitle>Update Traefik Environment</DialogTitle>
@@ -139,7 +134,7 @@ export const EditTraefikEnv = ({ children, serverId }: Props) => {
 				</DialogHeader>
 				{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
 
-				{isOpenedViaWildcard && (
+				{showDnsGuide && (
 					<AlertBlock type="info">
 						<strong>DNS Challenge for Wildcard Certificates:</strong>{" "}
 						To use wildcard domains (e.g., *.example.com) with HTTPS,

--- a/packages/server/src/db/validations/domain.ts
+++ b/packages/server/src/db/validations/domain.ts
@@ -38,6 +38,30 @@ export const domain = z
 			});
 		}
 
+		if (input.host.startsWith("*.")) {
+			const baseDomain = input.host.slice(2);
+			if (!baseDomain || baseDomain.includes("*")) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["host"],
+					message:
+						"Invalid wildcard domain format. Use *.example.com",
+				});
+			}
+
+			if (
+				input.https &&
+				input.certificateType === "none"
+			) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["certificateType"],
+					message:
+						"Wildcard domains require Let's Encrypt (DNS Challenge) or a Custom certificate resolver for HTTPS",
+				});
+			}
+		}
+
 		// Validate stripPath requires a valid path
 		if (input.stripPath && (!input.path || input.path === "/")) {
 			ctx.addIssue({
@@ -99,6 +123,32 @@ export const domainCompose = z
 				path: ["customCertResolver"],
 				message: "Required when certificate type is custom",
 			});
+		}
+
+		// Validate wildcard domain format
+		if (input.host.startsWith("*.")) {
+			const baseDomain = input.host.slice(2);
+			if (!baseDomain || baseDomain.includes("*")) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["host"],
+					message:
+						"Invalid wildcard domain format. Use *.example.com",
+				});
+			}
+
+			// Wildcard domains with HTTPS need letsencrypt (auto DNS challenge) or custom
+			if (
+				input.https &&
+				input.certificateType === "none"
+			) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					path: ["certificateType"],
+					message:
+						"Wildcard domains require Let's Encrypt (DNS Challenge) or a Custom certificate resolver for HTTPS",
+				});
+			}
 		}
 
 		// Validate stripPath requires a valid path

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -316,7 +316,7 @@ export const getDefaultTraefikConfig = () => {
 						email: "test@localhost.com",
 						storage: "/etc/dokploy/traefik/dynamic/acme-dns.json",
 						dnsChallenge: {
-							provider: "cloudflare",
+							provider: process.env.TRAEFIK_DNS_PROVIDER || "cloudflare",
 						},
 					},
 				},
@@ -380,7 +380,7 @@ export const getDefaultServerTraefikConfig = () => {
 					email: "test@localhost.com",
 					storage: "/etc/dokploy/traefik/dynamic/acme-dns.json",
 					dnsChallenge: {
-						provider: "cloudflare",
+						provider: process.env.TRAEFIK_DNS_PROVIDER || "cloudflare",
 					},
 				},
 			},

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -311,6 +311,15 @@ export const getDefaultTraefikConfig = () => {
 						},
 					},
 				},
+				"letsencrypt-dns": {
+					acme: {
+						email: "test@localhost.com",
+						storage: "/etc/dokploy/traefik/dynamic/acme-dns.json",
+						dnsChallenge: {
+							provider: "cloudflare",
+						},
+					},
+				},
 			},
 		}),
 	};
@@ -363,6 +372,15 @@ export const getDefaultServerTraefikConfig = () => {
 					storage: "/etc/dokploy/traefik/dynamic/acme.json",
 					httpChallenge: {
 						entryPoint: "web",
+					},
+				},
+			},
+			"letsencrypt-dns": {
+				acme: {
+					email: "test@localhost.com",
+					storage: "/etc/dokploy/traefik/dynamic/acme-dns.json",
+					dnsChallenge: {
+						provider: "cloudflare",
 					},
 				},
 			},

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -19,6 +19,7 @@ import type {
 	PropertiesNetworks,
 } from "./types";
 import { encodeBase64 } from "./utils";
+import { buildHostRule, isWildcardDomain } from "../traefik/domain";
 
 export const cloneCompose = async (compose: Compose) => {
 	let command = "set -e;";
@@ -261,8 +262,10 @@ export const createDomainLabels = (
 		internalPath,
 	} = domain;
 	const routerName = `${appName}-${uniqueConfigKey}-${entrypoint}`;
+	const hostRule = buildHostRule(host);
+	const wildcardDomain = isWildcardDomain(host);
 	const labels = [
-		`traefik.http.routers.${routerName}.rule=Host(\`${host}\`)${path && path !== "/" ? ` && PathPrefix(\`${path}\`)` : ""}`,
+		`traefik.http.routers.${routerName}.rule=${hostRule}${path && path !== "/" ? ` && PathPrefix(\`${path}\`)` : ""}`,
 		`traefik.http.routers.${routerName}.entrypoints=${entrypoint}`,
 		`traefik.http.services.${routerName}.loadbalancer.server.port=${port}`,
 		`traefik.http.routers.${routerName}.service=${routerName}`,
@@ -310,8 +313,11 @@ export const createDomainLabels = (
 	// Add TLS configuration for websecure
 	if (entrypoint === "websecure") {
 		if (certificateType === "letsencrypt") {
+			const resolverName = wildcardDomain
+				? "letsencrypt-dns"
+				: "letsencrypt";
 			labels.push(
-				`traefik.http.routers.${routerName}.tls.certresolver=letsencrypt`,
+				`traefik.http.routers.${routerName}.tls.certresolver=${resolverName}`,
 			);
 		} else if (certificateType === "custom" && customCertResolver) {
 			labels.push(

--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -118,6 +118,20 @@ const toPunycode = (host: string): string => {
 	}
 };
 
+export const isWildcardDomain = (host: string): boolean => {
+	return host.startsWith("*.");
+};
+
+export const buildHostRule = (host: string): string => {
+	if (isWildcardDomain(host)) {
+		const baseDomain = host.slice(2);
+		const escapedDomain = baseDomain.replace(/\./g, "\\.");
+		return `HostRegexp(\`^.+\\.${escapedDomain}$\`)`;
+	}
+	const punycodeHost = toPunycode(host);
+	return `Host(\`${punycodeHost}\`)`;
+};
+
 export const createRouterConfig = async (
 	app: ApplicationNested,
 	domain: Domain,
@@ -128,9 +142,10 @@ export const createRouterConfig = async (
 
 	const { host, path, https, uniqueConfigKey, internalPath, stripPath } =
 		domain;
-	const punycodeHost = toPunycode(host);
+	const hostRule = buildHostRule(host);
+	const wildcardDomain = isWildcardDomain(host);
 	const routerConfig: HttpRouter = {
-		rule: `Host(\`${punycodeHost}\`)${path !== null && path !== "/" ? ` && PathPrefix(\`${path}\`)` : ""}`,
+		rule: `${hostRule}${path !== null && path !== "/" ? ` && PathPrefix(\`${path}\`)` : ""}`,
 		service: `${appName}-service-${uniqueConfigKey}`,
 		middlewares: [],
 		entryPoints: [entryPoint],
@@ -176,7 +191,10 @@ export const createRouterConfig = async (
 
 	if (entryPoint === "websecure") {
 		if (certificateType === "letsencrypt") {
-			routerConfig.tls = { certResolver: "letsencrypt" };
+			const resolverName = wildcardDomain
+				? "letsencrypt-dns"
+				: "letsencrypt";
+			routerConfig.tls = { certResolver: resolverName };
 		} else if (certificateType === "custom" && domain.customCertResolver) {
 			routerConfig.tls = { certResolver: domain.customCertResolver };
 		} else if (certificateType === "none") {


### PR DESCRIPTION
## What does this PR do?

Adds full wildcard domain support (e.g., `*.example.com`) to Dokploy, including correct Traefik routing rules, automatic DNS challenge certificate resolver selection, and user-friendly UI guidance.

## Changes

### Backend
- **Router rule fix**: Wildcard domains now use `HostRegexp()` instead of [Host()](cci:1://file:///Users/dijitalgen/Documents/GitHub/dokploy/packages/server/src/utils/traefik/domain.ts:124:0-132:2) for Traefik v3 Go regex syntax
- **Auto DNS resolver**: When a wildcard domain uses Let's Encrypt, the `letsencrypt-dns` cert resolver is automatically selected
- **Default Traefik config**: Added `letsencrypt-dns` resolver with DNS challenge alongside the existing `letsencrypt` HTTP challenge resolver
- **Validation**: Wildcard domain format validation (`*.example.com`) and blocks `none` certificate type for wildcard HTTPS domains

### Frontend
- **Wildcard info alert**: When user enters a `*.` host, an info message explains wildcard matching
- **DNS Challenge warning**: When wildcard + Let's Encrypt is selected, a warning explains DNS challenge is required with a link to Traefik Environment settings
- **Auto-open Traefik Env dialog**: Clicking the warning link navigates to Settings and automatically opens the Traefik Environment dialog with DNS provider setup guide
- **DNS provider guide**: Shows common provider credentials (Cloudflare, Route53, DigitalOcean, Hetzner)

<img width="636" height="810" alt="Screenshot 2026-03-08 at 1 14 54 AM" src="https://github.com/user-attachments/assets/437bf272-2b11-4f35-b512-b7df5e01f4a2" />


## How to test

1. Create/edit a domain with host `*.example.com`
2. Verify the wildcard info alert appears
3. Enable HTTPS → Select Let's Encrypt → Verify DNS challenge warning appears
4. Click the "Settings → Web Server → Traefik Environment" link → Verify dialog auto-opens with DNS guide
5. Try selecting certificate type "None" with wildcard + HTTPS → Verify validation error

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds full wildcard domain support (`*.example.com`) to Dokploy, including correct Traefik v3 `HostRegexp` routing rules, automatic `letsencrypt-dns` cert resolver selection, a new default DNS challenge resolver in the Traefik config, and UI guidance for DNS provider setup.

Key concerns:

- **Silent failure for existing installations**: `createDefaultTraefikConfig` returns early when `traefik.yml` already exists, so the new `letsencrypt-dns` resolver block is never written for any currently-running Dokploy instance. Users who upgrade and configure a wildcard domain will get a router referencing `certresolver=letsencrypt-dns`, but Traefik won't find the resolver — certificate issuance will silently fail.
- **Incomplete DNS guide for non-Cloudflare users**: The Traefik Env dialog guide correctly lists API credential env vars (e.g., `CF_DNS_API_TOKEN`, `AWS_ACCESS_KEY_ID`), but omits the fact that `TRAEFIK_DNS_PROVIDER` must also be set in **Dokploy's** environment to match the chosen provider. Without it, the generated `traefik.yml` defaults to `provider: cloudflare`, causing Traefik to use Cloudflare API calls with the wrong credentials.
- **Dialog description always references wildcard SSL**: The updated `DialogDescription` unconditionally mentions wildcard SSL even when the dialog is opened in non-wildcard settings contexts.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge — wildcard HTTPS will silently fail on all existing installations, and the DNS provider setup guide is incomplete for non-Cloudflare users.
- The cert-resolver migration issue means that the primary use case (wildcard + Let's Encrypt on an existing install) will produce no certificates without manual intervention. Combined with the missing `TRAEFIK_DNS_PROVIDER` documentation, non-Cloudflare users following the in-app guide will also fail silently.
- `packages/server/src/setup/traefik-setup.ts` (migration of existing configs) and `apps/dokploy/components/dashboard/settings/web-server/edit-traefik-env.tsx` (incomplete DNS provider guidance).

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/server/src/setup/traefik-setup.ts`, line 401-402 ([link](https://github.com/dokploy/dokploy/blob/af1bce32efb2a00ba6ee6eddb9e2c80932154b30/packages/server/src/setup/traefik-setup.ts#L401-L402)) 

   `acme.json` is explicitly chmod'd to `600` (line 401), which Traefik requires. However, the new `acme-dns.json` referenced in the config is never initialized or chmod'd. For consistency and to prevent Traefik permission errors, add equivalent initialization:

   ```ts
   const acmeDnsJsonPath = path.join(DYNAMIC_TRAEFIK_PATH, "acme-dns.json");
   if (existsSync(acmeDnsJsonPath)) {
     chmodSync(acmeDnsJsonPath, "600");
   }
   ```

2. `packages/server/src/setup/traefik-setup.ts`, line 395-423 ([link](https://github.com/dokploy/dokploy/blob/33cb7b7f8ba5b2edb4efd41358288c02b990e0af/packages/server/src/setup/traefik-setup.ts#L395-L423)) 

   **Existing installations won't receive the `letsencrypt-dns` resolver**

   `createDefaultTraefikConfig` (which writes `traefik.yml`) returns early when the file already exists:

   ```typescript
   } else if (stats.isFile()) {
     console.log("Main config already exists");
     return;  // <-- skips all changes for existing installs
   }
   ```

   This means any Dokploy instance that was set up before this PR will never have the `letsencrypt-dns` cert resolver written to its `traefik.yml`. When a wildcard domain is configured with `letsencrypt`, the router will reference `certresolver=letsencrypt-dns` but Traefik will silently ignore the resolver (or log an error) because it isn't defined in the config — certificates will never be issued.

   Existing users will need to either manually add the resolver block to their `traefik.yml` or delete the file and let Dokploy regenerate it. Consider adding a migration step or an explicit check that merges the new resolver into an existing config.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 33cb7b7</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->