### PR TITLE
fix(server): add explicit HostIp to Traefik port bindings

### DIFF
--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -21,6 +21,7 @@ export const TRAEFIK_PORT =
 export const TRAEFIK_HTTP3_PORT =
 	Number.parseInt(process.env.TRAEFIK_HTTP3_PORT!, 10) || 443;
 export const TRAEFIK_VERSION = process.env.TRAEFIK_VERSION || "3.6.7";
+export const TRAEFIK_BIND_IP = process.env.TRAEFIK_BIND_IP || "0.0.0.0";
 
 export interface TraefikOptions {
 	env?: string[];
@@ -47,11 +48,18 @@ export const initializeStandaloneTraefik = async ({
 		[`${TRAEFIK_HTTP3_PORT}/udp`]: {},
 	};
 
-	const portBindings: Record<string, Array<{ HostPort: string }>> = {
-		[`${TRAEFIK_PORT}/tcp`]: [{ HostPort: TRAEFIK_PORT.toString() }],
-		[`${TRAEFIK_SSL_PORT}/tcp`]: [{ HostPort: TRAEFIK_SSL_PORT.toString() }],
+	const portBindings: Record<
+		string,
+		Array<{ HostPort: string; HostIp: string }>
+	> = {
+		[`${TRAEFIK_PORT}/tcp`]: [
+			{ HostPort: TRAEFIK_PORT.toString(), HostIp: TRAEFIK_BIND_IP },
+		],
+		[`${TRAEFIK_SSL_PORT}/tcp`]: [
+			{ HostPort: TRAEFIK_SSL_PORT.toString(), HostIp: TRAEFIK_BIND_IP },
+		],
 		[`${TRAEFIK_HTTP3_PORT}/udp`]: [
-			{ HostPort: TRAEFIK_HTTP3_PORT.toString() },
+			{ HostPort: TRAEFIK_HTTP3_PORT.toString(), HostIp: TRAEFIK_BIND_IP },
 		],
 	};
 
@@ -61,13 +69,17 @@ export const initializeStandaloneTraefik = async ({
 
 	if (enableDashboard) {
 		exposedPorts["8080/tcp"] = {};
-		portBindings["8080/tcp"] = [{ HostPort: "8080" }];
+		portBindings["8080/tcp"] = [
+			{ HostPort: "8080", HostIp: TRAEFIK_BIND_IP },
+		];
 	}
 
 	for (const port of additionalPorts) {
 		const portKey = `${port.targetPort}/${port.protocol ?? "tcp"}`;
 		exposedPorts[portKey] = {};
-		portBindings[portKey] = [{ HostPort: port.publishedPort.toString() }];
+		portBindings[portKey] = [
+			{ HostPort: port.publishedPort.toString(), HostIp: TRAEFIK_BIND_IP },
+		];
 	}
 
 	const settings: ContainerCreateOptions = {


### PR DESCRIPTION
## Description

Traefik port bindings in `initializeStandaloneTraefik` currently omit the `HostIp` field:

```typescript
portBindings[`80/tcp`] = [{ HostPort: "80" }]; // no HostIp
```

This causes Docker to inherit the daemon's default bind IP. If a user sets `"ip": "127.0.0.1"` in `/etc/docker/daemon.json` — a [common hardening step](https://blog.jakesaunders.dev/my-server-started-mining-monero-this-morning/) to prevent containers from accidentally binding to public interfaces — Traefik's ports 80/443 also become localhost-only, **breaking all public access**.

## Changes

- Add `TRAEFIK_BIND_IP` environment variable (defaults to `0.0.0.0` for backward compatibility)
- Set `HostIp` explicitly on all port bindings in `initializeStandaloneTraefik`:
  - Main HTTP/HTTPS/HTTP3 ports
  - Dashboard port (8080)
  - Additional ports loop

This makes Dokploy compatible with Docker daemon-level IP hardening while preserving existing behavior by default.

## Checklist

- [x] My branch was forked from `canary`
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I tested locally

## Related Issues

Refs #2915 — this is a partial fix covering Traefik port bindings. The broader per-service IP binding requested in #2915 would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Traefik port bindings in `initializeStandaloneTraefik` to be compatible with Docker daemons that have a restricted default bind IP (e.g. `"ip": "127.0.0.1"` in `daemon.json`). It introduces a `TRAEFIK_BIND_IP` environment variable (defaulting to `0.0.0.0`) and sets it as `HostIp` on every port binding, overriding the daemon default and restoring public accessibility without requiring daemon reconfiguration.

- All five port-binding sites are consistently updated: HTTP (80), HTTPS (443), HTTP3 (443/udp), dashboard (8080), and the additional-ports loop.
- Default value `0.0.0.0` preserves existing behavior for users who have not configured Docker IP hardening.
- `initializeTraefikService` (Swarm mode) is intentionally left unchanged and the PR description correctly scopes this as a partial fix.
- No input validation is performed on `TRAEFIK_BIND_IP`; an invalid IP will produce a cryptic Docker error at container creation time rather than a clear startup warning (see inline comment).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, backward-compatible, and correctly addresses the stated problem with no logic regressions.

All findings are P2 (no input validation on the new env var). The core logic is correct, the default value preserves backward compatibility, and the fix is applied consistently to every affected port binding site.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server/src/setup/traefik-setup.ts | Adds explicit HostIp to all port bindings in initializeStandaloneTraefik using a new TRAEFIK_BIND_IP env var (defaults to 0.0.0.0). The change is minimal, backward-compatible, and correctly applied to all five binding sites. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(server): add explicit HostIp to Trae..."](https://github.com/dokploy/dokploy/commit/f8266595727a50311a0025658c4e319011c4fac9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26723290)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->