### PR TITLE
fix: validate invitation email matches signup email

### DIFF
--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -148,10 +148,12 @@ const { handler, api } = betterAuth({
 						const xDokployToken =
 							context?.request?.headers?.get("x-dokploy-token");
 						if (xDokployToken) {
-							const invitation = await getUserByToken(xDokployToken);
-							if (!invitation) {
+							let invitation: Awaited<ReturnType<typeof getUserByToken>>;
+							try {
+								invitation = await getUserByToken(xDokployToken);
+							} catch {
 								throw new APIError("BAD_REQUEST", {
-									message: "User not found",
+									message: "Invalid invitation token",
 								});
 							}
 							if (invitation.isExpired) {
@@ -164,7 +166,7 @@ const { handler, api } = betterAuth({
 									message: "Invitation has already been used",
 								});
 							}
-							if (_user.email !== invitation.email) {
+							if (_user.email.toLowerCase().trim() !== invitation.email.toLowerCase().trim()) {
 								throw new APIError("BAD_REQUEST", {
 									message: "Email does not match invitation",
 								});

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -148,10 +148,15 @@ const { handler, api } = betterAuth({
 						const xDokployToken =
 							context?.request?.headers?.get("x-dokploy-token");
 						if (xDokployToken) {
-							const user = await getUserByToken(xDokployToken);
-							if (!user) {
+							const invitation = await getUserByToken(xDokployToken);
+							if (!invitation) {
 								throw new APIError("BAD_REQUEST", {
 									message: "User not found",
+								});
+							}
+							if (_user.email !== invitation.email) {
+								throw new APIError("BAD_REQUEST", {
+									message: "Email does not match invitation",
 								});
 							}
 						} else {

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -154,6 +154,16 @@ const { handler, api } = betterAuth({
 									message: "User not found",
 								});
 							}
+							if (invitation.isExpired) {
+								throw new APIError("BAD_REQUEST", {
+									message: "Invitation has expired",
+								});
+							}
+							if (invitation.status !== "pending") {
+								throw new APIError("BAD_REQUEST", {
+									message: "Invitation has already been used",
+								});
+							}
 							if (_user.email !== invitation.email) {
 								throw new APIError("BAD_REQUEST", {
 									message: "Email does not match invitation",

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -166,7 +166,10 @@ const { handler, api } = betterAuth({
 									message: "Invitation has already been used",
 								});
 							}
-							if (_user.email.toLowerCase().trim() !== invitation.email.toLowerCase().trim()) {
+							if (
+								_user.email.toLowerCase().trim() !==
+								invitation.email.toLowerCase().trim()
+							) {
 								throw new APIError("BAD_REQUEST", {
 									message: "Email does not match invitation",
 								});


### PR DESCRIPTION
## What is this PR about?

Fixes a security vulnerability where an invited user could bypass the disabled email field (via DevTools or direct API call) and create an account with a different email than the one invited. The backend now validates that the signup email matches the invitation email (case-insensitive), and also checks that the invitation is not expired and has not already been used.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4039

## Screenshots (if applicable)

N/A