### PR TITLE
fix: Broken install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To get started, run the following command on a VPS:
 Want to skip the installation process? [Try the Dokploy Cloud](https://app.dokploy.com).
 
 ```bash
-curl -sSL https://dokploy.com/install.sh | sh
+curl -sSL https://dokploy.com/install.sh | bash
 ```
 
 For detailed documentation, visit [docs.dokploy.com](https://docs.dokploy.com).


### PR DESCRIPTION
## What is this PR about?

This fixes the issue where the installation instructions are instructing to have the user run the install script under the wrong shell.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the installation command in `README.md` to explicitly use `bash` instead of `sh` when piping the install script. This is a valid documentation fix: on many Linux distributions (e.g. Ubuntu, Debian), `sh` resolves to `dash`, which lacks bash-specific features that the install script likely relies on, causing the install to fail or behave unexpectedly. The markdown code block was already annotated as `bash`, so the command now matches the declared shell, eliminating a source of installation failures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single-line documentation fix with no code changes, configuration updates, or logic modifications.
- The change is minimal and correct: replacing `sh` with `bash` in the install command aligns the actual shell invoked with the code block language hint and prevents installation failures on systems where `sh` is `dash`. No source code, logic, or configuration is affected. The fix directly addresses a known issue in the installation instructions.
- No files require special attention.

<sub>Last reviewed commit: 2da45d3</sub>

<!-- /greptile_comment -->