### PR TITLE
fix: improve port conflict detection by enhancing error messages and …

### DIFF
--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -149,12 +149,12 @@ export const settingsRouter = createTRPCRouter({
 				// Check if port 8080 is already in use before enabling dashboard
 				const portCheck = await checkPortInUse(8080, input.serverId);
 				if (portCheck.isInUse) {
-					const conflictingContainer = portCheck.conflictingContainer
-						? ` by container "${portCheck.conflictingContainer}"`
+					const conflictInfo = portCheck.conflictingContainer
+						? ` by ${portCheck.conflictingContainer}`
 						: "";
 					throw new TRPCError({
 						code: "CONFLICT",
-						message: `Port 8080 is already in use${conflictingContainer}. Please stop the conflicting service or use a different port for the Traefik dashboard.`,
+						message: `Port 8080 is already in use${conflictInfo}. Please stop the conflicting service or use a different port for the Traefik dashboard.`,
 					});
 				}
 				newPorts.push({

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -413,17 +413,38 @@ export const checkPortInUse = async (
 	serverId?: string,
 ): Promise<{ isInUse: boolean; conflictingContainer?: string }> => {
 	try {
-		const command = `docker ps -a --format '{{.Names}}' | grep -v '^dokploy-traefik$' | while read name; do docker port "$name" 2>/dev/null | grep -q ':${port}' && echo "$name" && break; done || true`;
-		const { stdout } = serverId
-			? await execAsyncRemote(serverId, command)
-			: await execAsync(command);
+		// Check if port is in use by a Docker container
+		const dockerCommand = `docker ps -a --format '{{.Names}}' | grep -v '^dokploy-traefik$' | while read name; do docker port "$name" 2>/dev/null | grep -q ':${port}' && echo "$name" && break; done || true`;
+		const { stdout: dockerOut } = serverId
+			? await execAsyncRemote(serverId, dockerCommand)
+			: await execAsync(dockerCommand);
 
-		const container = stdout.trim();
+		const container = dockerOut.trim();
 
-		return {
-			isInUse: !!container,
-			conflictingContainer: container || undefined,
-		};
+		if (container) {
+			return {
+				isInUse: true,
+				conflictingContainer: `container "${container}"`,
+			};
+		}
+
+		// Check if port is in use by a host-level service (non-Docker)
+		// Dokploy runs inside a container, so we spawn an ephemeral container
+		// with --net=host to share the host's network stack and use nc -z to
+		// check if something is listening on the port
+		const hostCommand = `docker run --rm --net=host busybox sh -c 'nc -z 0.0.0.0 ${port} 2>/dev/null && echo in_use || echo free'`;
+		const { stdout: hostOut } = serverId
+			? await execAsyncRemote(serverId, hostCommand)
+			: await execAsync(hostCommand);
+
+		if (hostOut.includes("in_use")) {
+			return {
+				isInUse: true,
+				conflictingContainer: "a host-level service",
+			};
+		}
+
+		return { isInUse: false };
 	} catch (error) {
 		console.error("Error checking port availability:", error);
 		return { isInUse: false };


### PR DESCRIPTION
…adding host-level service checks

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3806

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves port conflict detection in `checkPortInUse` by (1) moving the quoted container-name formatting into the return value itself, and (2) adding a second host-level probe via an ephemeral `docker run --rm --net=host busybox nc -z` container to catch non-Docker services that may already occupy a port.

**Key changes:**
- `packages/server/src/services/settings.ts`: `checkPortInUse` now runs a two-stage check — first Docker containers (excluding `dokploy-traefik`), then a host-network `nc -z` probe for any remaining listeners.
- `apps/dokploy/server/api/routers/settings.ts`: Error message construction is updated to match the new string format returned by `checkPortInUse`.

**Issue found:**
- The host-level `nc -z` probe does not account for `dokploy-traefik` being excluded from the Docker check. If Traefik itself is already listening on the target port, the probe will misreport it as "a host-level service", producing a misleading conflict error when users try to reconfigure existing Traefik ports.

<h3>Confidence Score: 3/5</h3>

- The PR is mostly safe but introduces a logic gap where Traefik's own ports can trigger a misleading conflict error.
- The Docker-container check path is unchanged and correct. The new host-level probe adds useful detection for non-Docker services. However, there is a concrete logic bug where Traefik (which is explicitly excluded from the Docker check) can be misidentified as a "host-level service" when reconfiguring its own ports, potentially blocking legitimate operations with a confusing UX.
- packages/server/src/services/settings.ts — specifically the `checkPortInUse` function logic around the Traefik exclusion

<sub>Last reviewed commit: ce82e23</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->