### PR TITLE
fix(github): preview limit check should not block updates to existing previews

### DIFF
--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -471,10 +471,6 @@ export default async function handler(
 					if (!hasLabel) continue;
 				}
 
-				const previewLimit = app?.previewLimit || 0;
-				if (app?.previewDeployments?.length > previewLimit) {
-					continue;
-				}
 				const previewDeploymentResult =
 					await findPreviewDeploymentByApplicationId(app.applicationId, prId);
 
@@ -482,6 +478,11 @@ export default async function handler(
 					previewDeploymentResult?.previewDeploymentId || "";
 
 				if (!previewDeploymentResult && shouldCreateDeployment) {
+					// Only enforce the limit for new previews, not updates to existing ones
+					const previewLimit = app?.previewLimit ?? 3;
+					if (app?.previewDeployments?.length >= previewLimit) {
+						continue;
+					}
 					const previewDeployment = await createPreviewDeployment({
 						applicationId: app.applicationId as string,
 						branch: prBranch,

--- a/apps/dokploy/server/queues/deployments-queue.ts
+++ b/apps/dokploy/server/queues/deployments-queue.ts
@@ -75,6 +75,19 @@ const createDeploymentWorker = () =>
 				}
 			} catch (error) {
 				console.log("Error", error);
+				if (job.data.applicationType === "application") {
+					await updateApplicationStatus(job.data.applicationId, "error").catch(
+						() => {},
+					);
+				} else if (job.data.applicationType === "compose") {
+					await updateCompose(job.data.composeId, {
+						composeStatus: "error",
+					}).catch(() => {});
+				} else if (job.data.applicationType === "application-preview") {
+					await updatePreviewDeployment(job.data.previewDeploymentId, {
+						previewStatus: "error",
+					}).catch(() => {});
+				}
 			}
 		},
 		{


### PR DESCRIPTION
Fixes #4074

## What happened

The preview deployment limit check in the GitHub webhook handler ran **before** `findPreviewDeploymentByApplicationId()`. Pushing a commit to an open PR whose application had already reached its preview limit would silently drop the rebuild event — the deployment was never queued even though no new preview was being created.

## Fix

Moved the limit check inside the `if (!previewDeploymentResult && shouldCreateDeployment)` block so it only fires when a **new** preview deployment would be created. Updates to existing previews (i.e. new commits pushed to already-open PRs) always proceed regardless of the limit.

Also fixed two secondary issues noted in the bug report:
- `const previewLimit = app?.previewLimit || 0` was defaulting to `0` when the app's configured limit was falsy. The DB schema default is `3`. Changed to `?? 3` so a deliberately configured value of `0` is also respected.
- Changed `>` to `>=` so the limit is enforced at exactly `previewLimit` previews rather than allowing one extra beyond the limit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related bugs in the GitHub webhook preview deployment flow: (1) the preview limit check was running before the existing-preview lookup, blocking updates to already-open PRs, and (2) the deployment worker's catch block never updated statuses to `"error"` on failure.

The restructuring in `github.ts` is logically correct — moving the limit guard inside `if (!previewDeploymentResult && shouldCreateDeployment)` ensures only new preview creation is gated by the limit, while commits to existing previews always proceed. The `?? 3` / `>=` corrections are also accurate fixes.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — both changes are targeted, correct fixes for well-described bugs with no new risk introduced.

All three sub-fixes (limit-check relocation, `?? 3` default, `>=` comparison) are logically sound, and the new error-status handling in the worker's catch block mirrors the existing try-block pattern. No new logic paths or edge cases are introduced that could cause regressions.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(github): preview limit check should ..."](https://github.com/dokploy/dokploy/commit/47c451eee8508e2effcb067ff5e4e92bc1338453) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27323427)</sub>

<!-- /greptile_comment -->