### PR TITLE
feat: allow MongoDB backup of all databases when database name is empty

### DIFF
--- a/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
@@ -79,7 +79,7 @@ const Schema = z
 		schedule: z.string().min(1, "Schedule (Cron) required"),
 		prefix: z.string().min(1, "Prefix required"),
 		enabled: z.boolean(),
-		database: z.string().min(1, "Database required"),
+		database: z.string(),
 		keepLatestCount: z.coerce.number().optional(),
 		serviceName: z.string().nullable(),
 		databaseType: z
@@ -114,6 +114,14 @@ const Schema = z
 			.optional(),
 	})
 	.superRefine((data, ctx) => {
+		if (!data.database && data.databaseType !== "mongo") {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Database required",
+				path: ["database"],
+			});
+		}
+
 		if (data.backupType === "compose" && !data.databaseType) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
@@ -580,6 +588,8 @@ export const HandleBackup = ({
 								control={form.control}
 								name="database"
 								render={({ field }) => {
+									const currentDbType =
+										form.watch("databaseType") || databaseType;
 									return (
 										<FormItem>
 											<FormLabel>Database</FormLabel>
@@ -593,6 +603,11 @@ export const HandleBackup = ({
 													{...field}
 												/>
 											</FormControl>
+											{currentDbType === "mongo" && (
+												<FormDescription>
+													Leave empty to back up all databases
+												</FormDescription>
+											)}
 											<FormMessage />
 										</FormItem>
 									);

--- a/packages/server/src/db/schema/backups.ts
+++ b/packages/server/src/db/schema/backups.ts
@@ -143,7 +143,7 @@ const createSchema = createInsertSchema(backups, {
 	destinationId: z.string(),
 	enabled: z.boolean().optional(),
 	prefix: z.string().min(1),
-	database: z.string().min(1),
+	database: z.string(),
 	schedule: z.string(),
 	keepLatestCount: z.number().optional(),
 	databaseType: z.enum([

--- a/packages/server/src/db/schema/backups.ts
+++ b/packages/server/src/db/schema/backups.ts
@@ -161,6 +161,14 @@ const createSchema = createInsertSchema(backups, {
 	libsqlId: z.string().optional(),
 	userId: z.string().optional(),
 	metadata: z.any().optional(),
+}).superRefine((data, ctx) => {
+	if (!data.database && data.databaseType !== "mongo") {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Database is required for this database type",
+			path: ["database"],
+		});
+	}
 });
 
 export const apiCreateBackup = createSchema.pick({

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -116,7 +116,8 @@ export const getMongoBackupCommand = (
 	databaseUser: string,
 	databasePassword: string,
 ) => {
-	return `docker exec -i $CONTAINER_ID bash -c "set -o pipefail; mongodump -d '${database}' -u '${databaseUser}' -p '${databasePassword}' --archive --authenticationDatabase admin --gzip"`;
+	const dbFlag = database ? `-d '${database}'` : "";
+	return `docker exec -i $CONTAINER_ID bash -c "set -o pipefail; mongodump ${dbFlag} -u '${databaseUser}' -p '${databasePassword}' --archive --authenticationDatabase admin --gzip"`;
 };
 
 export const getLibsqlBackupCommand = (database: string) => {

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -116,8 +116,8 @@ export const getMongoBackupCommand = (
 	databaseUser: string,
 	databasePassword: string,
 ) => {
-	const dbFlag = database ? `-d '${database}'` : "";
-	return `docker exec -i $CONTAINER_ID bash -c "set -o pipefail; mongodump ${dbFlag} -u '${databaseUser}' -p '${databasePassword}' --archive --authenticationDatabase admin --gzip"`;
+	const dbFlag = database ? `-d '${database}' ` : "";
+	return `docker exec -i $CONTAINER_ID bash -c "set -o pipefail; mongodump ${dbFlag}-u '${databaseUser}' -p '${databasePassword}' --archive --authenticationDatabase admin --gzip"`;
 };
 
 export const getLibsqlBackupCommand = (database: string) => {


### PR DESCRIPTION
## Summary
Closes #4186

- When the database field is left empty for MongoDB backups, `mongodump` runs without the `-d` flag, dumping all databases in the instance
- Other database types (Postgres, MySQL, MariaDB, libsql) still require a database name
- Added UI hint for MongoDB: "Leave empty to back up all databases"

## Changes
- **`packages/server/src/utils/backups/utils.ts`** — Conditionally include `-d` flag in `getMongoBackupCommand`
- **`packages/server/src/db/schema/backups.ts`** — Relaxed `database` field validation from `min(1)` to allow empty string
- **`apps/dokploy/components/dashboard/database/backups/handle-backup.tsx`** — Added `superRefine` to require non-empty database for non-mongo types; added `FormDescription` hint for MongoDB

## Test plan
- [ ] Create a MongoDB backup with an empty database name → should dump all databases
- [ ] Create a MongoDB backup with a specific database name → should dump only that database (existing behavior)
- [ ] Create a Postgres/MySQL/MariaDB backup with empty database → should show validation error
- [ ] Verify existing backups continue to work without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for MongoDB "dump all databases" mode by omitting the `-d` flag when the database field is empty, with corresponding frontend validation to require a database name only for non-MongoDB types. The frontend changes are clean and correct, but the server-side `createSchema` in `backups.ts` was relaxed globally (all types) without adding a compensating type-conditional refinement — meaning direct API calls can create broken backup configs for Postgres/MySQL/MariaDB/LibSQL with an empty database name that will silently fail at runtime.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding server-side databaseType-conditional validation to the backup schema.

There is one P1 defect: the server-side schema allows an empty database for all database types without enforcing the same databaseType-conditional rule as the frontend. A direct API call can persist a broken backup config that silently fails at execution time. All other changes (the mongodump flag logic, the UI hint, and the frontend superRefine) are correct.

packages/server/src/db/schema/backups.ts — createSchema needs a superRefine or per-schema refinement to reject empty database for non-mongo types.

<sub>Reviews (1): Last reviewed commit: ["feat: allow MongoDB backup of all databa..."](https://github.com/dokploy/dokploy/commit/0bb0fcd9ecc307b73408515ee4d177872a93310a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27932259)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->