### PR TITLE
fix: preserve server schedule failures through tee pipeline

### DIFF
--- a/packages/server/src/utils/schedules/utils.ts
+++ b/packages/server/src/utils/schedules/utils.ts
@@ -159,7 +159,7 @@ export const runCommand = async (scheduleId: string) => {
 			const { SCHEDULES_PATH } = paths(true);
 			const fullPath = path.join(SCHEDULES_PATH, appName || "");
 			const command = `
-				set -e
+				set -euo pipefail
 				echo "Running script" >> ${deployment.logPath};
 				bash -c ${fullPath}/script.sh 2>&1 | tee -a ${deployment.logPath} || { 
 					echo "❌ Command failed" >> ${deployment.logPath};


### PR DESCRIPTION
## Summary
Server schedules currently wrap the remote script with `tee -a <log>` but only use `set -e`.

That means the pipeline exit status comes from `tee`, not from the scheduled script. If the remote script exits non-zero but `tee` succeeds, Dokploy can still mark the deployment as `done`.

This change enables `pipefail` for the `scheduleType === "server"` execution path so non-zero script exits propagate correctly.

## Reproduction
With the current code, a server schedule like this can still finish as `done`:

```bash
#!/usr/bin/env bash
set -euo pipefail
exit 42
```

The current wrapper is:

```bash
set -e
bash -c /path/to/script.sh 2>&1 | tee -a /path/to/log || {
  echo "❌ Command failed" >> /path/to/log
  exit 1
}
echo "✅ Command executed successfully" >> /path/to/log
```

Because the pipeline does not use `pipefail`, `tee` can return `0` and hide the script failure.

## Fix
Change the wrapper to:

```bash
set -euo pipefail
```

so the pipeline fails when the scheduled script fails.

## Validation
- `pnpm exec biome check packages/server/src/utils/schedules/utils.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real bug in the `server` schedule type where shell pipeline exit codes were silently dropped. The wrapper command used `set -e` but not `pipefail`, meaning the pipeline `bash -c script.sh 2>&1 | tee -a log` would return `tee`'s exit code (typically 0) rather than the script's exit code. If the scheduled script exited non-zero, the `|| { echo "❌ Command failed"; exit 1; }` guard would never fire and the deployment would be incorrectly marked as `done`.

The one-line fix — changing `set -e` to `set -euo pipefail` — correctly addresses this. With `pipefail`, a non-zero exit from any command in a pipeline propagates as the pipeline's exit status, causing the `||` handler to trigger and the deployment to be correctly marked as `error`.

Key observations:
- `set -euo pipefail` is a standard bash idiom; `-u` (nounset) is a safe addition since all variables (`${deployment.logPath}`, `${fullPath}`) are interpolated by TypeScript before the shell sees them.
- The other schedule paths (`application`/`compose` remote and `dokploy-server`) don't use `tee` in a pipeline, so they don't have the same issue and don't require the same fix.
- The change is minimal, targeted, and fixes the exact failure mode described in the PR.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the fix is minimal, targeted, and correctly resolves a real deployment status bug in the server schedule path.
- Single-line change from `set -e` to `set -euo pipefail`, which is the canonical fix for the described `tee`-pipeline exit-code problem. No regressions are introduced: all variable substitutions are TypeScript-side, `-u` is safe here, and the `||` guard still works correctly with `pipefail` active. No other files are affected.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: preserve server schedule failures t..."](https://github.com/dokploy/dokploy/commit/eb80f79862b751029de4ba3a4fe655003926850a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27079080)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->