### PR TITLE
fix: surface actual error message in ntfy test connection

### DIFF
--- a/apps/dokploy/server/api/routers/notification.ts
+++ b/apps/dokploy/server/api/routers/notification.ts
@@ -677,7 +677,10 @@ export const notificationRouter = createTRPCRouter({
 			} catch (error) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
-					message: "Error testing the notification",
+					message:
+						error instanceof Error
+							? `Error testing the notification: ${error.message}`
+							: "Error testing the notification",
 					cause: error,
 				});
 			}


### PR DESCRIPTION
## Summary
- The ntfy test connection catch block was returning a generic `"Error testing the notification"` message, hiding the actual error from the ntfy server (SSL, DNS, auth, etc.)
- Now includes the underlying error message in the tRPC response so users can actually diagnose the issue

Closes #4047

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `testNtfyConnection` tRPC mutation to surface the underlying error message (SSL, DNS, auth, etc.) instead of the generic `\"Error testing the notification\"` fallback, directly addressing issue #4047. The change is minimal, correct, and non-breaking.

- The fix is valid and safe to merge
- 10 other notification test handlers (`testTelegramConnection`, `testGotifyConnection`, `testMattermostConnection`, `testLarkConnection`, `testPushoverConnection`, and more) still swallow the real error behind the same generic message
- `testSlackConnection` already surfaces errors but uses a different format (no `\"Error testing...\"` prefix, `\"Unknown error\"` fallback), creating a minor inconsistency across handlers

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a small, targeted improvement to error reporting with no functional risk.

The change is correct and non-breaking. The only concern is incomplete coverage (other handlers still use generic messages), but this does not block the fix from being merged.

No files require special attention; the single changed file (notification.ts) contains the complete, self-contained fix.

<sub>Reviews (1): Last reviewed commit: ["fix: surface actual error message in ntf..."](https://github.com/dokploy/dokploy/commit/ac65cc97f4e41cbfa0f99bb32d304668de0fe41c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27408608)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->