### PR TITLE
Update gitea.ts

### DIFF
--- a/packages/server/src/utils/providers/gitea.ts
+++ b/packages/server/src/utils/providers/gitea.ts
@@ -170,7 +170,7 @@ export const cloneGiteaRepository = async ({
 
 	const repoClone = `${giteaOwner}/${giteaRepository}.git`;
 	const cloneUrl = buildGiteaCloneUrl(
-		giteaProvider.giteaUrl,
+		giteaProvider.giteaInternalUrl || giteaProvider.giteaUrl,
 		giteaProvider.accessToken!,
 		giteaOwner!,
 		giteaRepository!,


### PR DESCRIPTION
https://github.com/Dokploy/dokploy/issues/4066

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4066

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an oversight in `cloneGiteaRepository` where `giteaProvider.giteaUrl` was used directly instead of preferring `giteaProvider.giteaInternalUrl` when available. Every other network-call site in the same file (`refreshGiteaToken`, `testGiteaConnection`, `getGiteaRepositories`, `getGiteaBranches`) already applied the `giteaInternalUrl || giteaUrl` fallback pattern, so this was the only remaining inconsistency, causing git clones to fail or bypass the internal network path when Gitea is co-hosted with Dokploy.

- **Fix**: `buildGiteaCloneUrl` is now called with `giteaProvider.giteaInternalUrl || giteaProvider.giteaUrl`, matching the pattern used everywhere else in the file.
- **Correctness**: `giteaInternalUrl` is `text | null` in the schema, so the `||` fallback correctly resolves to `giteaUrl` when it is `null` or unset. No type or runtime issues.
- No other changes were made to the file.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, targeted fix with no side-effects.
- The change is a one-line consistency fix that brings `cloneGiteaRepository` in line with every other function in the same file. The fallback logic (`null || giteaUrl`) is idiomatic and correct. No new behaviour is introduced when `giteaInternalUrl` is unset.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Update gitea.ts"](https://github.com/dokploy/dokploy/commit/8ee374dc6be30d8bb3391ce1ec6d28ed4b356f8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26232358)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->