### PR TITLE
refactor(traefik): improve config removal logic and error handling

### DIFF
--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -5,7 +5,7 @@ import { paths } from "@dokploy/server/constants";
 import type { Domain } from "@dokploy/server/services/domain";
 import { parse, stringify } from "yaml";
 import { encodeBase64 } from "../docker/utils";
-import { execAsyncRemote } from "../process/execAsync";
+import { execAsync, execAsyncRemote } from "../process/execAsync";
 import type { FileConfig, HttpLoadBalancerService } from "./file-types";
 
 export const createTraefikConfig = (appName: string) => {
@@ -57,18 +57,16 @@ export const removeTraefikConfig = async (
 	try {
 		const { DYNAMIC_TRAEFIK_PATH } = paths(!!serverId);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
+		const command = `rm -f ${configPath}`;
 
 		if (serverId) {
-			await execAsyncRemote(serverId, `rm ${configPath}`);
+			await execAsyncRemote(serverId, command);
 		} else {
-			if (fs.existsSync(configPath)) {
-				await fs.promises.unlink(configPath);
-			}
+			await execAsync(command);
 		}
-		if (fs.existsSync(configPath)) {
-			await fs.promises.unlink(configPath);
-		}
-	} catch {}
+	} catch (error) {
+		console.error(`Error removing traefik config for ${appName}:`, error);
+	}
 };
 
 export const removeTraefikConfigRemote = async (
@@ -78,8 +76,13 @@ export const removeTraefikConfigRemote = async (
 	try {
 		const { DYNAMIC_TRAEFIK_PATH } = paths(true);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
-		await execAsyncRemote(serverId, `rm ${configPath}`);
-	} catch {}
+		await execAsyncRemote(serverId, `rm -f ${configPath}`);
+	} catch (error) {
+		console.error(
+			`Error removing remote traefik config for ${appName}:`,
+			error,
+		);
+	}
 };
 
 export const loadOrCreateConfig = (appName: string): FileConfig => {


### PR DESCRIPTION
- Consolidated command execution for removing Traefik config files by using a single command string.
- Enhanced error handling to log issues encountered during the removal process for both local and remote configurations.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4086 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the Traefik config removal helpers in `application.ts` with three improvements: it fixes a genuine bug where local `fs.promises.unlink` was called unconditionally even after a successful remote `rm` (the final block sat outside the `if/else`); it adds the `-f` flag to `rm` so missing-file errors are silently ignored on both local and remote paths; and it adds structured `console.error` logging to the previously empty `catch` blocks.

**Key observations**
- The bug fix is correct — the old code would attempt a local file deletion even when `serverId` was set (i.e., a remote server target).
- The `-f` flag addition is a good defensive improvement, eliminating spurious errors when a config file is already absent.
- The local deletion path now uses `execAsync("rm -f ...")` instead of the previous `fs.promises.unlink` call. This is consistent with the remote approach but introduces an avoidable shell spawn and leaves the unquoted `configPath` variable susceptible to shell metacharacter interpretation if `appName` ever contains special characters. Using `fs.promises.unlink` with an `ENOENT` guard would be slightly safer and cheaper for the local case.

<h3>Confidence Score: 5/5</h3>

Safe to merge — fixes a real but low-impact bug and the only remaining finding is a P2 style suggestion.

The PR resolves a confirmed bug (double local deletion on remote path) and improves observability. The single open comment is a P2 style preference (native `fs` API vs shell) with no current production impact since application names in Dokploy are alphanumeric/hyphen-only and the local path constant is fixed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/server/src/utils/traefik/application.ts | Fixes a real bug (unconditional local `unlink` after remote `rm`), adds `-f` to suppress missing-file errors, and improves error logging. Local deletion now uses `execAsync` shell command instead of the native `fs` API, introducing minor shell-overhead and a theoretical path-injection surface. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(traefik): improve config remova..."](https://github.com/dokploy/dokploy/commit/8053ee7724ada9d5557da5d1cf740adced10486a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26780592)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->