### PR TITLE
feat: add SFTP, FTP, and Google Drive backup destinations

### DIFF
--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 import { AlertBlock } from "@/components/shared/alert-block";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Dialog,
 	DialogContent,
@@ -37,7 +38,17 @@ import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 import { S3_PROVIDERS } from "./constants";
 
-const addDestination = z.object({
+type DestinationType = "s3" | "sftp" | "ftp" | "gdrive";
+
+const DESTINATION_TYPES: { value: DestinationType; label: string }[] = [
+	{ value: "s3", label: "S3 / S3-Compatible" },
+	{ value: "sftp", label: "SFTP" },
+	{ value: "ftp", label: "FTP" },
+	{ value: "gdrive", label: "Google Drive" },
+];
+
+const s3Schema = z.object({
+	destinationType: z.literal("s3"),
 	name: z.string().min(1, "Name is required"),
 	provider: z.string().min(1, "Provider is required"),
 	accessKeyId: z.string().min(1, "Access Key Id is required"),
@@ -47,6 +58,46 @@ const addDestination = z.object({
 	endpoint: z.string().min(1, "Endpoint is required"),
 	serverId: z.string().optional(),
 });
+
+const sftpSchema = z.object({
+	destinationType: z.literal("sftp"),
+	name: z.string().min(1, "Name is required"),
+	host: z.string().min(1, "Host is required"),
+	port: z.string().default("22"),
+	user: z.string().min(1, "User is required"),
+	password: z.string().min(1, "Password is required"),
+	remotePath: z.string().default("/"),
+	serverId: z.string().optional(),
+});
+
+const ftpSchema = z.object({
+	destinationType: z.literal("ftp"),
+	name: z.string().min(1, "Name is required"),
+	host: z.string().min(1, "Host is required"),
+	port: z.string().default("21"),
+	user: z.string().min(1, "User is required"),
+	password: z.string().min(1, "Password is required"),
+	remotePath: z.string().default("/"),
+	explicitTls: z.boolean().default(false),
+	serverId: z.string().optional(),
+});
+
+const gdriveSchema = z.object({
+	destinationType: z.literal("gdrive"),
+	name: z.string().min(1, "Name is required"),
+	serviceAccountKey: z
+		.string()
+		.min(1, "Service Account JSON is required"),
+	rootFolderId: z.string().optional(),
+	serverId: z.string().optional(),
+});
+
+const addDestination = z.discriminatedUnion("destinationType", [
+	s3Schema,
+	sftpSchema,
+	ftpSchema,
+	gdriveSchema,
+]);
 
 type AddDestination = z.infer<typeof addDestination>;
 
@@ -65,14 +116,10 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		: api.destination.create.useMutation();
 
 	const { data: destination } = api.destination.one.useQuery(
-		{
-			destinationId: destinationId || "",
-		},
-		{
-			enabled: !!destinationId,
-			refetchOnWindowFocus: false,
-		},
+		{ destinationId: destinationId || "" },
+		{ enabled: !!destinationId, refetchOnWindowFocus: false },
 	);
+
 	const {
 		mutateAsync: testConnection,
 		isPending: isPendingConnection,
@@ -82,6 +129,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 
 	const form = useForm<AddDestination>({
 		defaultValues: {
+			destinationType: "s3",
 			provider: "",
 			accessKeyId: "",
 			bucket: "",
@@ -89,36 +137,137 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 			region: "",
 			secretAccessKey: "",
 			endpoint: "",
-		},
+		} as AddDestination,
 		resolver: zodResolver(addDestination),
 	});
+
+	const destinationType = form.watch("destinationType");
+
 	useEffect(() => {
 		if (destination) {
-			form.reset({
-				name: destination.name,
-				provider: destination.provider || "",
-				accessKeyId: destination.accessKey,
-				secretAccessKey: destination.secretAccessKey,
-				bucket: destination.bucket,
-				region: destination.region,
-				endpoint: destination.endpoint,
-			});
+			const type = (destination.destinationType ?? "s3") as DestinationType;
+			if (type === "s3") {
+				form.reset({
+					destinationType: "s3",
+					name: destination.name,
+					provider: destination.provider || "",
+					accessKeyId: destination.accessKey,
+					secretAccessKey: destination.secretAccessKey,
+					bucket: destination.bucket,
+					region: destination.region,
+					endpoint: destination.endpoint,
+				});
+			} else if (type === "sftp") {
+				const cfg = destination.providerConfig as {
+					host: string;
+					port: string;
+					user: string;
+					password: string;
+					remotePath: string;
+				};
+				form.reset({
+					destinationType: "sftp",
+					name: destination.name,
+					host: cfg?.host ?? "",
+					port: cfg?.port ?? "22",
+					user: cfg?.user ?? "",
+					password: cfg?.password ?? "",
+					remotePath: cfg?.remotePath ?? "/",
+				});
+			} else if (type === "ftp") {
+				const cfg = destination.providerConfig as {
+					host: string;
+					port: string;
+					user: string;
+					password: string;
+					remotePath: string;
+					explicitTls: boolean;
+				};
+				form.reset({
+					destinationType: "ftp",
+					name: destination.name,
+					host: cfg?.host ?? "",
+					port: cfg?.port ?? "21",
+					user: cfg?.user ?? "",
+					password: cfg?.password ?? "",
+					remotePath: cfg?.remotePath ?? "/",
+					explicitTls: cfg?.explicitTls ?? false,
+				});
+			} else if (type === "gdrive") {
+				const cfg = destination.providerConfig as {
+					serviceAccountKey: string;
+					rootFolderId?: string;
+				};
+				form.reset({
+					destinationType: "gdrive",
+					name: destination.name,
+					serviceAccountKey: cfg?.serviceAccountKey ?? "",
+					rootFolderId: cfg?.rootFolderId ?? "",
+				});
+			}
 		} else {
-			form.reset();
+			form.reset({ destinationType: "s3" } as AddDestination);
 		}
 	}, [form, form.reset, form.formState.isSubmitSuccessful, destination]);
 
-	const onSubmit = async (data: AddDestination) => {
-		await mutateAsync({
-			provider: data.provider || "",
-			accessKey: data.accessKeyId,
-			bucket: data.bucket,
-			endpoint: data.endpoint,
+	const buildApiPayload = (data: AddDestination) => {
+		if (data.destinationType === "s3") {
+			return {
+				destinationType: "s3" as const,
+				name: data.name,
+				provider: data.provider,
+				accessKey: data.accessKeyId,
+				bucket: data.bucket,
+				endpoint: data.endpoint,
+				region: data.region,
+				secretAccessKey: data.secretAccessKey,
+				serverId: data.serverId,
+			};
+		}
+		if (data.destinationType === "sftp") {
+			return {
+				destinationType: "sftp" as const,
+				name: data.name,
+				providerConfig: {
+					host: data.host,
+					port: data.port,
+					user: data.user,
+					password: data.password,
+					remotePath: data.remotePath,
+				},
+				serverId: data.serverId,
+			};
+		}
+		if (data.destinationType === "ftp") {
+			return {
+				destinationType: "ftp" as const,
+				name: data.name,
+				providerConfig: {
+					host: data.host,
+					port: data.port,
+					user: data.user,
+					password: data.password,
+					remotePath: data.remotePath,
+					explicitTls: data.explicitTls,
+				},
+				serverId: data.serverId,
+			};
+		}
+		// gdrive
+		return {
+			destinationType: "gdrive" as const,
 			name: data.name,
-			region: data.region,
-			secretAccessKey: data.secretAccessKey,
-			destinationId: destinationId || "",
-		})
+			providerConfig: {
+				serviceAccountKey: data.serviceAccountKey,
+				rootFolderId: data.rootFolderId,
+			},
+			serverId: data.serverId,
+		};
+	};
+
+	const onSubmit = async (data: AddDestination) => {
+		const payload = buildApiPayload(data);
+		await mutateAsync({ ...payload, destinationId: destinationId || "" } as Parameters<typeof mutateAsync>[0])
 			.then(async () => {
 				toast.success(`Destination ${destinationId ? "Updated" : "Created"}`);
 				await utils.destination.all.invalidate();
@@ -135,59 +284,15 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 	};
 
 	const handleTestConnection = async (serverId?: string) => {
-		const result = await form.trigger([
-			"provider",
-			"accessKeyId",
-			"secretAccessKey",
-			"bucket",
-			"endpoint",
-		]);
-
-		if (!result) {
-			const errors = form.formState.errors;
-			const errorFields = Object.entries(errors)
-				.map(([field, error]) => `${field}: ${error?.message}`)
-				.filter(Boolean)
-				.join("\n");
-
-			toast.error("Please fill all required fields", {
-				description: errorFields,
-			});
-			return;
-		}
-
+		const values = form.getValues();
 		if (isCloud && !serverId) {
 			toast.error("Please select a server");
 			return;
 		}
-
-		const provider = form.getValues("provider");
-		const accessKey = form.getValues("accessKeyId");
-		const secretKey = form.getValues("secretAccessKey");
-		const bucket = form.getValues("bucket");
-		const endpoint = form.getValues("endpoint");
-		const region = form.getValues("region");
-
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
-
-		await testConnection({
-			provider,
-			accessKey,
-			bucket,
-			endpoint,
-			name: "Test",
-			region,
-			secretAccessKey: secretKey,
-			serverId,
-		})
-			.then(() => {
-				toast.success("Connection Success");
-			})
-			.catch((e) => {
-				toast.error("Error connecting to provider", {
-					description: `${e.message}\n\nTry manually: rclone ls ${connectionString}`,
-				});
-			});
+		const payload = buildApiPayload(values as AddDestination);
+		await testConnection({ ...payload, serverId } as Parameters<typeof testConnection>[0])
+			.then(() => toast.success("Connection Success"))
+			.catch((e) => toast.error("Error connecting to destination", { description: e.message }));
 	};
 
 	return (
@@ -197,9 +302,9 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 					<Button
 						variant="ghost"
 						size="icon"
-						className="group hover:bg-blue-500/10 "
+						className="group hover:bg-blue-500/10"
 					>
-						<PenBoxIcon className="size-3.5  text-primary group-hover:text-blue-500" />
+						<PenBoxIcon className="size-3.5 text-primary group-hover:text-blue-500" />
 					</Button>
 				) : (
 					<Button className="cursor-pointer space-x-3">
@@ -214,9 +319,8 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 						{destinationId ? "Update" : "Add"} Destination
 					</DialogTitle>
 					<DialogDescription>
-						In this section, you can configure and add new destinations for your
-						backups. Please ensure that you provide the correct information to
-						guarantee secure and efficient storage.
+						Configure a backup destination. Supports S3-compatible storage,
+						SFTP, FTP, and Google Drive via a service account.
 					</DialogDescription>
 				</DialogHeader>
 				{(isError || isErrorConnection) && (
@@ -229,148 +333,363 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 					<form
 						id="hook-form-destination-add"
 						onSubmit={form.handleSubmit(onSubmit)}
-						className="grid w-full gap-4 "
+						className="grid w-full gap-4"
 					>
+						{/* Destination name */}
 						<FormField
 							control={form.control}
 							name="name"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Name</FormLabel>
-										<FormControl>
-											<Input placeholder={"S3 Bucket"} {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name</FormLabel>
+									<FormControl>
+										<Input placeholder="My Backup Destination" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
 						/>
+
+						{/* Destination type selector */}
 						<FormField
 							control={form.control}
-							name="provider"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Provider</FormLabel>
-										<FormControl>
-											<Select
-												onValueChange={field.onChange}
-												defaultValue={field.value}
-												value={field.value}
-											>
-												<FormControl>
+							name="destinationType"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Destination Type</FormLabel>
+									<FormControl>
+										<Select
+											onValueChange={(v) => {
+												field.onChange(v);
+												// Reset type-specific fields when switching
+												form.setValue("name", form.getValues("name"));
+											}}
+											value={field.value}
+										>
+											<SelectTrigger>
+												<SelectValue placeholder="Select a destination type" />
+											</SelectTrigger>
+											<SelectContent>
+												{DESTINATION_TYPES.map((t) => (
+													<SelectItem key={t.value} value={t.value}>
+														{t.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+
+						{/* ── S3 fields ── */}
+						{destinationType === "s3" && (
+							<>
+								<FormField
+									control={form.control}
+									name="provider"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>S3 Provider</FormLabel>
+											<FormControl>
+												<Select
+													onValueChange={field.onChange}
+													defaultValue={field.value}
+													value={field.value}
+												>
 													<SelectTrigger>
 														<SelectValue placeholder="Select a S3 Provider" />
 													</SelectTrigger>
-												</FormControl>
-												<SelectContent>
-													{S3_PROVIDERS.map((s3Provider) => (
-														<SelectItem
-															key={s3Provider.key}
-															value={s3Provider.key}
-														>
-															{s3Provider.name}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
+													<SelectContent>
+														{S3_PROVIDERS.map((s3Provider) => (
+															<SelectItem key={s3Provider.key} value={s3Provider.key}>
+																{s3Provider.name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="accessKeyId"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Access Key Id</FormLabel>
+											<FormControl>
+												<Input placeholder="xcas41dasde" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="secretAccessKey"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Secret Access Key</FormLabel>
+											<FormControl>
+												<Input placeholder="asd123asdasw" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="bucket"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Bucket</FormLabel>
+											<FormControl>
+												<Input placeholder="dokploy-bucket" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="region"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Region</FormLabel>
+											<FormControl>
+												<Input placeholder="us-east-1" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="endpoint"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Endpoint</FormLabel>
+											<FormControl>
+												<Input placeholder="https://us.bucket.aws/s3" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</>
+						)}
 
-						<FormField
-							control={form.control}
-							name="accessKeyId"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
-										<FormControl>
-											<Input placeholder={"xcas41dasde"} {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-						<FormField
-							control={form.control}
-							name="secretAccessKey"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"asd123asdasw"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="bucket"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"dokploy-bucket"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="region"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"us-east-1"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="endpoint"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
-									<FormControl>
-										<Input
-											placeholder={"https://us.bucket.aws/s3"}
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+						{/* ── SFTP fields ── */}
+						{destinationType === "sftp" && (
+							<>
+								<FormField
+									control={form.control}
+									name="host"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Host</FormLabel>
+											<FormControl>
+												<Input placeholder="sftp.example.com" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="port"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Port</FormLabel>
+											<FormControl>
+												<Input placeholder="22" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="user"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Username</FormLabel>
+											<FormControl>
+												<Input placeholder="backup-user" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="password"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Password</FormLabel>
+											<FormControl>
+												<Input type="password" placeholder="••••••••" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="remotePath"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Remote Path</FormLabel>
+											<FormControl>
+												<Input placeholder="/backups" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</>
+						)}
+
+						{/* ── FTP fields ── */}
+						{destinationType === "ftp" && (
+							<>
+								<FormField
+									control={form.control}
+									name="host"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Host</FormLabel>
+											<FormControl>
+												<Input placeholder="ftp.example.com" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="port"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Port</FormLabel>
+											<FormControl>
+												<Input placeholder="21" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="user"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Username</FormLabel>
+											<FormControl>
+												<Input placeholder="backup-user" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="password"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Password</FormLabel>
+											<FormControl>
+												<Input type="password" placeholder="••••••••" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="remotePath"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Remote Path</FormLabel>
+											<FormControl>
+												<Input placeholder="/backups" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="explicitTls"
+									render={({ field }) => (
+										<FormItem className="flex flex-row items-center gap-2">
+											<FormControl>
+												<Checkbox
+													checked={field.value}
+													onCheckedChange={field.onChange}
+												/>
+											</FormControl>
+											<FormLabel className="!mt-0">Use Explicit TLS (FTPS)</FormLabel>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</>
+						)}
+
+						{/* ── Google Drive fields ── */}
+						{destinationType === "gdrive" && (
+							<>
+								<FormField
+									control={form.control}
+									name="serviceAccountKey"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Service Account JSON</FormLabel>
+											<FormControl>
+												<textarea
+													className="flex min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+													placeholder='{"type": "service_account", ...}'
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="rootFolderId"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Root Folder ID (optional)</FormLabel>
+											<FormControl>
+												<Input
+													placeholder="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</>
+						)}
 					</form>
 
 					<DialogFooter
 						className={cn(
 							isCloud ? "!flex-col" : "flex-row",
-							"flex w-full  !justify-between gap-4",
+							"flex w-full !justify-between gap-4",
 						)}
 					>
 						{isCloud ? (
 							<div className="flex flex-col gap-4 border p-2 rounded-lg">
 								<span className="text-sm text-muted-foreground">
-									Select a server to test the destination. If you don't have a
-									server choose the default one.
+									Select a server to test the destination.
 								</span>
 								<FormField
 									control={form.control}
@@ -397,19 +716,18 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 																	{server.name}
 																</SelectItem>
 															))}
-															<SelectItem value={"none"}>None</SelectItem>
+															<SelectItem value="none">None</SelectItem>
 														</SelectGroup>
 													</SelectContent>
 												</Select>
 											</FormControl>
-
 											<FormMessage />
 										</FormItem>
 									)}
 								/>
 								<Button
 									type="button"
-									variant={"secondary"}
+									variant="secondary"
 									isLoading={isPendingConnection}
 									onClick={async () => {
 										await handleTestConnection(form.getValues("serverId"));

--- a/apps/dokploy/drizzle/0155_backup_multi_destination.sql
+++ b/apps/dokploy/drizzle/0155_backup_multi_destination.sql
@@ -1,0 +1,8 @@
+-- Add multi-provider destination support (SFTP, FTP, Google Drive)
+ALTER TABLE "destination" ADD COLUMN "destinationType" text NOT NULL DEFAULT 's3';--> statement-breakpoint
+ALTER TABLE "destination" ADD COLUMN "providerConfig" jsonb;--> statement-breakpoint
+ALTER TABLE "destination" ALTER COLUMN "accessKey" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "destination" ALTER COLUMN "secretAccessKey" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "destination" ALTER COLUMN "bucket" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "destination" ALTER COLUMN "region" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "destination" ALTER COLUMN "endpoint" SET DEFAULT '';

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -47,26 +47,47 @@ export const destinationRouter = createTRPCRouter({
 	testConnection: withPermission("destination", "create")
 		.input(apiCreateDestination)
 		.mutation(async ({ input }) => {
-			const { secretAccessKey, bucket, region, endpoint, accessKey, provider } =
-				input;
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
+				const retryFlags =
+					"--retries 1 --low-level-retries 1 --timeout 10s --contimeout 5s";
+
+				let rcloneCommand: string;
+
+				if (input.destinationType === "sftp") {
+					const cfg = input.providerConfig;
+					const port = cfg.port ?? "22";
+					const rcloneDestination = `:sftp:${cfg.remotePath ?? "/"}`;
+					rcloneCommand = `SFTP_PASS=$(rclone obscure "${cfg.password}"); rclone ls --sftp-host="${cfg.host}" --sftp-user="${cfg.user}" --sftp-pass="$SFTP_PASS" --sftp-port="${port}" ${retryFlags} "${rcloneDestination}"`;
+				} else if (input.destinationType === "ftp") {
+					const cfg = input.providerConfig;
+					const port = cfg.port ?? "21";
+					const ftpFlags = cfg.explicitTls ? "--ftp-explicit-tls" : "";
+					const rcloneDestination = `:ftp:${cfg.remotePath ?? "/"}`;
+					rcloneCommand = `FTP_PASS=$(rclone obscure "${cfg.password}"); rclone ls --ftp-host="${cfg.host}" --ftp-user="${cfg.user}" --ftp-pass="$FTP_PASS" --ftp-port="${port}" ${ftpFlags} ${retryFlags} "${rcloneDestination}"`;
+				} else if (input.destinationType === "gdrive") {
+					const cfg = input.providerConfig;
+					const rootFolder = cfg.rootFolderId ?? "";
+					const rcloneDestination = rootFolder
+						? `:drive,root_folder_id=${rootFolder}:`
+						: ":drive:";
+					rcloneCommand = `rclone ls --drive-service-account-credentials="${cfg.serviceAccountKey.replace(/"/g, '\\"')}" ${retryFlags} "${rcloneDestination}"`;
+				} else {
+					// S3 / S3-compatible
+					const { secretAccessKey, bucket, region, endpoint, accessKey, provider } = input as Extract<typeof input, { destinationType: "s3" }>;
+					const rcloneFlags = [
+						`--s3-access-key-id="${accessKey}"`,
+						`--s3-secret-access-key="${secretAccessKey}"`,
+						`--s3-region="${region}"`,
+						`--s3-endpoint="${endpoint}"`,
+						"--s3-no-check-bucket",
+						"--s3-force-path-style",
+						retryFlags,
+					];
+					if (provider) {
+						rcloneFlags.unshift(`--s3-provider="${provider}"`);
+					}
+					rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} ":s3:${bucket}"`;
 				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
@@ -86,7 +107,7 @@ export const destinationRouter = createTRPCRouter({
 					message:
 						error instanceof Error
 							? error?.message
-							: "Error connecting to bucket",
+							: "Error connecting to destination",
 					cause: error,
 				});
 			}

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -1,10 +1,36 @@
 import { relations } from "drizzle-orm";
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { organization } from "./account";
 import { backups } from "./backups";
+
+export type DestinationType = "s3" | "sftp" | "ftp" | "gdrive";
+
+export interface SFTPConfig {
+	host: string;
+	port: string;
+	user: string;
+	password: string;
+	remotePath: string;
+}
+
+export interface FTPConfig {
+	host: string;
+	port: string;
+	user: string;
+	password: string;
+	remotePath: string;
+	explicitTls: boolean;
+}
+
+export interface GDriveConfig {
+	serviceAccountKey: string;
+	rootFolderId?: string;
+}
+
+export type ProviderConfig = SFTPConfig | FTPConfig | GDriveConfig;
 
 export const destinations = pgTable("destination", {
 	destinationId: text("destinationId")
@@ -12,12 +38,19 @@ export const destinations = pgTable("destination", {
 		.primaryKey()
 		.$defaultFn(() => nanoid()),
 	name: text("name").notNull(),
+	// S3 / S3-compatible fields (kept for backwards compatibility)
 	provider: text("provider"),
-	accessKey: text("accessKey").notNull(),
-	secretAccessKey: text("secretAccessKey").notNull(),
-	bucket: text("bucket").notNull(),
-	region: text("region").notNull(),
-	endpoint: text("endpoint").notNull(),
+	accessKey: text("accessKey").notNull().default(""),
+	secretAccessKey: text("secretAccessKey").notNull().default(""),
+	bucket: text("bucket").notNull().default(""),
+	region: text("region").notNull().default(""),
+	endpoint: text("endpoint").notNull().default(""),
+	// Multi-provider fields
+	destinationType: text("destinationType")
+		.$type<DestinationType>()
+		.notNull()
+		.default("s3"),
+	providerConfig: jsonb("providerConfig").$type<ProviderConfig>(),
 	organizationId: text("organizationId")
 		.notNull()
 		.references(() => organization.id, { onDelete: "cascade" }),
@@ -35,6 +68,34 @@ export const destinationsRelations = relations(
 	}),
 );
 
+const sftpConfigSchema = z.object({
+	host: z.string().min(1),
+	port: z.string().default("22"),
+	user: z.string().min(1),
+	password: z.string().min(1),
+	remotePath: z.string().default("/"),
+});
+
+const ftpConfigSchema = z.object({
+	host: z.string().min(1),
+	port: z.string().default("21"),
+	user: z.string().min(1),
+	password: z.string().min(1),
+	remotePath: z.string().default("/"),
+	explicitTls: z.boolean().default(false),
+});
+
+const gdriveConfigSchema = z.object({
+	serviceAccountKey: z.string().min(1),
+	rootFolderId: z.string().optional(),
+});
+
+export const providerConfigSchema = z.discriminatedUnion("type", [
+	z.object({ type: z.literal("sftp") }).merge(sftpConfigSchema),
+	z.object({ type: z.literal("ftp") }).merge(ftpConfigSchema),
+	z.object({ type: z.literal("gdrive") }).merge(gdriveConfigSchema),
+]);
+
 const createSchema = createInsertSchema(destinations, {
 	destinationId: z.string(),
 	name: z.string().min(1),
@@ -44,22 +105,44 @@ const createSchema = createInsertSchema(destinations, {
 	endpoint: z.string(),
 	secretAccessKey: z.string(),
 	region: z.string(),
+	destinationType: z.enum(["s3", "sftp", "ftp", "gdrive"]).default("s3"),
 });
 
-export const apiCreateDestination = createSchema
-	.pick({
-		name: true,
-		provider: true,
-		accessKey: true,
-		bucket: true,
-		region: true,
-		endpoint: true,
-		secretAccessKey: true,
-	})
-	.required()
-	.extend({
+export const apiCreateDestination = z.discriminatedUnion("destinationType", [
+	// S3 / S3-compatible
+	z.object({
+		destinationType: z.literal("s3"),
+		name: z.string().min(1),
+		provider: z.string().min(1),
+		accessKey: z.string().min(1),
+		secretAccessKey: z.string().min(1),
+		bucket: z.string().min(1),
+		region: z.string(),
+		endpoint: z.string().min(1),
 		serverId: z.string().optional(),
-	});
+	}),
+	// SFTP
+	z.object({
+		destinationType: z.literal("sftp"),
+		name: z.string().min(1),
+		providerConfig: sftpConfigSchema,
+		serverId: z.string().optional(),
+	}),
+	// FTP
+	z.object({
+		destinationType: z.literal("ftp"),
+		name: z.string().min(1),
+		providerConfig: ftpConfigSchema,
+		serverId: z.string().optional(),
+	}),
+	// Google Drive
+	z.object({
+		destinationType: z.literal("gdrive"),
+		name: z.string().min(1),
+		providerConfig: gdriveConfigSchema,
+		serverId: z.string().optional(),
+	}),
+]);
 
 export const apiFindOneDestination = z.object({
 	destinationId: z.string().min(1),
@@ -71,18 +154,39 @@ export const apiRemoveDestination = createSchema
 	})
 	.required();
 
-export const apiUpdateDestination = createSchema
-	.pick({
-		name: true,
-		accessKey: true,
-		bucket: true,
-		region: true,
-		endpoint: true,
-		secretAccessKey: true,
-		destinationId: true,
-		provider: true,
-	})
-	.required()
-	.extend({
-		serverId: z.string().optional(),
-	});
+export const apiUpdateDestination = z
+	.discriminatedUnion("destinationType", [
+		z.object({
+			destinationType: z.literal("s3"),
+			destinationId: z.string().min(1),
+			name: z.string().min(1),
+			provider: z.string().min(1),
+			accessKey: z.string().min(1),
+			secretAccessKey: z.string().min(1),
+			bucket: z.string().min(1),
+			region: z.string(),
+			endpoint: z.string().min(1),
+			serverId: z.string().optional(),
+		}),
+		z.object({
+			destinationType: z.literal("sftp"),
+			destinationId: z.string().min(1),
+			name: z.string().min(1),
+			providerConfig: sftpConfigSchema,
+			serverId: z.string().optional(),
+		}),
+		z.object({
+			destinationType: z.literal("ftp"),
+			destinationId: z.string().min(1),
+			name: z.string().min(1),
+			providerConfig: ftpConfigSchema,
+			serverId: z.string().optional(),
+		}),
+		z.object({
+			destinationType: z.literal("gdrive"),
+			destinationId: z.string().min(1),
+			name: z.string().min(1),
+			providerConfig: gdriveConfigSchema,
+			serverId: z.string().optional(),
+		}),
+	]);

--- a/packages/server/src/services/destination.ts
+++ b/packages/server/src/services/destination.ts
@@ -13,12 +13,25 @@ export const createDestintation = async (
 	input: z.infer<typeof apiCreateDestination>,
 	organizationId: string,
 ) => {
+	const insertData =
+		input.destinationType === "s3"
+			? { ...input, organizationId }
+			: {
+					name: input.name,
+					destinationType: input.destinationType,
+					providerConfig: input.providerConfig,
+					organizationId,
+					// S3 fields default to empty string for non-S3 types
+					accessKey: "",
+					secretAccessKey: "",
+					bucket: "",
+					region: "",
+					endpoint: "",
+				};
+
 	const newDestination = await db
 		.insert(destinations)
-		.values({
-			...input,
-			organizationId: organizationId,
-		})
+		.values(insertData as typeof destinations.$inferInsert)
 		.returning()
 		.then((value) => value[0]);
 

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -8,7 +8,7 @@ import { findEnvironmentById } from "@dokploy/server/services/environment";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getRcloneConfig, normalizeS3Path } from "./utils";
 
 export const runComposeBackup = async (
 	compose: Compose,
@@ -21,7 +21,7 @@ export const runComposeBackup = async (
 	const destination = backup.destination;
 	const backupFileName = `${new Date().toISOString()}.${databaseType === "mongo" ? "bson" : "sql"}.gz`;
 	const s3AppName = serviceName ? `${appName}_${serviceName}` : appName;
-	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const filePath = `${s3AppName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "Compose Backup",
@@ -29,14 +29,15 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rclone = getRcloneConfig(destination);
+		const rcloneDestination = rclone.remotePath(filePath);
+		const rcloneCommand = `rclone rcat ${rclone.flags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rclone.preamble,
 		);
 		if (compose.serverId) {
 			await execAsyncRemote(compose.serverId, backupCommand);

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -10,7 +10,7 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import { getRcloneConfig, normalizeS3Path, scheduleBackup } from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -131,19 +131,19 @@ export const keepLatestNBackups = async (
 	if (!backup.keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(backup.destination);
+		const rclone = getRcloneConfig(backup.destination);
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${backup.destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = rclone.remotePath(`${appName}/${normalizeS3Path(backup.prefix)}`);
 
 		// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
-		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;
+		const rcloneList = `rclone lsf ${rclone.flags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;
 		// when we pipe the above command with this one, we only get the list of files we want to delete
 		const sortAndPickUnwantedBackups = `sort -r | tail -n +$((${backup.keepLatestCount}+1)) | xargs -I{}`;
 		// this command deletes the files
 		// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
-		const rcloneDelete = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		const rcloneDelete = `rclone delete ${rclone.flags.join(" ")} ${backupFilesPath}{}`;
 
-		const rcloneCommand = `${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
+		const rcloneCommand = `${rclone.preamble ? `${rclone.preamble}; ` : ""}${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
 
 		if (serverId) {
 			await execAsyncRemote(serverId, rcloneCommand);

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -8,7 +8,7 @@ import type { Libsql } from "@dokploy/server/services/libsql";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getRcloneConfig, normalizeS3Path } from "./utils";
 
 export const runLibsqlBackup = async (
 	libsql: Libsql,
@@ -26,17 +26,18 @@ export const runLibsqlBackup = async (
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${new Date().toISOString()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const filePath = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rclone = getRcloneConfig(destination);
+		const rcloneDestination = rclone.remotePath(filePath);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rclone.flags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rclone.preamble,
 		);
 		if (libsql.serverId) {
 			await execAsyncRemote(libsql.serverId, backupCommand);

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -8,7 +8,7 @@ import type { Mariadb } from "@dokploy/server/services/mariadb";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getRcloneConfig, normalizeS3Path } from "./utils";
 
 export const runMariadbBackup = async (
 	mariadb: Mariadb,
@@ -20,21 +20,22 @@ export const runMariadbBackup = async (
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${new Date().toISOString()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const filePath = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "MariaDB Backup",
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rclone = getRcloneConfig(destination);
+		const rcloneDestination = rclone.remotePath(filePath);
+		const rcloneCommand = `rclone rcat ${rclone.flags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rclone.preamble,
 		);
 		if (mariadb.serverId) {
 			await execAsyncRemote(mariadb.serverId, backupCommand);

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -8,7 +8,7 @@ import type { Mongo } from "@dokploy/server/services/mongo";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getRcloneConfig, normalizeS3Path } from "./utils";
 
 export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 	const { environmentId, name, appName } = mongo;
@@ -17,21 +17,22 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${new Date().toISOString()}.bson.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const filePath = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "MongoDB Backup",
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rclone = getRcloneConfig(destination);
+		const rcloneDestination = rclone.remotePath(filePath);
+		const rcloneCommand = `rclone rcat ${rclone.flags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rclone.preamble,
 		);
 
 		if (mongo.serverId) {

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -8,7 +8,7 @@ import type { MySql } from "@dokploy/server/services/mysql";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupCommand, getRcloneConfig, normalizeS3Path } from "./utils";
 
 export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	const { environmentId, name, appName } = mysql;
@@ -17,7 +17,7 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${new Date().toISOString()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const filePath = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "MySQL Backup",
@@ -25,15 +25,16 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rclone = getRcloneConfig(destination);
+		const rcloneDestination = rclone.remotePath(filePath);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rclone.flags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rclone.preamble,
 		);
 
 		if (mysql.serverId) {

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -8,7 +8,11 @@ import type { Postgres } from "@dokploy/server/services/postgres";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getBackupCommand, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupCommand,
+	getRcloneConfig,
+	normalizeS3Path,
+} from "./utils";
 
 export const runPostgresBackup = async (
 	postgres: Postgres,
@@ -26,17 +30,17 @@ export const runPostgresBackup = async (
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${new Date().toISOString()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const filePath = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rclone = getRcloneConfig(destination);
+		const rcloneDestination = rclone.remotePath(filePath);
+		const rcloneCommand = `rclone rcat ${rclone.flags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rclone.preamble,
 		);
 		if (postgres.serverId) {
 			await execAsyncRemote(postgres.serverId, backupCommand);

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -82,6 +82,101 @@ export const getS3Credentials = (destination: Destination) => {
 	return rcloneFlags;
 };
 
+export interface RcloneConfig {
+	/** Shell preamble (variable assignments) to inject before rclone, e.g. password obscuring */
+	preamble: string;
+	/** rclone flags array */
+	flags: string[];
+	/** Generate the full rclone remote path for a given file path */
+	remotePath: (filePath: string) => string;
+}
+
+/**
+ * Returns rclone config (preamble, flags, remote path) for any destination type.
+ * Centralises credential building so all backup/restore callers stay DRY.
+ */
+export const getRcloneConfig = (destination: Destination): RcloneConfig => {
+	const type = destination.destinationType ?? "s3";
+
+	if (type === "sftp") {
+		const cfg = destination.providerConfig as {
+			host: string;
+			port?: string;
+			user: string;
+			password: string;
+			remotePath?: string;
+		};
+		const port = cfg?.port ?? "22";
+		const remotePath = cfg?.remotePath ?? "/";
+		return {
+			preamble: `RCLONE_SFTP_PASS=$(rclone obscure "${cfg?.password ?? ""}")`,
+			flags: [
+				`--sftp-host="${cfg?.host ?? ""}"`,
+				`--sftp-user="${cfg?.user ?? ""}"`,
+				`--sftp-pass="$RCLONE_SFTP_PASS"`,
+				`--sftp-port="${port}"`,
+			],
+			remotePath: (filePath: string) =>
+				`:sftp:${remotePath.replace(/\/$/, "")}/${filePath}`,
+		};
+	}
+
+	if (type === "ftp") {
+		const cfg = destination.providerConfig as {
+			host: string;
+			port?: string;
+			user: string;
+			password: string;
+			remotePath?: string;
+			explicitTls?: boolean;
+		};
+		const port = cfg?.port ?? "21";
+		const remotePath = cfg?.remotePath ?? "/";
+		const flags = [
+			`--ftp-host="${cfg?.host ?? ""}"`,
+			`--ftp-user="${cfg?.user ?? ""}"`,
+			`--ftp-pass="$RCLONE_FTP_PASS"`,
+			`--ftp-port="${port}"`,
+		];
+		if (cfg?.explicitTls) {
+			flags.push("--ftp-explicit-tls");
+		}
+		return {
+			preamble: `RCLONE_FTP_PASS=$(rclone obscure "${cfg?.password ?? ""}")`,
+			flags,
+			remotePath: (filePath: string) =>
+				`:ftp:${remotePath.replace(/\/$/, "")}/${filePath}`,
+		};
+	}
+
+	if (type === "gdrive") {
+		const cfg = destination.providerConfig as {
+			serviceAccountKey: string;
+			rootFolderId?: string;
+		};
+		const rootFolderId = cfg?.rootFolderId ?? "";
+		return {
+			preamble: "",
+			flags: [
+				`--drive-service-account-credentials="${(cfg?.serviceAccountKey ?? "").replace(/"/g, '\\"')}"`,
+			],
+			remotePath: (filePath: string) =>
+				rootFolderId
+					? `:drive,root_folder_id=${rootFolderId}:${filePath}`
+					: `:drive:${filePath}`,
+		};
+	}
+
+	// Default: S3 / S3-compatible
+	const s3Flags = getS3Credentials(destination);
+	return {
+		preamble: "",
+		flags: s3Flags,
+		remotePath: (filePath: string) =>
+			`:s3:${destination.bucket}/${filePath}`,
+	};
+};
+
 export const getPostgresBackupCommand = (
 	database: string,
 	databaseUser: string,
@@ -247,9 +342,13 @@ export const getBackupCommand = (
 	backup: BackupSchedule,
 	rcloneCommand: string,
 	logPath: string,
+	rclonePreamble = "",
 ) => {
 	const containerSearch = getContainerSearchCommand(backup);
 	const backupCommand = generateBackupCommand(backup);
+	const destinationType = backup.destination?.destinationType ?? "s3";
+	const uploadLabel =
+		destinationType === "s3" ? "S3" : destinationType.toUpperCase();
 
 	logger.info(
 		{
@@ -263,6 +362,7 @@ export const getBackupCommand = (
 
 	return `
 	set -eo pipefail;
+	${rclonePreamble}
 	echo "[$(date)] Starting backup process..." >> ${logPath};
 	echo "[$(date)] Executing backup command..." >> ${logPath};
 	CONTAINER_ID=$(${containerSearch})
@@ -282,16 +382,16 @@ export const getBackupCommand = (
 	}
 
 	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
+	echo "[$(date)] Starting upload to ${uploadLabel}..." >> ${logPath};
 
 	# Run the upload command and capture the exit status
 	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
+		echo "[$(date)] ❌ Error: Upload to ${uploadLabel} failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
 		exit 1;
 	}
 
-	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
+	echo "[$(date)] ✅ Upload to ${uploadLabel} completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -10,7 +10,7 @@ import {
 } from "@dokploy/server/services/deployment";
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { execAsync } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path } from "./utils";
+import { getRcloneConfig, normalizeS3Path } from "./utils";
 
 export const runWebServerBackup = async (backup: BackupSchedule) => {
 	if (IS_CLOUD) {
@@ -26,12 +26,13 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
+		const rclone = getRcloneConfig(destination);
 		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const filePath = `${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const remotePath = rclone.remotePath(filePath);
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -79,10 +80,10 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 
 			writeStream.write("Zipped database and filesystem\n");
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${tempDir}/${backupFileName}" "${s3Path}"`;
-			writeStream.write("Running command to upload backup to S3\n");
+			const uploadCommand = `${rclone.preamble ? `${rclone.preamble}; ` : ""}rclone copyto ${rclone.flags.join(" ")} "${tempDir}/${backupFileName}" "${remotePath}"`;
+			writeStream.write("Running command to upload backup\n");
 			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			writeStream.write("Uploaded backup ✅\n");
 			writeStream.end();
 			await updateDeploymentStatus(deployment.deploymentId, "done");
 			return true;

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneConfig } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -23,13 +23,13 @@ export const restoreComposeBackup = async (
 		}
 		const { serverId, appName, composeType } = compose;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		let rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
+		const backupPath = bucketPath(backupInput.backupFile);
+		let rcloneCommand = `rclone cat ${rclone.flags.join(" ")} "${backupPath}" | gunzip`;
 
 		if (backupInput.metadata?.mongo) {
-			rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+			rcloneCommand = `rclone copy ${rclone.flags.join(" ")} "${backupPath}"`;
 		}
 
 		let credentials: DatabaseCredentials = {};

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Libsql } from "@dokploy/server/services/libsql";
 import type { z } from "zod";
-import { getS3Credentials, getServiceContainerCommand } from "../backups/utils";
+import { getRcloneConfig, getServiceContainerCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 
 export const restoreLibsqlBackup = async (
@@ -14,12 +14,12 @@ export const restoreLibsqlBackup = async (
 	try {
 		const { appName, serverId } = libsql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
 
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
+		const backupPath = bucketPath(backupInput.backupFile);
 
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const rcloneCommand = `rclone cat ${rclone.flags.join(" ")} "${backupPath}"`;
 
 		emit("Starting restore...");
 		emit(`Backup path: ${backupPath}`);

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mariadb } from "@dokploy/server/services/mariadb";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneConfig } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +15,11 @@ export const restoreMariadbBackup = async (
 	try {
 		const { appName, serverId, databaseUser, databasePassword } = mariadb;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
+		const backupPath = bucketPath(backupInput.backupFile);
 
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = `rclone cat ${rclone.flags.join(" ")} "${backupPath}" | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mongo } from "@dokploy/server/services/mongo";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneConfig } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,10 +15,10 @@ export const restoreMongoBackup = async (
 	try {
 		const { appName, databasePassword, databaseUser, serverId } = mongo;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		const rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
+		const backupPath = bucketPath(backupInput.backupFile);
+		const rcloneCommand = `rclone copy ${rclone.flags.join(" ")} "${backupPath}"`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { MySql } from "@dokploy/server/services/mysql";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneConfig } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +15,11 @@ export const restoreMySqlBackup = async (
 	try {
 		const { appName, databaseRootPassword, serverId } = mysql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
+		const backupPath = bucketPath(backupInput.backupFile);
 
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = `rclone cat ${rclone.flags.join(" ")} "${backupPath}" | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Postgres } from "@dokploy/server/services/postgres";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneConfig } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,12 +15,12 @@ export const restorePostgresBackup = async (
 	try {
 		const { appName, databaseUser, serverId } = postgres;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
 
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
+		const backupPath = bucketPath(backupInput.backupFile);
 
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = `rclone cat ${rclone.flags.join(" ")} "${backupPath}" | gunzip`;
 
 		emit("Starting restore...");
 		emit(`Backup path: ${backupPath}`);

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneConfig } from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
 export const restoreWebServerBackup = async (
@@ -15,9 +15,9 @@ export const restoreWebServerBackup = async (
 		return;
 	}
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupFile}`;
+		const rclone = getRcloneConfig(destination);
+		const bucketPath = (filePath) => rclone.remotePath(filePath);
+		const backupPath = bucketPath(backupFile);
 		const { BASE_PATH } = paths();
 
 		// Create a temporary directory outside of BASE_PATH
@@ -35,7 +35,7 @@ export const restoreWebServerBackup = async (
 			// Download backup from S3
 			emit("Downloading backup from S3...");
 			await execAsync(
-				`rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${tempDir}/${backupFile}"`,
+				`rclone copyto ${rclone.flags.join(" ")} "${backupPath}" "${tempDir}/${backupFile}"`,
 			);
 
 			// List files before extraction

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { paths } from "@dokploy/server/constants";
 import { findComposeById } from "@dokploy/server/services/compose";
 import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
-import { getS3Credentials, normalizeS3Path } from "../backups/utils";
+import { getRcloneConfig, normalizeS3Path } from "../backups/utils";
 
 export const getVolumeServiceAppName = (
 	volumeBackup: Awaited<ReturnType<typeof findVolumeBackupById>>,
@@ -33,12 +33,12 @@ export const backupVolume = async (
 	const destination = volumeBackup.destination;
 	const s3AppName = getVolumeServiceAppName(volumeBackup);
 	const backupFileName = `${volumeName}-${new Date().toISOString()}.tar`;
-	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
-	const rcloneFlags = getS3Credentials(volumeBackup.destination);
-	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+	const filePath = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
+	const rclone = getRcloneConfig(volumeBackup.destination);
+	const rcloneDestination = rclone.remotePath(filePath);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeBackup.appName);
 
-	const rcloneCommand = `rclone copyto ${rcloneFlags.join(" ")} "${volumeBackupPath}/${backupFileName}" "${rcloneDestination}"`;
+	const rcloneCommand = `${rclone.preamble ? `${rclone.preamble}; ` : ""}rclone copyto ${rclone.flags.join(" ")} "${volumeBackupPath}/${backupFileName}" "${rcloneDestination}"`;
 
 	const backupCommand = `
 	set -e

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -3,7 +3,7 @@ import {
 	findApplicationById,
 	findComposeById,
 	findDestinationById,
-	getS3Credentials,
+	getRcloneConfig,
 	paths,
 } from "../..";
 
@@ -18,12 +18,11 @@ export const restoreVolume = async (
 	const destination = await findDestinationById(destinationId);
 	const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeName);
-	const rcloneFlags = getS3Credentials(destination);
-	const bucketPath = `:s3:${destination.bucket}`;
-	const backupPath = `${bucketPath}/${backupFileName}`;
+	const rclone = getRcloneConfig(destination);
+	const backupPath = rclone.remotePath(backupFileName);
 
-	// Command to download backup file from S3
-	const downloadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${volumeBackupPath}/${backupFileName}"`;
+	// Command to download backup file from remote destination
+	const downloadCommand = `${rclone.preamble ? `${rclone.preamble}; ` : ""}rclone copyto ${rclone.flags.join(" ")} "${backupPath}" "${volumeBackupPath}/${backupFileName}"`;
 
 	// Base restore command that creates the volume and restores data
 	const baseRestoreCommand = `

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -10,7 +10,7 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { getS3Credentials, normalizeS3Path } from "../backups/utils";
+import { getRcloneConfig, normalizeS3Path } from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
 
@@ -82,12 +82,12 @@ const cleanupOldVolumeBackups = async (
 	if (!keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
+		const rclone = getRcloneConfig(destination);
 		const s3AppName = getVolumeServiceAppName(volumeBackup);
-		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
-		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
+		const backupFilesPath = rclone.remotePath(`${s3AppName}/${normalizeS3Path(prefix || "")}`);
+		const listCommand = `rclone lsf ${rclone.flags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
-		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		const deleteCommand = `rclone delete ${rclone.flags.join(" ")} ${backupFilesPath}{}`;
 		const fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
 
 		if (serverId) {


### PR DESCRIPTION
## What is this PR about?

Adds SFTP, FTP, and Google Drive as backup destination types alongside existing S3 support. Previously only S3 was supported. This allows users to backup databases and volumes to SFTP servers, FTP servers, or Google Drive using a service account.

## Checklist

- [x] Created a dedicated branch based on the canary branch.
- [x] Read the CONTRIBUTING.md suggestions.
- [ ] Tested in local instance.

## Issues related

closes #416

## Changes

- New destinationType (text, default s3) and providerConfig (jsonb) columns on destination table
- Migration: 0155_backup_multi_destination.sql
- New getRcloneConfig(destination) utility returning {preamble, flags, remotePath} for SFTP/FTP/GDrive/S3
- All backup + restore executors migrated from getS3Credentials to getRcloneConfig
- testConnection mutation supports all 4 provider types
- apiCreateDestination/apiUpdateDestination are now discriminated unions on destinationType
- handle-destinations.tsx rewritten with dynamic per-provider form fields

/claim #416

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds SFTP, FTP, and Google Drive as backup destinations alongside existing S3 support. The core architecture is sound, but three P1 defects were found: shell injection via unescaped passwords in SFTP/FTP preamble commands, and missing preamble in all restore files and volume-backup cleanup (causing SFTP/FTP restores and cleanup to always fail).

<h3>Confidence Score: 4/5</h3>

Not safe to merge: SFTP/FTP restores are broken at runtime and passwords are vulnerable to shell injection

Three P1 issues requiring fixes before merge; the backup path is correct but restore and cleanup paths were overlooked

packages/server/src/utils/restore/ (all 7 files), packages/server/src/utils/volume-backups/utils.ts, packages/server/src/utils/backups/utils.ts lines 112+145, apps/dokploy/server/api/routers/destination.ts lines 60+66

<sub>Reviews (1): Last reviewed commit: ["feat: add SFTP, FTP, and Google Drive ba..."](https://github.com/dokploy/dokploy/commit/0fac6bfe7e29700d749328968ea6909dec0dc2d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26701163)</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->