### PR TITLE
fix: allow members to use SSH keys for deployments without full access

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -55,7 +55,7 @@ interface Props {
 
 export const SaveGitProvider = ({ applicationId }: Props) => {
 	const { data, refetch } = api.application.one.useQuery({ applicationId });
-	const { data: sshKeys } = api.sshKey.all.useQuery();
+	const { data: sshKeys } = api.sshKey.allForApps.useQuery();
 	const router = useRouter();
 
 	const { mutateAsync, isPending } =

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
@@ -55,7 +55,7 @@ interface Props {
 
 export const SaveGitProviderCompose = ({ composeId }: Props) => {
 	const { data, refetch } = api.compose.one.useQuery({ composeId });
-	const { data: sshKeys } = api.sshKey.all.useQuery();
+	const { data: sshKeys } = api.sshKey.allForApps.useQuery();
 	const router = useRouter();
 
 	const { mutateAsync, isPending } = api.compose.update.useMutation();

--- a/apps/dokploy/server/api/routers/ssh-key.ts
+++ b/apps/dokploy/server/api/routers/ssh-key.ts
@@ -8,7 +8,11 @@ import {
 import { db } from "@dokploy/server/db";
 import { TRPCError } from "@trpc/server";
 import { desc, eq } from "drizzle-orm";
-import { createTRPCRouter, withPermission } from "@/server/api/trpc";
+import {
+	createTRPCRouter,
+	protectedProcedure,
+	withPermission,
+} from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
 import {
 	apiCreateSshKey,
@@ -79,6 +83,16 @@ export const sshRouter = createTRPCRouter({
 		}),
 	all: withPermission("sshKeys", "read").query(async ({ ctx }) => {
 		return await db.query.sshKeys.findMany({
+			where: eq(sshKeys.organizationId, ctx.session.activeOrganizationId),
+			orderBy: desc(sshKeys.createdAt),
+		});
+	}),
+	allForApps: protectedProcedure.query(async ({ ctx }) => {
+		return await db.query.sshKeys.findMany({
+			columns: {
+				sshKeyId: true,
+				name: true,
+			},
 			where: eq(sshKeys.organizationId, ctx.session.activeOrganizationId),
 			orderBy: desc(sshKeys.createdAt),
 		});


### PR DESCRIPTION
## What is this PR about?

Members couldn't use admin-managed SSH keys for git-based deployments without having `Access to SSH Keys` permission, which also exposed the SSH Keys management panel. This was a regression introduced in v0.28.7 with the new RBAC system.

Added a new `allForApps` endpoint in the SSH key router that uses `protectedProcedure` (authenticated only, no permission check) and returns only `sshKeyId` and `name`. The git provider dropdowns now use this endpoint instead of `all`, so members can select SSH keys for their apps without needing access to the SSH Keys management panel.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4069

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `allForApps` tRPC endpoint on the SSH key router using `protectedProcedure` (authentication only, no permission check) that returns only `sshKeyId` and `name`, scoped to the caller's active organization. Both git-provider dropdowns switch from `sshKey.all` to `sshKey.allForApps`, restoring the ability for members to select SSH keys for deployments without the SSH Keys management permission.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the fix is minimal, correct, and does not expose any sensitive SSH key material.

The new endpoint is properly scoped by organizationId (matching the existing `all` endpoint pattern), returns only non-sensitive fields (id and name, no private key material), and requires authentication via protectedProcedure. No P0 or P1 issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: allow members to use SSH keys for d..."](https://github.com/dokploy/dokploy/commit/343514d4ebccb5e27c1a31aa9a603be9589cb9a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27417336)</sub>

<!-- /greptile_comment -->