### PR TITLE
Remove whitelabel license requirement - use adminProcedure instead of…

### DIFF
--- a/apps/dokploy/pages/dashboard/settings/whitelabeling.tsx
+++ b/apps/dokploy/pages/dashboard/settings/whitelabeling.tsx
@@ -4,7 +4,6 @@ import type { GetServerSidePropsContext } from "next";
 import type { ReactElement } from "react";
 import superjson from "superjson";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
-import { EnterpriseFeatureGate } from "@/components/proprietary/enterprise-feature-gate";
 import { WhitelabelingSettings } from "@/components/proprietary/whitelabeling/whitelabeling-settings";
 import { Card } from "@/components/ui/card";
 import { appRouter } from "@/server/api/root";
@@ -16,16 +15,7 @@ const Page = () => {
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl mx-auto w-full">
 					<div className="rounded-xl bg-background shadow-md">
 						<div className="p-6">
-							<EnterpriseFeatureGate
-								lockedProps={{
-									title: "Enterprise Whitelabeling",
-									description:
-										"Whitelabeling allows you to fully customize logos, colors, CSS, error pages, and more. Add a valid license to configure it.",
-									ctaLabel: "Go to License",
-								}}
-							>
-								<WhitelabelingSettings />
-							</EnterpriseFeatureGate>
+							<WhitelabelingSettings />
 						</div>
 					</div>
 				</Card>

--- a/apps/dokploy/server/api/routers/proprietary/whitelabeling.ts
+++ b/apps/dokploy/server/api/routers/proprietary/whitelabeling.ts
@@ -6,8 +6,8 @@ import {
 import { TRPCError } from "@trpc/server";
 import { apiUpdateWhitelabeling } from "@/server/db/schema";
 import {
+	adminProcedure,
 	createTRPCRouter,
-	enterpriseProcedure,
 	protectedProcedure,
 	publicProcedure,
 } from "../../trpc";
@@ -21,7 +21,7 @@ export const whitelabelingRouter = createTRPCRouter({
 		return settings?.whitelabelingConfig ?? null;
 	}),
 
-	update: enterpriseProcedure
+	update: adminProcedure
 		.input(apiUpdateWhitelabeling)
 		.mutation(async ({ input, ctx }) => {
 			if (IS_CLOUD) {
@@ -45,7 +45,7 @@ export const whitelabelingRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	reset: enterpriseProcedure.mutation(async ({ ctx }) => {
+	reset: adminProcedure.mutation(async ({ ctx }) => {
 		if (IS_CLOUD) {
 			throw new TRPCError({
 				code: "BAD_REQUEST",


### PR DESCRIPTION
… enterpriseProcedure

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the enterprise license requirement from the whitelabeling feature by switching backend endpoints (`update`, `reset`) from `enterpriseProcedure` to `adminProcedure` and removing the `EnterpriseFeatureGate` UI wrapper on the frontend. The net effect is that whitelabeling is now accessible to any admin/owner without a valid enterprise license.

- Backend: `update` and `reset` endpoints in `whitelabeling.ts` now use `adminProcedure` (role check only) instead of `enterpriseProcedure` (role check + license validation)
- Frontend: The `EnterpriseFeatureGate` wrapper and its import are removed from the whitelabeling page, rendering `WhitelabelingSettings` directly
- Access control is preserved: the page-level `getServerSideProps` still restricts access to owners, and both mutation handlers still explicitly check for `owner` role
- Other enterprise features (SSO, custom roles) remain gated behind `enterpriseProcedure`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it intentionally removes a license gate while preserving role-based access control.
- The change is straightforward: replacing enterpriseProcedure with adminProcedure and removing the frontend gate. Role-based access control is fully preserved (owner-only checks remain in both getServerSideProps and the mutation handlers). The only minor concern is the redundant inner owner check that rejects admins after they pass adminProcedure, but this is a pre-existing pattern and not a regression.
- No files require special attention. Both files have clean, well-scoped changes.

<sub>Last reviewed commit: ac94aaf</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->