### PR TITLE
fix: start server listener before initialization to prevent healthcheck failures

### DIFF
--- a/apps/dokploy/server/server.ts
+++ b/apps/dokploy/server/server.ts
@@ -56,6 +56,8 @@ void app.prepare().then(async () => {
 			setupDockerStatsMonitoringSocketServer(server);
 		}
 
+		server.listen(PORT, HOST);
+		console.log(`Server Started on: http://${HOST}:${PORT}`);
 		if (process.env.NODE_ENV === "production" && !IS_CLOUD) {
 			createDefaultMiddlewares();
 			await initializeNetwork();
@@ -65,9 +67,6 @@ void app.prepare().then(async () => {
 			await initVolumeBackupsCronJobs();
 			await sendDokployRestartNotifications();
 		}
-
-		server.listen(PORT, HOST);
-		console.log(`Server Started on: http://${HOST}:${PORT}`);
 		await initEnterpriseBackupCronJobs();
 
 		if (!IS_CLOUD) {


### PR DESCRIPTION
## Summary
- Moves `server.listen()` before the initialization block so the HTTP server responds to healthchecks immediately
- Previously, slow operations like SMTP timeouts in `sendDokployRestartNotifications()` blocked the server from listening, causing Docker healthcheck failures and container restarts

Closes #4049

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves `server.listen()` before the production initialization block so the HTTP server can respond to Docker healthchecks (`/api/trpc/settings.health`) immediately after `app.prepare()`, rather than waiting for potentially slow operations like SMTP timeouts in `sendDokployRestartNotifications()` to complete.

The ordering is safe: all WebSocket handlers are still registered before `server.listen()`; `createDefaultMiddlewares()` is a synchronous filesystem-only write (no coupling to the HTTP server object); all init functions have internal error handling; and the health endpoint depends only on the DB connection, not on any of the deferred init steps.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the reordering is correct and solves a real production reliability issue with no regressions.

No P0 or P1 findings. WebSocket setup remains before listen(), createDefaultMiddlewares() is synchronous and filesystem-only, all init functions are internally fault-tolerant, and the healthcheck endpoint is independent of the deferred init work.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: start server listener before initia..."](https://github.com/dokploy/dokploy/commit/cc74f9e38cc0cc54b35f8372b4b8da422372d37f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27416234)</sub>

<!-- /greptile_comment -->