### PR TITLE
fix: prevent unhandled rejection in trustedOrigins on DB failure

### DIFF
--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -74,27 +74,32 @@ const { handler, api } = betterAuth({
 		disabled: process.env.NODE_ENV === "production",
 	},
 	async trustedOrigins() {
-		if (IS_CLOUD) {
-			return getTrustedOrigins();
+		try {
+			if (IS_CLOUD) {
+				return await getTrustedOrigins();
+			}
+			const [trustedOrigins, settings] = await Promise.all([
+				getTrustedOrigins(),
+				getWebServerSettings(),
+			]);
+			if (!settings) return [];
+			const devOrigins =
+				process.env.NODE_ENV === "development"
+					? [
+							"http://localhost:3000",
+							"https://absolutely-handy-falcon.ngrok-free.app",
+						]
+					: [];
+			return [
+				...(settings?.serverIp ? [`http://${settings?.serverIp}:3000`] : []),
+				...(settings?.host ? [`https://${settings?.host}`] : []),
+				...devOrigins,
+				...trustedOrigins,
+			];
+		} catch (error) {
+			console.error("Failed to resolve trusted origins:", error);
+			return [];
 		}
-		const [trustedOrigins, settings] = await Promise.all([
-			getTrustedOrigins(),
-			getWebServerSettings(),
-		]);
-		if (!settings) return [];
-		const devOrigins =
-			process.env.NODE_ENV === "development"
-				? [
-						"http://localhost:3000",
-						"https://absolutely-handy-falcon.ngrok-free.app",
-					]
-				: [];
-		return [
-			...(settings?.serverIp ? [`http://${settings?.serverIp}:3000`] : []),
-			...(settings?.host ? [`https://${settings?.host}`] : []),
-			...devOrigins,
-			...trustedOrigins,
-		];
 	},
 	emailVerification: {
 		sendOnSignUp: true,


### PR DESCRIPTION
## What is this PR about?

The previous fix (#3951) added error handling inside `getTrustedOrigins()`, but the `trustedOrigins()` callback in `auth.ts` also calls `getWebServerSettings()` via `Promise.all`. When the DB is unreachable, `getWebServerSettings()` throws and the `Promise.all` rejects, causing an unhandled rejection that crashes the server.

This PR wraps the entire `trustedOrigins()` callback with a try/catch, returning `[]` as a safe fallback on failure.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3948

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps the `trustedOrigins()` callback in `auth.ts` with a try/catch to prevent an unhandled rejection that crashes the server when the database is unreachable. The prior fix (#3951) added error handling inside `getTrustedOrigins()`, but `getWebServerSettings()` — called via `Promise.all` in the non-cloud path — had no such protection. This PR completes the fix by catching errors at the callback level and returning `[]` as a safe fallback.

- Wraps the entire `trustedOrigins()` async callback in try/catch, returning `[]` on failure
- Adds `await` to the `IS_CLOUD` branch's `getTrustedOrigins()` call so the catch block can intercept its errors
- Logs the error via `console.error` for observability
- The empty-array fallback is a secure default: it denies untrusted origins rather than inadvertently allowing them

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped defensive fix with a secure fallback.
- The change is small (one file, wrapping existing logic in try/catch), the fallback value `[]` is the most secure option (deny by default), the error is logged for debugging, and the fix correctly addresses the exact gap described in the linked issue. No behavioral change in the happy path.
- No files require special attention.

<sub>Last reviewed commit: ee42a39</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->