### PR TITLE
fix: inject COMPOSE_PROJECT_NAME to prevent orphaned containers on redeploy

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -106,6 +106,7 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 	const envFilePath = join(dirname(composeFilePath), ".env");
 
 	let envContent = `APP_NAME=${appName}\n`;
+	envContent += `COMPOSE_PROJECT_NAME=${appName}\n`;
 	envContent += env || "";
 	if (!envContent.includes("DOCKER_CONFIG")) {
 		envContent += "\nDOCKER_CONFIG=/root/.docker";


### PR DESCRIPTION
## Summary
- Injects `COMPOSE_PROJECT_NAME=${appName}` into the compose `.env` file
- Prevents orphaned containers when users switch between custom commands (without `-p`) and the default deploy command
- Docker Compose now always uses the correct project name regardless of the command used

Closes #4019

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `COMPOSE_PROJECT_NAME=${appName}` to the generated `.env` file so that Docker Compose consistently uses the app's canonical project name regardless of whether a user-supplied custom command includes `-p` or not. The fix is minimal and targets a real orphaned-container bug (#4019).

One behavioural note worth being aware of: users who previously deployed with a custom command that omitted `-p` will have had their containers named by Docker Compose's directory-inferred project name (likely `code`). On their first redeploy after this change, those old containers will be treated as orphaned and replaced by new containers under the `appName` project. This is a one-time, intentional migration and is exactly what the fix is meant to accomplish.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line, targeted fix with no P0/P1 issues.

The change is a minimal, correct one-liner that mirrors the existing `-p ${appName}` flag already used in the default command. The placement before user-supplied env preserves user overridability via dotenv last-wins semantics. No new security surface, no breaking API change. All remaining observations are informational P2 at most.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: inject COMPOSE\_PROJECT\_NAME to prev..."](https://github.com/dokploy/dokploy/commit/cb64482649cba0717a55da30c181ecf4bc45527c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27934553)</sub>

<!-- /greptile_comment -->