### PR TITLE
fix: prevent Watch Paths tooltip button from submitting the form

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -1,5 +1,5 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { CheckIcon, ChevronsUpDown, X } from "lucide-react";
+import { CheckIcon, ChevronsUpDown, HelpCircle, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -416,10 +416,8 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 										<FormLabel>Watch Paths</FormLabel>
 										<TooltipProvider>
 											<Tooltip>
-												<TooltipTrigger>
-													<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
-														?
-													</div>
+												<TooltipTrigger asChild>
+													<HelpCircle className="size-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer" />
 												</TooltipTrigger>
 												<TooltipContent>
 													<p>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -1,5 +1,5 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { KeyRoundIcon, LockIcon, X } from "lucide-react";
+import { HelpCircle, KeyRoundIcon, LockIcon, X } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
@@ -228,10 +228,8 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 									<FormLabel>Watch Paths</FormLabel>
 									<TooltipProvider>
 										<Tooltip>
-											<TooltipTrigger>
-												<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
-													?
-												</div>
+											<TooltipTrigger asChild>
+												<HelpCircle className="size-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer" />
 											</TooltipTrigger>
 											<TooltipContent className="max-w-[300px]">
 												<p>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
@@ -1,5 +1,5 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { KeyRoundIcon, LockIcon, X } from "lucide-react";
+import { HelpCircle, KeyRoundIcon, LockIcon, X } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
@@ -230,10 +230,8 @@ export const SaveGitProviderCompose = ({ composeId }: Props) => {
 									<FormLabel>Watch Paths</FormLabel>
 									<TooltipProvider>
 										<Tooltip>
-											<TooltipTrigger>
-												<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
-													?
-												</div>
+											<TooltipTrigger asChild>
+												<HelpCircle className="size-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer" />
 											</TooltipTrigger>
 											<TooltipContent className="max-w-[300px]">
 												<p>


### PR DESCRIPTION
## What is this PR about?

The "Watch Paths" tooltip info button in the Git, Bitbucket, and Compose Git provider forms was unintentionally submitting the form when clicked. This happened because `<TooltipTrigger>` renders an internal `<button>` element, which defaults to `type="submit"` inside a `<form>`. The fix adds the `asChild` prop to `<TooltipTrigger>` and replaces the custom `<div>` with a `<HelpCircle>` icon, consistent with the GitHub, GitLab, and Gitea provider components where this already works correctly.
## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3976

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the "Watch Paths" tooltip info button was unintentionally triggering form submission in the Git, Bitbucket, and Compose Git provider forms. The root cause was that Radix UI's `<TooltipTrigger>` renders a `<button>` element by default, which browsers treat as `type="submit"` when nested inside a `<form>`. By adding the `asChild` prop, `<TooltipTrigger>` delegates rendering to its child (`<HelpCircle>` — an SVG element), which carries no submit semantics.

The fix is minimal, correct, and directly mirrors the pattern already in use across the GitHub, GitLab, and Gitea provider components. No issues were found.

- `save-bitbucket-provider.tsx`, `save-git-provider.tsx`, `save-git-provider-compose.tsx`: Added `asChild` to `<TooltipTrigger>` and replaced the hand-rolled `<div>?</div>` badge with the shared `<HelpCircle>` icon, aligning all six provider forms to the same pattern.
- Visual styling is also improved — the `HelpCircle` icon with `hover:text-foreground transition-colors` matches the design used in the already-fixed providers.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a focused, low-risk bug fix with no logic changes beyond the tooltip trigger rendering.
- The change is identical across all three files and exactly matches the established, working pattern from the GitHub/GitLab/Gitea providers already in the codebase. There are no side-effects, no new dependencies, and the fix directly addresses the described root cause (implicit button type="submit").
- No files require special attention.

<sub>Last reviewed commit: 290267b</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->