### PR TITLE
feat: update Docker configuration to use DOKPLOY environment variables

### DIFF
--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -3,9 +3,9 @@ import Docker from "dockerode";
 
 export const IS_CLOUD = process.env.IS_CLOUD === "true";
 export const DOCKER_API_VERSION = process.env.DOCKER_API_VERSION;
-export const DOCKER_HOST = process.env.DOCKER_HOST;
-export const DOCKER_PORT = process.env.DOCKER_PORT
-	? Number(process.env.DOCKER_PORT)
+export const DOKPLOY_DOCKER_HOST = process.env.DOKPLOY_DOCKER_HOST;
+export const DOKPLOY_DOCKER_PORT = process.env.DOKPLOY_DOCKER_PORT
+	? Number(process.env.DOKPLOY_DOCKER_PORT)
 	: undefined;
 
 export const CLEANUP_CRON_JOB = "50 23 * * *";
@@ -13,11 +13,11 @@ export const docker = new Docker({
 	...(DOCKER_API_VERSION && {
 		version: DOCKER_API_VERSION,
 	}),
-	...(DOCKER_HOST && {
-		host: DOCKER_HOST,
+	...(DOKPLOY_DOCKER_HOST && {
+		host: DOKPLOY_DOCKER_HOST,
 	}),
-	...(DOCKER_PORT && {
-		port: DOCKER_PORT,
+	...(DOKPLOY_DOCKER_PORT && {
+		port: DOKPLOY_DOCKER_PORT,
 	}),
 });
 


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3955

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames `DOCKER_HOST` and `DOCKER_PORT` environment variables to `DOKPLOY_DOCKER_HOST` and `DOKPLOY_DOCKER_PORT` respectively, using an application-specific prefix to avoid conflicts with Docker's own well-known `DOCKER_HOST` env var (which dockerode and the Docker CLI also read). This is a **breaking change** for existing users who have set these env vars.

- `DOCKER_HOST` → `DOKPLOY_DOCKER_HOST` and `DOCKER_PORT` → `DOKPLOY_DOCKER_PORT` are correctly renamed in both the exported constants and the `Docker` constructor options.
- **Inconsistency**: `DOCKER_API_VERSION` was not renamed to `DOKPLOY_DOCKER_API_VERSION`, leaving the three related Docker connection env vars on different naming conventions.
- No other files import these constants, so no additional code changes are required.
- The `.env.example` files do not reference these env vars and were not updated, but they don't currently document these optional settings anyway.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it introduces a breaking env var rename with one minor inconsistency left over.
- The change is small and well-scoped — it only touches constant declarations and their use in the Docker constructor. The logic is correct. The only concern is the inconsistency where `DOCKER_API_VERSION` was not renamed alongside the other two variables, and the fact that existing users with `DOCKER_HOST`/`DOCKER_PORT` set will need to update their environment.
- packages/server/src/constants/index.ts — minor inconsistency with DOCKER_API_VERSION not being renamed.

<sub>Last reviewed commit: 3501996</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->