### PR TITLE
fix(traefik): disable HTTP/2 on websecure to fix WebSocket connections

### DIFF
--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -285,6 +285,9 @@ export const getDefaultTraefikConfig = () => {
 			},
 			websecure: {
 				address: `:${TRAEFIK_SSL_PORT}`,
+				http2: {
+					maxConcurrentStreams: 0,
+				},
 				http3: {
 					advertisedPort: TRAEFIK_HTTP3_PORT,
 				},


### PR DESCRIPTION
Hi there! 👋

First off, thanks for building Dokploy — it's an amazing piece of work and I've really enjoyed digging into the codebase.

This PR addresses the WebSocket connection issues described in #4202. The problem is that when browsers negotiate HTTP/2 with Traefik's  entrypoint, the WebSocket upgrade fails because Dokploy's WS endpoints currently rely on the HTTP/1.1  header mechanism (via the  library with ).

As a temporary but pragmatic fix, I've added  to the default Traefik config. This forces browsers back to HTTP/1.1 for the entrypoint, which restores:
- deployment logs
- container logs  
- real-time stats monitoring
- the Web terminal

I know disabling HTTP/2 (and by extension HTTP/3 ALPN) isn't ideal long-term. A proper RFC 8441 implementation would be the better fix, but that looks like a much larger effort across the WebSocket server layer. Happy to help explore that in a follow-up if there's interest 😊

I wasn't able to spin up a full local Dokploy stack in my current environment, but the change is scoped and the generated config syntax aligns with the existing  types. If anyone can give this a quick spin on a test instance, that would be awesome!

Let me know if you'd prefer a different approach or want me to adjust anything. Really appreciate your time reviewing this! 🙏

Closes #4202

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix WebSocket connection failures on the `websecure` entrypoint by setting `http2.maxConcurrentStreams: 0` to disable HTTP/2. Unfortunately, Traefik's documentation requires this value to be **greater than zero** (default 250), so the value `0` is invalid and will not disable HTTP/2 — the underlying WebSocket breakage will remain.

- The `maxConcurrentStreams: 0` setting is ignored or treated as an error by Traefik; HTTP/2 stays active and WebSocket upgrades continue to fail.
- There is no direct entrypoint flag in Traefik to disable HTTP/2 for client-facing connections; a different approach (e.g., RFC 8441 support, `serversTransport.disableHTTP2` for backend legs, or a separate HTTP/1.1 entrypoint) is needed.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — the fix does not achieve its stated goal and will not resolve the WebSocket issue.

The single change sets `maxConcurrentStreams: 0`, which Traefik requires to be > 0. The value is invalid, so HTTP/2 is not disabled and the WebSocket bug remains unfixed. Merging this gives users false confidence that the issue is resolved while changing nothing in practice.

packages/server/src/setup/traefik-setup.ts

<sub>Reviews (1): Last reviewed commit: ["fix(traefik): disable HTTP/2 on websecur..."](https://github.com/dokploy/dokploy/commit/479997016bdec6feda21f8c69f09f2e50255f049) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28107255)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->