### PR TITLE
fix: update success message for service deployment to reflect queued …

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -777,7 +777,7 @@ const EnvironmentPage = (
 		}
 		if (success > 0) {
 			toast.success(
-				`${success} service${success !== 1 ? "s" : ""} deployed successfully`,
+				`${success} service${success !== 1 ? "s" : ""} queued for deployment`,
 			);
 		}
 		if (failed > 0) {


### PR DESCRIPTION
…status

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3827

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a misleading success toast message in the bulk service deployment flow. Previously, the message reported that services were "deployed successfully," which was inaccurate since `mutateAsync` calls on deployment actions only queue the deployment rather than completing it synchronously. The message now reads "queued for deployment," which is a more accurate reflection of the actual behavior.

- Changed the success toast message from `"${success} service(s) deployed successfully"` to `"${success} service(s) queued for deployment"` in the bulk deploy handler of the environment page.
- Note: the corresponding error toast message (`"failed to deploy"`) is unchanged and remains reasonable, as it refers to failure at the point of attempting to queue the service.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a one-line UX copy fix with no logic changes.
- The change is a single string literal update in a toast message. No logic, state, or API behavior is modified. The new wording accurately describes the asynchronous queueing behavior of deployment actions.
- No files require special attention.

<sub>Last reviewed commit: 75a4e8e</sub>

<!-- /greptile_comment -->