### PR TITLE
fix: exclude volume-backups from web server backup rsync command

### DIFF
--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -67,7 +67,7 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 			await execAsync(cleanupCommand);
 
 			await execAsync(
-				`rsync -a --ignore-errors --no-specials --no-devices ${BASE_PATH}/ ${tempDir}/filesystem/`,
+				`rsync -a --ignore-errors --no-specials --no-devices --exclude='volume-backups/' ${BASE_PATH}/ ${tempDir}/filesystem/`,
 			);
 
 			writeStream.write("Copied filesystem to temp directory\n");


### PR DESCRIPTION
- Updated the rsync command in the runWebServerBackup function to exclude the 'volume-backups/' directory, ensuring that unnecessary data is not copied during the backup process.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3971 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `--exclude='volume-backups/'` to the rsync command in `runWebServerBackup`, preventing potentially large Docker volume backup files from bloating web server backups. The change is a minimal, targeted fix for issue #3971.

**Key changes:**
- `packages/server/src/utils/backups/web-server.ts`: Excludes `volume-backups/` from rsync during web server backup.

**Issues found:**
- The exclude pattern `'volume-backups/'` is not anchored to the rsync source root. Using `'/volume-backups/'` (with a leading `/`) would be more precise, though the current version works correctly given the known directory structure.
- More importantly, the corresponding restore function (`restoreWebServerBackup`) performs a blanket `rm -rf "${BASE_PATH}/"*` to clear the destination before restoring. Since `volume-backups/` is now excluded from the backup, any existing volume backups will be permanently deleted during a restore and will not be recovered. The restore logic should be updated to preserve `volume-backups/` across the restore operation.

<h3>Confidence Score: 2/5</h3>

- The backup exclusion is correct, but the restore counterpart has a data-loss risk that should be addressed before merging.
- The rsync change itself is correct and harmless. However, by excluding `volume-backups/` from backups without updating the restore logic, any user who restores a web server backup will silently lose all their Docker volume backups — the restore wipes `BASE_PATH` entirely before copying files back, and since `volume-backups/` is no longer in the archive, it is never restored.
- `packages/server/src/utils/restore/web-server.ts` — the blanket `rm -rf "${BASE_PATH}/"*` will destroy `volume-backups/` during restore since it is no longer included in backups.

<sub>Last reviewed commit: a2f1421</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->