### PR TITLE
feat: add FTP and SFTP support for backup destinations

### DIFF
--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -43,12 +43,13 @@ import { S3_PROVIDERS } from "./constants";
 
 const addDestination = z.object({
 	name: z.string().min(1, "Name is required"),
-	provider: z.string().min(1, "Provider is required"),
-	accessKeyId: z.string().min(1, "Access Key Id is required"),
-	secretAccessKey: z.string().min(1, "Secret Access Key is required"),
-	bucket: z.string().min(1, "Bucket is required"),
-	region: z.string(),
-	endpoint: z.string().min(1, "Endpoint is required"),
+	destinationType: z.enum(["s3", "ftp", "sftp"]).default("s3"),
+	provider: z.string().optional(),
+	accessKeyId: z.string().min(1, "Username / Access Key is required"),
+	secretAccessKey: z.string().min(1, "Password / Secret Key is required"),
+	bucket: z.string().optional(),
+	region: z.string().optional(),
+	endpoint: z.string().min(1, "Host / Endpoint is required"),
 	serverId: z.string().optional(),
 	additionalFlags: z
 		.array(
@@ -96,6 +97,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 
 	const form = useForm<AddDestination>({
 		defaultValues: {
+			destinationType: "s3",
 			provider: "",
 			accessKeyId: "",
 			bucket: "",
@@ -113,10 +115,17 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		name: "additionalFlags",
 	});
 
+	const destinationType = form.watch("destinationType");
+	const isS3 = destinationType === "s3";
+	const isFTP = destinationType === "ftp";
+	const isSFTP = destinationType === "sftp";
+
 	useEffect(() => {
 		if (destination) {
 			form.reset({
 				name: destination.name,
+				destinationType:
+					(destination.destinationType as "s3" | "ftp" | "sftp") ?? "s3",
 				provider: destination.provider || "",
 				accessKeyId: destination.accessKey,
 				secretAccessKey: destination.secretAccessKey,
@@ -135,12 +144,13 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		await mutateAsync({
 			provider: data.provider || "",
 			accessKey: data.accessKeyId,
-			bucket: data.bucket,
+			bucket: data.bucket || "",
 			endpoint: data.endpoint,
 			name: data.name,
-			region: data.region,
+			region: data.region || "",
 			secretAccessKey: data.secretAccessKey,
 			destinationId: destinationId || "",
+			destinationType: data.destinationType,
 			additionalFlags: data.additionalFlags?.map((f) => f.value) ?? [],
 		})
 			.then(async () => {
@@ -163,10 +173,8 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 
 	const handleTestConnection = async (serverId?: string) => {
 		const result = await form.trigger([
-			"provider",
 			"accessKeyId",
 			"secretAccessKey",
-			"bucket",
 			"endpoint",
 			"additionalFlags",
 		]);
@@ -195,18 +203,18 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		const bucket = form.getValues("bucket");
 		const endpoint = form.getValues("endpoint");
 		const region = form.getValues("region");
-
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
+		const type = form.getValues("destinationType");
 
 		await testConnection({
-			provider,
+			provider: provider || "",
 			accessKey,
-			bucket,
+			bucket: bucket || "",
 			endpoint,
 			name: "Test",
-			region,
+			region: region || "",
 			secretAccessKey: secretKey,
 			serverId,
+			destinationType: type,
 			additionalFlags:
 				form.getValues("additionalFlags")?.map((f) => f.value) ?? [],
 		})
@@ -214,8 +222,8 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 				toast.success("Connection Success");
 			})
 			.catch((e) => {
-				toast.error("Error connecting to provider", {
-					description: `${e.message}\n\nTry manually: rclone ls ${connectionString}`,
+				toast.error("Error connecting to destination", {
+					description: e.message,
 				});
 			});
 	};
@@ -269,7 +277,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 									<FormItem>
 										<FormLabel>Name</FormLabel>
 										<FormControl>
-											<Input placeholder={"S3 Bucket"} {...field} />
+											<Input placeholder={"My Backup Destination"} {...field} />
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -278,39 +286,69 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 						/>
 						<FormField
 							control={form.control}
-							name="provider"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Provider</FormLabel>
-										<FormControl>
-											<Select
-												onValueChange={field.onChange}
-												defaultValue={field.value}
-												value={field.value}
-											>
-												<FormControl>
-													<SelectTrigger>
-														<SelectValue placeholder="Select a S3 Provider" />
-													</SelectTrigger>
-												</FormControl>
-												<SelectContent>
-													{S3_PROVIDERS.map((s3Provider) => (
-														<SelectItem
-															key={s3Provider.key}
-															value={s3Provider.key}
-														>
-															{s3Provider.name}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
+							name="destinationType"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Destination Type</FormLabel>
+									<FormControl>
+										<Select
+											onValueChange={field.onChange}
+											defaultValue={field.value}
+											value={field.value}
+										>
+											<FormControl>
+												<SelectTrigger>
+													<SelectValue placeholder="Select destination type" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value="s3">S3 / Object Storage</SelectItem>
+												<SelectItem value="ftp">FTP</SelectItem>
+												<SelectItem value="sftp">SFTP</SelectItem>
+											</SelectContent>
+										</Select>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
 						/>
+						{isS3 && (
+							<FormField
+								control={form.control}
+								name="provider"
+								render={({ field }) => {
+									return (
+										<FormItem>
+											<FormLabel>Provider</FormLabel>
+											<FormControl>
+												<Select
+													onValueChange={field.onChange}
+													defaultValue={field.value}
+													value={field.value}
+												>
+													<FormControl>
+														<SelectTrigger>
+															<SelectValue placeholder="Select a S3 Provider" />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														{S3_PROVIDERS.map((s3Provider) => (
+															<SelectItem
+																key={s3Provider.key}
+																value={s3Provider.key}
+															>
+																{s3Provider.name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									);
+								}}
+							/>
+						)}
 
 						<FormField
 							control={form.control}
@@ -318,9 +356,12 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => {
 								return (
 									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
+										<FormLabel>{isS3 ? "Access Key Id" : "Username"}</FormLabel>
 										<FormControl>
-											<Input placeholder={"xcas41dasde"} {...field} />
+											<Input
+												placeholder={isS3 ? "xcas41dasde" : "user"}
+												{...field}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -333,10 +374,16 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
+										<FormLabel>
+											{isS3 ? "Secret Access Key" : "Password"}
+										</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"asd123asdasw"} {...field} />
+										<Input
+											placeholder={isS3 ? "asd123asdasw" : "••••••••"}
+											type={isS3 ? "text" : "password"}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -348,10 +395,15 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
+										<FormLabel>
+											{isS3 ? "Bucket" : "Remote Path (Optional)"}
+										</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"dokploy-bucket"} {...field} />
+										<Input
+											placeholder={isS3 ? "dokploy-bucket" : "/backups"}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -363,10 +415,13 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
+										<FormLabel>{isS3 ? "Region" : "Port"}</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"us-east-1"} {...field} />
+										<Input
+											placeholder={isS3 ? "us-east-1" : isFTP ? "21" : "22"}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -377,10 +432,16 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							name="endpoint"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
+									<FormLabel>{isS3 ? "Endpoint" : "Host"}</FormLabel>
 									<FormControl>
 										<Input
-											placeholder={"https://us.bucket.aws/s3"}
+											placeholder={
+												isS3
+													? "https://us.bucket.aws/s3"
+													: isFTP
+														? "ftp.example.com"
+														: "sftp.example.com"
+											}
 											{...field}
 										/>
 									</FormControl>

--- a/apps/dokploy/drizzle/0165_purple_war_machine.sql
+++ b/apps/dokploy/drizzle/0165_purple_war_machine.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "destination" ADD COLUMN "destinationType" text DEFAULT 's3' NOT NULL;

--- a/apps/dokploy/drizzle/meta/_journal.json
+++ b/apps/dokploy/drizzle/meta/_journal.json
@@ -1156,6 +1156,13 @@
       "when": 1775369858244,
       "tag": "0164_slippery_sasquatch",
       "breakpoints": true
+    },
+    {
+      "idx": 165,
+      "version": "7",
+      "when": 1744000000000,
+      "tag": "0165_purple_war_machine",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -55,28 +55,62 @@ export const destinationRouter = createTRPCRouter({
 				accessKey,
 				provider,
 				additionalFlags,
+				destinationType,
 			} = input;
+			const type = destinationType ?? "s3";
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
+				let rcloneCommand: string;
+
+				if (type === "ftp") {
+					const port = region || "21";
+					const flags = [
+						`--ftp-host="${endpoint}"`,
+						`--ftp-port="${port}"`,
+						`--ftp-user="${accessKey}"`,
+						`--ftp-pass="${secretAccessKey}"`,
+						"--retries 1",
+						"--low-level-retries 1",
+						"--timeout 10s",
+						"--contimeout 5s",
+					];
+					if (additionalFlags?.length) flags.push(...additionalFlags);
+					const base = bucket ? `${bucket}/` : "";
+					rcloneCommand = `rclone ls ${flags.join(" ")} ":ftp:${base}"`;
+				} else if (type === "sftp") {
+					const port = region || "22";
+					const flags = [
+						`--sftp-host="${endpoint}"`,
+						`--sftp-port="${port}"`,
+						`--sftp-user="${accessKey}"`,
+						"--retries 1",
+						"--low-level-retries 1",
+						"--timeout 10s",
+						"--contimeout 5s",
+					];
+					if (additionalFlags?.length) flags.push(...additionalFlags);
+					const base = bucket ? `${bucket}/` : "";
+					rcloneCommand = `SFTP_PASS=$(rclone obscure "${secretAccessKey}") && rclone ls ${flags.join(" ")} --sftp-pass="$SFTP_PASS" ":sftp:${base}"`;
+				} else {
+					const rcloneFlags = [
+						`--s3-access-key-id="${accessKey}"`,
+						`--s3-secret-access-key="${secretAccessKey}"`,
+						`--s3-region="${region}"`,
+						`--s3-endpoint="${endpoint}"`,
+						"--s3-no-check-bucket",
+						"--s3-force-path-style",
+						"--retries 1",
+						"--low-level-retries 1",
+						"--timeout 10s",
+						"--contimeout 5s",
+					];
+					if (provider) {
+						rcloneFlags.unshift(`--s3-provider="${provider}"`);
+					}
+					if (additionalFlags?.length) {
+						rcloneFlags.push(...additionalFlags);
+					}
+					rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} ":s3:${bucket}"`;
 				}
-				if (additionalFlags?.length) {
-					rcloneFlags.push(...additionalFlags);
-				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
@@ -88,7 +122,7 @@ export const destinationRouter = createTRPCRouter({
 				if (IS_CLOUD) {
 					await execAsyncRemote(input.serverId || "", rcloneCommand);
 				} else {
-					await execAsync(rcloneCommand);
+					await execAsync(rcloneCommand, { shell: "/bin/bash" });
 				}
 			} catch (error) {
 				throw new TRPCError({
@@ -96,7 +130,7 @@ export const destinationRouter = createTRPCRouter({
 					message:
 						error instanceof Error
 							? error?.message
-							: "Error connecting to bucket",
+							: "Error connecting to destination",
 					cause: error,
 				});
 			}

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -23,6 +23,7 @@ export const destinations = pgTable("destination", {
 	region: text("region").notNull(),
 	endpoint: text("endpoint").notNull(),
 	additionalFlags: text("additionalFlags").array(),
+	destinationType: text("destinationType").notNull().default("s3"),
 	organizationId: text("organizationId")
 		.notNull()
 		.references(() => organization.id, { onDelete: "cascade" }),
@@ -49,6 +50,7 @@ const createSchema = createInsertSchema(destinations, {
 	endpoint: z.string(),
 	secretAccessKey: z.string(),
 	region: z.string(),
+	destinationType: z.enum(["s3", "sftp", "ftp"]).default("s3"),
 	additionalFlags: z
 		.array(z.string().regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR))
 		.default([]),
@@ -64,6 +66,7 @@ export const apiCreateDestination = createSchema
 		endpoint: true,
 		secretAccessKey: true,
 		additionalFlags: true,
+		destinationType: true,
 	})
 	.required()
 	.extend({
@@ -91,6 +94,7 @@ export const apiUpdateDestination = createSchema
 		destinationId: true,
 		provider: true,
 		additionalFlags: true,
+		destinationType: true,
 	})
 	.required()
 	.extend({

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -9,9 +9,10 @@ import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
+	buildRcloneUploadCommand,
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "./utils";
 
@@ -34,9 +35,14 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneDestination = getDestinationPath(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = buildRcloneUploadCommand(
+			destination,
+			rcloneDestination,
+		);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -10,7 +10,13 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import {
+	getDestinationCredentials,
+	getDestinationPath,
+	getSFTPCredentials,
+	normalizeS3Path,
+	scheduleBackup,
+} from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -131,24 +137,38 @@ export const keepLatestNBackups = async (
 	if (!backup.keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(backup.destination);
+		const destination = backup.destination;
+		const type = destination.destinationType ?? "s3";
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${backup.destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
-
-		// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
-		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;
+		const subPath = `${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = getDestinationPath(destination, subPath);
+		const includePattern = `*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}`;
 		// when we pipe the above command with this one, we only get the list of files we want to delete
 		const sortAndPickUnwantedBackups = `sort -r | tail -n +$((${backup.keepLatestCount}+1)) | xargs -I{}`;
-		// this command deletes the files
-		// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
-		const rcloneDelete = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
 
-		const rcloneCommand = `${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
+		let rcloneCommand: string;
+		if (type === "sftp") {
+			const { flags, password } = getSFTPCredentials(destination);
+			const flagStr = flags.join(" ");
+			// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
+			const rcloneList = `rclone lsf ${flagStr} --sftp-pass="$SFTP_PASS" --include "${includePattern}" "${backupFilesPath}"`;
+			// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
+			const rcloneDelete = `rclone delete ${flagStr} --sftp-pass="$SFTP_PASS" "${backupFilesPath}{}"`;
+			rcloneCommand = `SFTP_PASS=$(rclone obscure "${password}") && ${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
+		} else {
+			const { flags } = getDestinationCredentials(destination);
+			const flagStr = flags.join(" ");
+			// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
+			const rcloneList = `rclone lsf ${flagStr} --include "${includePattern}" "${backupFilesPath}"`;
+			// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
+			const rcloneDelete = `rclone delete ${flagStr} "${backupFilesPath}{}"`;
+			rcloneCommand = `${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
+		}
 
 		if (serverId) {
 			await execAsyncRemote(serverId, rcloneCommand);
 		} else {
-			await execAsync(rcloneCommand);
+			await execAsync(rcloneCommand, { shell: "/bin/bash" });
 		}
 	} catch (error) {
 		console.error(error);

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -9,9 +9,10 @@ import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
+	buildRcloneUploadCommand,
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "./utils";
 
@@ -33,10 +34,14 @@ export const runLibsqlBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneDestination = getDestinationPath(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = buildRcloneUploadCommand(
+			destination,
+			rcloneDestination,
+		);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -9,9 +9,10 @@ import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
+	buildRcloneUploadCommand,
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "./utils";
 
@@ -32,9 +33,14 @@ export const runMariadbBackup = async (
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneDestination = getDestinationPath(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = buildRcloneUploadCommand(
+			destination,
+			rcloneDestination,
+		);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -9,9 +9,10 @@ import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
+	buildRcloneUploadCommand,
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "./utils";
 
@@ -29,9 +30,14 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneDestination = getDestinationPath(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = buildRcloneUploadCommand(
+			destination,
+			rcloneDestination,
+		);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -9,9 +9,10 @@ import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
+	buildRcloneUploadCommand,
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "./utils";
 
@@ -30,10 +31,14 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneDestination = getDestinationPath(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = buildRcloneUploadCommand(
+			destination,
+			rcloneDestination,
+		);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -9,9 +9,10 @@ import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
+	buildRcloneUploadCommand,
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "./utils";
 
@@ -33,10 +34,14 @@ export const runPostgresBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneDestination = getDestinationPath(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = buildRcloneUploadCommand(
+			destination,
+			rcloneDestination,
+		);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -89,6 +89,163 @@ export const getS3Credentials = (destination: Destination) => {
 	return rcloneFlags;
 };
 
+// For FTP destinations, accessKey=username, secretAccessKey=password,
+// endpoint=host, region=port, bucket=remote base path
+export const getFTPCredentials = (destination: Destination) => {
+	const { accessKey, secretAccessKey, region, endpoint } = destination;
+	const port = region || "21";
+	const rcloneFlags = [
+		`--ftp-host="${endpoint}"`,
+		`--ftp-port="${port}"`,
+		`--ftp-user="${accessKey}"`,
+		`--ftp-pass="${secretAccessKey}"`,
+	];
+
+	if (destination.additionalFlags?.length) {
+		rcloneFlags.push(...destination.additionalFlags);
+	}
+
+	return rcloneFlags;
+};
+
+// For SFTP destinations, accessKey=username, secretAccessKey=password,
+// endpoint=host, region=port, bucket=remote base path
+export const getSFTPCredentials = (destination: Destination) => {
+	const { accessKey, secretAccessKey, region, endpoint } = destination;
+	const port = region || "22";
+	const rcloneFlags = [
+		`--sftp-host="${endpoint}"`,
+		`--sftp-port="${port}"`,
+		`--sftp-user="${accessKey}"`,
+	];
+
+	if (destination.additionalFlags?.length) {
+		rcloneFlags.push(...destination.additionalFlags);
+	}
+
+	// SFTP password must be obscured via rclone; handled in getDestinationRcloneCommand
+	return { flags: rcloneFlags, password: secretAccessKey };
+};
+
+export const getDestinationCredentials = (destination: Destination) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "ftp") return { flags: getFTPCredentials(destination) };
+	if (type === "sftp") return getSFTPCredentials(destination);
+	return { flags: getS3Credentials(destination) };
+};
+
+// Returns the rclone remote path string for the given destination and sub-path
+export const getDestinationPath = (
+	destination: Destination,
+	subPath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	const base = destination.bucket ? `${destination.bucket}/` : "";
+	if (type === "ftp") return `:ftp:${base}${subPath}`;
+	if (type === "sftp") return `:sftp:${base}${subPath}`;
+	return `:s3:${destination.bucket}/${subPath}`;
+};
+
+// Builds the full rclone upload command, handling SFTP password obscuring
+export const buildRcloneUploadCommand = (
+	destination: Destination,
+	remotePath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone rcat ${flags.join(" ")} --sftp-pass="$SFTP_PASS" "${remotePath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone rcat ${flags.join(" ")} "${remotePath}"`;
+};
+
+// Builds the rclone list command for a remote path
+export const buildRcloneListCommand = (
+	destination: Destination,
+	remotePath: string,
+	includePattern: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone lsf ${flags.join(" ")} --sftp-pass="$SFTP_PASS" --include "${includePattern}" "${remotePath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone lsf ${flags.join(" ")} --include "${includePattern}" "${remotePath}"`;
+};
+
+// Builds the rclone delete command for a remote path
+export const buildRcloneDeleteCommand = (
+	destination: Destination,
+	remotePath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone delete ${flags.join(" ")} --sftp-pass="$SFTP_PASS" "${remotePath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone delete ${flags.join(" ")} "${remotePath}"`;
+};
+
+export const buildRcloneCopytoCommand = (
+	destination: Destination,
+	localPath: string,
+	remotePath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone copyto ${flags.join(" ")} --sftp-pass="$SFTP_PASS" "${localPath}" "${remotePath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone copyto ${flags.join(" ")} "${localPath}" "${remotePath}"`;
+};
+
+// Builds the rclone copyto command for downloading a file from remote to local
+export const buildRcloneDownloadCommand = (
+	destination: Destination,
+	remotePath: string,
+	localPath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone copyto ${flags.join(" ")} --sftp-pass="$SFTP_PASS" "${remotePath}" "${localPath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone copyto ${flags.join(" ")} "${remotePath}" "${localPath}"`;
+};
+
+// Builds the rclone cat command for reading a file (used in restore)
+export const buildRcloneCatCommand = (
+	destination: Destination,
+	remotePath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone cat ${flags.join(" ")} --sftp-pass="$SFTP_PASS" "${remotePath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone cat ${flags.join(" ")} "${remotePath}"`;
+};
+
+// Builds the rclone copy command for downloading a file (used in restore)
+export const buildRcloneCopyCommand = (
+	destination: Destination,
+	remotePath: string,
+) => {
+	const type = destination.destinationType ?? "s3";
+	if (type === "sftp") {
+		const { flags, password } = getSFTPCredentials(destination);
+		return `SFTP_PASS=$(rclone obscure "${password}") && rclone copy ${flags.join(" ")} --sftp-pass="$SFTP_PASS" "${remotePath}"`;
+	}
+	const { flags } = getDestinationCredentials(destination);
+	return `rclone copy ${flags.join(" ")} "${remotePath}"`;
+};
+
 export const getPostgresBackupCommand = (
 	database: string,
 	databaseUser: string,
@@ -289,16 +446,16 @@ export const getBackupCommand = (
 	}
 
 	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
+	echo "[$(date)] Starting upload to destination..." >> ${logPath};
 
 	# Run the upload command and capture the exit status
 	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
+		echo "[$(date)] ❌ Error: Upload to destination failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
 		exit 1;
 	}
 
-	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
+	echo "[$(date)] ✅ Upload to destination completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -11,14 +11,19 @@ import {
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { sendDokployBackupNotifications } from "../notifications/dokploy-backup";
 import { execAsync } from "../process/execAsync";
-import { getBackupTimestamp, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	buildRcloneCopytoCommand,
+	getBackupTimestamp,
+	getDestinationPath,
+	normalizeS3Path,
+} from "./utils";
 
 function formatBytes(bytes?: number) {
 	if (bytes === undefined) return "Unknown size";
 	if (bytes === 0) return "0 B";
 	const sizes = ["B", "KB", "MB", "GB", "TB"];
 	const i = Math.floor(Math.log(bytes) / Math.log(1024));
-	const value = bytes / Math.pow(1024, i);
+	const value = bytes / 1024 ** i;
 	return `${value.toFixed(2)} ${sizes[i]} (${bytes} bytes)`;
 }
 
@@ -36,12 +41,12 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 	let computedBackupSize: number | undefined;
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
 		const timestamp = getBackupTimestamp();
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const subPath = `${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const remotePath = getDestinationPath(destination, subPath);
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -98,10 +103,14 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 				// If stat fails, keep undefined
 			}
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${zipPath}" "${s3Path}"`;
-			writeStream.write("Running command to upload backup to S3\n");
-			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			const uploadCommand = buildRcloneCopytoCommand(
+				destination,
+				zipPath,
+				remotePath,
+			);
+			writeStream.write("Running command to upload backup to destination\n");
+			await execAsync(uploadCommand, { shell: "/bin/bash" });
+			writeStream.write("Uploaded backup to destination ✅\n");
 			writeStream.end();
 			await sendDokployBackupNotifications({
 				type: "success",

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import {
+	buildRcloneCatCommand,
+	buildRcloneCopyCommand,
+	getDestinationPath,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -23,13 +27,11 @@ export const restoreComposeBackup = async (
 		}
 		const { serverId, appName, composeType } = compose;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		let rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const backupPath = getDestinationPath(destination, backupInput.backupFile);
+		let rcloneCommand = `${buildRcloneCatCommand(destination, backupPath)} | gunzip`;
 
 		if (backupInput.metadata?.mongo) {
-			rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+			rcloneCommand = buildRcloneCopyCommand(destination, backupPath);
 		}
 
 		let credentials: DatabaseCredentials = {};

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Libsql } from "@dokploy/server/services/libsql";
 import type { z } from "zod";
-import { getS3Credentials, getServiceContainerCommand } from "../backups/utils";
+import {
+	buildRcloneCatCommand,
+	getDestinationPath,
+	getServiceContainerCommand,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 
 export const restoreLibsqlBackup = async (
@@ -14,12 +18,8 @@ export const restoreLibsqlBackup = async (
 	try {
 		const { appName, serverId } = libsql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const backupPath = getDestinationPath(destination, backupInput.backupFile);
+		const rcloneCommand = buildRcloneCatCommand(destination, backupPath);
 
 		emit("Starting restore...");
 		emit(`Backup path: ${backupPath}`);

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mariadb } from "@dokploy/server/services/mariadb";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { buildRcloneCatCommand, getDestinationPath } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +15,8 @@ export const restoreMariadbBackup = async (
 	try {
 		const { appName, serverId, databaseUser, databasePassword } = mariadb;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const backupPath = getDestinationPath(destination, backupInput.backupFile);
+		const rcloneCommand = `${buildRcloneCatCommand(destination, backupPath)} | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mongo } from "@dokploy/server/services/mongo";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { buildRcloneCopyCommand, getDestinationPath } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,10 +15,8 @@ export const restoreMongoBackup = async (
 	try {
 		const { appName, databasePassword, databaseUser, serverId } = mongo;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		const rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const backupPath = getDestinationPath(destination, backupInput.backupFile);
+		const rcloneCommand = buildRcloneCopyCommand(destination, backupPath);
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { MySql } from "@dokploy/server/services/mysql";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { buildRcloneCatCommand, getDestinationPath } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +15,8 @@ export const restoreMySqlBackup = async (
 	try {
 		const { appName, databaseRootPassword, serverId } = mysql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const backupPath = getDestinationPath(destination, backupInput.backupFile);
+		const rcloneCommand = `${buildRcloneCatCommand(destination, backupPath)} | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Postgres } from "@dokploy/server/services/postgres";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { buildRcloneCatCommand, getDestinationPath } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,12 +15,8 @@ export const restorePostgresBackup = async (
 	try {
 		const { appName, databaseUser, serverId } = postgres;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const backupPath = getDestinationPath(destination, backupInput.backupFile);
+		const rcloneCommand = `${buildRcloneCatCommand(destination, backupPath)} | gunzip`;
 
 		emit("Starting restore...");
 		emit(`Backup path: ${backupPath}`);

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
-import { getS3Credentials } from "../backups/utils";
+import {
+	buildRcloneDownloadCommand,
+	getDestinationPath,
+} from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
 export const restoreWebServerBackup = async (
@@ -15,9 +18,7 @@ export const restoreWebServerBackup = async (
 		return;
 	}
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupFile}`;
+		const backupPath = getDestinationPath(destination, backupFile);
 		const { BASE_PATH } = paths();
 
 		// Create a temporary directory outside of BASE_PATH
@@ -32,10 +33,15 @@ export const restoreWebServerBackup = async (
 			emit("Creating temporary directory...");
 			await execAsync(`mkdir -p ${tempDir}`);
 
-			// Download backup from S3
-			emit("Downloading backup from S3...");
+			// Download backup from destination
+			emit("Downloading backup from destination...");
 			await execAsync(
-				`rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${tempDir}/${backupFile}"`,
+				buildRcloneDownloadCommand(
+					destination,
+					backupPath,
+					`${tempDir}/${backupFile}`,
+				),
+				{ shell: "/bin/bash" },
 			);
 
 			// List files before extraction

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -3,8 +3,9 @@ import { paths } from "@dokploy/server/constants";
 import { findComposeById } from "@dokploy/server/services/compose";
 import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
 import {
+	buildRcloneCopytoCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getDestinationPath,
 	normalizeS3Path,
 } from "../backups/utils";
 
@@ -38,11 +39,14 @@ export const backupVolume = async (
 	const s3AppName = getVolumeServiceAppName(volumeBackup);
 	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar`;
 	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
-	const rcloneFlags = getS3Credentials(volumeBackup.destination);
-	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+	const rcloneDestination = getDestinationPath(destination, bucketDestination);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeBackup.appName);
 
-	const rcloneCommand = `rclone copyto ${rcloneFlags.join(" ")} "${volumeBackupPath}/${backupFileName}" "${rcloneDestination}"`;
+	const rcloneCommand = buildRcloneCopytoCommand(
+		destination,
+		`${volumeBackupPath}/${backupFileName}`,
+		rcloneDestination,
+	);
 
 	const backupCommand = `
 	set -e
@@ -60,9 +64,9 @@ export const backupVolume = async (
   `;
 
 	const uploadCommand = `
-  echo "Starting upload to S3..."
+  echo "Starting upload to destination..."
   ${rcloneCommand}
-  echo "Upload to S3 done ✅"
+  echo "Upload to destination done ✅"
   echo "Cleaning up local backup file..."
   rm "${volumeBackupPath}/${backupFileName}"
   echo "Local backup file cleaned up ✅"

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -3,9 +3,12 @@ import {
 	findApplicationById,
 	findComposeById,
 	findDestinationById,
-	getS3Credentials,
 	paths,
 } from "../..";
+import {
+	buildRcloneDownloadCommand,
+	getDestinationPath,
+} from "../backups/utils";
 
 export const restoreVolume = async (
 	id: string,
@@ -18,12 +21,14 @@ export const restoreVolume = async (
 	const destination = await findDestinationById(destinationId);
 	const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeName);
-	const rcloneFlags = getS3Credentials(destination);
-	const bucketPath = `:s3:${destination.bucket}`;
-	const backupPath = `${bucketPath}/${backupFileName}`;
+	const backupPath = getDestinationPath(destination, backupFileName);
 
-	// Command to download backup file from S3
-	const downloadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${volumeBackupPath}/${backupFileName}"`;
+	// Command to download backup file from destination
+	const downloadCommand = buildRcloneDownloadCommand(
+		destination,
+		backupPath,
+		`${volumeBackupPath}/${backupFileName}`,
+	);
 
 	// Base restore command that creates the volume and restores data
 	const baseRestoreCommand = `

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -10,7 +10,12 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { getS3Credentials, normalizeS3Path } from "../backups/utils";
+import {
+	getDestinationCredentials,
+	getDestinationPath,
+	getSFTPCredentials,
+	normalizeS3Path,
+} from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
 
@@ -82,18 +87,31 @@ const cleanupOldVolumeBackups = async (
 	if (!keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
+		const type = destination.destinationType ?? "s3";
 		const s3AppName = getVolumeServiceAppName(volumeBackup);
-		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
-		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
+		const subPath = `${s3AppName}/${normalizeS3Path(prefix || "")}`;
+		const backupFilesPath = getDestinationPath(destination, subPath);
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
-		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
-		const fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
+
+		let fullCommand: string;
+		if (type === "sftp") {
+			const { flags, password } = getSFTPCredentials(destination);
+			const flagStr = flags.join(" ");
+			const listCommand = `rclone lsf ${flagStr} --sftp-pass="$SFTP_PASS" --include "${volumeName}-*.tar" "${backupFilesPath}"`;
+			const deleteCommand = `rclone delete ${flagStr} --sftp-pass="$SFTP_PASS" "${backupFilesPath}{}"`;
+			fullCommand = `SFTP_PASS=$(rclone obscure "${password}") && ${listCommand} | ${sortAndPick} ${deleteCommand}`;
+		} else {
+			const { flags } = getDestinationCredentials(destination);
+			const flagStr = flags.join(" ");
+			const listCommand = `rclone lsf ${flagStr} --include "${volumeName}-*.tar" "${backupFilesPath}"`;
+			const deleteCommand = `rclone delete ${flagStr} "${backupFilesPath}{}"`;
+			fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
+		}
 
 		if (serverId) {
 			await execAsyncRemote(serverId, fullCommand);
 		} else {
-			await execAsync(fullCommand);
+			await execAsync(fullCommand, { shell: "/bin/bash" });
 		}
 	} catch (error) {
 		console.error("Volume backup retention error", error);


### PR DESCRIPTION
Fixes #416

## Summary

- Adds a `destinationType` column (`s3` | `ftp` | `sftp`) to the destination schema with a Drizzle migration
- Introduces generic rclone command builders (`buildRcloneUploadCommand`, `buildRcloneDownloadCommand`, `buildRcloneCatCommand`, `buildRcloneCopyCommand`, `buildRcloneCopytoCommand`, `buildRcloneListCommand`, `buildRcloneDeleteCommand`) that dispatch by destination type and handle SFTP password obscuring via `rclone obscure`
- Updates all backup handlers (Postgres, MySQL, MariaDB, MongoDB, LibSQL, Compose, web-server) to use the generic destination helpers instead of hardcoded S3 paths
- Updates `keepLatestNBackups` and volume-backup cleanup to support FTP/SFTP retention
- Updates all restore handlers (Postgres, MySQL, MariaDB, MongoDB, LibSQL, Compose, web-server restore) for FTP/SFTP support
- Updates the `testConnection` tRPC endpoint to test FTP and SFTP connections
- Updates the destination form UI: adds a Destination Type selector and shows contextual field labels (Host/Endpoint, Port/Region, Username/Access Key, Password/Secret Key, Remote Path/Bucket) based on selected type

## Field reuse for FTP/SFTP destinations

Existing destination fields are reused to avoid breaking schema changes:

| Field | S3 | FTP / SFTP |
|---|---|---|
| `endpoint` | S3 endpoint URL | Host |
| `region` | Region | Port (defaults: FTP=21, SFTP=22) |
| `accessKey` | Access Key ID | Username |
| `secretAccessKey` | Secret Access Key | Password |
| `bucket` | Bucket name | Remote base path (optional) |

## SFTP password handling

rclone requires SFTP passwords to be "obscured". This is handled at command-build time:
```bash
SFTP_PASS=$(rclone obscure "password") && rclone rcat --sftp-... --sftp-pass="$SFTP_PASS" ":sftp:path"
```

## Test plan

- [ ] Create an S3 destination and verify existing backup/restore flows are unaffected
- [ ] Create an FTP destination, test connection, run a backup, verify file appears on FTP server
- [ ] Create an SFTP destination, test connection, run a backup, verify file appears on SFTP server
- [ ] Verify keepLatestNBackups prunes old backups on FTP/SFTP destinations
- [ ] Run `pnpm biome check .` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds FTP and SFTP as first-class backup-destination types alongside S3, reusing existing schema fields and introducing generic rclone command builders that dispatch by type. There are two functional defects in the new code: FTP passwords are passed as plaintext to `--ftp-pass` (rclone requires obscured values, so every FTP backup and restore will fail to authenticate), and SFTP passwords are interpolated directly inside a double-quoted shell `$(…)` substitution, causing breakage on any password that contains a `"` and enabling arbitrary command execution for passwords containing `` ` `` or `$(…)`.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — FTP destinations are non-functional and SFTP passwords with shell metacharacters break or inject into backup execution.

Two P1 defects affect the core feature being added: FTP authentication always fails because the password is never obscured, and the SFTP obscure step is vulnerable to shell injection for any password containing double-quotes or command-substitution characters. Both issues are on the critical path of the new functionality.

packages/server/src/utils/backups/utils.ts (lines 94–109 for FTP plaintext password, lines 150–247 for SFTP injection), packages/server/src/utils/backups/index.ts (line 157), packages/server/src/utils/volume-backups/utils.ts (line 102), apps/dokploy/server/api/routers/destination.ts (line 92)

<sub>Reviews (1): Last reviewed commit: ["feat: add FTP and SFTP support for backu..."](https://github.com/dokploy/dokploy/commit/f5e12e7c43d09adcdfd481c5494e0baf11f22ca3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27503614)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->