### PR TITLE
feat(docker): implement container removal functionality

### DIFF
--- a/apps/dokploy/components/dashboard/docker/remove/remove-container.tsx
+++ b/apps/dokploy/components/dashboard/docker/remove/remove-container.tsx
@@ -38,8 +38,8 @@ export const RemoveContainerDialog = ({ containerId, serverId }: Props) => {
 					<AlertDialogDescription>
 						This will permanently remove the container{" "}
 						<span className="font-semibold">{containerId}</span>. If the
-						container is running, it will be forcefully stopped and removed. This
-						action cannot be undone.
+						container is running, it will be forcefully stopped and removed.
+						This action cannot be undone.
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>

--- a/apps/dokploy/components/dashboard/docker/remove/remove-container.tsx
+++ b/apps/dokploy/components/dashboard/docker/remove/remove-container.tsx
@@ -1,0 +1,66 @@
+import { toast } from "sonner";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { api } from "@/utils/api";
+
+interface Props {
+	containerId: string;
+	serverId?: string;
+}
+
+export const RemoveContainerDialog = ({ containerId, serverId }: Props) => {
+	const utils = api.useUtils();
+	const { mutateAsync, isPending } = api.docker.removeContainer.useMutation();
+
+	return (
+		<AlertDialog>
+			<AlertDialogTrigger asChild>
+				<DropdownMenuItem
+					className="w-full cursor-pointer text-red-500 hover:!text-red-600"
+					onSelect={(e) => e.preventDefault()}
+				>
+					Remove Container
+				</DropdownMenuItem>
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Are you sure?</AlertDialogTitle>
+					<AlertDialogDescription>
+						This will permanently remove the container{" "}
+						<span className="font-semibold">{containerId}</span>. If the
+						container is running, it will be forcefully stopped and removed. This
+						action cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						disabled={isPending}
+						onClick={async () => {
+							await mutateAsync({ containerId, serverId })
+								.then(async () => {
+									toast.success("Container removed successfully");
+									await utils.docker.getContainers.invalidate();
+								})
+								.catch((err) => {
+									toast.error(err.message);
+								});
+						}}
+					>
+						Confirm
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/docker/show/colums.tsx
+++ b/apps/dokploy/components/dashboard/docker/show/colums.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ShowContainerConfig } from "../config/show-container-config";
 import { ShowDockerModalLogs } from "../logs/show-docker-modal-logs";
+import { RemoveContainerDialog } from "../remove/remove-container";
 import { DockerTerminalModal } from "../terminal/docker-terminal-modal";
 import type { Container } from "./show-containers";
 
@@ -127,6 +128,7 @@ export const columns: ColumnDef<Container>[] = [
 						>
 							Terminal
 						</DockerTerminalModal>
+						<RemoveContainerDialog containerId={container.containerId} serverId={container.serverId} />
 					</DropdownMenuContent>
 				</DropdownMenu>
 			);

--- a/apps/dokploy/components/dashboard/docker/show/colums.tsx
+++ b/apps/dokploy/components/dashboard/docker/show/colums.tsx
@@ -128,7 +128,10 @@ export const columns: ColumnDef<Container>[] = [
 						>
 							Terminal
 						</DockerTerminalModal>
-						<RemoveContainerDialog containerId={container.containerId} serverId={container.serverId} />
+						<RemoveContainerDialog
+							containerId={container.containerId}
+							serverId={container.serverId}
+						/>
 					</DropdownMenuContent>
 				</DropdownMenu>
 			);

--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -1,4 +1,5 @@
 import {
+	containerRemove,
 	containerRestart,
 	findServerById,
 	getConfig,
@@ -50,6 +51,32 @@ export const dockerRouter = createTRPCRouter({
 				resourceName: input.containerId,
 			});
 			return result;
+		}),
+
+	removeContainer: withPermission("docker", "read")
+		.input(
+			z.object({
+				containerId: z
+					.string()
+					.min(1)
+					.regex(containerIdRegex, "Invalid container id."),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			await containerRemove(input.containerId, input.serverId);
+			await audit(ctx, {
+				action: "delete",
+				resourceType: "docker",
+				resourceId: input.containerId,
+				resourceName: input.containerId,
+			});
 		}),
 
 	getConfig: withPermission("docker", "read")

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -371,6 +371,21 @@ export const containerRestart = async (containerId: string) => {
 	} catch {}
 };
 
+export const containerRemove = async (
+	containerId: string,
+	serverId?: string,
+) => {
+	const command = `docker rm -f ${containerId}`;
+	const { stderr } = serverId
+		? await execAsyncRemote(serverId, command)
+		: await execAsync(command);
+
+	if (stderr) {
+		console.error(`Error: ${stderr}`);
+		throw new Error(stderr);
+	}
+};
+
 export const getSwarmNodes = async (serverId?: string) => {
 	try {
 		let stdout = "";


### PR DESCRIPTION
- Added RemoveContainerDialog component for user confirmation before removing a Docker container.
- Integrated the dialog into the container management UI.
- Implemented server-side logic for container removal, including permission checks and error handling.
- Updated API router to include the new removeContainer mutation.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes https://github.com/Dokploy/dokploy/issues/2779

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds container removal functionality to the Dokploy Docker management UI. It introduces a `RemoveContainerDialog` confirmation component, hooks it into the container table's action menu, adds a `removeContainer` tRPC mutation with ownership checks and audit logging, and implements the underlying `containerRemove` service function using `docker rm -f`.

Key observations:
- The `removeContainer` mutation is gated behind `withPermission("docker", "read")` — the same level as read-only queries — because the `docker` resource in the access-control schema only exposes `["read"]`. This means any user with docker-read access can permanently delete containers. The access-control schema should be extended with a `"delete"` action for the docker resource to properly scope this destructive capability.
- `containerRemove` throws on any `stderr` output from Docker. While `docker rm -f` only writes genuine errors to stderr, some Docker CLI versions/configurations may emit informational or deprecation warnings to stderr, which would trigger a false error even when the container was removed successfully.
- `AlertDialogAction` auto-closes the dialog on click before the async mutation resolves; if the removal fails the dialog is already dismissed and the user can only see the toast, with no in-place retry option.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for basic functionality, but the permission design allows any docker-read user to delete containers — a privilege concern that should be resolved before wide deployment.
- The feature works correctly in the happy path and is well-integrated into the existing codebase patterns. However, gating a permanent, irreversible delete operation behind the same `"read"` permission level as view-only queries is a meaningful security design gap. The access-control schema needs a dedicated `"delete"` action for the docker resource before this reaches production in multi-user environments.
- apps/dokploy/server/api/routers/docker.ts (permission level on removeContainer) and packages/server/src/lib/access-control.ts (docker resource actions schema).

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/b7e30d7ec32508b2e14f6972e28b82eb0adb84f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26214304)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->