### PR TITLE
fix: extractImageTag misidentifies registry port as tag

### DIFF
--- a/apps/dokploy/__test__/deploy/github.test.ts
+++ b/apps/dokploy/__test__/deploy/github.test.ts
@@ -427,9 +427,9 @@ describe("Docker Image Name and Tag Extraction", () => {
 
 		it("should extract tag from registry with port and tag", () => {
 			expect(extractImageTag("registry:5000/image:tag")).toBe("tag");
-			expect(
-				extractImageTag("registry.example.com:5000/myimage:v2.0"),
-			).toBe("v2.0");
+			expect(extractImageTag("registry.example.com:5000/myimage:v2.0")).toBe(
+				"v2.0",
+			);
 			expect(extractImageTag("localhost:5000/app:sha-abc123")).toBe(
 				"sha-abc123",
 			);

--- a/apps/dokploy/__test__/deploy/github.test.ts
+++ b/apps/dokploy/__test__/deploy/github.test.ts
@@ -415,5 +415,24 @@ describe("Docker Image Name and Tag Extraction", () => {
 			expect(extractImageTag("my-image:123")).toBe("123");
 			expect(extractImageTag("my-image:1")).toBe("1");
 		});
+
+		it("should return 'latest' for registry with port but no tag", () => {
+			expect(extractImageTag("registry.example.com:5000/myimage")).toBe(
+				"latest",
+			);
+			expect(extractImageTag("registry:5000/fedora/httpd")).toBe("latest");
+			expect(extractImageTag("localhost:5000/myapp")).toBe("latest");
+			expect(extractImageTag("my-registry.io:443/org/app")).toBe("latest");
+		});
+
+		it("should extract tag from registry with port and tag", () => {
+			expect(extractImageTag("registry:5000/image:tag")).toBe("tag");
+			expect(
+				extractImageTag("registry.example.com:5000/myimage:v2.0"),
+			).toBe("v2.0");
+			expect(extractImageTag("localhost:5000/app:sha-abc123")).toBe(
+				"sha-abc123",
+			);
+		});
 	});
 });

--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -319,8 +319,19 @@ export function extractImageTag(dockerImage: string | null) {
 		return null;
 	}
 
-	const tag = dockerImage.split(":").pop();
-	return tag === dockerImage ? "latest" : tag;
+	const lastColonIndex = dockerImage.lastIndexOf(":");
+	if (lastColonIndex === -1) {
+		return "latest";
+	}
+
+	const afterColon = dockerImage.substring(lastColonIndex + 1);
+	const isPortWithPath = /^\d{1,5}\//.test(afterColon);
+
+	if (isPortWithPath) {
+		return "latest";
+	}
+
+	return afterColon;
 }
 
 /**


### PR DESCRIPTION
## What is this PR about?

Fixes `extractImageTag` which used a naive `split(":").pop()` that treated registry port numbers as image tags (e.g. `registry:5000/image` returned `"5000/image"` instead of `"latest"`). Now uses `lastIndexOf(":")` and checks if the suffix is a port followed by a path, consistent with how `extractImageName` already handles this. Added tests for registry-with-port scenarios.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4082

## Screenshots (if applicable)

N/A