### PR TITLE
fix: correct stripPath and addPrefix middleware order

### DIFF
--- a/apps/dokploy/__test__/traefik/traefik.test.ts
+++ b/apps/dokploy/__test__/traefik/traefik.test.ts
@@ -424,6 +424,26 @@ test("Custom entrypoint with internalPath adds addprefix middleware", async () =
 	expect(router.entryPoints).toEqual(["custom"]);
 });
 
+test("stripPath and internalPath together: stripprefix must come before addprefix", async () => {
+	const router = await createRouterConfig(
+		baseApp,
+		{
+			...baseDomain,
+			path: "/public",
+			stripPath: true,
+			internalPath: "/app/v2",
+		},
+		"web",
+	);
+
+	const stripIndex = router.middlewares?.indexOf("stripprefix--1") ?? -1;
+	const addIndex = router.middlewares?.indexOf("addprefix--1") ?? -1;
+
+	expect(stripIndex).toBeGreaterThanOrEqual(0);
+	expect(addIndex).toBeGreaterThanOrEqual(0);
+	expect(stripIndex).toBeLessThan(addIndex);
+});
+
 test("Custom entrypoint with https and custom cert resolver", async () => {
 	const router = await createRouterConfig(
 		baseApp,

--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -151,14 +151,16 @@ export const createRouterConfig = async (
 		routerConfig.middlewares?.push("redirect-to-https");
 	} else {
 		// Add path rewriting middleware if needed
-		if (internalPath && internalPath !== "/" && internalPath !== path) {
-			const pathMiddleware = `addprefix-${appName}-${uniqueConfigKey}`;
-			routerConfig.middlewares?.push(pathMiddleware);
-		}
-
+		// stripPrefix must come before addPrefix so Traefik strips the
+		// public path first, then prepends the internal path.
 		if (stripPath && path && path !== "/") {
 			const stripMiddleware = `stripprefix-${appName}-${uniqueConfigKey}`;
 			routerConfig.middlewares?.push(stripMiddleware);
+		}
+
+		if (internalPath && internalPath !== "/" && internalPath !== path) {
+			const pathMiddleware = `addprefix-${appName}-${uniqueConfigKey}`;
+			routerConfig.middlewares?.push(pathMiddleware);
 		}
 
 		// redirects - skip for preview deployments as wildcard subdomains


### PR DESCRIPTION
## Summary
- Swaps the order of `stripPrefix` and `addPrefix` middleware in Traefik router config so `stripPrefix` runs first
- When both `stripPath` and `internalPath` are set, requests like `/public/api/users` now correctly resolve to `/app/v2/api/users` instead of `/app/v2/public/api/users`
- Adds test verifying middleware ordering when both options are active

Closes #4061

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a middleware ordering bug in Traefik router configuration where `addPrefix` was registered before `stripPrefix`, causing requests like `/public/api/users` to incorrectly resolve to `/app/v2/public/api/users` instead of `/app/v2/api/users`. The fix swaps the push order so `stripPrefix` is always registered first, and adds a focused test to lock in the correct ordering.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it corrects a clear middleware ordering bug with no regressions introduced.

The change is minimal and targeted: a two-block swap in a single function, backed by a new test that directly asserts the correct ordering. The logic is straightforwardly correct for Traefik's sequential middleware model, and no existing tests are broken. No P0/P1 findings identified.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: swap stripPrefix and addPrefix midd..."](https://github.com/dokploy/dokploy/commit/f8eb3c2b766943a2a3d0a99ffa950eb89d810db9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27937235)</sub>

<!-- /greptile_comment -->