### PR TITLE
fix(webhooks): normalize watch path changed-file matching

### DIFF
--- a/apps/dokploy/__test__/deploy/normalize-changed-files.test.ts
+++ b/apps/dokploy/__test__/deploy/normalize-changed-files.test.ts
@@ -24,7 +24,10 @@ describe("normalizeChangedFilesFromCommits", () => {
 				{
 					added: undefined,
 					modified: [undefined, "steam/src/app.ts", ""],
-					removed: [null, "shared/migrations/0007_csfloat_buy_attempt_flows.ts"],
+					removed: [
+						null,
+						"shared/migrations/0007_csfloat_buy_attempt_flows.ts",
+					],
 				},
 				undefined,
 				{

--- a/apps/dokploy/__test__/deploy/normalize-changed-files.test.ts
+++ b/apps/dokploy/__test__/deploy/normalize-changed-files.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizeChangedFilesFromCommits } from "../../../../packages/server/src/utils/watch-paths/normalize-changed-files";
+
+describe("normalizeChangedFilesFromCommits", () => {
+	it("merges added, modified, and removed files from commit payloads", () => {
+		expect(
+			normalizeChangedFilesFromCommits([
+				{
+					added: ["docker-compose.dokploy.yml"],
+					modified: ["steam/src/app.ts"],
+					removed: ["old/file.ts"],
+				},
+			]),
+		).toEqual([
+			"docker-compose.dokploy.yml",
+			"steam/src/app.ts",
+			"old/file.ts",
+		]);
+	});
+
+	it("ignores missing and non-string file entries instead of returning nullish values", () => {
+		expect(
+			normalizeChangedFilesFromCommits([
+				{
+					added: undefined,
+					modified: [undefined, "steam/src/app.ts", ""],
+					removed: [null, "shared/migrations/0007_csfloat_buy_attempt_flows.ts"],
+				},
+				undefined,
+				{
+					added: ["steamCSFloat/src/csfloatScanning.ts"],
+				},
+			] as any),
+		).toEqual([
+			"steam/src/app.ts",
+			"shared/migrations/0007_csfloat_buy_attempt_flows.ts",
+			"steamCSFloat/src/csfloatScanning.ts",
+		]);
+	});
+
+	it("returns an empty list when commits are missing", () => {
+		expect(normalizeChangedFilesFromCommits(undefined as any)).toEqual([]);
+		expect(normalizeChangedFilesFromCommits([])).toEqual([]);
+	});
+});

--- a/apps/dokploy/__test__/deploy/watch-paths.test.ts
+++ b/apps/dokploy/__test__/deploy/watch-paths.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldDeploy } from "../../../../packages/server/src/utils/watch-paths/should-deploy";
+
+describe("shouldDeploy", () => {
+	it("returns false instead of throwing when modified files are missing", () => {
+		expect(() => shouldDeploy(["steam/**"], undefined as any)).not.toThrow();
+		expect(shouldDeploy(["steam/**"], undefined as any)).toBe(false);
+	});
+
+	it("returns false instead of throwing when modified files contain nullish entries only", () => {
+		expect(() => shouldDeploy(["steam/**"], [undefined] as any)).not.toThrow();
+		expect(shouldDeploy(["steam/**"], [undefined] as any)).toBe(false);
+	});
+
+	it("still matches valid modified paths when nullish entries are mixed in", () => {
+		expect(shouldDeploy(["steam/**"], [undefined, "steam/src/app.ts"] as any)).toBe(
+			true,
+		);
+	});
+});

--- a/apps/dokploy/__test__/deploy/watch-paths.test.ts
+++ b/apps/dokploy/__test__/deploy/watch-paths.test.ts
@@ -13,8 +13,8 @@ describe("shouldDeploy", () => {
 	});
 
 	it("still matches valid modified paths when nullish entries are mixed in", () => {
-		expect(shouldDeploy(["steam/**"], [undefined, "steam/src/app.ts"] as any)).toBe(
-			true,
-		);
+		expect(
+			shouldDeploy(["steam/**"], [undefined, "steam/src/app.ts"] as any),
+		).toBe(true);
 	});
 });

--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -142,21 +142,13 @@ export default async function handler(
 			let normalizedCommits: string[] = [];
 
 			if (provider === "github") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			} else if (provider === "gitlab") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			} else if (provider === "gitea") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			} else if (provider === "soft-serve") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			}
 
 			const shouldDeployPaths = shouldDeploy(

--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -2,6 +2,7 @@ import {
 	type Bitbucket,
 	getBitbucketHeaders,
 	IS_CLOUD,
+	normalizeChangedFilesFromCommits,
 	shouldDeploy,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
@@ -110,8 +111,8 @@ export default async function handler(
 			}
 			// If webhook doesn't provide image info, we'll use the configured image (old behavior)
 		} else if (sourceType === "github") {
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
+			const normalizedCommits = normalizeChangedFilesFromCommits(
+				req.body?.commits,
 			);
 
 			const shouldDeployPaths = shouldDeploy(
@@ -141,20 +142,20 @@ export default async function handler(
 			let normalizedCommits: string[] = [];
 
 			if (provider === "github") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			} else if (provider === "gitlab") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			} else if (provider === "gitea") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			} else if (provider === "soft-serve") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			}
 
@@ -170,8 +171,8 @@ export default async function handler(
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);
 
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
+			const normalizedCommits = normalizeChangedFilesFromCommits(
+				req.body?.commits,
 			);
 
 			const shouldDeployPaths = shouldDeploy(

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -1,4 +1,8 @@
-import { IS_CLOUD, shouldDeploy } from "@dokploy/server";
+import {
+	IS_CLOUD,
+	normalizeChangedFilesFromCommits,
+	shouldDeploy,
+} from "@dokploy/server";
 import { db } from "@dokploy/server/db";
 import { eq } from "drizzle-orm";
 import type { NextApiRequest, NextApiResponse } from "next";
@@ -53,8 +57,8 @@ export default async function handler(
 
 		if (sourceType === "github") {
 			const branchName = extractBranchName(req.headers, req.body);
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
+			const normalizedCommits = normalizeChangedFilesFromCommits(
+				req.body?.commits,
 			);
 
 			const shouldDeployPaths = shouldDeploy(
@@ -73,8 +77,8 @@ export default async function handler(
 			}
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
+			const normalizedCommits = normalizeChangedFilesFromCommits(
+				req.body?.commits,
 			);
 
 			const shouldDeployPaths = shouldDeploy(
@@ -124,16 +128,16 @@ export default async function handler(
 			let normalizedCommits: string[] = [];
 
 			if (provider === "github") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			} else if (provider === "gitlab") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			} else if (provider === "gitea") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
+				normalizedCommits = normalizeChangedFilesFromCommits(
+					req.body?.commits,
 				);
 			}
 
@@ -149,8 +153,8 @@ export default async function handler(
 		} else if (sourceType === "gitea") {
 			const branchName = extractBranchName(req.headers, req.body);
 
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
+			const normalizedCommits = normalizeChangedFilesFromCommits(
+				req.body?.commits,
 			);
 
 			const shouldDeployPaths = shouldDeploy(

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -128,17 +128,11 @@ export default async function handler(
 			let normalizedCommits: string[] = [];
 
 			if (provider === "github") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			} else if (provider === "gitlab") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			} else if (provider === "gitea") {
-				normalizedCommits = normalizeChangedFilesFromCommits(
-					req.body?.commits,
-				);
+				normalizedCommits = normalizeChangedFilesFromCommits(req.body?.commits);
 			}
 
 			const shouldDeployPaths = shouldDeploy(

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -6,6 +6,7 @@ import {
 	findPreviewDeploymentByApplicationId,
 	findPreviewDeploymentsByPullRequestId,
 	IS_CLOUD,
+	normalizeChangedFilesFromCommits,
 	removePreviewDeployment,
 	shouldDeploy,
 } from "@dokploy/server";
@@ -213,8 +214,8 @@ export default async function handler(
 			const deploymentTitle = extractCommitMessage(req.headers, req.body);
 			const deploymentHash = extractHash(req.headers, req.body);
 			const owner = githubBody?.repository?.owner?.name;
-			const normalizedCommits = githubBody?.commits?.flatMap(
-				(commit: any) => commit.modified,
+			const normalizedCommits = normalizeChangedFilesFromCommits(
+				githubBody?.commits,
 			);
 
 			const apps = await db.query.applications.findMany({

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -132,4 +132,5 @@ export * from "./utils/traefik/types";
 export * from "./utils/traefik/web-server";
 export * from "./utils/volume-backups/index";
 export * from "./utils/watch-paths/should-deploy";
+export * from "./utils/watch-paths/normalize-changed-files";
 export * from "./wss/utils";

--- a/packages/server/src/utils/watch-paths/normalize-changed-files.ts
+++ b/packages/server/src/utils/watch-paths/normalize-changed-files.ts
@@ -17,5 +17,7 @@ export const normalizeChangedFilesFromCommits = (
 				(paths) => paths || [],
 			);
 		})
-		.filter((path): path is string => typeof path === "string" && path.length > 0);
+		.filter(
+			(path): path is string => typeof path === "string" && path.length > 0,
+		);
 };

--- a/packages/server/src/utils/watch-paths/normalize-changed-files.ts
+++ b/packages/server/src/utils/watch-paths/normalize-changed-files.ts
@@ -1,0 +1,21 @@
+interface CommitLike {
+	added?: Array<string | null | undefined> | null;
+	modified?: Array<string | null | undefined> | null;
+	removed?: Array<string | null | undefined> | null;
+}
+
+export const normalizeChangedFilesFromCommits = (
+	commits: Array<CommitLike | null | undefined> | null | undefined,
+): string[] => {
+	return (commits || [])
+		.flatMap((commit) => {
+			if (!commit) {
+				return [];
+			}
+
+			return [commit.added, commit.modified, commit.removed].flatMap(
+				(paths) => paths || [],
+			);
+		})
+		.filter((path): path is string => typeof path === "string" && path.length > 0);
+};

--- a/packages/server/src/utils/watch-paths/should-deploy.ts
+++ b/packages/server/src/utils/watch-paths/should-deploy.ts
@@ -2,8 +2,16 @@ import micromatch from "micromatch";
 
 export const shouldDeploy = (
 	watchPaths: string[] | null,
-	modifiedFiles: string[],
+	modifiedFiles: Array<string | null | undefined> | null | undefined,
 ): boolean => {
 	if (!watchPaths || watchPaths?.length === 0) return true;
-	return micromatch.some(modifiedFiles, watchPaths);
+	const normalizedModifiedFiles = (modifiedFiles || []).filter(
+		(path): path is string => typeof path === "string" && path.length > 0,
+	);
+
+	if (normalizedModifiedFiles.length === 0) {
+		return false;
+	}
+
+	return micromatch.some(normalizedModifiedFiles, watchPaths);
 };


### PR DESCRIPTION
## What is this PR about?

This PR fixes a crash in Dokploy webhook-driven auto-deploys when Watch Paths are enabled and the incoming webhook payload contains missing or partial changed-file arrays. It makes watch path evaluation defensive against nullish file lists and normalizes changed files across `added`, `modified`, and `removed` entries before matching.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

Closes #4081

## Screenshots (if applicable)

N/A

## Additional notes

### What changed
- make `shouldDeploy()` return `false` instead of throwing when the changed-file list is missing or contains only nullish values
- add `normalizeChangedFilesFromCommits()` to merge `added`, `modified`, and `removed` paths and filter invalid entries
- update the GitHub, GitLab, and Compose webhook handlers to use the normalized changed-file list
- add regression tests covering nullish inputs and mixed webhook payload shapes

### How this was tested
- `pnpm install`
- `cp apps/dokploy/.env.example apps/dokploy/.env`
- `pnpm run dokploy:setup`
- `pnpm run server:script`
- `pnpm run dokploy:dev`
- verified local app startup on `http://127.0.0.1:3000` with redirect to `/register`
- `pnpm exec vitest run __test__/deploy/watch-paths.test.ts __test__/deploy/normalize-changed-files.test.ts --config __test__/vitest.config.ts`

### Environment note
- tested locally on macOS with Node `24.4.0`
- native module install required explicit SDK environment variables for the local machine toolchain:
  - `SDKROOT=$(xcrun --show-sdk-path)`
  - `CPLUS_INCLUDE_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in Dokploy's webhook-driven auto-deploy when Watch Paths are configured and the incoming payload contains a missing or partial `commits` array. It introduces `normalizeChangedFilesFromCommits()` to safely merge `added`, `modified`, and `removed` file paths from each commit while filtering out null/undefined/empty entries, updates `shouldDeploy()` to be null-safe (returning `false` instead of crashing on missing file lists), and applies both changes across all webhook handlers (GitHub, GitLab, Gitea, soft-serve, and Compose variants).

**Key changes:**
- New `normalizeChangedFilesFromCommits()` utility in `packages/server/src/utils/watch-paths/normalize-changed-files.ts` that defensively aggregates all three file-change buckets per commit
- `shouldDeploy()` updated to accept `null | undefined` input and return `false` for empty normalized file lists instead of passing `undefined` to `micromatch.some()`
- All webhook handler call-sites migrated from the crash-prone `flatMap((c) => c.modified)` pattern to the new utility — this also broadens watch-path matching to include `added` and `removed` files (intentional, correct behavior)
- Regression tests covering nullish inputs, mixed payloads, and empty-commit edge cases

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped, well-tested, and only changes crash behavior to a safe default of skipping the deploy.

All changes are defensive null-safety improvements with no logic regressions. The only semantic change beyond the crash fix (now including added/removed files in watch-path matching) is intentional, documented, and correct. Tests cover the key regression scenarios.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server/src/utils/watch-paths/normalize-changed-files.ts | New utility that cleanly merges added/modified/removed paths from commit payloads, filtering all nullish and empty-string values. Implementation is correct and the CommitLike interface is appropriately typed. |
| packages/server/src/utils/watch-paths/should-deploy.ts | Updated to accept null/undefined modifiedFiles input, returning false instead of crashing when the normalized file list is empty. |
| apps/dokploy/pages/api/deploy/[refreshToken].ts | All flatMap commit.modified call-sites replaced with normalizeChangedFilesFromCommits across github, gitlab, gitea, and soft-serve providers. |
| apps/dokploy/pages/api/deploy/compose/[refreshToken].ts | Same migration applied to Compose webhook handler for github, gitlab, and gitea providers. |
| apps/dokploy/pages/api/deploy/github.ts | GitHub-specific webhook handler updated to use normalizeChangedFilesFromCommits. |
| apps/dokploy/__test__/deploy/normalize-changed-files.test.ts | New regression tests covering merged file arrays, nullish/empty filtering, and empty commit input. |
| apps/dokploy/__test__/deploy/watch-paths.test.ts | New regression tests covering shouldDeploy behavior with undefined, nullish-only, and mixed file arrays. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(webhooks): normalize changed file pa..."](https://github.com/dokploy/dokploy/commit/b1141e2e58b2e130847d6c67bb9a4257b47325df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26665010)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->