### PR TITLE
fix: add authSource and directConnection params to MongoDB connection URLs

### DIFF
--- a/apps/dokploy/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
@@ -82,7 +82,7 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 		const buildConnectionUrl = () => {
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mongodb://${data?.databaseUser}:${data?.databasePassword}@${getIp}:${port}`;
+			return `mongodb://${data?.databaseUser}:${data?.databasePassword}@${getIp}:${port}/?authSource=admin&directConnection=true`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/apps/dokploy/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-external-mongo-credentials.tsx
@@ -82,7 +82,8 @@ export const ShowExternalMongoCredentials = ({ mongoId }: Props) => {
 		const buildConnectionUrl = () => {
 			const port = form.watch("externalPort") || data?.externalPort;
 
-			return `mongodb://${data?.databaseUser}:${data?.databasePassword}@${getIp}:${port}/?authSource=admin&directConnection=true`;
+			const params = `authSource=admin${data?.replicaSets ? "" : "&directConnection=true"}`;
+			return `mongodb://${data?.databaseUser}:${data?.databasePassword}@${getIp}:${port}/?${params}`;
 		};
 
 		setConnectionUrl(buildConnectionUrl());

--- a/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -47,7 +47,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
 									disabled
-									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017`}
+									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017/?authSource=admin&directConnection=true`}
 								/>
 							</div>
 						</div>

--- a/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -47,7 +47,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 								<Label>Internal Connection URL </Label>
 								<ToggleVisibilityInput
 									disabled
-									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017/?authSource=admin&directConnection=true`}
+									value={`mongodb://${data?.databaseUser}:${data?.databasePassword}@${data?.appName}:27017/?authSource=admin${data?.replicaSets ? "" : "&directConnection=true"}`}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
## Summary

- Fixes #4105
- MongoDB connection URLs (both external and internal) were missing required query parameters, causing authentication failures when users copy the displayed URL without modification.
- Added `?authSource=admin&directConnection=true` to both connection strings.

## Changes

- `show-external-mongo-credentials.tsx`: appended `?authSource=admin&directConnection=true` to external connection URL
- `show-internal-mongo-credentials.tsx`: appended `?authSource=admin&directConnection=true` to internal connection URL

## Test plan

- [x] Deploy a MongoDB instance in Dokploy
- [x] Navigate to the MongoDB credentials panel
- [x] Verify the External Connection URL includes `?authSource=admin&directConnection=true`
- [x] Verify the Internal Connection URL includes `?authSource=admin&directConnection=true`
- [x] Confirm the URLs connect successfully without manual modification

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes MongoDB authentication failures (issue #4105) by appending authentication query parameters to both the external and internal connection URLs displayed in the credentials panels. The change is minimal, targeted, and follows the correct MongoDB URI specification.

**Key changes:**
- `show-external-mongo-credentials.tsx`: External connection URL now includes the `authSource` and `directConnection` query parameters
- `show-internal-mongo-credentials.tsx`: Internal connection URL now includes the same query parameters

**Notes:**
- Setting `authSource` to `admin` is the correct default authentication database for a MongoDB container, matching the typical Dokploy deployment model.
- Setting `directConnection` to `true` is appropriate for standalone Docker-based MongoDB instances, but it is a hardcoded assumption. Users who configure a replica set or route traffic through a proxy may need to adjust these parameters manually.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are pure display-string fixes with no logic, state, or API impact.

Both changes are single-line string additions to credential display components. The parameters added are correct for the standard Dokploy MongoDB deployment model. The only finding is a P2 style note about directConnection being a hardcoded standalone-topology assumption, which does not block the merge.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/dokploy/components/dashboard/mongo/general/show-external-mongo-credentials.tsx | Appends authSource and directConnection query parameters to the external connection URL. Correct for standalone MongoDB containers; slash-before-query-string follows the MongoDB URI spec. |
| apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx | Appends authSource and directConnection query parameters to the internal connection URL. Mirrors the external change; consistent and correct for the standard single-container deployment model. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add authSource and directConnection..."](https://github.com/dokploy/dokploy/commit/148c91bf5e0db0b7ece43c3a1be41dd9e84befaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26765469)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->