### PR TITLE
feat(deployments): Add option to copy webhook url by clicking on it

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -235,6 +235,7 @@ export const ShowDeployments = ({
 								<Badge
 									role="button"
 									tabIndex={0}
+									aria-label="Copy webhook URL to clipboard"
 									className="p-2 rounded-md ml-1 mr-1 hover:border-primary hover:text-primary-foreground hover:bg-primary hover:cursor-pointer whitespace-normal break-all"
 									variant="outline"
 									onKeyDown={(event) => {


### PR DESCRIPTION
## What is this PR about?

Change deployments webhook URL to be a clickable badge that copies the url into clipboard. 

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

## Screenshots (if applicable)

<img width="788" height="211" alt="image" src="https://github.com/user-attachments/assets/c022496e-4061-4a7f-aa2c-5b8b560dc53c" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the deployments panel by converting the static webhook URL text into a clickable `Badge` that copies the URL to the clipboard, improving the user experience for setting up git provider webhooks.

Key changes:
- Extracts the webhook URL into a `useMemo` (`webhookUrl`) to avoid duplicating the template literal logic.
- Wraps the URL in a `Badge` with `onClick`, `onKeyDown` (Enter/Space), `role="button"`, `tabIndex={0}`, `aria-label`, and `whitespace-normal break-all` for correct wrapping — all good accessibility and UX choices.
- Adds the `copy-to-clipboard` package and a `Copy` icon from `lucide-react`.
- One remaining concern: both `onClick` and `onKeyDown` always call `toast.success("Copied to clipboard.")` without checking the boolean return value of `copy()`. If the clipboard write fails (denied permissions, HTTP context, older browser fallback), the user is falsely told the copy succeeded.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; the change is small, focused, and the only issue is a minor UX edge case around error handling for clipboard failures.
- The implementation is clean and correctly addresses accessibility (keyboard navigation, ARIA attributes) and responsive layout. The single open issue — unconditionally showing a success toast regardless of whether `copy()` actually succeeded — is a non-critical UX concern rather than a functional bug in the happy path, which is why the score sits at 4 rather than 5.
- No files require special attention beyond the minor clipboard error-handling note in `show-deployments.tsx`.

<sub>Last reviewed commit: de201d0</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->