### PR TITLE
fix: enhance container metrics query to support wildcard matching for…

### DIFF
--- a/apps/monitoring/database/containers.go
+++ b/apps/monitoring/database/containers.go
@@ -54,13 +54,13 @@ func (db *DB) GetLastNContainerMetrics(containerName string, limit int) ([]Conta
 		WITH recent_metrics AS (
 			SELECT metrics_json
 			FROM container_metrics
-			WHERE container_name = ?
+			WHERE container_name = ? OR container_name LIKE ?
 			ORDER BY timestamp DESC
 			LIMIT ?
 		)
 		SELECT metrics_json FROM recent_metrics ORDER BY json_extract(metrics_json, '$.timestamp') ASC
 	`
-	rows, err := db.Query(query, containerName, limit)
+	rows, err := db.Query(query, containerName, containerName+".%", limit)
 	if err != nil {
 		return nil, err
 	}
@@ -90,12 +90,12 @@ func (db *DB) GetAllMetricsContainer(containerName string) ([]ContainerMetric, e
 		WITH recent_metrics AS (
 			SELECT metrics_json
 			FROM container_metrics
-			WHERE container_name = ?
+			WHERE container_name = ? OR container_name LIKE ?
 			ORDER BY timestamp DESC
 		)
 		SELECT metrics_json FROM recent_metrics ORDER BY json_extract(metrics_json, '$.timestamp') ASC
 	`
-	rows, err := db.Query(query, containerName)
+	rows, err := db.Query(query, containerName, containerName+".%")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
… container names

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3896

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the container metrics queries in `apps/monitoring/database/containers.go` to support Docker Swarm replica naming conventions by adding an `OR container_name LIKE ?` clause with a `containerName + ".%"` pattern, so a query for `my_service` also returns metrics for replicas named `my_service.1.abc123`, etc.

**Issue identified:**
The LIKE pattern is constructed directly from the raw `containerName` without escaping SQLite wildcard characters (`_` and `%`). Docker container names routinely contain underscores (Docker Compose generates names like `stack_service`), so `_` in the name will act as a single-character wildcard in LIKE and match unintended containers. Both `GetLastNContainerMetrics` (line 63) and `GetAllMetricsContainer` (line 98) share this escaping gap.

The fix should escape these characters and use an `ESCAPE` clause in the SQL before the PR is ready to merge.

<h3>Confidence Score: 2/5</h3>

- The PR introduces a subtle but real logic bug that causes incorrect metrics to be returned for container names containing underscores due to unescaped LIKE wildcards.
- The PR's intent is correct and addresses the root issue of finding Swarm replica containers. However, the unescaped `_` wildcard in the LIKE pattern is a real logic error given how common underscores are in Docker container names (Docker Compose generates names like `myproject_service`). Until LIKE wildcard escaping is added, the fix will return metrics for unrelated containers, making it unsafe to merge as-is.
- apps/monitoring/database/containers.go — both query functions (lines 63 and 98) need LIKE wildcard escaping with an ESCAPE clause before the fix is safe to ship.

<sub>Last reviewed commit: c00aa6a</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=09330bde-2058-497c-9c64-ceae637fb5b2))

<!-- /greptile_comment -->