### PR TITLE
fix(git-provider): allow all organization members to see git integrations

### DIFF
--- a/apps/dokploy/server/api/routers/bitbucket.ts
+++ b/apps/dokploy/server/api/routers/bitbucket.ts
@@ -14,6 +14,7 @@ import {
 	withPermission,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertGitProviderAccess } from "@/server/api/utils/git-provider";
 import {
 	apiBitbucketTestConnection,
 	apiCreateBitbucket,
@@ -50,8 +51,10 @@ export const bitbucketRouter = createTRPCRouter({
 		}),
 	one: protectedProcedure
 		.input(apiFindOneBitbucket)
-		.query(async ({ input }) => {
-			return await findBitbucketById(input.bitbucketId);
+		.query(async ({ input, ctx }) => {
+			const provider = await findBitbucketById(input.bitbucketId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
+			return provider;
 		}),
 	bitbucketProviders: protectedProcedure.query(async ({ ctx }) => {
 		let result = await db.query.bitbucket.findMany({
@@ -63,30 +66,34 @@ export const bitbucketRouter = createTRPCRouter({
 			},
 		});
 
-		result = result.filter((provider) => {
-			return (
+		result = result.filter(
+			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId
-			);
-		});
+				ctx.session.activeOrganizationId,
+		);
 		return result;
 	}),
 
 	getBitbucketRepositories: protectedProcedure
 		.input(apiFindOneBitbucket)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const provider = await findBitbucketById(input.bitbucketId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			return await getBitbucketRepositories(input.bitbucketId);
 		}),
 	getBitbucketBranches: protectedProcedure
 		.input(apiFindBitbucketBranches)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const provider = await findBitbucketById(input.bitbucketId || "");
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			return await getBitbucketBranches(input);
 		}),
 	testConnection: protectedProcedure
 		.input(apiBitbucketTestConnection)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			try {
+				const provider = await findBitbucketById(input.bitbucketId);
+				assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 				const result = await testBitbucketConnection(input);
 
 				return `Found ${result} repositories`;
@@ -100,6 +107,8 @@ export const bitbucketRouter = createTRPCRouter({
 	update: withPermission("gitProviders", "create")
 		.input(apiUpdateBitbucket)
 		.mutation(async ({ input, ctx }) => {
+			const provider = await findBitbucketById(input.bitbucketId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			const result = await updateBitbucket(input.bitbucketId, {
 				...input,
 				organizationId: ctx.session.activeOrganizationId,

--- a/apps/dokploy/server/api/routers/git-provider.ts
+++ b/apps/dokploy/server/api/routers/git-provider.ts
@@ -1,8 +1,9 @@
 import { findGitProviderById, removeGitProvider } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { audit } from "@/server/api/utils/audit";
+import { assertGitProviderAccess } from "@/server/api/utils/git-provider";
 import {
 	createTRPCRouter,
 	protectedProcedure,
@@ -20,10 +21,7 @@ export const gitProviderRouter = createTRPCRouter({
 				gitea: true,
 			},
 			orderBy: desc(gitProvider.createdAt),
-			where: and(
-				eq(gitProvider.userId, ctx.session.userId),
-				eq(gitProvider.organizationId, ctx.session.activeOrganizationId),
-			),
+			where: eq(gitProvider.organizationId, ctx.session.activeOrganizationId),
 		});
 	}),
 	remove: withPermission("gitProviders", "delete")
@@ -32,12 +30,7 @@ export const gitProviderRouter = createTRPCRouter({
 			try {
 				const gitProvider = await findGitProviderById(input.gitProviderId);
 
-				if (gitProvider.organizationId !== ctx.session.activeOrganizationId) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You are not allowed to delete this Git provider",
-					});
-				}
+				assertGitProviderAccess(gitProvider, ctx.session.activeOrganizationId, "git");
 				await audit(ctx, {
 					action: "delete",
 					resourceType: "gitProvider",

--- a/apps/dokploy/server/api/routers/git-provider.ts
+++ b/apps/dokploy/server/api/routers/git-provider.ts
@@ -30,7 +30,7 @@ export const gitProviderRouter = createTRPCRouter({
 			try {
 				const gitProvider = await findGitProviderById(input.gitProviderId);
 
-				assertGitProviderAccess(gitProvider, ctx.session.activeOrganizationId, "git");
+				assertGitProviderAccess(gitProvider, ctx.session.activeOrganizationId);
 				await audit(ctx, {
 					action: "delete",
 					resourceType: "gitProvider",

--- a/apps/dokploy/server/api/routers/gitea.ts
+++ b/apps/dokploy/server/api/routers/gitea.ts
@@ -16,6 +16,7 @@ import {
 	withPermission,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertGitProviderAccess } from "@/server/api/utils/git-provider";
 import {
 	apiCreateGitea,
 	apiFindGiteaBranches,
@@ -52,9 +53,13 @@ export const giteaRouter = createTRPCRouter({
 			}
 		}),
 
-	one: protectedProcedure.input(apiFindOneGitea).query(async ({ input }) => {
-		return await findGiteaById(input.giteaId);
-	}),
+	one: protectedProcedure
+		.input(apiFindOneGitea)
+		.query(async ({ input, ctx }) => {
+			const provider = await findGiteaById(input.giteaId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
+			return provider;
+		}),
 
 	giteaProviders: protectedProcedure.query(async ({ ctx }) => {
 		let result = await db.query.gitea.findMany({
@@ -66,8 +71,7 @@ export const giteaRouter = createTRPCRouter({
 		result = result.filter(
 			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId,
+				ctx.session.activeOrganizationId,
 		);
 
 		const filtered = result
@@ -86,7 +90,7 @@ export const giteaRouter = createTRPCRouter({
 
 	getGiteaRepositories: protectedProcedure
 		.input(apiFindOneGitea)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
 			const { giteaId } = input;
 
 			if (!giteaId) {
@@ -95,6 +99,9 @@ export const giteaRouter = createTRPCRouter({
 					message: "Gitea provider ID is required.",
 				});
 			}
+
+			const provider = await findGiteaById(giteaId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 
 			try {
 				const repositories = await getGiteaRepositories(giteaId);
@@ -110,7 +117,7 @@ export const giteaRouter = createTRPCRouter({
 
 	getGiteaBranches: protectedProcedure
 		.input(apiFindGiteaBranches)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
 			const { giteaId, owner, repositoryName } = input;
 
 			if (!giteaId || !owner || !repositoryName) {
@@ -120,6 +127,9 @@ export const giteaRouter = createTRPCRouter({
 						"Gitea provider ID, owner, and repository name are required.",
 				});
 			}
+
+			const provider = await findGiteaById(giteaId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 
 			try {
 				return await getGiteaBranches({
@@ -138,13 +148,14 @@ export const giteaRouter = createTRPCRouter({
 
 	testConnection: protectedProcedure
 		.input(apiGiteaTestConnection)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			const giteaId = input.giteaId ?? "";
 
 			try {
-				const result = await testGiteaConnection({
-					giteaId,
-				});
+				const provider = await findGiteaById(giteaId);
+				assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
+
+				const result = await testGiteaConnection({ giteaId });
 
 				return `Found ${result} repositories`;
 			} catch (error) {
@@ -159,6 +170,9 @@ export const giteaRouter = createTRPCRouter({
 	update: withPermission("gitProviders", "create")
 		.input(apiUpdateGitea)
 		.mutation(async ({ input, ctx }) => {
+			const provider = await findGiteaById(input.giteaId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
+
 			if (input.name) {
 				await updateGitProvider(input.gitProviderId, {
 					name: input.name,
@@ -186,7 +200,7 @@ export const giteaRouter = createTRPCRouter({
 
 	getGiteaUrl: protectedProcedure
 		.input(apiFindOneGitea)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
 			const { giteaId } = input;
 
 			if (!giteaId) {
@@ -196,9 +210,10 @@ export const giteaRouter = createTRPCRouter({
 				});
 			}
 
-			const giteaProvider = await findGiteaById(giteaId);
+			const provider = await findGiteaById(giteaId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 
 			// Return the base URL of the Gitea instance
-			return giteaProvider.giteaUrl;
+			return provider.giteaUrl;
 		}),
 });

--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -14,6 +14,7 @@ import {
 	withPermission,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertGitProviderAccess } from "@/server/api/utils/git-provider";
 import {
 	apiFindGithubBranches,
 	apiFindOneGithub,
@@ -21,17 +22,25 @@ import {
 } from "@/server/db/schema";
 
 export const githubRouter = createTRPCRouter({
-	one: protectedProcedure.input(apiFindOneGithub).query(async ({ input }) => {
-		return await findGithubById(input.githubId);
-	}),
+	one: protectedProcedure
+		.input(apiFindOneGithub)
+		.query(async ({ input, ctx }) => {
+			const provider = await findGithubById(input.githubId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
+			return provider;
+		}),
 	getGithubRepositories: protectedProcedure
 		.input(apiFindOneGithub)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const provider = await findGithubById(input.githubId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			return await getGithubRepositories(input.githubId);
 		}),
 	getGithubBranches: protectedProcedure
 		.input(apiFindGithubBranches)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const provider = await findGithubById(input.githubId || "");
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			return await getGithubBranches(input);
 		}),
 	githubProviders: protectedProcedure.query(async ({ ctx }) => {
@@ -44,8 +53,7 @@ export const githubRouter = createTRPCRouter({
 		result = result.filter(
 			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId,
+				ctx.session.activeOrganizationId,
 		);
 
 		const filtered = result
@@ -64,8 +72,10 @@ export const githubRouter = createTRPCRouter({
 
 	testConnection: protectedProcedure
 		.input(apiFindOneGithub)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			try {
+				const provider = await findGithubById(input.githubId);
+				assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 				const result = await getGithubRepositories(input.githubId);
 				return `Found ${result.length} repositories`;
 			} catch (err) {
@@ -78,6 +88,8 @@ export const githubRouter = createTRPCRouter({
 	update: withPermission("gitProviders", "create")
 		.input(apiUpdateGithub)
 		.mutation(async ({ input, ctx }) => {
+			const provider = await findGithubById(input.githubId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			await updateGitProvider(input.gitProviderId, {
 				name: input.name,
 				organizationId: ctx.session.activeOrganizationId,

--- a/apps/dokploy/server/api/routers/gitlab.ts
+++ b/apps/dokploy/server/api/routers/gitlab.ts
@@ -16,6 +16,7 @@ import {
 	withPermission,
 } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
+import { assertGitProviderAccess } from "@/server/api/utils/git-provider";
 import {
 	apiCreateGitlab,
 	apiFindGitlabBranches,
@@ -50,9 +51,13 @@ export const gitlabRouter = createTRPCRouter({
 				});
 			}
 		}),
-	one: protectedProcedure.input(apiFindOneGitlab).query(async ({ input }) => {
-		return await findGitlabById(input.gitlabId);
-	}),
+	one: protectedProcedure
+		.input(apiFindOneGitlab)
+		.query(async ({ input, ctx }) => {
+			const provider = await findGitlabById(input.gitlabId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
+			return provider;
+		}),
 	gitlabProviders: protectedProcedure.query(async ({ ctx }) => {
 		let result = await db.query.gitlab.findMany({
 			with: {
@@ -60,13 +65,11 @@ export const gitlabRouter = createTRPCRouter({
 			},
 		});
 
-		result = result.filter((provider) => {
-			return (
+		result = result.filter(
+			(provider) =>
 				provider.gitProvider.organizationId ===
-					ctx.session.activeOrganizationId &&
-				provider.gitProvider.userId === ctx.session.userId
-			);
-		});
+				ctx.session.activeOrganizationId,
+		);
 		const filtered = result
 			.filter((provider) => haveGitlabRequirements(provider))
 			.map((provider) => {
@@ -83,19 +86,25 @@ export const gitlabRouter = createTRPCRouter({
 	}),
 	getGitlabRepositories: protectedProcedure
 		.input(apiFindOneGitlab)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const provider = await findGitlabById(input.gitlabId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			return await getGitlabRepositories(input.gitlabId);
 		}),
 
 	getGitlabBranches: protectedProcedure
 		.input(apiFindGitlabBranches)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const provider = await findGitlabById(input.gitlabId || "");
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			return await getGitlabBranches(input);
 		}),
 	testConnection: protectedProcedure
 		.input(apiGitlabTestConnection)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
 			try {
+				const provider = await findGitlabById(input.gitlabId || "");
+				assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 				const result = await testGitlabConnection(input);
 
 				return `Found ${result} repositories`;
@@ -109,6 +118,8 @@ export const gitlabRouter = createTRPCRouter({
 	update: withPermission("gitProviders", "create")
 		.input(apiUpdateGitlab)
 		.mutation(async ({ input, ctx }) => {
+			const provider = await findGitlabById(input.gitlabId);
+			assertGitProviderAccess(provider, ctx.session.activeOrganizationId);
 			if (input.name) {
 				await updateGitProvider(input.gitProviderId, {
 					name: input.name,

--- a/apps/dokploy/server/api/utils/git-provider.ts
+++ b/apps/dokploy/server/api/utils/git-provider.ts
@@ -1,0 +1,18 @@
+import { TRPCError } from "@trpc/server";
+
+export function assertGitProviderAccess(
+	provider: { organizationId: string } | { gitProvider: { organizationId: string } },
+	activeOrganizationId: string,
+) {
+	const organizationId =
+		"organizationId" in provider
+			? provider.organizationId
+			: provider.gitProvider.organizationId;
+
+	if (organizationId !== activeOrganizationId) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "You are not allowed to access this git provider",
+		});
+	}
+}


### PR DESCRIPTION
## What is this PR about?

Previously, git provider integrations (GitHub, GitLab, Bitbucket, Gitea) were only visible to the user who created them due to filtering by both organizationId and userId. This prevented other admins in the same organization from seeing or using shared integrations.

Remove userId filtering from list queries and authorization checks so that all users in an organization can access git integrations created within that organization.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance.

## Issues related (if applicable)

closes https://github.com/Dokploy/dokploy/issues/3489

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `userId` filtering from all git provider list queries and authorization checks, so that all members of an organization can see and use git integrations created within that org. The approach is sound and consistent across all four providers (GitHub, GitLab, Bitbucket, Gitea), but there is one build-breaking issue to fix.

- In `apps/dokploy/server/api/routers/git-provider.ts` line 33, `assertGitProviderAccess` is called with a third argument `\"git\"` that the function does not accept (2-parameter signature), producing a TypeScript compile error (\"Expected 2 arguments, but got 3\") that will fail the build.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until the spurious third argument on line 33 of git-provider.ts is removed — it is a TypeScript compile error.

One P1 finding: a stray third argument passed to a 2-parameter function will break the TypeScript build. All other changes are clean and correctly implement the intended org-scoped access control.

apps/dokploy/server/api/routers/git-provider.ts — line 33 has an extra argument that causes a compile error.

<sub>Reviews (1): Last reviewed commit: ["fix(git-provider): allow all organizatio..."](https://github.com/dokploy/dokploy/commit/2bf1f764224acef07b25b2a8e24d5aa8c2958422) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27264800)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->