### PR TITLE
fix: prevent orphaned containers when deleting compose services

### DIFF
--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -440,17 +440,16 @@ export const removeCompose = async (
 			}
 		} else {
 			const command = `
-			 docker network disconnect ${compose.appName} dokploy-traefik;
-			cd ${projectPath} && env -i PATH="$PATH" docker compose -p ${compose.appName} down ${
+			docker network disconnect ${compose.appName} dokploy-traefik;
+			env -i PATH="$PATH" docker compose -p ${compose.appName} down ${
 				deleteVolumes ? "--volumes" : ""
-			} && rm -rf ${projectPath}`;
+			};
+			rm -rf ${projectPath}`;
 
 			if (compose.serverId) {
 				await execAsyncRemote(compose.serverId, command);
 			} else {
-				await execAsync(command, {
-					cwd: projectPath,
-				});
+				await execAsync(command);
 			}
 		}
 	} catch (error) {


### PR DESCRIPTION
## Summary

- Fixes `composeType: "compose"` deletion leaving orphaned containers and volumes running
- Commands were chained with `&&`, so if the project directory was missing, `cd` would fail and `docker compose down` would never execute
- Uses `;` to run each command independently, matching the existing `stack` deletion pattern from PR #3692

Closes #4064

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes orphaned containers left behind when deleting compose services (`composeType: "compose"`). The root cause was that commands were chained with `&&`, so if the project directory didn't exist, the `cd` would fail and `docker compose down` would never execute. The fix replaces `&&` with `;` so each command runs independently, and removes the now-unnecessary `cd` and `cwd` option since `docker compose -p <project-name> down` can identify containers by their project label without needing the compose file in the working directory. This aligns the behavior with the existing `stack` deletion pattern introduced in PR #3692.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, correct, and mirrors the established pattern for stack-type deletion.

The change is a targeted fix: replacing && with ; ensures docker compose -p <name> down always runs even when the project directory is absent. docker compose -p <name> down correctly identifies containers via project labels without a compose file. rm -rf with the -f flag silently succeeds on non-existent paths, so there are no new error surface areas. All findings are P2 or better.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns introduced by this PR. Note that `compose.appName` is interpolated directly into shell commands, but this is a pre-existing pattern unchanged by this diff.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent orphaned containers when de..."](https://github.com/dokploy/dokploy/commit/825e6b654c11f302f4353e2166e566b6e2859c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27930386)</sub>

<!-- /greptile_comment -->