### PR TITLE
fix: compose patches overwritten by domain injection

### DIFF
--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -251,15 +251,22 @@ export const deployCompose = async ({
 		} else {
 			await execAsync(commandWithLog);
 		}
-		command = "set -e;";
 		if (compose.sourceType !== "raw") {
+			command = "set -e;";
 			command += await generateApplyPatchesCommand({
 				id: compose.composeId,
 				type: "compose",
 				serverId: compose.serverId,
 			});
+			commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
+			if (compose.serverId) {
+				await execAsyncRemote(compose.serverId, commandWithLog);
+			} else {
+				await execAsync(commandWithLog);
+			}
 		}
 
+		command = "set -e;";
 		command += await getBuildComposeCommand(entity);
 		commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (compose.serverId) {
@@ -357,6 +364,23 @@ export const rebuildCompose = async ({
 		} else {
 			await execAsync(commandWithLog);
 		}
+
+		if (compose.sourceType !== "raw") {
+			command = "set -e;";
+			command += await generateApplyPatchesCommand({
+				id: compose.composeId,
+				type: "compose",
+				serverId: compose.serverId,
+			});
+			commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
+			if (compose.serverId) {
+				await execAsyncRemote(compose.serverId, commandWithLog);
+			} else {
+				await execAsync(commandWithLog);
+			}
+		}
+
+		command = "set -e;";
 		command += await getBuildComposeCommand(compose);
 		commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (compose.serverId) {


### PR DESCRIPTION
## What is this PR about?

Fixes a bug where compose patches were being overwritten by domain injection during deployment. `writeDomainsToCompose()` reads the compose file in Node.js before the shell script runs, so patches applied as shell commands were being overwritten with the stale pre-patch content. This splits patch execution into a separate step that runs before `getBuildComposeCommand()`. Also adds missing patch support to `rebuildCompose()` which was skipping patches entirely on redeploys.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4113

## Screenshots (if applicable)

N/A