### PR TITLE
fix: add runtime type guard for cpu.value in monitoring tab

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -220,11 +220,11 @@ export const ContainerFreeMonitoring = ({
 					<CardContent>
 						<div className="flex flex-col gap-2 w-full">
 							<span className="text-sm text-muted-foreground">
-								Used: {currentData.cpu.value}
+								Used: {String(currentData.cpu.value ?? "0%")}
 							</span>
 							<Progress
 								value={Number.parseInt(
-									currentData.cpu.value.replace("%", ""),
+									String(currentData.cpu.value ?? "0%").replace("%", ""),
 									10,
 								)}
 								className="w-[100%]"


### PR DESCRIPTION
## Summary
- Fixes the `c.cpu.value.replace is not a function` crash on the monitoring tab when `cpu.value` is a number or null instead of a string
- Adds `String()` conversion with `"0%"` fallback, matching the defensive approach already used for memory values

Closes #4062

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds defensive runtime guards for `cpu.value` in the free container monitoring tab, wrapping it with `String(value ?? "0%")` to prevent crashes when the WebSocket or API response delivers a number or `null` instead of the expected string. The fix is minimal and consistent with the defensive pattern already used for memory values in the same component.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the crash is fixed with a targeted, consistent guard and no regressions are introduced.

The only remaining finding is a P2 type-annotation improvement that doesn't affect runtime behaviour. All P0/P1 concerns are addressed.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx`, line 49-52 ([link](https://github.com/dokploy/dokploy/blob/b079cbd427940d9370aa5b103fbc8eff6b16f2ae/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx#L49-L52)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **TypeScript type doesn't reflect runtime reality**

   The `DockerStats` interface still declares `cpu.value` as `string`, but this PR exists precisely because it can arrive as `number | null` at runtime. The `?? "0%"` guard is then effectively invisible to TypeScript — the compiler won't warn about future callers that use `.replace()` without the guard. Consider updating the type to match what the data source can actually produce:

   ```ts
   cpu: {
     value: string | number | null;
     time: string;
   };
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: add runtime type guard for cpu.valu..."](https://github.com/dokploy/dokploy/commit/b079cbd427940d9370aa5b103fbc8eff6b16f2ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27936232)</sub>

<!-- /greptile_comment -->