### PR TITLE
fix: Docker login fails with GAR JSON key authentication

### DIFF
--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -1,5 +1,6 @@
 import { findAllDeploymentsByApplicationId } from "@dokploy/server/services/deployment";
 import type { Registry } from "@dokploy/server/services/registry";
+import { safeDockerLoginCommand } from "@dokploy/server/services/registry";
 import { createRollback } from "@dokploy/server/services/rollbacks";
 import type { ApplicationNested } from "../builders";
 
@@ -115,10 +116,16 @@ const getRegistryCommands = (
 	imageName: string,
 	registryTag: string,
 ): string => {
+	const loginCommand = safeDockerLoginCommand(
+		registry.registryUrl,
+		registry.username,
+		registry.password,
+	);
+
 	return `
 echo "📦 [Enabled Registry] Uploading image to '${registry.registryType}' | '${registryTag}'" ;
-echo "${registry.password}" | docker login ${registry.registryUrl} -u '${registry.username}' --password-stdin || { 
-	echo "❌ DockerHub Failed" ;
+${loginCommand} || { 
+	echo "❌ Registry Login Failed" ;
 	exit 1;
 }
 echo "✅ Registry Login Success" ;

--- a/packages/server/src/utils/providers/docker.ts
+++ b/packages/server/src/utils/providers/docker.ts
@@ -18,7 +18,7 @@ echo "Pulling ${dockerImage}";
 				username,
 				password,
 			);
-			
+
 			command += `
 if ! ${loginCommand} 2>&1; then
 	echo "❌ Login failed";

--- a/packages/server/src/utils/providers/docker.ts
+++ b/packages/server/src/utils/providers/docker.ts
@@ -1,3 +1,4 @@
+import { safeDockerLoginCommand } from "@dokploy/server/services/registry";
 import type { ApplicationNested } from "../builders";
 
 export const buildRemoteDocker = async (application: ApplicationNested) => {
@@ -12,8 +13,14 @@ echo "Pulling ${dockerImage}";
 		`;
 
 		if (username && password) {
+			const loginCommand = safeDockerLoginCommand(
+				registryUrl || "",
+				username,
+				password,
+			);
+			
 			command += `
-if ! echo "${password}" | docker login --username "${username}" --password-stdin "${registryUrl || ""}" 2>&1; then
+if ! ${loginCommand} 2>&1; then
 	echo "❌ Login failed";
 	exit 1;
 fi


### PR DESCRIPTION
## What is this PR about?

This PR fixes Docker registry authentication failures when using Google Artifact Registry (GAR) with JSON key credentials. The issue was caused by improper handling of special characters in JSON keys during docker login commands. The fix introduces a safeDockerLoginCommand helper function that properly escapes shell special characters and uses printf %s instead of echo to safely pass passwords containing newlines, quotes, and other special characters to docker login --password-stdin.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3935 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Docker registry login failures when using Google Artifact Registry (GAR) JSON key credentials by replacing the unsafe `echo "${password}" | docker login ...` pattern with a new `safeDockerLoginCommand` helper that properly single-quote-escapes all inputs and uses `printf %s` to pass the password to stdin — correctly handling special characters (newlines, double-quotes, `$`, backticks, etc.) that a JSON service account key typically contains.

- `shEscape` in `registry.ts` uses POSIX single-quote escaping (`'\''` for embedded single quotes), which prevents all shell interpretation inside the quoted string — this is the correct approach.
- `printf %s` avoids the trailing-newline and escape-sequence interpretation issues of `echo`, and since the password is always passed as a single-quoted argument, `%` characters in the password are not treated as `printf` format specifiers.
- Both call sites (`upload.ts` and `docker.ts`) are updated consistently.
- One minor style suggestion: the `printf` format string `%s` should be quoted as `'%s'` per best practice, though it is functionally equivalent here.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it correctly addresses the described shell-injection/escaping bug with a well-established POSIX technique.
- The escaping logic (`shEscape` + single-quoting) is correct and handles all edge cases in a GAR JSON key (actual newlines, double-quotes, `$`, backticks). `printf %s` is a well-known improvement over `echo` for piping passwords. The only finding is the cosmetic `printf %s` vs `printf '%s'` style point — no functional bugs were identified.
- No files require special attention beyond the minor `printf` format-string quoting suggestion in `packages/server/src/services/registry.ts`.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/server/src/services/registry.ts`, line 27 ([link](https://github.com/dokploy/dokploy/blob/484ceec43de8f35854433d0bffbd9876f350b5d2/packages/server/src/services/registry.ts#L27)) 

   **Quote the `printf` format string**

   The format string `%s` is unquoted. While this is functionally safe here since `%s` contains no shell metacharacters, quoting it as `'%s'` is considered best practice — it also makes the intent clearer and guards against any future refactoring where the format string might become a variable.

   

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 484ceec</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->