### PR TITLE
fix: replace deprecated Slack actions with mrkdwn link field

### DIFF
--- a/packages/server/src/utils/notifications/build-error.ts
+++ b/packages/server/src/utils/notifications/build-error.ts
@@ -240,14 +240,13 @@ export const sendBuildErrorNotifications = async ({
 									value: `\`\`\`${errorMessage}\`\`\``,
 									short: false,
 								},
-							],
-							actions: [
 								{
-									type: "button",
-									text: "View Build Details",
-									url: buildLink,
+									title: "Details",
+									value: `<${buildLink}|View Build Details>`,
+									short: false,
 								},
 							],
+							mrkdwn_in: ["fields"],
 						},
 					],
 				});

--- a/packages/server/src/utils/notifications/build-success.ts
+++ b/packages/server/src/utils/notifications/build-success.ts
@@ -256,14 +256,13 @@ export const sendBuildSuccessNotifications = async ({
 									value: date.toLocaleString(),
 									short: true,
 								},
-							],
-							actions: [
 								{
-									type: "button",
-									text: "View Build Details",
-									url: buildLink,
+									title: "Details",
+									value: `<${buildLink}|View Build Details>`,
+									short: false,
 								},
 							],
+							mrkdwn_in: ["fields"],
 						},
 					],
 				});


### PR DESCRIPTION
## What is this PR about?

The `actions` array in Slack attachments requires Interactive Components to be configured on the Slack app, which causes notifications to fail silently. This replaces the deprecated `actions` buttons with a Details field using Slack mrkdwn hyperlink syntax (`<url|text>`) and adds `mrkdwn_in: ["fields"]` so the link renders as clickable.

Supersedes #4054 (same fix but with the missing `mrkdwn_in` that PR lacked).

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4053

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Slack build notifications by replacing the deprecated `actions` button array (which requires Interactive Components to be configured on the Slack app) with a `Details` field using Slack mrkdwn hyperlink syntax (`<url|text>`), and adds `mrkdwn_in: ["fields"]` to enable link rendering. The fix is applied consistently in both `build-error.ts` and `build-success.ts`; no other notification files used the deprecated pattern.

<h3>Confidence Score: 5/5</h3>

Safe to merge — fixes silent Slack notification failures with no regression risk.

The change is minimal, targeted, and correct. Both changed files are updated consistently with proper Slack mrkdwn field syntax (`<url|text>`) and the required `mrkdwn_in: ["fields"]` property. No P0/P1 issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: replace deprecated Slack actions wi..."](https://github.com/dokploy/dokploy/commit/6cde04ea39ca89ec5784565e9332f91c7f857cfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27407741)</sub>

<!-- /greptile_comment -->