### PR TITLE
fix: add unzip to arch server set up

### DIFF
--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -466,7 +466,7 @@ const installUtilities = () => `
 
 	case "$OS_TYPE" in
 	arch)
-		$SUDO_CMD pacman -Sy --noconfirm --needed curl wget git git-lfs jq openssl >/dev/null || true
+		$SUDO_CMD pacman -Sy --noconfirm --needed unzip curl wget git git-lfs jq openssl >/dev/null || true
 		;;
 	alpine)
 		$SUDO_CMD sed -i '/^#.*\/community/s/^#//' /etc/apk/repositories


### PR DESCRIPTION
Adds missing `unzip` installation when `arch` is used as a target. This has been fixed in https://github.com/Dokploy/dokploy/pull/1051 for Debian/Ubuntu targets.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `unzip` to the `pacman` install command for Arch Linux in `installUtilities()`, matching the fix already applied to Debian/Ubuntu targets in #1051. The change is correct and brings Arch in line with all other supported distros (alpine, ubuntu/debian, centos/fedora) that already install `unzip`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no risk.

The change is a single-line addition of a missing package to an OS install list. It is consistent with the existing pattern across all other distros and matches the intent of the previously merged #1051. The only finding is a P2 observation about SLES/openSUSE also missing `unzip`, which is out of scope for this PR and does not block merge.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/server/src/setup/server-setup.ts`, line 495-496 ([link](https://github.com/dokploy/dokploy/blob/f21931da60fcd5e9f7116a6bde1d39e2dc55b5b5/packages/server/src/setup/server-setup.ts#L495-L496)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`unzip` also missing for SLES/openSUSE**

   The same gap this PR fixes for Arch exists in the SLES/openSUSE branch — `unzip` is absent while every other distro (alpine, ubuntu/debian, centos/fedora, arch after this fix) installs it.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: add unzip to arch server set up"](https://github.com/dokploy/dokploy/commit/f21931da60fcd5e9f7116a6bde1d39e2dc55b5b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27743171)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->