### PR TITLE
fix(permissions): decouple env editing and domain service list from "Create Services" permission

### DIFF
--- a/apps/dokploy/components/dashboard/application/environment/show-enviroment.tsx
+++ b/apps/dokploy/components/dashboard/application/environment/show-enviroment.tsx
@@ -55,16 +55,16 @@ export const ShowEnvironment = ({ id, type }: Props) => {
 	const [isEnvVisible, setIsEnvVisible] = useState(true);
 
 	const mutationMap = {
-		postgres: () => api.postgres.update.useMutation(),
-		redis: () => api.redis.update.useMutation(),
-		mysql: () => api.mysql.update.useMutation(),
-		mariadb: () => api.mariadb.update.useMutation(),
-		mongo: () => api.mongo.update.useMutation(),
-		compose: () => api.compose.update.useMutation(),
+		postgres: () => api.postgres.saveEnvironment.useMutation(),
+		redis: () => api.redis.saveEnvironment.useMutation(),
+		mysql: () => api.mysql.saveEnvironment.useMutation(),
+		mariadb: () => api.mariadb.saveEnvironment.useMutation(),
+		mongo: () => api.mongo.saveEnvironment.useMutation(),
+		compose: () => api.compose.saveEnvironment.useMutation(),
 	};
 	const { mutateAsync, isPending } = mutationMap[type]
 		? mutationMap[type]()
-		: api.mongo.update.useMutation();
+		: api.mongo.saveEnvironment.useMutation();
 
 	const form = useForm<EnvironmentSchema>({
 		defaultValues: {
@@ -86,15 +86,18 @@ export const ShowEnvironment = ({ id, type }: Props) => {
 	}, [data, form]);
 
 	const onSubmit = async (formData: EnvironmentSchema) => {
-		mutateAsync({
-			mongoId: id || "",
-			postgresId: id || "",
-			redisId: id || "",
-			mysqlId: id || "",
-			mariadbId: id || "",
-			composeId: id || "",
-			env: formData.environment,
-		})
+		const payloadMap = {
+			postgres: { postgresId: id, env: formData.environment },
+			redis: { redisId: id, env: formData.environment },
+			mysql: { mysqlId: id, env: formData.environment },
+			mariadb: { mariadbId: id, env: formData.environment },
+			mongo: { mongoId: id, env: formData.environment },
+			compose: { composeId: id, env: formData.environment },
+		} as const;
+
+		(mutateAsync as (input: (typeof payloadMap)[typeof type]) => Promise<unknown>)(
+			payloadMap[type],
+		)
 			.then(async () => {
 				toast.success("Environments Added");
 				await refetch();

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -60,6 +60,7 @@ import {
 	apiFindCompose,
 	apiRandomizeCompose,
 	apiRedeployCompose,
+	apiSaveEnvironmentVariablesCompose,
 	apiUpdateCompose,
 	compose as composeTable,
 	environments,
@@ -189,6 +190,30 @@ export const composeRouter = createTRPCRouter({
 			});
 			return updated;
 		}),
+	saveEnvironment: protectedProcedure
+		.input(apiSaveEnvironmentVariablesCompose)
+		.mutation(async ({ input, ctx }) => {
+			await checkServicePermissionAndAccess(ctx, input.composeId, {
+				envVars: ["write"],
+			});
+			const service = await updateCompose(input.composeId, {
+				env: input.env,
+			});
+
+			if (!service) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error adding environment variables",
+				});
+			}
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "compose",
+				resourceId: input.composeId,
+			});
+			return true;
+		}),
 	delete: protectedProcedure
 		.input(apiDeleteCompose)
 		.mutation(async ({ input, ctx }) => {
@@ -278,7 +303,7 @@ export const composeRouter = createTRPCRouter({
 		.input(apiFetchServices)
 		.query(async ({ input, ctx }) => {
 			await checkServicePermissionAndAccess(ctx, input.composeId, {
-				service: ["create"],
+				service: ["read"],
 			});
 			return await loadServices(input.composeId, input.type);
 		}),

--- a/packages/server/src/db/schema/compose.ts
+++ b/packages/server/src/db/schema/compose.ts
@@ -223,7 +223,14 @@ export const apiUpdateCompose = createSchema
 		composeFile: z.string().optional(),
 		command: z.string().optional(),
 	})
-	.omit({ serverId: true });
+	.omit({ serverId: true, env: true });
+
+export const apiSaveEnvironmentVariablesCompose = createSchema
+	.pick({
+		composeId: true,
+		env: true,
+	})
+	.required();
 
 export const apiRandomizeCompose = createSchema
 	.pick({

--- a/packages/server/src/db/schema/mariadb.ts
+++ b/packages/server/src/db/schema/mariadb.ts
@@ -204,7 +204,7 @@ export const apiUpdateMariaDB = createSchema
 		mariadbId: z.string().min(1),
 		dockerImage: z.string().optional(),
 	})
-	.omit({ serverId: true });
+	.omit({ serverId: true, env: true });
 
 export const apiRebuildMariadb = createSchema
 	.pick({

--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -193,7 +193,7 @@ export const apiUpdateMongo = createSchema
 		mongoId: z.string().min(1),
 		dockerImage: z.string().optional(),
 	})
-	.omit({ serverId: true });
+	.omit({ serverId: true, env: true });
 
 export const apiResetMongo = createSchema
 	.pick({

--- a/packages/server/src/db/schema/mysql.ts
+++ b/packages/server/src/db/schema/mysql.ts
@@ -201,7 +201,7 @@ export const apiUpdateMySql = createSchema
 		mysqlId: z.string().min(1),
 		dockerImage: z.string().optional(),
 	})
-	.omit({ serverId: true });
+	.omit({ serverId: true, env: true });
 
 export const apiRebuildMysql = createSchema
 	.pick({

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -194,7 +194,7 @@ export const apiUpdatePostgres = createSchema
 		postgresId: z.string().min(1),
 		dockerImage: z.string().optional(),
 	})
-	.omit({ serverId: true });
+	.omit({ serverId: true, env: true });
 
 export const apiRebuildPostgres = createSchema
 	.pick({

--- a/packages/server/src/db/schema/redis.ts
+++ b/packages/server/src/db/schema/redis.ts
@@ -180,7 +180,7 @@ export const apiUpdateRedis = createSchema
 		redisId: z.string().min(1),
 		dockerImage: z.string().optional(),
 	})
-	.omit({ serverId: true });
+	.omit({ serverId: true, env: true });
 
 export const apiRebuildRedis = createSchema
 	.pick({


### PR DESCRIPTION
## Summary

Fixes #4052

The "Create Services" (`canCreateServices`) permission was incorrectly required for two unrelated operations:

- **Domain service dropdown:** `compose.loadServices` checked `service: ["create"]` for a read-only operation (parsing YAML to list service names). Changed to `service: ["read"]`.
- **Environment editing on DB/Compose:** The `ShowEnvironment` component used the generic `update` mutation (gated by `service: ["create"]`) instead of the dedicated `saveEnvironment` endpoints (correctly gated by `envVars: ["write"]`).

## Changes

| File | Change |
|------|--------|
| `apps/dokploy/server/api/routers/compose.ts` | `loadServices`: `service: ["create"]` → `service: ["read"]`; added `saveEnvironment` endpoint with `envVars: ["write"]` |
| `packages/server/src/db/schema/compose.ts` | Omit `env` from `apiUpdateCompose`; add `apiSaveEnvironmentVariablesCompose` schema |
| `packages/server/src/db/schema/{postgres,mysql,mariadb,redis,mongo}.ts` | Omit `env` from update schemas to force usage of `saveEnvironment` |
| `apps/dokploy/components/.../show-enviroment.tsx` | Use `saveEnvironment` mutations with per-service typed payloads |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly decouples two read/write operations from the `canCreateServices` (`service: ["create"]`) permission by routing them through their appropriate permission gates.

**What changed:**
- `compose.loadServices` now requires `service: ["read"]` instead of `service: ["create"]` — appropriate since parsing YAML to list service names is a read-only operation
- A new `saveEnvironment` tRPC procedure is added to the compose router, gated by `envVars: ["write"]`, exactly matching the pre-existing pattern on postgres, redis, mysql, mariadb, and mongo routers
- `env` is omitted from all six `apiUpdate*` schemas (compose, postgres, redis, mysql, mariadb, mongo), enforcing that env changes go exclusively through the dedicated `saveEnvironment` endpoint
- `ShowEnvironment` now dispatches per-service `saveEnvironment` mutations with typed payloads instead of the catch-all `update` mutation

**Review notes:**
- The `import` endpoint in `compose.ts` still calls `updateCompose()` directly with an `env` field. This is intentional and safe — the internal `updateCompose(id, data: Partial<Compose>)` function is not constrained by `apiUpdateCompose` and is protected by `service: ["create"]` permission, which is correct for template imports.
- The `apiSaveEnvironmentVariablesCompose` schema mirrors the exact `.pick().required()` pattern used by all sibling service schemas.
- No other UI components that call `.update` on these services pass `env` in their payloads, so there is no regression risk from omitting `env` from the update schemas.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it tightens permissions correctly and introduces no regressions.
- The changes are minimal, targeted, and consistent with the existing permission patterns across all other service routers. The new `saveEnvironment` endpoint for compose follows the exact same structure as the already-shipped endpoints for postgres/redis/mysql/mariadb/mongo. The schema omissions for `env` in the update validators are safe because no other frontend components pass `env` through those update mutations. The fix for `loadServices` is a straightforward and clearly correct permission downgrade.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(permissions): decouple env editing a..."](https://github.com/dokploy/dokploy/commit/9f61d9b245c2b0020b59b684c4b446af61f99579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26074549)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->