### PR TITLE
feat(users): add credentials-based user provisioning for self-hosted

### DIFF
--- a/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
@@ -34,14 +34,36 @@ import {
 } from "@/components/ui/select";
 import { api } from "@/utils/api";
 
-const addInvitation = z.object({
-	email: z
-		.string()
-		.min(1, "Email is required")
-		.email({ message: "Invalid email" }),
-	role: z.string().min(1, "Role is required"),
-	notificationId: z.string().optional(),
-});
+const addInvitation = z
+	.object({
+		mode: z.enum(["invitation", "credentials"]),
+		email: z
+			.string()
+			.min(1, "Email is required")
+			.email({ message: "Invalid email" }),
+		role: z.string().min(1, "Role is required"),
+		notificationId: z.string().optional(),
+		password: z.string().optional(),
+		confirmPassword: z.string().optional(),
+	})
+	.superRefine((data, ctx) => {
+		if (data.mode === "credentials") {
+			if (!data.password || data.password.length < 8) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Password must be at least 8 characters",
+					path: ["password"],
+				});
+			}
+			if (data.password !== data.confirmPassword) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: "Passwords do not match",
+					path: ["confirmPassword"],
+				});
+			}
+		}
+	});
 
 type AddInvitation = z.infer<typeof addInvitation>;
 
@@ -54,61 +76,83 @@ export const AddInvitation = () => {
 	const { mutateAsync: inviteMember, isPending: isInviting } =
 		api.organization.inviteMember.useMutation();
 	const { mutateAsync: sendInvitation } = api.user.sendInvitation.useMutation();
+	const {
+		mutateAsync: createUserWithCredentials,
+		isPending: isCreatingWithCredentials,
+	} = api.user.createUserWithCredentials.useMutation();
 	const { data: customRoles } = api.customRole.all.useQuery();
 	const [error, setError] = useState<string | null>(null);
 
 	const form = useForm<AddInvitation>({
 		defaultValues: {
+			mode: "invitation",
 			email: "",
 			role: "member",
 			notificationId: "",
+			password: "",
+			confirmPassword: "",
 		},
 		resolver: zodResolver(addInvitation),
 	});
+
+	const mode = form.watch("mode");
 	useEffect(() => {
 		form.reset();
 	}, [form, form.formState.isSubmitSuccessful, form.reset]);
 
 	const onSubmit = async (data: AddInvitation) => {
 		try {
-			const result = await inviteMember({
-				email: data.email.toLowerCase(),
-				role: data.role,
-			});
-
-			if (!isCloud && data.notificationId) {
-				await sendInvitation({
-					invitationId: result!.id,
-					notificationId: data.notificationId || "",
-				})
-					.then(() => {
-						toast.success("Invitation created and email sent");
-					})
-					.catch((error: any) => {
-						toast.error(error.message);
-					});
+			if (data.mode === "credentials") {
+				await createUserWithCredentials({
+					email: data.email.toLowerCase(),
+					password: data.password!,
+					role: data.role,
+				});
+				toast.success("User created successfully");
+				utils.user.all.invalidate();
 			} else {
-				toast.success("Invitation created");
+				const result = await inviteMember({
+					email: data.email.toLowerCase(),
+					role: data.role,
+				});
+
+				if (!isCloud && data.notificationId) {
+					await sendInvitation({
+						invitationId: result!.id,
+						notificationId: data.notificationId || "",
+					})
+						.then(() => {
+							toast.success("Invitation created and email sent");
+						})
+						.catch((error: any) => {
+							toast.error(error.message);
+						});
+				} else {
+					toast.success("Invitation created");
+				}
+				utils.organization.allInvitations.invalidate();
 			}
 			setError(null);
 			setOpen(false);
 		} catch (error: any) {
-			setError(error.message || "Failed to create invitation");
+			setError(error.message || "Failed to create user");
 		}
-
-		utils.organization.allInvitations.invalidate();
 	};
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger className="" asChild>
 				<Button>
-					<PlusIcon className="h-4 w-4" /> Add Invitation
+					<PlusIcon className="h-4 w-4" /> Add User
 				</Button>
 			</DialogTrigger>
 			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
-					<DialogTitle>Add Invitation</DialogTitle>
-					<DialogDescription>Invite a new user</DialogDescription>
+					<DialogTitle>Add User</DialogTitle>
+					<DialogDescription>
+						{mode === "credentials"
+							? "Create a new user with email and password"
+							: "Invite a new user via email"}
+					</DialogDescription>
 				</DialogHeader>
 				{error && <AlertBlock type="error">{error}</AlertBlock>}
 
@@ -118,6 +162,37 @@ export const AddInvitation = () => {
 						onSubmit={form.handleSubmit(onSubmit)}
 						className="grid w-full gap-4 "
 					>
+						{!isCloud && (
+							<FormField
+								control={form.control}
+								name="mode"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Method</FormLabel>
+										<Select
+											onValueChange={field.onChange}
+											defaultValue={field.value}
+										>
+											<FormControl>
+												<SelectTrigger>
+													<SelectValue placeholder="Select method" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value="invitation">
+													Invitation (send email)
+												</SelectItem>
+												<SelectItem value="credentials">
+													Credentials (set password directly)
+												</SelectItem>
+											</SelectContent>
+										</Select>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						)}
+
 						<FormField
 							control={form.control}
 							name="email"
@@ -172,7 +247,49 @@ export const AddInvitation = () => {
 							}}
 						/>
 
-						{!isCloud && (
+						{mode === "credentials" && (
+							<>
+								<FormField
+									control={form.control}
+									name="password"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Password</FormLabel>
+											<FormControl>
+												<Input
+													type="password"
+													placeholder="Password"
+													{...field}
+												/>
+											</FormControl>
+											<FormDescription>
+												Minimum 8 characters
+											</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="confirmPassword"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Confirm Password</FormLabel>
+											<FormControl>
+												<Input
+													type="password"
+													placeholder="Confirm Password"
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</>
+						)}
+
+						{!isCloud && mode === "invitation" && (
 							<FormField
 								control={form.control}
 								name="notificationId"
@@ -214,11 +331,11 @@ export const AddInvitation = () => {
 						)}
 						<DialogFooter className="flex w-full flex-row">
 							<Button
-								isLoading={isInviting}
+								isLoading={isInviting || isCreatingWithCredentials}
 								form="hook-form-add-invitation"
 								type="submit"
 							>
-								Create
+								{mode === "credentials" ? "Create User" : "Send Invitation"}
 							</Button>
 						</DialogFooter>
 					</form>

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -21,7 +21,10 @@ import {
 	apiUpdateUser,
 	invitation,
 	member,
+	organizationRole,
+	user,
 } from "@dokploy/server/db/schema";
+import { nanoid } from "nanoid";
 import {
 	hasPermission,
 	resolvePermissions,
@@ -556,6 +559,99 @@ export const userRouter = createTRPCRouter({
 
 			return organizations.length;
 		}),
+	createUserWithCredentials: withPermission("member", "create")
+		.input(
+			z.object({
+				email: z.string().email(),
+				password: z.string().min(8, "Password must be at least 8 characters"),
+				role: z.string().min(1, "Role is required"),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (IS_CLOUD) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message:
+						"This feature is only available for self-hosted instances",
+				});
+			}
+
+			const orgId = ctx.session.activeOrganizationId;
+			const email = input.email.toLowerCase();
+
+			const existingUser = await db.query.user.findFirst({
+				where: eq(user.email, email),
+			});
+
+			if (existingUser) {
+				const existingMember = await db.query.member.findFirst({
+					where: and(
+						eq(member.organizationId, orgId),
+						eq(member.userId, existingUser.id),
+					),
+				});
+
+				if (existingMember) {
+					throw new TRPCError({
+						code: "CONFLICT",
+						message: "User is already a member of this organization",
+					});
+				}
+			}
+
+			if (!["owner", "admin", "member"].includes(input.role)) {
+				const customRole = await db.query.organizationRole.findFirst({
+					where: and(
+						eq(organizationRole.organizationId, orgId),
+						eq(organizationRole.role, input.role),
+					),
+				});
+
+				if (!customRole) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: `Role "${input.role}" not found`,
+					});
+				}
+			}
+
+			const now = new Date();
+			const userId = nanoid();
+
+			await db.transaction(async (tx) => {
+				await tx.insert(user).values({
+					id: userId,
+					email,
+					emailVerified: true,
+					updatedAt: now,
+				});
+
+				await tx.insert(account).values({
+					accountId: nanoid(),
+					providerId: "credential",
+					userId,
+					password: bcrypt.hashSync(input.password, 10),
+					createdAt: now,
+					updatedAt: now,
+				});
+
+				await tx.insert(member).values({
+					userId,
+					organizationId: orgId,
+					role: input.role as any,
+					createdAt: now,
+				});
+			});
+
+			await audit(ctx, {
+				action: "create",
+				resourceType: "user",
+				resourceId: userId,
+				resourceName: email,
+				metadata: { type: "createUserWithCredentials", role: input.role },
+			});
+		}),
+
 	sendInvitation: withPermission("member", "create")
 		.input(
 			z.object({


### PR DESCRIPTION
## What is this PR about?

Allow organization owners/admins to add new users by setting an email and password directly, without requiring an email provider or invitation flow. The new "Credentials" method creates the user account and organization membership in a single transaction.

The existing invitation flow is unchanged. The new method is self-hosted only — cloud instances are blocked at the API level.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

https://github.com/Dokploy/dokploy/issues/3686

closes #123

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Credentials" provisioning path so self-hosted org owners/admins can create new users directly with an email and password, bypassing the invitation/email flow. The frontend changes are clean and well-structured. The server-side mutation has one definite runtime bug and two lower-priority concerns.

- **P1 — existing user causes a raw DB error**: When `existingUser` is found but is not yet a member of the current org, the code falls through and tries to insert a new `user` row with the same email address, which will always throw a database unique-constraint violation. A guard to throw a descriptive `CONFLICT` error (or add the existing user as a member) is needed.
- **P2 — `bcrypt.hashSync` blocks the event loop**: The synchronous hashing call can stall all in-flight requests for ~50–200 ms; `bcrypt.hash` (async) should be used instead.
- **P2 — admin can assign the "owner" role**: The built-in role allow-list does not prevent an admin from creating a new `owner`-role user, which is a privilege escalation path. Caller-role validation would mitigate this.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the existing-user duplicate-insert bug is fixed; it will produce an unhandled DB error for any email already present in the system.

One confirmed P1 logic bug (existing global user silently falls through to a failing DB insert) must be resolved before this feature is usable. The P2 findings (sync bcrypt, admin→owner role escalation) are worth addressing but do not block the happy path.

apps/dokploy/server/api/routers/user.ts — the createUserWithCredentials mutation

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dokploy/server/api/routers/user.ts | Adds createUserWithCredentials mutation with a P1 bug: when a user with the given email already exists globally (but not in the current org) the duplicate-insert will fail with a raw DB unique-constraint error. Also uses bcrypt.hashSync (blocks the event loop) and allows admins to assign the owner role. |
| apps/dokploy/components/dashboard/settings/users/add-invitation.tsx | Extends the invitation dialog with a new Credentials mode (email + password) hidden on cloud. Zod validation, form reset, and loading state are all handled correctly. No issues found. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(users): add credentials-based user ..."](https://github.com/dokploy/dokploy/commit/98866ef5f8c7de7b10986517ec8796513c61a333) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26707147)</sub>

> Greptile also left **3 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->