### PR TITLE
fix(subscriptions): set done=true when deployment/restore completes so the while loop can exit

### DIFF
--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -547,7 +547,7 @@ export const backupRouter = createTRPCRouter({
 			const queue: string[] = [];
 			let done = false;
 			const onLog = (log: string) => queue.push(log);
-			(async () => {
+			const runRestore = async () => {
 				if (input.backupType === "database") {
 					if (input.databaseType === "postgres") {
 						const postgres = await findPostgresById(input.databaseId);
@@ -571,8 +571,13 @@ export const backupRouter = createTRPCRouter({
 					const compose = await findComposeById(input.databaseId);
 					await restoreComposeBackup(compose, destination, input, onLog);
 				}
-			})()
-				.catch(() => {})
+			};
+			runRestore()
+				.catch((error) => {
+					onLog(
+						`Error: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				})
 				.finally(() => {
 					done = true;
 				});

--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -545,52 +545,37 @@ export const backupRouter = createTRPCRouter({
 			}
 			const destination = await findDestinationById(input.destinationId);
 			const queue: string[] = [];
-			const done = false;
-			if (input.backupType === "database") {
-				if (input.databaseType === "postgres") {
-					const postgres = await findPostgresById(input.databaseId);
-
-					restorePostgresBackup(postgres, destination, input, (log) => {
-						queue.push(log);
-					});
+			let done = false;
+			const onLog = (log: string) => queue.push(log);
+			(async () => {
+				if (input.backupType === "database") {
+					if (input.databaseType === "postgres") {
+						const postgres = await findPostgresById(input.databaseId);
+						await restorePostgresBackup(postgres, destination, input, onLog);
+					} else if (input.databaseType === "mysql") {
+						const mysql = await findMySqlById(input.databaseId);
+						await restoreMySqlBackup(mysql, destination, input, onLog);
+					} else if (input.databaseType === "mariadb") {
+						const mariadb = await findMariadbById(input.databaseId);
+						await restoreMariadbBackup(mariadb, destination, input, onLog);
+					} else if (input.databaseType === "mongo") {
+						const mongo = await findMongoById(input.databaseId);
+						await restoreMongoBackup(mongo, destination, input, onLog);
+					} else if (input.databaseType === "libsql") {
+						const libsql = await findLibsqlById(input.databaseId);
+						await restoreLibsqlBackup(libsql, destination, input, onLog);
+					} else if (input.databaseType === "web-server") {
+						await restoreWebServerBackup(destination, input.backupFile, onLog);
+					}
+				} else if (input.backupType === "compose") {
+					const compose = await findComposeById(input.databaseId);
+					await restoreComposeBackup(compose, destination, input, onLog);
 				}
-
-				if (input.databaseType === "mysql") {
-					const mysql = await findMySqlById(input.databaseId);
-					restoreMySqlBackup(mysql, destination, input, (log) => {
-						queue.push(log);
-					});
-				}
-				if (input.databaseType === "mariadb") {
-					const mariadb = await findMariadbById(input.databaseId);
-					restoreMariadbBackup(mariadb, destination, input, (log) => {
-						queue.push(log);
-					});
-				}
-				if (input.databaseType === "mongo") {
-					const mongo = await findMongoById(input.databaseId);
-					restoreMongoBackup(mongo, destination, input, (log) => {
-						queue.push(log);
-					});
-				}
-				if (input.databaseType === "libsql") {
-					const libsql = await findLibsqlById(input.databaseId);
-					restoreLibsqlBackup(libsql, destination, input, (log) => {
-						queue.push(log);
-					});
-				}
-				if (input.databaseType === "web-server") {
-					restoreWebServerBackup(destination, input.backupFile, (log) => {
-						queue.push(log);
-					});
-				}
-			}
-			if (input.backupType === "compose") {
-				const compose = await findComposeById(input.databaseId);
-				restoreComposeBackup(compose, destination, input, (log) => {
-					queue.push(log);
+			})()
+				.catch(() => {})
+				.finally(() => {
+					done = true;
 				});
-			}
 			while (!done || queue.length > 0) {
 				if (queue.length > 0) {
 					yield queue.shift()!;

--- a/apps/dokploy/server/api/routers/libsql.ts
+++ b/apps/dokploy/server/api/routers/libsql.ts
@@ -246,11 +246,15 @@ export const libsqlRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const queue: string[] = [];
-			const done = false;
+			let done = false;
 
 			deployLibsql(input.libsqlId, (log) => {
 				queue.push(log);
-			});
+			})
+				.catch(() => {})
+				.finally(() => {
+					done = true;
+				});
 
 			while (!done || queue.length > 0) {
 				if (queue.length > 0) {

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -228,11 +228,15 @@ export const mongoRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const queue: string[] = [];
-			const done = false;
+			let done = false;
 
 			deployMongo(input.mongoId, (log) => {
 				queue.push(log);
-			});
+			})
+				.catch(() => {})
+				.finally(() => {
+					done = true;
+				});
 
 			while (!done || queue.length > 0) {
 				if (queue.length > 0) {

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -230,11 +230,15 @@ export const mysqlRouter = createTRPCRouter({
 			});
 
 			const queue: string[] = [];
-			const done = false;
+			let done = false;
 
 			deployMySql(input.mysqlId, (log) => {
 				queue.push(log);
-			});
+			})
+				.catch(() => {})
+				.finally(() => {
+					done = true;
+				});
 
 			while (!done || queue.length > 0) {
 				if (queue.length > 0) {

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -233,11 +233,15 @@ export const postgresRouter = createTRPCRouter({
 			});
 
 			const queue: string[] = [];
-			const done = false;
+			let done = false;
 
 			deployPostgres(input.postgresId, (log) => {
 				queue.push(log);
-			});
+			})
+				.catch(() => {})
+				.finally(() => {
+					done = true;
+				});
 
 			while (!done || queue.length > 0) {
 				if (queue.length > 0) {

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -251,11 +251,15 @@ export const redisRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const queue: string[] = [];
-			const done = false;
+			let done = false;
 
 			deployRedis(input.redisId, (log) => {
 				queue.push(log);
-			});
+			})
+				.catch(() => {})
+				.finally(() => {
+					done = true;
+				});
 
 			while (!done || queue.length > 0) {
 				if (queue.length > 0) {


### PR DESCRIPTION
Fixes #4120

## Problem

Six tRPC subscription endpoints declare `done` with `const` and never reassign it:

```ts
const done = false; // never changes — loop is effectively while(true)
```

The `while (!done || queue.length > 0)` condition reduces to `while (true || ...)`, so the loop only exits via `signal?.aborted`. When the client disconnects before the deployment finishes (e.g. page navigation), logs may silently be lost and the async work keeps running without any opportunity to drain remaining queue entries.

Affected files: `postgres.ts`, `mysql.ts`, `redis.ts`, `mongo.ts`, `libsql.ts`, `backup.ts`

## Fix

- Changed `const done = false` → `let done = false`
- Called the async deploy/restore function without `await` and chained `.catch(() => {}).finally(() => { done = true; })` so the loop naturally exits after all logs are flushed once the operation completes
- `backup.ts`: refactored the multiple conditional branches into an immediately-invoked async IIFE to get a single Promise to attach `.finally()` to. Also consolidated the repeated `if` checks into `if/else if` since only one branch can match at a time.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real bug where `const done = false` was never reassigned, causing the `while (!done || queue.length > 0)` loop to effectively run as `while (true)` — only exiting via `signal?.aborted`. The fix correctly changes `done` to `let` and sets it to `true` in a `.finally()` callback so the loop terminates naturally once deployment/restore completes and all queued logs are drained.

**Key changes:**
- `postgres.ts`, `mysql.ts`, `redis.ts`, `mongo.ts`, `libsql.ts`: `const done = false` → `let done = false`, with `.catch(() => {}).finally(() => { done = true; })` chained onto the deploy function call. This is safe because each `deployXxx` function already catches errors internally, logs them via the `onData` callback, then re-throws — so the `.catch(() => {})` only silences a re-throw that has already been communicated through the log stream.
- `backup.ts`: Refactors multiple sequential fire-and-forget calls into a single awaited IIFE with the same `.finally()` pattern. The `if` → `if/else if` conversion is semantically correct since only one branch can match. However, this introduces a subtle regression: the `findXxxById` lookup calls (e.g., `findPostgresById`) were previously `await`-ed at the top level of the subscription generator, so lookup failures (e.g., `NOT_FOUND`) propagated as tRPC errors to the client. Inside the IIFE they are now swallowed by `.catch(() => {})` with no log pushed, leaving the client with no feedback on failure.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the 5 simple deploy files; backup.ts has a regression where lookup errors are silently swallowed instead of propagated to the client.

The core bug fix is correct and well-reasoned across all 6 files. The simple deploy files (postgres, mysql, redis, mongo, libsql) are clean because those deploy functions already surface errors through the log callback. The backup.ts IIFE approach introduces a behavioral regression: findXxxById errors that previously propagated as tRPC NOT_FOUND errors are now silently swallowed with no log pushed to the client, leaving the subscription to close without feedback. This warrants attention before merging.

apps/dokploy/server/api/routers/backup.ts — the .catch(() => {}) on the IIFE silently discards errors from lookup functions that don't log via the onData callback.

<sub>Reviews (1): Last reviewed commit: ["fix(subscriptions): change const done to..."](https://github.com/dokploy/dokploy/commit/5978c4135e96e98d29a3f88d3be04908d9d2c5d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27223475)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->