### PR TITLE
fix: quote and escape environment variable values

### DIFF
--- a/apps/dokploy/__test__/env/environment.test.ts
+++ b/apps/dokploy/__test__/env/environment.test.ts
@@ -1,6 +1,7 @@
 import {
 	prepareEnvironmentVariables,
 	prepareEnvironmentVariablesForShell,
+	quoteDotenvValue,
 } from "@dokploy/server/index";
 import { describe, expect, it } from "vitest";
 
@@ -360,6 +361,50 @@ SIMPLE=\${{environment.SIMPLE_VAR}}
 			"ANOTHER_TEST=value with 'quotes' inside",
 			"SIMPLE=no-quotes",
 		]);
+	});
+});
+
+describe("quoteDotenvValue (dotenv value quoting)", () => {
+	it("wraps a simple value in double quotes", () => {
+		expect(quoteDotenvValue("KEY=value")).toBe('KEY="value"');
+	});
+
+	it("returns pair unchanged when no = present", () => {
+		expect(quoteDotenvValue("NOEQUALS")).toBe("NOEQUALS");
+	});
+
+	it("handles empty value", () => {
+		expect(quoteDotenvValue("KEY=")).toBe('KEY=""');
+	});
+
+	it("escapes backslashes", () => {
+		expect(quoteDotenvValue("PATH=C:\\Users\\docs")).toBe(
+			'PATH="C:\\\\Users\\\\docs"',
+		);
+	});
+
+	it("escapes double quotes in values", () => {
+		expect(quoteDotenvValue('MSG=say "hello"')).toBe(
+			'MSG="say \\"hello\\""',
+		);
+	});
+
+	it("escapes literal newlines from dotenv expansion", () => {
+		expect(quoteDotenvValue("MSG=line1\nline2")).toBe('MSG="line1\\nline2"');
+	});
+
+	it("escapes carriage returns", () => {
+		expect(quoteDotenvValue("MSG=line1\rline2")).toBe('MSG="line1\\rline2"');
+	});
+
+	it("escapes dollar signs to prevent variable expansion", () => {
+		expect(quoteDotenvValue("PRICE=$100")).toBe('PRICE="\\$100"');
+	});
+
+	it("handles value with multiple special characters", () => {
+		expect(quoteDotenvValue('COMPLEX=a\\b"c\n$d')).toBe(
+			'COMPLEX="a\\\\b\\"c\\n\\$d"',
+		);
 	});
 });
 

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -8,6 +8,7 @@ import {
 	encodeBase64,
 	getEnvironmentVariablesObject,
 	prepareEnvironmentVariables,
+	quoteDotenvValue,
 } from "../docker/utils";
 
 export type ComposeNested = InferResultType<
@@ -119,7 +120,9 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 		envContent,
 		compose.environment.project.env,
 		compose.environment.env,
-	).join("\n");
+	)
+		.map(quoteDotenvValue)
+		.join("\n");
 
 	const encodedContent = encodeBase64(envFileContent);
 	return `

--- a/packages/server/src/utils/builders/utils.ts
+++ b/packages/server/src/utils/builders/utils.ts
@@ -1,5 +1,9 @@
 import { dirname, join } from "node:path";
-import { encodeBase64, prepareEnvironmentVariables } from "../docker/utils";
+import {
+	encodeBase64,
+	prepareEnvironmentVariables,
+	quoteDotenvValue,
+} from "../docker/utils";
 
 export const createEnvFileCommand = (
 	directory: string,
@@ -11,7 +15,9 @@ export const createEnvFileCommand = (
 		env,
 		projectEnv,
 		environmentEnv,
-	).join("\n");
+	)
+		.map(quoteDotenvValue)
+		.join("\n");
 
 	const encodedContent = encodeBase64(envFileContent || "");
 	const envFilePath = join(dirname(directory), ".env");

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -408,6 +408,13 @@ export const prepareEnvironmentVariables = (
 	return resolvedVars;
 };
 
+export const quoteDotenvValue = (pair: string): string => {
+	const i = pair.indexOf("=");
+	if (i === -1) return pair;
+	const value = pair.substring(i + 1).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	return `${pair.substring(0, i)}="${value}"`;
+};
+
 export const prepareEnvironmentVariablesForShell = (
 	serviceEnv: string | null,
 	projectEnv?: string | null,

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -408,11 +408,22 @@ export const prepareEnvironmentVariables = (
 	return resolvedVars;
 };
 
+const DOTENV_ESCAPE_MAP: Record<string, string> = {
+	"\\": "\\\\",
+	'"': '\\"',
+	"\n": "\\n",
+	"\r": "\\r",
+	$: "\\$",
+};
+
 export const quoteDotenvValue = (pair: string): string => {
-	const i = pair.indexOf("=");
-	if (i === -1) return pair;
-	const value = pair.substring(i + 1).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-	return `${pair.substring(0, i)}="${value}"`;
+	const eqIndex = pair.indexOf("=");
+	if (eqIndex === -1) return pair;
+	const key = pair.substring(0, eqIndex);
+	const value = pair
+		.substring(eqIndex + 1)
+		.replace(/[\\"$\n\r]/g, (ch) => DOTENV_ESCAPE_MAP[ch] ?? ch);
+	return `${key}="${value}"`;
 };
 
 export const prepareEnvironmentVariablesForShell = (


### PR DESCRIPTION
Ensure environment variables containing spaces or special characters are correctly handled in generated .env files by quoting and escaping values.

## What is this PR about?

When deploying a service with Docker build type, environment variable values containing spaces (e.g., `APP_NAME=This is an awesome app`) cause the build to fail with `Failed to parse dotenv file. Encountered unexpected
  whitespace.`

This happens because values are written to `.env` files unquoted, and manually adding quotes in the UI doesn't help since dotenv.parse() strips them before writing.

This PR adds a `quoteEnvValue()` helper that
  wraps values in double quotes with proper escaping of `\` and `"` when generating `.env` files, applied to both Dockerfile and Docker Compose build paths.

## Issues related

Fixes #4137

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `quoteDotenvValue` helper that wraps `.env` values in double quotes with proper `\` and `"` escaping, and applies it to both the Dockerfile and Docker Compose build paths. The fix correctly addresses the whitespace parse error by ensuring values with spaces are quoted before being written to `.env` files. The escaping order (backslashes before double quotes) is correct, and since `prepareEnvironmentVariables` runs `dotenv.parse()` first, any user-supplied quotes are already stripped — so double-quoting is not a concern.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix correctly handles the primary issue and doesn't introduce regressions.

All findings are P2. The one flagged edge case (literal newlines in values producing multi-line entries) requires an unusual combination of circumstances and most parsers handle it fine. The core logic is sound.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: quote and escape environment variab..."](https://github.com/dokploy/dokploy/commit/135b7354c36ecf03f25030bf3e32811eccb9dea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27327037)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->