### PR TITLE
feat: add maxAliasCount option to parse function for improved Docker …

### DIFF
--- a/packages/server/src/utils/docker/compose.ts
+++ b/packages/server/src/utils/docker/compose.ts
@@ -18,7 +18,9 @@ export const randomizeComposeFile = async (
 ) => {
 	const compose = await findComposeById(composeId);
 	const composeFile = compose.composeFile;
-	const composeData = parse(composeFile) as ComposeSpecification;
+	const composeData = parse(composeFile, {
+		maxAliasCount: 10000,
+	}) as ComposeSpecification;
 
 	const randomSuffix = suffix || generateRandomHash();
 

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -63,7 +63,9 @@ export const loadDockerCompose = async (
 
 	if (existsSync(path)) {
 		const yamlStr = readFileSync(path, "utf8");
-		const parsedConfig = parse(yamlStr) as ComposeSpecification;
+		const parsedConfig = parse(yamlStr, {
+			maxAliasCount: 10000,
+		}) as ComposeSpecification;
 		return parsedConfig;
 	}
 	return null;
@@ -86,7 +88,9 @@ export const loadDockerComposeRemote = async (
 			return null;
 		}
 		if (!stdout) return null;
-		const parsedConfig = parse(stdout) as ComposeSpecification;
+		const parsedConfig = parse(stdout, {
+			maxAliasCount: 10000,
+		}) as ComposeSpecification;
 		return parsedConfig;
 	} catch {
 		return null;


### PR DESCRIPTION
…Compose file handling

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3924

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `maxAliasCount: 10000` to three `yaml.parse()` call sites in Docker Compose file handling, fixing a parsing failure for files that exceed the library's default 100-alias limit. The change is minimal, targeted, and correctly addresses the referenced issue (#3924).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge. It applies a single, well-understood configuration option to three YAML parsing call sites to fix a legitimate issue with Compose files that exceed the default alias limit.
- The change is minimal and correct. It adds `maxAliasCount: 10000` to three `yaml.parse()` calls, directly addressing the reported issue where legitimate Docker Compose files fail to parse due to exceeding the default 100-alias limit. The modification is straightforward with no side effects or functional regressions. The code change logic is trivially correct.
- No files require special attention. Both modified files contain straightforward, correct implementations of the fix.

<sub>Last reviewed commit: 076262e</sub>

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->