### PR TITLE
fix: correct permission checks for compose loadServices and env editing

### DIFF
--- a/apps/dokploy/components/dashboard/application/environment/show-environment.tsx
+++ b/apps/dokploy/components/dashboard/application/environment/show-environment.tsx
@@ -56,17 +56,17 @@ export const ShowEnvironment = ({ id, type }: Props) => {
 	const [isEnvVisible, setIsEnvVisible] = useState(true);
 
 	const mutationMap = {
-		compose: () => api.compose.update.useMutation(),
-		libsql: () => api.libsql.update.useMutation(),
-		mariadb: () => api.mariadb.update.useMutation(),
-		mongo: () => api.mongo.update.useMutation(),
-		mysql: () => api.mysql.update.useMutation(),
-		postgres: () => api.postgres.update.useMutation(),
-		redis: () => api.redis.update.useMutation(),
+		compose: () => api.compose.saveEnvironment.useMutation(),
+		libsql: () => api.libsql.saveEnvironment.useMutation(),
+		mariadb: () => api.mariadb.saveEnvironment.useMutation(),
+		mongo: () => api.mongo.saveEnvironment.useMutation(),
+		mysql: () => api.mysql.saveEnvironment.useMutation(),
+		postgres: () => api.postgres.saveEnvironment.useMutation(),
+		redis: () => api.redis.saveEnvironment.useMutation(),
 	};
 	const { mutateAsync, isPending } = mutationMap[type]
 		? mutationMap[type]()
-		: api.mongo.update.useMutation();
+		: api.mongo.saveEnvironment.useMutation();
 
 	const form = useForm<EnvironmentSchema>({
 		defaultValues: {

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -61,6 +61,7 @@ import {
 	apiFindCompose,
 	apiRandomizeCompose,
 	apiRedeployCompose,
+	apiSaveEnvironmentVariablesCompose,
 	apiUpdateCompose,
 	compose as composeTable,
 	environments,
@@ -201,6 +202,31 @@ export const composeRouter = createTRPCRouter({
 			});
 			return updated;
 		}),
+	saveEnvironment: protectedProcedure
+		.input(apiSaveEnvironmentVariablesCompose)
+		.mutation(async ({ input, ctx }) => {
+			await checkServicePermissionAndAccess(ctx, input.composeId, {
+				envVars: ["write"],
+			});
+			const updated = await updateCompose(input.composeId, {
+				env: input.env,
+			});
+
+			if (!updated) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error adding environment variables",
+				});
+			}
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "compose",
+				resourceId: input.composeId,
+				resourceName: updated?.name,
+			});
+			return true;
+		}),
 	delete: protectedProcedure
 		.input(apiDeleteCompose)
 		.mutation(async ({ input, ctx }) => {
@@ -290,7 +316,7 @@ export const composeRouter = createTRPCRouter({
 		.input(apiFetchServices)
 		.query(async ({ input, ctx }) => {
 			await checkServicePermissionAndAccess(ctx, input.composeId, {
-				service: ["create"],
+				service: ["read"],
 			});
 			return await loadServices(input.composeId, input.type);
 		}),

--- a/packages/server/src/db/schema/compose.ts
+++ b/packages/server/src/db/schema/compose.ts
@@ -225,6 +225,13 @@ export const apiUpdateCompose = createSchema
 	})
 	.omit({ serverId: true });
 
+export const apiSaveEnvironmentVariablesCompose = createSchema
+	.pick({
+		composeId: true,
+		env: true,
+	})
+	.required();
+
 export const apiRandomizeCompose = createSchema
 	.pick({
 		composeId: true,


### PR DESCRIPTION
## Summary

Fixes #4052

- **`compose.loadServices`** required `service: ["create"]` but it's a read-only operation (parses YAML and returns service names). Changed to `service: ["read"]`.
- **Environment editing** on database/compose services used the generic `update` mutation which requires `service: ["create"]`. All database routers already had `saveEnvironment` endpoints with correct `envVars: ["write"]` permission, but compose was missing one. Added `compose.saveEnvironment` and updated the frontend to use `saveEnvironment` for all service types.

### Changes

1. `packages/server/src/db/schema/compose.ts` — Added `apiSaveEnvironmentVariablesCompose` input schema
2. `apps/dokploy/server/api/routers/compose.ts` — Changed `loadServices` permission to `service: ["read"]`, added `saveEnvironment` endpoint with `envVars: ["write"]`
3. `apps/dokploy/components/dashboard/application/environment/show-environment.tsx` — Updated all mutation calls from `.update` to `.saveEnvironment`

## Test plan

- [ ] Create a member user without "Create Services" permission but with project access
- [ ] Verify the member can load compose service names in the domain form dropdown
- [ ] Verify the member can edit and save environment variables on compose services
- [ ] Verify the member can edit and save environment variables on database services (postgres, mysql, mariadb, redis, mongo)
- [ ] Verify that users with full permissions can still update services normally via the `update` mutation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two permission check bugs for compose services and refactors environment variable saving to use purpose-specific endpoints across all service types.

- **`compose.loadServices`** had `service: ["create"]` permission but is a purely read-only operation (parses YAML and returns service names). Correctly changed to `service: ["read"]`.
- **`compose.saveEnvironment`** is a new endpoint added with `envVars: ["write"]` permission, following the exact same pattern already established for all other service types (`mongo`, `postgres`, `redis`, etc.). Previously, compose was the only service type missing this endpoint, meaning environment variable saves for compose went through the generic `.update` mutation which incorrectly required `service: ["create"]` permission.
- **`show-environment.tsx`** is updated to call `.saveEnvironment` (instead of `.update`) for all 7 service types in the mutation map, so members with `envVars.write` but without `service.create` can now save environment variables on any service type.
- The new `apiSaveEnvironmentVariablesCompose` schema in `compose.ts` is minimal and follows the exact same pattern as `apiSaveEnvironmentVariablesMongo` and its siblings.
- The `saveEnvironment` endpoint correctly fires an audit event and throws a `BAD_REQUEST` error if the update returns nothing, consistent with all other service `saveEnvironment` implementations.

<h3>Confidence Score: 5/5</h3>

Safe to merge — focused permission fix with no behavioural regressions for existing users.

All three changes are minimal, correct, and consistent with established patterns in the codebase. The new `saveEnvironment` endpoint mirrors every other service's implementation exactly. The `loadServices` permission change is semantically correct (read-only operation now requires read permission). No logic errors, security regressions, or unhandled edge cases were found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: correct permission checks for compo..."](https://github.com/dokploy/dokploy/commit/91b44720ef045a48bba9bdc5407a3013e6c9a294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27408054)</sub>

<!-- /greptile_comment -->