### PR TITLE
fix(volume-backup): allow clearing backup retention limit to unlimited

### DIFF
--- a/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
@@ -208,7 +208,7 @@ export const HandleVolumeBackups = ({
 
 		await mutateAsync({
 			...values,
-			keepLatestCount: preparedKeepLatestCount ?? undefined,
+			keepLatestCount: preparedKeepLatestCount,
 			destinationId: values.destinationId,
 			volumeBackupId: volumeBackupId || "",
 			serviceType: volumeBackupType,


### PR DESCRIPTION
Fixes #4184.

Once a positive "Keep Latest Backups" value is saved on a volume backup, clearing the field and saving no longer resets it to unlimited — the old value persists.

The form's submit handler correctly sets `preparedKeepLatestCount` to `null` when the input is empty (line 207), but then `preparedKeepLatestCount ?? undefined` on line 211 converts the `null` back to `undefined` because `??` treats `null` as nullish. Drizzle ORM silently ignores `undefined` fields in UPDATE operations, so the column is never set to SQL `NULL`.

**Before:** clearing the field → `null ?? undefined` → `undefined` → Drizzle skips the column → old value persists
**After:** clearing the field → `null` → Drizzle sets `keepLatestCount = NULL` → retention is unlimited

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where clearing the \"Keep Latest Backups\" field on a volume backup form failed to reset the value to unlimited. The root cause was `preparedKeepLatestCount ?? undefined` converting `null` to `undefined`, which Drizzle ORM silently skips in UPDATE operations — leaving the old value in the database. Removing `?? undefined` so that `null` is passed directly causes Drizzle to issue `SET keepLatestCount = NULL`, correctly clearing the limit.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal one-line fix that correctly resolves the described bug.

The change is a single targeted removal of `?? undefined`, which is exactly the right fix. The `updateVolumeBackupSchema` accepts `null` for the nullable `keepLatestCount` column, and Drizzle ORM correctly translates `null` to SQL `NULL` in `.set()`. No regressions are possible since `null` was previously the intended value for "unlimited" retention.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(volume-backup): allow clearing backu..."](https://github.com/dokploy/dokploy/commit/4f410c7ede934626c53b273f42f568349a4eed08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27947169)</sub>

<!-- /greptile_comment -->