### PR TITLE
fix: invalidate notification.one query cache on update

### DIFF
--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -737,6 +737,9 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 					});
 					setVisible(false);
 					await utils.notification.all.invalidate();
+					if (notificationId) {
+						await utils.notification.one.invalidate({ notificationId });
+					}
 				})
 				.catch(() => {
 					toast.error(


### PR DESCRIPTION
## What is this PR about?

When editing a notification and saving changes, only the `notification.all` query cache was invalidated. The `notification.one` query retained stale cached data, causing the edit form to display previous values when clicking "Edit" again on the same notification.

This fix adds `notification.one` cache invalidation after a successful update, ensuring the form always reflects the latest saved data.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stale-cache bug in the notification edit flow: after saving an update, only `notification.all` was being invalidated, leaving `notification.one` with stale data and causing the edit form to show old values on subsequent opens. The fix adds a `notification.one` invalidation call guarded by a `notificationId` check inside the shared success handler.

- The logic is correct and minimal — all update mutation paths funnel into the same `.then()` block, so every update type now benefits from the fix.
- The `notificationId` guard is appropriate since `notification.one` only applies to existing notifications.
- The three new lines use spaces while the rest of the file uses tabs for indentation — a minor style inconsistency worth tidying up.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; the change is small, targeted, and logically correct.
- The fix is a single, well-scoped addition that correctly invalidates the `notification.one` query cache on update. No risk of regressions — the new call is guarded by the existing `notificationId` check and sits in the success path only. The only finding is a trivial indentation inconsistency.
- No files require special attention.

<sub>Last reviewed commit: d95b4dc</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->