### PR TITLE
fix: sort schedules by name in list query

### DIFF
--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -14,7 +14,7 @@ import {
 	updateSchedule,
 } from "@dokploy/server/services/schedule";
 import { TRPCError } from "@trpc/server";
-import { desc, eq } from "drizzle-orm";
+import { asc, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
 import { removeJob, schedule } from "@/server/utils/backup";
@@ -157,6 +157,7 @@ export const scheduleRouter = createTRPCRouter({
 			};
 			return db.query.schedules.findMany({
 				where: where[input.scheduleType],
+				orderBy: [asc(schedules.name)],
 				with: {
 					application: true,
 					server: true,

--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -157,7 +157,7 @@ export const scheduleRouter = createTRPCRouter({
 			};
 			return db.query.schedules.findMany({
 				where: where[input.scheduleType],
-				orderBy: [asc(schedules.name)],
+				orderBy: [asc(schedules.createdAt)],
 				with: {
 					application: true,
 					server: true,


### PR DESCRIPTION
## Summary
- Schedules in the web UI were displayed in arbitrary (database insertion) order
- Added `orderBy: [asc(schedules.name)]` to the `schedule.list` query so they are returned sorted alphabetically by name

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the arbitrary ordering of scheduled tasks in the UI by adding `orderBy: [asc(schedules.name)]` to the `schedule.list` query, ensuring results are returned sorted alphabetically by name.

- The change is minimal and correct: `asc` is properly imported from `drizzle-orm` and applied to the `schedules.name` column, which is already in use throughout the router.
- The `orderBy` array syntax is the right approach for Drizzle ORM's `findMany`.
- No other queries or endpoints are affected by this change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single-line, non-breaking addition of deterministic sort ordering to a read query.
- The change is isolated to one query, uses a well-established Drizzle ORM API, touches no mutation logic, and has no impact on data integrity or security.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: sort schedules by name in list quer..."](https://github.com/dokploy/dokploy/commit/e9202bfb154368ff471ca4567283d70c46ab78d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27144601)</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->