### PR TITLE
feat(database-credentials): add password update functionality for Mar…

### DIFF
--- a/apps/dokploy/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
@@ -1,14 +1,19 @@
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import { toast } from "sonner";
 
 interface Props {
 	mariadbId: string;
 }
 export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 	const { data } = api.mariadb.one.useQuery({ mariadbId });
+	const utils = api.useUtils();
+	const { mutateAsync: changePassword } =
+		api.mariadb.changePassword.useMutation();
 	return (
 		<>
 			<div className="flex w-full flex-col gap-5 ">
@@ -28,19 +33,42 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										disabled
 										value={data?.databasePassword}
+									/>
+									<UpdateDatabasePassword
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												mariadbId,
+												password: newPassword,
+												type: "user",
+											});
+											toast.success("Password updated successfully");
+											utils.mariadb.one.invalidate({ mariadbId });
+										}}
 									/>
 								</div>
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Root Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										disabled
 										value={data?.databaseRootPassword}
+									/>
+									<UpdateDatabasePassword
+										label="Root Password"
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												mariadbId,
+												password: newPassword,
+												type: "root",
+											});
+											toast.success("Root password updated successfully");
+											utils.mariadb.one.invalidate({ mariadbId });
+										}}
 									/>
 								</div>
 							</div>

--- a/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -1,14 +1,19 @@
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import { toast } from "sonner";
 
 interface Props {
 	mongoId: string;
 }
 export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 	const { data } = api.mongo.one.useQuery({ mongoId });
+	const utils = api.useUtils();
+	const { mutateAsync: changePassword } =
+		api.mongo.changePassword.useMutation();
 	return (
 		<>
 			<div className="flex w-full flex-col gap-5 ">
@@ -25,10 +30,20 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										disabled
 										value={data?.databasePassword}
+									/>
+									<UpdateDatabasePassword
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												mongoId,
+												password: newPassword,
+											});
+											toast.success("Password updated successfully");
+											utils.mongo.one.invalidate({ mongoId });
+										}}
 									/>
 								</div>
 							</div>

--- a/apps/dokploy/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
@@ -1,14 +1,19 @@
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import { toast } from "sonner";
 
 interface Props {
 	mysqlId: string;
 }
 export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 	const { data } = api.mysql.one.useQuery({ mysqlId });
+	const utils = api.useUtils();
+	const { mutateAsync: changePassword } =
+		api.mysql.changePassword.useMutation();
 	return (
 		<>
 			<div className="flex w-full flex-col gap-5 ">
@@ -28,19 +33,42 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										disabled
 										value={data?.databasePassword}
+									/>
+									<UpdateDatabasePassword
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												mysqlId,
+												password: newPassword,
+												type: "user",
+											});
+											toast.success("Password updated successfully");
+											utils.mysql.one.invalidate({ mysqlId });
+										}}
 									/>
 								</div>
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Root Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										disabled
 										value={data?.databaseRootPassword}
+									/>
+									<UpdateDatabasePassword
+										label="Root Password"
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												mysqlId,
+												password: newPassword,
+												type: "root",
+											});
+											toast.success("Root password updated successfully");
+											utils.mysql.one.invalidate({ mysqlId });
+										}}
 									/>
 								</div>
 							</div>

--- a/apps/dokploy/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/apps/dokploy/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -1,14 +1,19 @@
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import { toast } from "sonner";
 
 interface Props {
 	postgresId: string;
 }
 export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 	const { data } = api.postgres.one.useQuery({ postgresId });
+	const utils = api.useUtils();
+	const { mutateAsync: changePassword } =
+		api.postgres.changePassword.useMutation();
 	return (
 		<>
 			<div className="flex w-full flex-col gap-5 ">
@@ -28,10 +33,20 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										value={data?.databasePassword}
 										disabled
+									/>
+									<UpdateDatabasePassword
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												postgresId,
+												password: newPassword,
+											});
+											toast.success("Password updated successfully");
+											utils.postgres.one.invalidate({ postgresId });
+										}}
 									/>
 								</div>
 							</div>

--- a/apps/dokploy/components/dashboard/redis/general/show-internal-redis-credentials.tsx
+++ b/apps/dokploy/components/dashboard/redis/general/show-internal-redis-credentials.tsx
@@ -1,14 +1,19 @@
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
+import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/utils/api";
+import { toast } from "sonner";
 
 interface Props {
 	redisId: string;
 }
 export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 	const { data } = api.redis.one.useQuery({ redisId });
+	const utils = api.useUtils();
+	const { mutateAsync: changePassword } =
+		api.redis.changePassword.useMutation();
 	return (
 		<>
 			<div className="flex w-full flex-col gap-5 ">
@@ -24,10 +29,20 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>
-								<div className="flex flex-row gap-4">
+								<div className="flex flex-row gap-2 items-center">
 									<ToggleVisibilityInput
 										value={data?.databasePassword}
 										disabled
+									/>
+									<UpdateDatabasePassword
+										onUpdatePassword={async (newPassword) => {
+											await changePassword({
+												redisId,
+												password: newPassword,
+											});
+											toast.success("Password updated successfully");
+											utils.redis.one.invalidate({ redisId });
+										}}
 									/>
 								</div>
 							</div>

--- a/apps/dokploy/components/shared/update-database-password.tsx
+++ b/apps/dokploy/components/shared/update-database-password.tsx
@@ -24,9 +24,17 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 
+const DATABASE_PASSWORD_REGEX = /^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/;
+
 const updatePasswordSchema = z
 	.object({
-		password: z.string().min(1, "Password is required"),
+		password: z
+			.string()
+			.min(1, "Password is required")
+			.regex(DATABASE_PASSWORD_REGEX, {
+				message:
+					"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters",
+			}),
 		confirmPassword: z.string().min(1, "Please confirm the password"),
 	})
 	.refine((data) => data.password === data.confirmPassword, {
@@ -63,15 +71,12 @@ export const UpdateDatabasePassword = ({
 			setIsOpen(false);
 		} catch (e) {
 			const raw = e instanceof Error ? e.message : "Error updating password";
-			const noContainer = raw.match(/No running container found for \S+/);
-			if (noContainer) {
+			if (/No running container found/i.test(raw)) {
 				setError(
 					"The database container is not running. Please start the service before changing the password.",
 				);
 			} else {
-				setError(
-					"Error updating password. Please check that the container is running and try again.",
-				);
+				setError(raw);
 			}
 		} finally {
 			setIsPending(false);
@@ -101,7 +106,7 @@ export const UpdateDatabasePassword = ({
 					</DialogDescription>
 				</DialogHeader>
 				{error && <AlertBlock type="error">{error}</AlertBlock>}
-				<AlertBlock type="warning">
+				<AlertBlock type="warning" className="my-4">
 					This will change the {label.toLowerCase()} both in the running
 					database container and in Dokploy. The container must be running for
 					this operation to succeed.

--- a/apps/dokploy/components/shared/update-database-password.tsx
+++ b/apps/dokploy/components/shared/update-database-password.tsx
@@ -1,0 +1,126 @@
+import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { PenBox } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+const updatePasswordSchema = z.object({
+	password: z.string().min(1, "Password is required"),
+});
+
+type UpdatePassword = z.infer<typeof updatePasswordSchema>;
+
+interface Props {
+	label?: string;
+	onUpdatePassword: (newPassword: string) => Promise<void>;
+}
+
+export const UpdateDatabasePassword = ({
+	label = "Password",
+	onUpdatePassword,
+}: Props) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [isPending, setIsPending] = useState(false);
+
+	const form = useForm<UpdatePassword>({
+		defaultValues: { password: "" },
+		resolver: zodResolver(updatePasswordSchema),
+	});
+
+	const onSubmit = async (formData: UpdatePassword) => {
+		setIsPending(true);
+		setError(null);
+		try {
+			await onUpdatePassword(formData.password);
+			form.reset();
+			setIsOpen(false);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Error updating password");
+		} finally {
+			setIsPending(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open={isOpen}
+			onOpenChange={(open) => {
+				setIsOpen(open);
+				if (!open) {
+					form.reset();
+					setError(null);
+				}
+			}}
+		>
+			<DialogTrigger asChild>
+				<Button variant="ghost" size="icon">
+					<PenBox className="size-3.5 text-muted-foreground" />
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Update {label}</DialogTitle>
+					<DialogDescription>
+						Enter the new {label.toLowerCase()} for the database
+					</DialogDescription>
+				</DialogHeader>
+				{error && <AlertBlock type="error">{error}</AlertBlock>}
+				<AlertBlock type="warning">
+					This will change the {label.toLowerCase()} both in the running
+					database container and in Dokploy. The container must be running
+					for this operation to succeed.
+				</AlertBlock>
+				<Form {...form}>
+					<form
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="grid w-full gap-4"
+					>
+						<FormField
+							control={form.control}
+							name="password"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>New {label}</FormLabel>
+									<FormControl>
+										<Input
+											type="password"
+											placeholder={`Enter new ${label.toLowerCase()}`}
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<DialogFooter>
+							<Button isLoading={isPending} type="submit">
+								Update
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/shared/update-database-password.tsx
+++ b/apps/dokploy/components/shared/update-database-password.tsx
@@ -56,12 +56,21 @@ export const UpdateDatabasePassword = ({
 			form.reset();
 			setIsOpen(false);
 		} catch (e) {
-			setError(e instanceof Error ? e.message : "Error updating password");
+			const raw = e instanceof Error ? e.message : "Error updating password";
+			const noContainer = raw.match(/No running container found for \S+/);
+			if (noContainer) {
+				setError(
+					"The database container is not running. Please start the service before changing the password.",
+				);
+			} else {
+				setError(
+					"Error updating password. Please check that the container is running and try again.",
+				);
+			}
 		} finally {
 			setIsPending(false);
 		}
 	};
-
 	return (
 		<Dialog
 			open={isOpen}

--- a/apps/dokploy/components/shared/update-database-password.tsx
+++ b/apps/dokploy/components/shared/update-database-password.tsx
@@ -88,8 +88,8 @@ export const UpdateDatabasePassword = ({
 				{error && <AlertBlock type="error">{error}</AlertBlock>}
 				<AlertBlock type="warning">
 					This will change the {label.toLowerCase()} both in the running
-					database container and in Dokploy. The container must be running
-					for this operation to succeed.
+					database container and in Dokploy. The container must be running for
+					this operation to succeed.
 				</AlertBlock>
 				<Form {...form}>
 					<form

--- a/apps/dokploy/components/shared/update-database-password.tsx
+++ b/apps/dokploy/components/shared/update-database-password.tsx
@@ -24,9 +24,15 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 
-const updatePasswordSchema = z.object({
-	password: z.string().min(1, "Password is required"),
-});
+const updatePasswordSchema = z
+	.object({
+		password: z.string().min(1, "Password is required"),
+		confirmPassword: z.string().min(1, "Please confirm the password"),
+	})
+	.refine((data) => data.password === data.confirmPassword, {
+		message: "Passwords do not match",
+		path: ["confirmPassword"],
+	});
 
 type UpdatePassword = z.infer<typeof updatePasswordSchema>;
 
@@ -44,7 +50,7 @@ export const UpdateDatabasePassword = ({
 	const [isPending, setIsPending] = useState(false);
 
 	const form = useForm<UpdatePassword>({
-		defaultValues: { password: "" },
+		defaultValues: { password: "", confirmPassword: "" },
 		resolver: zodResolver(updatePasswordSchema),
 	});
 
@@ -115,6 +121,23 @@ export const UpdateDatabasePassword = ({
 										<Input
 											type="password"
 											placeholder={`Enter new ${label.toLowerCase()}`}
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="confirmPassword"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Confirm {label}</FormLabel>
+									<FormControl>
+										<Input
+											type="password"
+											placeholder={`Confirm new ${label.toLowerCase()}`}
 											{...field}
 										/>
 									</FormControl>

--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -400,17 +400,22 @@ export const mariadbRouter = createTRPCRouter({
 				docker exec "$CONTAINER_ID" mariadb -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
 			`;
 
-			if (serverId) {
-				await execAsyncRemote(serverId, command);
-			} else {
-				await execAsync(command, { shell: "/bin/bash" });
-			}
+			await db.transaction(async (tx) => {
+				const setData =
+					type === "root"
+						? { databaseRootPassword: password }
+						: { databasePassword: password };
+				await tx
+					.update(mariadbTable)
+					.set(setData)
+					.where(eq(mariadbTable.mariadbId, mariadbId));
 
-			if (type === "root") {
-				await updateMariadbById(mariadbId, { databaseRootPassword: password });
-			} else {
-				await updateMariadbById(mariadbId, { databasePassword: password });
-			}
+				if (serverId) {
+					await execAsyncRemote(serverId, command);
+				} else {
+					await execAsync(command, { shell: "/bin/bash" });
+				}
+			});
 
 			await audit(ctx, {
 				action: "update",

--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -3,10 +3,13 @@ import {
 	createMariadb,
 	createMount,
 	deployMariadb,
+	execAsync,
+	execAsyncRemote,
 	findBackupsByDbId,
 	findEnvironmentById,
 	findMariadbById,
 	findProjectById,
+	getServiceContainerCommand,
 	IS_CLOUD,
 	rebuildDatabase,
 	removeMariadbById,
@@ -366,6 +369,56 @@ export const mariadbRouter = createTRPCRouter({
 				resourceId: mariadbId,
 				resourceName: service.appName,
 			});
+			return true;
+		}),
+	changePassword: protectedProcedure
+		.input(
+			z.object({
+				mariadbId: z.string().min(1),
+				password: z.string().min(1),
+				type: z.enum(["user", "root"]).default("user"),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			const { mariadbId, password, type } = input;
+			await checkServicePermissionAndAccess(ctx, mariadbId, {
+				service: ["create"],
+			});
+
+			const maria = await findMariadbById(mariadbId);
+			const { appName, serverId, databaseUser, databaseRootPassword } = maria;
+
+			const containerCmd = getServiceContainerCommand(appName);
+			const targetUser = type === "root" ? "root" : databaseUser;
+
+			const command = `
+				CONTAINER_ID=$(${containerCmd})
+				if [ -z "$CONTAINER_ID" ]; then
+					echo "No running container found for ${appName}" >&2
+					exit 1
+				fi
+				docker exec "$CONTAINER_ID" mariadb -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
+			`;
+
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command, { shell: "/bin/bash" });
+			}
+
+			if (type === "root") {
+				await updateMariadbById(mariadbId, { databaseRootPassword: password });
+			} else {
+				await updateMariadbById(mariadbId, { databasePassword: password });
+			}
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "service",
+				resourceId: mariadbId,
+				resourceName: appName,
+			});
+
 			return true;
 		}),
 	move: protectedProcedure

--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -43,6 +43,8 @@ import {
 	apiSaveEnvironmentVariablesMariaDB,
 	apiSaveExternalPortMariaDB,
 	apiUpdateMariaDB,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
 	environments,
 	mariadb as mariadbTable,
 	projects,
@@ -375,7 +377,12 @@ export const mariadbRouter = createTRPCRouter({
 		.input(
 			z.object({
 				mariadbId: z.string().min(1),
-				password: z.string().min(1),
+				password: z
+					.string()
+					.min(1)
+					.regex(DATABASE_PASSWORD_REGEX, {
+						message: DATABASE_PASSWORD_MESSAGE,
+					}),
 				type: z.enum(["user", "root"]).default("user"),
 			}),
 		)

--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -377,12 +377,9 @@ export const mariadbRouter = createTRPCRouter({
 		.input(
 			z.object({
 				mariadbId: z.string().min(1),
-				password: z
-					.string()
-					.min(1)
-					.regex(DATABASE_PASSWORD_REGEX, {
-						message: DATABASE_PASSWORD_MESSAGE,
-					}),
+				password: z.string().min(1).regex(DATABASE_PASSWORD_REGEX, {
+					message: DATABASE_PASSWORD_MESSAGE,
+				}),
 				type: z.enum(["user", "root"]).default("user"),
 			}),
 		)

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -419,13 +419,18 @@ export const mongoRouter = createTRPCRouter({
 				docker exec "$CONTAINER_ID" mongosh -u '${databaseUser}' -p '${databasePassword}' --authenticationDatabase admin --eval "db.getSiblingDB('admin').changeUserPassword('${databaseUser}', '${password}')"
 			`;
 
-			if (serverId) {
-				await execAsyncRemote(serverId, command);
-			} else {
-				await execAsync(command, { shell: "/bin/bash" });
-			}
+			await db.transaction(async (tx) => {
+				await tx
+					.update(mongoTable)
+					.set({ databasePassword: password })
+					.where(eq(mongoTable.mongoId, mongoId));
 
-			await updateMongoById(mongoId, { databasePassword: password });
+				if (serverId) {
+					await execAsyncRemote(serverId, command);
+				} else {
+					await execAsync(command, { shell: "/bin/bash" });
+				}
+			});
 
 			await audit(ctx, {
 				action: "update",

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -42,6 +42,8 @@ import {
 	apiSaveEnvironmentVariablesMongo,
 	apiSaveExternalPortMongo,
 	apiUpdateMongo,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
 	environments,
 	mongo as mongoTable,
 	projects,
@@ -397,7 +399,12 @@ export const mongoRouter = createTRPCRouter({
 		.input(
 			z.object({
 				mongoId: z.string().min(1),
-				password: z.string().min(1),
+				password: z
+					.string()
+					.min(1)
+					.regex(DATABASE_PASSWORD_REGEX, {
+						message: DATABASE_PASSWORD_MESSAGE,
+					}),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -3,10 +3,13 @@ import {
 	createMongo,
 	createMount,
 	deployMongo,
+	execAsync,
+	execAsyncRemote,
 	findBackupsByDbId,
 	findEnvironmentById,
 	findMongoById,
 	findProjectById,
+	getServiceContainerCommand,
 	IS_CLOUD,
 	rebuildDatabase,
 	removeMongoById,
@@ -388,6 +391,49 @@ export const mongoRouter = createTRPCRouter({
 				resourceId: mongoId,
 				resourceName: service.appName,
 			});
+			return true;
+		}),
+	changePassword: protectedProcedure
+		.input(
+			z.object({
+				mongoId: z.string().min(1),
+				password: z.string().min(1),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			const { mongoId, password } = input;
+			await checkServicePermissionAndAccess(ctx, mongoId, {
+				service: ["create"],
+			});
+
+			const mongo = await findMongoById(mongoId);
+			const { appName, serverId, databaseUser, databasePassword } = mongo;
+
+			const containerCmd = getServiceContainerCommand(appName);
+			const command = `
+				CONTAINER_ID=$(${containerCmd})
+				if [ -z "$CONTAINER_ID" ]; then
+					echo "No running container found for ${appName}" >&2
+					exit 1
+				fi
+				docker exec "$CONTAINER_ID" mongosh -u '${databaseUser}' -p '${databasePassword}' --authenticationDatabase admin --eval "db.getSiblingDB('admin').changeUserPassword('${databaseUser}', '${password}')"
+			`;
+
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command, { shell: "/bin/bash" });
+			}
+
+			await updateMongoById(mongoId, { databasePassword: password });
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "service",
+				resourceId: mongoId,
+				resourceName: appName,
+			});
+
 			return true;
 		}),
 	move: protectedProcedure

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -399,12 +399,9 @@ export const mongoRouter = createTRPCRouter({
 		.input(
 			z.object({
 				mongoId: z.string().min(1),
-				password: z
-					.string()
-					.min(1)
-					.regex(DATABASE_PASSWORD_REGEX, {
-						message: DATABASE_PASSWORD_MESSAGE,
-					}),
+				password: z.string().min(1).regex(DATABASE_PASSWORD_REGEX, {
+					message: DATABASE_PASSWORD_MESSAGE,
+				}),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -408,8 +408,6 @@ export const mysqlRouter = createTRPCRouter({
 			const { appName, serverId, databaseUser, databaseRootPassword } = my;
 
 			const containerCmd = getServiceContainerCommand(appName);
-			const authPassword =
-				type === "root" ? databaseRootPassword : databaseRootPassword;
 			const targetUser = type === "root" ? "root" : databaseUser;
 
 			const command = `
@@ -418,20 +416,25 @@ export const mysqlRouter = createTRPCRouter({
 					echo "No running container found for ${appName}" >&2
 					exit 1
 				fi
-				docker exec "$CONTAINER_ID" mysql -u root -p'${authPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
+				docker exec "$CONTAINER_ID" mysql -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
 			`;
 
-			if (serverId) {
-				await execAsyncRemote(serverId, command);
-			} else {
-				await execAsync(command, { shell: "/bin/bash" });
-			}
+			await db.transaction(async (tx) => {
+				const setData =
+					type === "root"
+						? { databaseRootPassword: password }
+						: { databasePassword: password };
+				await tx
+					.update(mysqlTable)
+					.set(setData)
+					.where(eq(mysqlTable.mysqlId, mysqlId));
 
-			if (type === "root") {
-				await updateMySqlById(mysqlId, { databaseRootPassword: password });
-			} else {
-				await updateMySqlById(mysqlId, { databasePassword: password });
-			}
+				if (serverId) {
+					await execAsyncRemote(serverId, command);
+				} else {
+					await execAsync(command, { shell: "/bin/bash" });
+				}
+			});
 
 			await audit(ctx, {
 				action: "update",

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -3,10 +3,13 @@ import {
 	createMount,
 	createMysql,
 	deployMySql,
+	execAsync,
+	execAsyncRemote,
 	findBackupsByDbId,
 	findEnvironmentById,
 	findMySqlById,
 	findProjectById,
+	getServiceContainerCommand,
 	IS_CLOUD,
 	rebuildDatabase,
 	removeMySqlById,
@@ -385,6 +388,58 @@ export const mysqlRouter = createTRPCRouter({
 				resourceId: mysqlId,
 				resourceName: service.appName,
 			});
+			return true;
+		}),
+	changePassword: protectedProcedure
+		.input(
+			z.object({
+				mysqlId: z.string().min(1),
+				password: z.string().min(1),
+				type: z.enum(["user", "root"]).default("user"),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			const { mysqlId, password, type } = input;
+			await checkServicePermissionAndAccess(ctx, mysqlId, {
+				service: ["create"],
+			});
+
+			const my = await findMySqlById(mysqlId);
+			const { appName, serverId, databaseUser, databaseRootPassword } = my;
+
+			const containerCmd = getServiceContainerCommand(appName);
+			const authPassword =
+				type === "root" ? databaseRootPassword : databaseRootPassword;
+			const targetUser = type === "root" ? "root" : databaseUser;
+
+			const command = `
+				CONTAINER_ID=$(${containerCmd})
+				if [ -z "$CONTAINER_ID" ]; then
+					echo "No running container found for ${appName}" >&2
+					exit 1
+				fi
+				docker exec "$CONTAINER_ID" mysql -u root -p'${authPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
+			`;
+
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command, { shell: "/bin/bash" });
+			}
+
+			if (type === "root") {
+				await updateMySqlById(mysqlId, { databaseRootPassword: password });
+			} else {
+				await updateMySqlById(mysqlId, { databasePassword: password });
+			}
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "service",
+				resourceId: mysqlId,
+				resourceName: appName,
+			});
+
 			return true;
 		}),
 	move: protectedProcedure

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -396,12 +396,9 @@ export const mysqlRouter = createTRPCRouter({
 		.input(
 			z.object({
 				mysqlId: z.string().min(1),
-				password: z
-					.string()
-					.min(1)
-					.regex(DATABASE_PASSWORD_REGEX, {
-						message: DATABASE_PASSWORD_MESSAGE,
-					}),
+				password: z.string().min(1).regex(DATABASE_PASSWORD_REGEX, {
+					message: DATABASE_PASSWORD_MESSAGE,
+				}),
 				type: z.enum(["user", "root"]).default("user"),
 			}),
 		)

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -42,6 +42,8 @@ import {
 	apiSaveEnvironmentVariablesMySql,
 	apiSaveExternalPortMySql,
 	apiUpdateMySql,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
 	environments,
 	mysql as mysqlTable,
 	projects,
@@ -394,7 +396,12 @@ export const mysqlRouter = createTRPCRouter({
 		.input(
 			z.object({
 				mysqlId: z.string().min(1),
-				password: z.string().min(1),
+				password: z
+					.string()
+					.min(1)
+					.regex(DATABASE_PASSWORD_REGEX, {
+						message: DATABASE_PASSWORD_MESSAGE,
+					}),
 				type: z.enum(["user", "root"]).default("user"),
 			}),
 		)

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -424,13 +424,19 @@ export const postgresRouter = createTRPCRouter({
 				fi
 				docker exec "$CONTAINER_ID" psql -U ${databaseUser} -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"
 			`;
-			if (serverId) {
-				await execAsyncRemote(serverId, command);
-			} else {
-				await execAsync(command, { shell: "/bin/bash" });
-			}
 
-			await updatePostgresById(postgresId, { databasePassword: password });
+			await db.transaction(async (tx) => {
+				await tx
+					.update(postgresTable)
+					.set({ databasePassword: password })
+					.where(eq(postgresTable.postgresId, postgresId));
+
+				if (serverId) {
+					await execAsyncRemote(serverId, command);
+				} else {
+					await execAsync(command, { shell: "/bin/bash" });
+				}
+			});
 
 			await audit(ctx, {
 				action: "update",

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -3,11 +3,14 @@ import {
 	createMount,
 	createPostgres,
 	deployPostgres,
+	execAsync,
+	execAsyncRemote,
 	findBackupsByDbId,
 	findEnvironmentById,
 	findPostgresById,
 	findProjectById,
 	getMountPath,
+	getServiceContainerCommand,
 	IS_CLOUD,
 	rebuildDatabase,
 	removePostgresById,
@@ -394,6 +397,49 @@ export const postgresRouter = createTRPCRouter({
 				resourceId: postgresId,
 				resourceName: service.appName,
 			});
+			return true;
+		}),
+	changePassword: protectedProcedure
+		.input(
+			z.object({
+				postgresId: z.string().min(1),
+				password: z.string().min(1),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			const { postgresId, password } = input;
+			await checkServicePermissionAndAccess(ctx, postgresId, {
+				service: ["create"],
+			});
+
+			const pg = await findPostgresById(postgresId);
+			const { appName, serverId, databaseUser } = pg;
+
+			const containerCmd = getServiceContainerCommand(appName);
+			const command = `
+				CONTAINER_ID=$(${containerCmd})
+				if [ -z "$CONTAINER_ID" ]; then
+					echo "No running container found for ${appName}" >&2
+					exit 1
+				fi
+				docker exec "$CONTAINER_ID" psql -U ${databaseUser} -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"
+			`;
+
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command, { shell: "/bin/bash" });
+			}
+
+			await updatePostgresById(postgresId, { databasePassword: password });
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "service",
+				resourceId: postgresId,
+				resourceName: appName,
+			});
+
 			return true;
 		}),
 	move: protectedProcedure

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -43,6 +43,8 @@ import {
 	apiSaveEnvironmentVariablesPostgres,
 	apiSaveExternalPortPostgres,
 	apiUpdatePostgres,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
 	environments,
 	postgres as postgresTable,
 	projects,
@@ -403,7 +405,12 @@ export const postgresRouter = createTRPCRouter({
 		.input(
 			z.object({
 				postgresId: z.string().min(1),
-				password: z.string().min(1),
+				password: z
+					.string()
+					.min(1)
+					.regex(DATABASE_PASSWORD_REGEX, {
+						message: DATABASE_PASSWORD_MESSAGE,
+					}),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -424,7 +424,6 @@ export const postgresRouter = createTRPCRouter({
 				fi
 				docker exec "$CONTAINER_ID" psql -U ${databaseUser} -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"
 			`;
-
 			if (serverId) {
 				await execAsyncRemote(serverId, command);
 			} else {

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -405,12 +405,9 @@ export const postgresRouter = createTRPCRouter({
 		.input(
 			z.object({
 				postgresId: z.string().min(1),
-				password: z
-					.string()
-					.min(1)
-					.regex(DATABASE_PASSWORD_REGEX, {
-						message: DATABASE_PASSWORD_MESSAGE,
-					}),
+				password: z.string().min(1).regex(DATABASE_PASSWORD_REGEX, {
+					message: DATABASE_PASSWORD_MESSAGE,
+				}),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -3,9 +3,12 @@ import {
 	createMount,
 	createRedis,
 	deployRedis,
+	execAsync,
+	execAsyncRemote,
 	findEnvironmentById,
 	findProjectById,
 	findRedisById,
+	getServiceContainerCommand,
 	IS_CLOUD,
 	rebuildDatabase,
 	removeRedisById,
@@ -375,6 +378,49 @@ export const redisRouter = createTRPCRouter({
 				resourceId: redisId,
 				resourceName: redis.appName,
 			});
+			return true;
+		}),
+	changePassword: protectedProcedure
+		.input(
+			z.object({
+				redisId: z.string().min(1),
+				password: z.string().min(1),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			const { redisId, password } = input;
+			await checkServicePermissionAndAccess(ctx, redisId, {
+				service: ["create"],
+			});
+
+			const rd = await findRedisById(redisId);
+			const { appName, serverId, databasePassword } = rd;
+
+			const containerCmd = getServiceContainerCommand(appName);
+			const command = `
+				CONTAINER_ID=$(${containerCmd})
+				if [ -z "$CONTAINER_ID" ]; then
+					echo "No running container found for ${appName}" >&2
+					exit 1
+				fi
+				docker exec "$CONTAINER_ID" redis-cli -a '${databasePassword}' CONFIG SET requirepass '${password}'
+			`;
+
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command, { shell: "/bin/bash" });
+			}
+
+			await updateRedisById(redisId, { databasePassword: password });
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "service",
+				resourceId: redisId,
+				resourceName: appName,
+			});
+
 			return true;
 		}),
 	move: protectedProcedure

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -386,12 +386,9 @@ export const redisRouter = createTRPCRouter({
 		.input(
 			z.object({
 				redisId: z.string().min(1),
-				password: z
-					.string()
-					.min(1)
-					.regex(DATABASE_PASSWORD_REGEX, {
-						message: DATABASE_PASSWORD_MESSAGE,
-					}),
+				password: z.string().min(1).regex(DATABASE_PASSWORD_REGEX, {
+					message: DATABASE_PASSWORD_MESSAGE,
+				}),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -41,6 +41,8 @@ import {
 	apiSaveEnvironmentVariablesRedis,
 	apiSaveExternalPortRedis,
 	apiUpdateRedis,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
 	environments,
 	projects,
 	redis as redisTable,
@@ -384,7 +386,12 @@ export const redisRouter = createTRPCRouter({
 		.input(
 			z.object({
 				redisId: z.string().min(1),
-				password: z.string().min(1),
+				password: z
+					.string()
+					.min(1)
+					.regex(DATABASE_PASSWORD_REGEX, {
+						message: DATABASE_PASSWORD_MESSAGE,
+					}),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -406,13 +406,18 @@ export const redisRouter = createTRPCRouter({
 				docker exec "$CONTAINER_ID" redis-cli -a '${databasePassword}' CONFIG SET requirepass '${password}'
 			`;
 
-			if (serverId) {
-				await execAsyncRemote(serverId, command);
-			} else {
-				await execAsync(command, { shell: "/bin/bash" });
-			}
+			await db.transaction(async (tx) => {
+				await tx
+					.update(redisTable)
+					.set({ databasePassword: password })
+					.where(eq(redisTable.redisId, redisId));
 
-			await updateRedisById(redisId, { databasePassword: password });
+				if (serverId) {
+					await execAsyncRemote(serverId, command);
+				} else {
+					await execAsync(command, { shell: "/bin/bash" });
+				}
+			});
 
 			await audit(ctx, {
 				action: "update",

--- a/packages/server/src/db/schema/libsql.ts
+++ b/packages/server/src/db/schema/libsql.ts
@@ -34,7 +34,11 @@ import {
 	type UpdateConfigSwarm,
 	UpdateConfigSwarmSchema,
 } from "./shared";
-import { generateAppName } from "./utils";
+import {
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
+	generateAppName,
+} from "./utils";
 
 export const libsql = pgTable("libsql", {
 	libsqlId: text("libsqlId")
@@ -111,9 +115,8 @@ const createSchema = createInsertSchema(libsql, {
 	databaseUser: z.string().min(1),
 	databasePassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		}),
 	sqldNode: z.enum(sqldNode.enumValues),
 	sqldPrimaryUrl: z.string().nullable(),

--- a/packages/server/src/db/schema/libsql.ts
+++ b/packages/server/src/db/schema/libsql.ts
@@ -113,11 +113,9 @@ const createSchema = createInsertSchema(libsql, {
 	appName: z.string().min(1),
 	createdAt: z.string(),
 	databaseUser: z.string().min(1),
-	databasePassword: z
-		.string()
-		.regex(DATABASE_PASSWORD_REGEX, {
-			message: DATABASE_PASSWORD_MESSAGE,
-		}),
+	databasePassword: z.string().regex(DATABASE_PASSWORD_REGEX, {
+		message: DATABASE_PASSWORD_MESSAGE,
+	}),
 	sqldNode: z.enum(sqldNode.enumValues),
 	sqldPrimaryUrl: z.string().nullable(),
 	enableNamespaces: z.boolean().default(false),

--- a/packages/server/src/db/schema/mariadb.ts
+++ b/packages/server/src/db/schema/mariadb.ts
@@ -28,7 +28,13 @@ import {
 	type UpdateConfigSwarm,
 	UpdateConfigSwarmSchema,
 } from "./shared";
-import { APP_NAME_MESSAGE, APP_NAME_REGEX, generateAppName } from "./utils";
+import {
+	APP_NAME_MESSAGE,
+	APP_NAME_REGEX,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
+	generateAppName,
+} from "./utils";
 
 export const mariadb = pgTable("mariadb", {
 	mariadbId: text("mariadbId")
@@ -110,15 +116,13 @@ const createSchema = createInsertSchema(mariadb, {
 	databaseUser: z.string().min(1),
 	databasePassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		}),
 	databaseRootPassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		})
 		.optional(),
 	dockerImage: z.string().default("mariadb:6"),

--- a/packages/server/src/db/schema/mariadb.ts
+++ b/packages/server/src/db/schema/mariadb.ts
@@ -114,11 +114,9 @@ const createSchema = createInsertSchema(mariadb, {
 	createdAt: z.string(),
 	databaseName: z.string().min(1),
 	databaseUser: z.string().min(1),
-	databasePassword: z
-		.string()
-		.regex(DATABASE_PASSWORD_REGEX, {
-			message: DATABASE_PASSWORD_MESSAGE,
-		}),
+	databasePassword: z.string().regex(DATABASE_PASSWORD_REGEX, {
+		message: DATABASE_PASSWORD_MESSAGE,
+	}),
 	databaseRootPassword: z
 		.string()
 		.regex(DATABASE_PASSWORD_REGEX, {

--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -35,7 +35,13 @@ import {
 	type UpdateConfigSwarm,
 	UpdateConfigSwarmSchema,
 } from "./shared";
-import { APP_NAME_MESSAGE, APP_NAME_REGEX, generateAppName } from "./utils";
+import {
+	APP_NAME_MESSAGE,
+	APP_NAME_REGEX,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
+	generateAppName,
+} from "./utils";
 
 export const mongo = pgTable("mongo", {
 	mongoId: text("mongoId")
@@ -112,9 +118,8 @@ const createSchema = createInsertSchema(mongo, {
 	name: z.string().min(1),
 	databasePassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		}),
 	databaseUser: z.string().min(1),
 	dockerImage: z.string().default("mongo:15"),

--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -116,11 +116,9 @@ const createSchema = createInsertSchema(mongo, {
 	createdAt: z.string(),
 	mongoId: z.string(),
 	name: z.string().min(1),
-	databasePassword: z
-		.string()
-		.regex(DATABASE_PASSWORD_REGEX, {
-			message: DATABASE_PASSWORD_MESSAGE,
-		}),
+	databasePassword: z.string().regex(DATABASE_PASSWORD_REGEX, {
+		message: DATABASE_PASSWORD_MESSAGE,
+	}),
 	databaseUser: z.string().min(1),
 	dockerImage: z.string().default("mongo:15"),
 	command: z.string().optional(),

--- a/packages/server/src/db/schema/mysql.ts
+++ b/packages/server/src/db/schema/mysql.ts
@@ -112,11 +112,9 @@ const createSchema = createInsertSchema(mysql, {
 	name: z.string().min(1),
 	databaseName: z.string().min(1),
 	databaseUser: z.string().min(1),
-	databasePassword: z
-		.string()
-		.regex(DATABASE_PASSWORD_REGEX, {
-			message: DATABASE_PASSWORD_MESSAGE,
-		}),
+	databasePassword: z.string().regex(DATABASE_PASSWORD_REGEX, {
+		message: DATABASE_PASSWORD_MESSAGE,
+	}),
 	databaseRootPassword: z
 		.string()
 		.regex(DATABASE_PASSWORD_REGEX, {

--- a/packages/server/src/db/schema/mysql.ts
+++ b/packages/server/src/db/schema/mysql.ts
@@ -28,7 +28,13 @@ import {
 	type UpdateConfigSwarm,
 	UpdateConfigSwarmSchema,
 } from "./shared";
-import { APP_NAME_MESSAGE, APP_NAME_REGEX, generateAppName } from "./utils";
+import {
+	APP_NAME_MESSAGE,
+	APP_NAME_REGEX,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
+	generateAppName,
+} from "./utils";
 
 export const mysql = pgTable("mysql", {
 	mysqlId: text("mysqlId")
@@ -108,15 +114,13 @@ const createSchema = createInsertSchema(mysql, {
 	databaseUser: z.string().min(1),
 	databasePassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		}),
 	databaseRootPassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		})
 		.optional(),
 	dockerImage: z.string().default("mysql:8"),

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -109,11 +109,9 @@ const createSchema = createInsertSchema(postgres, {
 		.max(63)
 		.regex(APP_NAME_REGEX, APP_NAME_MESSAGE)
 		.optional(),
-	databasePassword: z
-		.string()
-		.regex(DATABASE_PASSWORD_REGEX, {
-			message: DATABASE_PASSWORD_MESSAGE,
-		}),
+	databasePassword: z.string().regex(DATABASE_PASSWORD_REGEX, {
+		message: DATABASE_PASSWORD_MESSAGE,
+	}),
 	databaseName: z.string().min(1),
 	databaseUser: z.string().min(1),
 	dockerImage: z.string().default("postgres:18"),

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -28,7 +28,13 @@ import {
 	type UpdateConfigSwarm,
 	UpdateConfigSwarmSchema,
 } from "./shared";
-import { APP_NAME_MESSAGE, APP_NAME_REGEX, generateAppName } from "./utils";
+import {
+	APP_NAME_MESSAGE,
+	APP_NAME_REGEX,
+	DATABASE_PASSWORD_MESSAGE,
+	DATABASE_PASSWORD_REGEX,
+	generateAppName,
+} from "./utils";
 
 export const postgres = pgTable("postgres", {
 	postgresId: text("postgresId")
@@ -105,9 +111,8 @@ const createSchema = createInsertSchema(postgres, {
 		.optional(),
 	databasePassword: z
 		.string()
-		.regex(/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/, {
-			message:
-				"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility",
+		.regex(DATABASE_PASSWORD_REGEX, {
+			message: DATABASE_PASSWORD_MESSAGE,
 		}),
 	databaseName: z.string().min(1),
 	databaseUser: z.string().min(1),

--- a/packages/server/src/db/schema/utils.ts
+++ b/packages/server/src/db/schema/utils.ts
@@ -12,6 +12,13 @@ export const APP_NAME_REGEX = /^[a-zA-Z0-9._-]+$/;
 export const APP_NAME_MESSAGE =
 	"App name can only contain letters, numbers, dots, underscores and hyphens";
 
+/** Database password: blocks shell-dangerous characters like $ ! ' " \ / and spaces. */
+export const DATABASE_PASSWORD_REGEX =
+	/^[a-zA-Z0-9@#%^&*()_+\-=[\]{}|;:,.<>?~`]*$/;
+
+export const DATABASE_PASSWORD_MESSAGE =
+	"Password contains invalid characters. Please avoid: $ ! ' \" \\ / and space characters for database compatibility";
+
 export const generateAppName = (type: string) => {
 	const verb = faker.hacker.verb().replace(/ /g, "-");
 	const adjective = faker.hacker.adjective().replace(/ /g, "-");


### PR DESCRIPTION
…iaDB, MongoDB, MySQL, Postgres, and Redis

- Introduced a new `UpdateDatabasePassword` component to facilitate password updates for database credentials.
- Implemented password change mutations in the respective API routers for MariaDB, MongoDB, MySQL, Postgres, and Redis.
- Enhanced user experience by providing success notifications upon successful password updates.
- Updated UI components to include the new password update functionality, ensuring consistency across different database types.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4041 #933

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a live password-update feature for all five database types (MariaDB, MongoDB, MySQL, Postgres, Redis). A new shared `UpdateDatabasePassword` dialog component collects the new password, calls a per-database `changePassword` tRPC mutation, and invalidates the query cache on success. Each mutation shells out to the running container via `docker exec` to change the password at the DB level, then persists the new value in Dokploy's own store.

The UI integration and the overall flow are well-structured, but the server-side implementations have critical security and correctness issues that need to be resolved before merging:

- **Shell injection (P0)** — All five routers interpolate the user-supplied `password` directly into single-quoted shell strings without any escaping. A password containing a shell metacharacter would break out of the quoted context, potentially executing arbitrary commands on the host. This affects `postgres.ts`, `mysql.ts`, `mariadb.ts`, `mongo.ts`, and `redis.ts`.
- **Dead-code ternary in `mysql.ts` (P1)** — `authPassword` is computed with a ternary where both branches evaluate to `databaseRootPassword`, making the conditional pointless and the code misleading.
- **No password-confirmation field (P2)** — The `UpdateDatabasePassword` dialog accepts only a single password input. A typo will silently lock the database. Adding a confirmation field with a Zod `refine` check would prevent accidental lockouts.

<h3>Confidence Score: 1/5</h3>

Not safe to merge — the shell injection vulnerability allows an attacker who can set a database password to execute arbitrary commands on the host.

All five new server-side mutations contain a shell injection vulnerability that lets a crafted password break out of the single-quoted shell string and run arbitrary commands on the host. This is a critical security issue. There is also a dead-code ternary bug in mysql.ts and a minor UX gap in the shared component. These issues must be resolved before the PR is merged.

All five router files (postgres.ts, mysql.ts, mariadb.ts, mongo.ts, redis.ts) need the shell injection fixed. mysql.ts also needs the dead-code ternary removed.

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/e1e175b1e09a60a0c55c77e6b61842e9e80c1ee6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27343003)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->