### PR TITLE
feat: add tooltip to Daily Docker Cleanup toggle

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
@@ -69,11 +69,10 @@ export const ToggleDockerCleanup = ({ serverId }: Props) => {
 					</TooltipTrigger>
 					<TooltipContent side="top" className="max-w-sm">
 						<p>
-							Runs a full Docker cleanup daily, pruning stopped
-							containers, unused images, volumes, build cache, and
-							system resources. This may remove images built for
-							Compose services that run on-demand (backup runners,
-							cron jobs, one-off tasks).
+							Runs a full Docker cleanup daily, pruning stopped containers,
+							unused images, volumes, build cache, and system resources. This
+							may remove images built for Compose services that run on-demand
+							(backup runners, cron jobs, one-off tasks).
 						</p>
 						<p className="mt-1">
 							For custom cleanup strategies, use{" "}

--- a/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
@@ -1,7 +1,14 @@
-import { toast } from "sonner";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { api } from "@/utils/api";
+import { HelpCircle } from "lucide-react";
+import { toast } from "sonner";
 
 interface Props {
 	serverId?: string;
@@ -52,7 +59,37 @@ export const ToggleDockerCleanup = ({ serverId }: Props) => {
 	return (
 		<div className="flex items-center gap-4">
 			<Switch checked={!!enabled} onCheckedChange={handleToggle} />
-			<Label className="text-primary">Daily Docker Cleanup</Label>
+			<TooltipProvider delayDuration={0}>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Label className="text-primary flex items-center gap-1.5 cursor-pointer">
+							Daily Docker Cleanup
+							<HelpCircle className="size-4 text-muted-foreground" />
+						</Label>
+					</TooltipTrigger>
+					<TooltipContent side="top" className="max-w-sm">
+						<p>
+							Runs a full Docker cleanup daily, pruning stopped
+							containers, unused images, volumes, build cache, and
+							system resources. This may remove images built for
+							Compose services that run on-demand (backup runners,
+							cron jobs, one-off tasks).
+						</p>
+						<p className="mt-1">
+							For custom cleanup strategies, use{" "}
+							<a
+								href="https://docs.dokploy.com/docs/core/schedule-jobs#example-1-automatic-docker-cleanup"
+								target="_blank"
+								rel="noopener noreferrer"
+								className="underline text-primary"
+							>
+								Schedule Jobs
+							</a>{" "}
+							on your web server or remote servers.
+						</p>
+					</TooltipContent>
+				</Tooltip>
+			</TooltipProvider>
 		</div>
 	);
 };


### PR DESCRIPTION
## What is this PR about?

Adds an informative tooltip to the "Daily Docker Cleanup" toggle explaining that it runs a full Docker cleanup (containers, images, volumes, build cache, system) and that this may remove images built for on-demand Compose services. Links to the Schedule Jobs documentation for users who want custom cleanup strategies.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3973

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a helpful informational tooltip to the "Daily Docker Cleanup" toggle, explaining its scope (pruning containers, images, volumes, build cache, and system resources) and warning about potential side effects for on-demand Compose services. It also provides a link to the Schedule Jobs documentation for users who need custom cleanup strategies. The implementation is clean, the tooltip text is clear, and the external link correctly uses `rel="noopener noreferrer"`.

- Tooltip text accurately describes the cleanup behavior and its tradeoffs
- External documentation link uses `target="_blank"` and `rel="noopener noreferrer"` correctly
- The `<a>` tag embedded inside `TooltipContent` violates the WAI-ARIA 1.2 spec (`role="tooltip"` must not contain interactive elements) and is unreachable by keyboard or screen-reader users — a `Popover` or a small inline link would be more accessible

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is purely additive and cosmetic with no logic modifications

Score of 4 reflects that the change is isolated to one component, touches no business logic, and the single concern (interactive link inside a tooltip role) is a best-practice accessibility issue that does not break functionality for mouse users. It does make the embedded documentation link unreachable to keyboard-only users, which is worth addressing but is not a blocker.

apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx — interactive `<a>` inside `TooltipContent`

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/ebbc008dbef25b7f87e2ef67e67987ccdcf1dcf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27415604)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->