### PR TITLE
fix: webhook crash when commits is undefined with watch paths

### DIFF
--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -54,7 +54,11 @@ export default async function handler(
 		if (sourceType === "github") {
 			const branchName = extractBranchName(req.headers, req.body);
 			const normalizedCommits =
-				req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
+				req.body?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -73,7 +77,11 @@ export default async function handler(
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);
 			const normalizedCommits =
-				req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
+				req.body?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -123,13 +131,25 @@ export default async function handler(
 
 			if (provider === "github") {
 				normalizedCommits =
-					req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
+					req.body?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 			} else if (provider === "gitlab") {
 				normalizedCommits =
-					req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
+					req.body?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 			} else if (provider === "gitea") {
 				normalizedCommits =
-					req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
+					req.body?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 			}
 
 			const shouldDeployPaths = shouldDeploy(
@@ -145,7 +165,11 @@ export default async function handler(
 			const branchName = extractBranchName(req.headers, req.body);
 
 			const normalizedCommits =
-				req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
+				req.body?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -54,11 +54,13 @@ export default async function handler(
 		if (sourceType === "github") {
 			const branchName = extractBranchName(req.headers, req.body);
 			const normalizedCommits =
-				req.body?.commits?.flatMap((commit: any) => [
+				req.body?.commits
+					?.flatMap((commit: any) => [
 						...(commit.modified || []),
 						...(commit.added || []),
 						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					])
+					.filter(Boolean) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -77,11 +79,13 @@ export default async function handler(
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);
 			const normalizedCommits =
-				req.body?.commits?.flatMap((commit: any) => [
+				req.body?.commits
+					?.flatMap((commit: any) => [
 						...(commit.modified || []),
 						...(commit.added || []),
 						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					])
+					.filter(Boolean) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -131,25 +135,31 @@ export default async function handler(
 
 			if (provider === "github") {
 				normalizedCommits =
-					req.body?.commits?.flatMap((commit: any) => [
-						...(commit.modified || []),
-						...(commit.added || []),
-						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					req.body?.commits
+						?.flatMap((commit: any) => [
+							...(commit.modified || []),
+							...(commit.added || []),
+							...(commit.removed || []),
+						])
+						.filter(Boolean) || [];
 			} else if (provider === "gitlab") {
 				normalizedCommits =
-					req.body?.commits?.flatMap((commit: any) => [
-						...(commit.modified || []),
-						...(commit.added || []),
-						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					req.body?.commits
+						?.flatMap((commit: any) => [
+							...(commit.modified || []),
+							...(commit.added || []),
+							...(commit.removed || []),
+						])
+						.filter(Boolean) || [];
 			} else if (provider === "gitea") {
 				normalizedCommits =
-					req.body?.commits?.flatMap((commit: any) => [
-						...(commit.modified || []),
-						...(commit.added || []),
-						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					req.body?.commits
+						?.flatMap((commit: any) => [
+							...(commit.modified || []),
+							...(commit.added || []),
+							...(commit.removed || []),
+						])
+						.filter(Boolean) || [];
 			}
 
 			const shouldDeployPaths = shouldDeploy(
@@ -165,11 +175,13 @@ export default async function handler(
 			const branchName = extractBranchName(req.headers, req.body);
 
 			const normalizedCommits =
-				req.body?.commits?.flatMap((commit: any) => [
+				req.body?.commits
+					?.flatMap((commit: any) => [
 						...(commit.modified || []),
 						...(commit.added || []),
 						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					])
+					.filter(Boolean) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -54,9 +54,7 @@ export default async function handler(
 		if (sourceType === "github") {
 			const branchName = extractBranchName(req.headers, req.body);
 			const normalizedCommits =
-				req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				) || [];
+				req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -75,9 +73,7 @@ export default async function handler(
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);
 			const normalizedCommits =
-				req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				) || [];
+				req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -127,19 +123,13 @@ export default async function handler(
 
 			if (provider === "github") {
 				normalizedCommits =
-					req.body?.commits?.flatMap(
-						(commit: any) => commit.modified,
-					) || [];
+					req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
 			} else if (provider === "gitlab") {
 				normalizedCommits =
-					req.body?.commits?.flatMap(
-						(commit: any) => commit.modified,
-					) || [];
+					req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
 			} else if (provider === "gitea") {
 				normalizedCommits =
-					req.body?.commits?.flatMap(
-						(commit: any) => commit.modified,
-					) || [];
+					req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
 			}
 
 			const shouldDeployPaths = shouldDeploy(
@@ -155,9 +145,7 @@ export default async function handler(
 			const branchName = extractBranchName(req.headers, req.body);
 
 			const normalizedCommits =
-				req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				) || [];
+				req.body?.commits?.flatMap((commit: any) => commit.modified) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -53,9 +53,10 @@ export default async function handler(
 
 		if (sourceType === "github") {
 			const branchName = extractBranchName(req.headers, req.body);
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
-			);
+			const normalizedCommits =
+				req.body?.commits?.flatMap(
+					(commit: any) => commit.modified,
+				) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -73,9 +74,10 @@ export default async function handler(
 			}
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
-			);
+			const normalizedCommits =
+				req.body?.commits?.flatMap(
+					(commit: any) => commit.modified,
+				) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,
@@ -124,17 +126,20 @@ export default async function handler(
 			let normalizedCommits: string[] = [];
 
 			if (provider === "github") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				);
+				normalizedCommits =
+					req.body?.commits?.flatMap(
+						(commit: any) => commit.modified,
+					) || [];
 			} else if (provider === "gitlab") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				);
+				normalizedCommits =
+					req.body?.commits?.flatMap(
+						(commit: any) => commit.modified,
+					) || [];
 			} else if (provider === "gitea") {
-				normalizedCommits = req.body?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				);
+				normalizedCommits =
+					req.body?.commits?.flatMap(
+						(commit: any) => commit.modified,
+					) || [];
 			}
 
 			const shouldDeployPaths = shouldDeploy(
@@ -149,9 +154,10 @@ export default async function handler(
 		} else if (sourceType === "gitea") {
 			const branchName = extractBranchName(req.headers, req.body);
 
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
-			);
+			const normalizedCommits =
+				req.body?.commits?.flatMap(
+					(commit: any) => commit.modified,
+				) || [];
 
 			const shouldDeployPaths = shouldDeploy(
 				composeResult.watchPaths,

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -214,11 +214,13 @@ export default async function handler(
 			const deploymentHash = extractHash(req.headers, req.body);
 			const owner = githubBody?.repository?.owner?.name;
 			const normalizedCommits =
-				githubBody?.commits?.flatMap((commit: any) => [
+				githubBody?.commits
+					?.flatMap((commit: any) => [
 						...(commit.modified || []),
 						...(commit.added || []),
 						...(commit.removed || []),
-					]).filter(Boolean) || [];
+					])
+					.filter(Boolean) || [];
 
 			const apps = await db.query.applications.findMany({
 				where: and(

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -213,9 +213,10 @@ export default async function handler(
 			const deploymentTitle = extractCommitMessage(req.headers, req.body);
 			const deploymentHash = extractHash(req.headers, req.body);
 			const owner = githubBody?.repository?.owner?.name;
-			const normalizedCommits = githubBody?.commits?.flatMap(
-				(commit: any) => commit.modified,
-			);
+			const normalizedCommits =
+				githubBody?.commits?.flatMap(
+					(commit: any) => commit.modified,
+				) || [];
 
 			const apps = await db.query.applications.findMany({
 				where: and(

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -214,9 +214,7 @@ export default async function handler(
 			const deploymentHash = extractHash(req.headers, req.body);
 			const owner = githubBody?.repository?.owner?.name;
 			const normalizedCommits =
-				githubBody?.commits?.flatMap(
-					(commit: any) => commit.modified,
-				) || [];
+				githubBody?.commits?.flatMap((commit: any) => commit.modified) || [];
 
 			const apps = await db.query.applications.findMany({
 				where: and(

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -214,7 +214,11 @@ export default async function handler(
 			const deploymentHash = extractHash(req.headers, req.body);
 			const owner = githubBody?.repository?.owner?.name;
 			const normalizedCommits =
-				githubBody?.commits?.flatMap((commit: any) => commit.modified) || [];
+				githubBody?.commits?.flatMap((commit: any) => [
+						...(commit.modified || []),
+						...(commit.added || []),
+						...(commit.removed || []),
+					]).filter(Boolean) || [];
 
 			const apps = await db.query.applications.findMany({
 				where: and(


### PR DESCRIPTION
## What is this PR about?

When a webhook fires with an undefined or missing `commits` array and watch paths are configured, `flatMap` on `undefined` crashes the handler. This adds `|| []` fallback to all `normalizedCommits` assignments in both the compose and github webhook handlers so `shouldDeploy` receives an empty array instead of crashing.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4081

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly patches the `commits?.flatMap(...) || []` crash in the compose and GitHub webhook handlers. However, the identical bug remains in the main application webhook handler (`apps/dokploy/pages/api/deploy/[refreshToken].ts`), which was not modified by this PR — that file has the same unguarded `flatMap` pattern at six call sites that can still crash when `commits` is absent and `watchPaths` are configured.

<h3>Confidence Score: 4/5</h3>

Safe to merge for compose and GitHub handler paths, but the same crash still exists in the main application webhook handler.

The two fixed files are correct, but the main [refreshToken].ts handler — which handles the majority of individual application webhooks — still has the exact same unfixed bug at multiple call sites. This is a P1 regression risk for any application using watch paths.

apps/dokploy/pages/api/deploy/[refreshToken].ts — contains six unfixed instances of the same `commits?.flatMap(...)` crash pattern.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/pages/api/deploy/[refreshToken].ts`, line 113-115 ([link](https://github.com/dokploy/dokploy/blob/36e131cf1249f97efc2aef59de71af9af4cc4a04/apps/dokploy/pages/api/deploy/[refreshToken].ts#L113-L115)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Same crash not fixed in main application handler**

   The `flatMap` on `commits` can still return `undefined` when the commits array is absent in the webhook payload, which is then passed directly to `shouldDeploy` — crashing micromatch whenever `watchPaths` are configured. This same pattern appears at five other locations in this file: lines 144, 148, 152, and 156 (inside the `sourceType === "git"` block for each provider), lines 173–175 (`gitlab`), and lines 219–221 (`gitea`). All need the same `|| []` fallback added.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/36e131cf1249f97efc2aef59de71af9af4cc4a04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27407537)</sub>

<!-- /greptile_comment -->