### PR TITLE
feat: add optional dockerImage field to database schemas

### DIFF
--- a/packages/server/src/db/schema/mariadb.ts
+++ b/packages/server/src/db/schema/mariadb.ts
@@ -202,6 +202,7 @@ export const apiUpdateMariaDB = createSchema
 	.partial()
 	.extend({
 		mariadbId: z.string().min(1),
+		dockerImage: z.string().optional(),
 	})
 	.omit({ serverId: true });
 

--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -191,6 +191,7 @@ export const apiUpdateMongo = createSchema
 	.partial()
 	.extend({
 		mongoId: z.string().min(1),
+		dockerImage: z.string().optional(),
 	})
 	.omit({ serverId: true });
 

--- a/packages/server/src/db/schema/mysql.ts
+++ b/packages/server/src/db/schema/mysql.ts
@@ -199,6 +199,7 @@ export const apiUpdateMySql = createSchema
 	.partial()
 	.extend({
 		mysqlId: z.string().min(1),
+		dockerImage: z.string().optional(),
 	})
 	.omit({ serverId: true });
 

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -192,6 +192,7 @@ export const apiUpdatePostgres = createSchema
 	.partial()
 	.extend({
 		postgresId: z.string().min(1),
+		dockerImage: z.string().optional(),
 	})
 	.omit({ serverId: true });
 

--- a/packages/server/src/db/schema/redis.ts
+++ b/packages/server/src/db/schema/redis.ts
@@ -178,6 +178,7 @@ export const apiUpdateRedis = createSchema
 	.partial()
 	.extend({
 		redisId: z.string().min(1),
+		dockerImage: z.string().optional(),
 	})
 	.omit({ serverId: true });
 


### PR DESCRIPTION
- Updated MariaDB, MongoDB, MySQL, PostgreSQL, and Redis schemas to include an optional dockerImage field for enhanced configuration flexibility.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3983 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an explicit `dockerImage: z.string().optional()` override in the `.extend()` block of all five database update schemas (`apiUpdateMariaDB`, `apiUpdateMongo`, `apiUpdateMySql`, `apiUpdatePostgres`, `apiUpdateRedis`). This removes the `.default()` value that was inherited from `createSchema.partial()`, preventing the default docker image tag from being silently applied during update operations when `dockerImage` is not included in the payload.

- Consistent one-line change applied identically across `mariadb.ts`, `mongo.ts`, `mysql.ts`, `postgres.ts`, and `redis.ts`
- Fixes the issue where updating a database service (e.g., changing command/args) could inadvertently reset the `dockerImage` to its schema default (e.g., `"mariadb:6"`) instead of preserving the user's custom image
- The frontend (`show-custom-command.tsx`) always sends `dockerImage` in its update payload, so this is a defensive fix for API consumers that may omit it

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted fix applied consistently across all five database schemas.
- Score of 5 reflects that the change is a single-line addition repeated identically across five files, with clear purpose (removing the default value from the update schema to prevent unintended overwrites). The pattern is consistent, the logic is correct, and the database column is NOT NULL so existing data is not at risk. No new dependencies, no schema migrations, and no behavioral changes for the primary frontend consumer which always sends dockerImage explicitly.
- No files require special attention

<sub>Last reviewed commit: bb521f3</sub>

<!-- /greptile_comment -->