### PR TITLE
fix: invalid docker host while using docker desktop

### DIFF
--- a/apps/dokploy/server/utils/docker.ts
+++ b/apps/dokploy/server/utils/docker.ts
@@ -24,7 +24,11 @@ export const isDockerDesktop = async () => {
 /** Returns the Docker host IP address. */
 export const getDockerHost = async (): Promise<string> => {
 	if (process.env.NODE_ENV === "production") {
-		if (process.platform === "linux" && !(await isWSL() || await isDockerDesktop())) {
+		const isLinux = process.platform === "linux"
+			? (await Promise.all([isWSL(), isDockerDesktop()])).every((v) => !v)
+			: false;
+
+		if (isLinux) {
 			try {
 				// Try to get the Docker bridge IP first
 				const { stdout } = await execAsync(

--- a/apps/dokploy/server/utils/docker.ts
+++ b/apps/dokploy/server/utils/docker.ts
@@ -11,10 +11,20 @@ export const isWSL = async () => {
 	}
 };
 
+/** Returns if running in Docker Desktop. */
+export const isDockerDesktop = async () => {
+	try {
+		const { stdout } = await execAsync("getent hosts host.docker.internal");
+		return !!stdout.trim();
+	} catch {
+		return false;
+	}
+};
+
 /** Returns the Docker host IP address. */
 export const getDockerHost = async (): Promise<string> => {
 	if (process.env.NODE_ENV === "production") {
-		if (process.platform === "linux" && !(await isWSL())) {
+		if (process.platform === "linux" && !(await isWSL() || await isDockerDesktop())) {
 			try {
 				// Try to get the Docker bridge IP first
 				const { stdout } = await execAsync(


### PR DESCRIPTION
## What is this PR about?

This PR fixes the Docker host resolution logic for users running Dokploy via Docker Desktop (macOS and Windows). Previously, the code assumed any Linux environment that wasn't WSL should use the Docker bridge IP — but containers running under Docker Desktop also have `host.docker.internal` available and should use that instead. A new `isDockerDesktop` helper detects this by checking whether `host.docker.internal` resolves via `getent hosts`. The `getDockerHost` function now skips the bridge IP path when either WSL or Docker Desktop is detected, ensuring a valid Docker host is returned in all cases.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `isDockerDesktop` helper that probes `getent hosts host.docker.internal` and uses it alongside the existing `isWSL` check to skip the Linux bridge-IP path in `getDockerHost`, fixing Docker host resolution for Docker Desktop on macOS/Windows. The detection logic is sound: Dokploy does not inject `host.docker.internal` into native Linux containers, so false positives are not a concern, and the `catch`-returning-`false` fallback safely handles environments where `getent` is unavailable.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic is correct and the only remaining finding is a minor performance suggestion.

No P0 or P1 issues. The isDockerDesktop check correctly identifies Docker Desktop environments via getent, the operator precedence in !(await isWSL() || await isDockerDesktop()) is correct (De Morgan: !A && !B), and the catch block gracefully handles environments where getent is unavailable.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: return a valid docker host for dock..."](https://github.com/dokploy/dokploy/commit/3e1189776238cd6fd24b75ec531146f210bc67bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27550560)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->