### PR TITLE
feat: FTP and SFTP 

### DIFF
--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -1,61 +1,61 @@
-import { normalizeS3Path } from "@dokploy/server/utils/backups/utils";
+import { normalizePath } from "@dokploy/server/utils/backups/utils";
 import { describe, expect, test } from "vitest";
 
-describe("normalizeS3Path", () => {
+describe("normalizePath", () => {
 	test("should handle empty and whitespace-only prefix", () => {
-		expect(normalizeS3Path("")).toBe("");
-		expect(normalizeS3Path("/")).toBe("");
-		expect(normalizeS3Path("  ")).toBe("");
-		expect(normalizeS3Path("\t")).toBe("");
-		expect(normalizeS3Path("\n")).toBe("");
-		expect(normalizeS3Path(" \n \t ")).toBe("");
+		expect(normalizePath("")).toBe("");
+		expect(normalizePath("/")).toBe("");
+		expect(normalizePath("  ")).toBe("");
+		expect(normalizePath("\t")).toBe("");
+		expect(normalizePath("\n")).toBe("");
+		expect(normalizePath(" \n \t ")).toBe("");
 	});
 
 	test("should trim whitespace from prefix", () => {
-		expect(normalizeS3Path(" prefix")).toBe("prefix/");
-		expect(normalizeS3Path("prefix ")).toBe("prefix/");
-		expect(normalizeS3Path(" prefix ")).toBe("prefix/");
-		expect(normalizeS3Path("\tprefix\t")).toBe("prefix/");
-		expect(normalizeS3Path(" prefix/nested ")).toBe("prefix/nested/");
+		expect(normalizePath(" prefix")).toBe("prefix/");
+		expect(normalizePath("prefix ")).toBe("prefix/");
+		expect(normalizePath(" prefix ")).toBe("prefix/");
+		expect(normalizePath("\tprefix\t")).toBe("prefix/");
+		expect(normalizePath(" prefix/nested ")).toBe("prefix/nested/");
 	});
 
 	test("should remove leading slashes", () => {
-		expect(normalizeS3Path("/prefix")).toBe("prefix/");
-		expect(normalizeS3Path("///prefix")).toBe("prefix/");
+		expect(normalizePath("/prefix")).toBe("prefix/");
+		expect(normalizePath("///prefix")).toBe("prefix/");
 	});
 
 	test("should remove trailing slashes", () => {
-		expect(normalizeS3Path("prefix/")).toBe("prefix/");
-		expect(normalizeS3Path("prefix///")).toBe("prefix/");
+		expect(normalizePath("prefix/")).toBe("prefix/");
+		expect(normalizePath("prefix///")).toBe("prefix/");
 	});
 
 	test("should remove both leading and trailing slashes", () => {
-		expect(normalizeS3Path("/prefix/")).toBe("prefix/");
-		expect(normalizeS3Path("///prefix///")).toBe("prefix/");
+		expect(normalizePath("/prefix/")).toBe("prefix/");
+		expect(normalizePath("///prefix///")).toBe("prefix/");
 	});
 
 	test("should handle nested paths", () => {
-		expect(normalizeS3Path("prefix/nested")).toBe("prefix/nested/");
-		expect(normalizeS3Path("/prefix/nested/")).toBe("prefix/nested/");
-		expect(normalizeS3Path("///prefix/nested///")).toBe("prefix/nested/");
+		expect(normalizePath("prefix/nested")).toBe("prefix/nested/");
+		expect(normalizePath("/prefix/nested/")).toBe("prefix/nested/");
+		expect(normalizePath("///prefix/nested///")).toBe("prefix/nested/");
 	});
 
 	test("should preserve middle slashes", () => {
-		expect(normalizeS3Path("prefix/nested/deep")).toBe("prefix/nested/deep/");
-		expect(normalizeS3Path("/prefix/nested/deep/")).toBe("prefix/nested/deep/");
+		expect(normalizePath("prefix/nested/deep")).toBe("prefix/nested/deep/");
+		expect(normalizePath("/prefix/nested/deep/")).toBe("prefix/nested/deep/");
 	});
 
 	test("should handle special characters", () => {
-		expect(normalizeS3Path("prefix-with-dashes")).toBe("prefix-with-dashes/");
-		expect(normalizeS3Path("prefix_with_underscores")).toBe(
+		expect(normalizePath("prefix-with-dashes")).toBe("prefix-with-dashes/");
+		expect(normalizePath("prefix_with_underscores")).toBe(
 			"prefix_with_underscores/",
 		);
-		expect(normalizeS3Path("prefix.with.dots")).toBe("prefix.with.dots/");
+		expect(normalizePath("prefix.with.dots")).toBe("prefix.with.dots/");
 	});
 
 	test("should handle the cases from the bug report", () => {
-		expect(normalizeS3Path("instance-backups/")).toBe("instance-backups/");
-		expect(normalizeS3Path("/instance-backups/")).toBe("instance-backups/");
-		expect(normalizeS3Path("instance-backups")).toBe("instance-backups/");
+		expect(normalizePath("instance-backups/")).toBe("instance-backups/");
+		expect(normalizePath("/instance-backups/")).toBe("instance-backups/");
+		expect(normalizePath("instance-backups")).toBe("instance-backups/");
 	});
 });

--- a/apps/dokploy/components/dashboard/settings/destination/destination-dialog.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/destination-dialog.tsx
@@ -1,0 +1,444 @@
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { PlusIcon, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { api } from "@/utils/api";
+import { DESTINATION_SCHEMAS, type DestinationType } from "./destination-schema";
+
+type DynamicFormValues = {
+    name: string;
+    serverId?: string;
+    additionalFlags: { value: string }[];
+} & Record<string, string | undefined | { value: string }[]>;
+
+interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    destinationId?: string;
+    type: DestinationType;
+}
+
+export const DestinationDialog = ({
+    open,
+    onOpenChange,
+    destinationId,
+    type,
+}: Props) => {
+    const utils = api.useUtils();
+    const { data: servers } = api.server.withSSHKey.useQuery();
+    const { data: isCloud } = api.settings.isCloud.useQuery();
+
+    const schema = DESTINATION_SCHEMAS.find((item) => item.type === type);
+    const properties = schema?.properties ?? [];
+
+    const defaultDynamicValues = Object.fromEntries(
+        properties.map((property) => [property.name, property.default]),
+    ) as Record<string, string>;
+
+    const { mutateAsync, isError, error, isPending } = destinationId
+        ? api.destination.update.useMutation()
+        : api.destination.create.useMutation();
+
+    const { data: destination } = api.destination.one.useQuery(
+        {
+            destinationId: destinationId || "",
+        },
+        {
+            enabled: !!destinationId,
+            refetchOnWindowFocus: false,
+        },
+    );
+
+    const {
+        mutateAsync: testConnection,
+        isPending: isPendingConnection,
+        error: connectionError,
+        isError: isErrorConnection,
+    } = api.destination.testConnection.useMutation();
+
+    const form = useForm<DynamicFormValues>({
+        defaultValues: {
+            name: "",
+            serverId: undefined,
+            additionalFlags: [],
+            ...defaultDynamicValues,
+        },
+    });
+
+    const { fields, append, remove } = useFieldArray({
+        control: form.control,
+        name: "additionalFlags",
+    });
+
+    useEffect(() => {
+        if (destination && destination.type === type) {
+            const credentialValues = properties.reduce<Record<string, string>>(
+                (acc, property) => {
+                    const value = destination[property.name as keyof typeof destination];
+                    acc[property.name] = typeof value === "string" ? value : property.default;
+                    return acc;
+                },
+                {},
+            );
+
+            form.reset({
+                name: destination.name,
+                additionalFlags:
+                    destination.additionalFlags?.map((flag) => ({ value: flag })) ?? [],
+                ...defaultDynamicValues,
+                ...credentialValues,
+            });
+            return;
+        }
+
+        form.reset({
+            name: "",
+            serverId: undefined,
+            additionalFlags: [],
+            ...defaultDynamicValues,
+        });
+    }, [destination, type, form, properties, defaultDynamicValues]);
+
+    const getCredentialPayload = (values: Record<string, unknown>) => {
+        return Object.fromEntries(
+            properties.map((property) => [property.name, values[property.name] ?? property.default]),
+        );
+    };
+
+    const getValidationErrors = (values: Record<string, unknown>) => {
+        const errors: string[] = [];
+        if (!values.name || String(values.name).trim().length === 0) {
+            errors.push("name: Name is required");
+        }
+        for (const property of properties) {
+            if (!property.required) {
+                continue;
+            }
+            const value = values[property.name];
+            if (typeof value !== "string" || value.trim().length === 0) {
+                errors.push(`${property.name}: ${property.label} is required`);
+            }
+        }
+        return errors;
+    };
+
+    const onSubmit = async (values: DynamicFormValues) => {
+        const validationErrors = getValidationErrors(values);
+        if (validationErrors.length > 0) {
+            toast.error("Please fill all required fields", {
+                description: validationErrors.join("\n"),
+            });
+            return;
+        }
+
+        const payload = {
+            type,
+            name: String(values.name || ""),
+            destinationId: destinationId || "",
+            additionalFlags: values.additionalFlags?.map((flag) => flag.value) ?? [],
+            ...getCredentialPayload(values),
+        };
+
+        await mutateAsync(payload as never)
+            .then(async () => {
+                toast.success(`Destination ${destinationId ? "Updated" : "Created"}`);
+                await utils.destination.all.invalidate();
+                if (destinationId) {
+                    await utils.destination.one.invalidate({ destinationId });
+                }
+                onOpenChange(false);
+            })
+            .catch((err) => {
+                toast.error(
+                    `Error ${destinationId ? "Updating" : "Creating"} the Destination`,
+                    {
+                        description: err.message,
+                    },
+                );
+            });
+    };
+
+    const handleTestConnection = async (serverId?: string) => {
+        const values = form.getValues();
+        const validationErrors = getValidationErrors(values);
+        if (validationErrors.length > 0) {
+            toast.error("Please fill all required fields", {
+                description: validationErrors.join("\n"),
+            });
+            return;
+        }
+
+        if (isCloud && !serverId) {
+            toast.error("Please select a server");
+            return;
+        }
+
+        const payload = {
+            type,
+            name: "Test",
+            serverId,
+            additionalFlags: values.additionalFlags?.map((flag) => flag.value) ?? [],
+            ...getCredentialPayload(values),
+        };
+
+        await testConnection(payload as never)
+            .then(() => {
+                toast.success("Connection Success");
+            })
+            .catch((err) => {
+                toast.error("Error connecting to provider", {
+                    description: err.message,
+                });
+            });
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>{destinationId ? "Update" : "Add"} Destination</DialogTitle>
+                    <DialogDescription>
+                        In this section, you can configure and add new destinations for your
+                        backups. Please ensure that you provide the correct information to
+                        guarantee secure and efficient storage.
+                    </DialogDescription>
+                </DialogHeader>
+                {(isError || isErrorConnection) && (
+                    <AlertBlock type="error" className="w-full">
+                        {connectionError?.message || error?.message}
+                    </AlertBlock>
+                )}
+
+                <Form {...form}>
+                    <form
+                        id={`hook-form-destination-${type}`}
+                        onSubmit={form.handleSubmit(onSubmit)}
+                        className="grid w-full gap-4"
+                    >
+                        <FormField
+                            control={form.control}
+                            name="name"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Name</FormLabel>
+                                    <FormControl>
+                                        <Input placeholder={`${schema?.name ?? "Destination"} Target`} {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {properties.map((property) => (
+                            <FormField
+                                key={property.name}
+                                control={form.control}
+                                name={property.name}
+                                render={({ field }) => {
+                                    const stringValue =
+                                        typeof field.value === "string" ? field.value : "";
+
+                                    return (
+                                        <FormItem>
+                                            <FormLabel>{property.label}</FormLabel>
+                                            <FormControl>
+                                                {property.type === "select" ? (
+                                                    <Select
+                                                        onValueChange={field.onChange}
+                                                        defaultValue={stringValue}
+                                                        value={stringValue}
+                                                    >
+                                                        <SelectTrigger>
+                                                            <SelectValue placeholder={property.description} />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            {(property.options ?? []).map(({key, name}) => (
+                                                                <SelectItem key={key} value={key}>
+                                                                    {name}
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                ) : (
+                                                    <Input
+                                                        type={
+                                                            property.type === "password"
+                                                                ? "password"
+                                                                : property.type
+                                                        }
+                                                        placeholder={property.description}
+                                                        {...field}
+                                                        value={stringValue}
+                                                    />
+                                                )}
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    );
+                                }}
+                            />
+                        ))}
+
+                        <div className="flex flex-col gap-2">
+                            <div className="flex items-center justify-between">
+                                <FormLabel>Additional Flags (Optional)</FormLabel>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => append({ value: "" })}
+                                >
+                                    <PlusIcon className="size-4" />
+                                    Add Flag
+                                </Button>
+                            </div>
+                            {fields.map((entry, index) => (
+                                <FormField
+                                    key={entry.id}
+                                    control={form.control}
+                                    name={`additionalFlags.${index}.value`}
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <div className="flex items-center gap-2">
+                                                <FormControl>
+                                                    <Input
+                                                        placeholder="--s3-sign-accept-encoding=false"
+                                                        {...field}
+                                                    />
+                                                </FormControl>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    onClick={() => remove(index)}
+                                                >
+                                                    <Trash2 className="size-4 text-muted-foreground" />
+                                                </Button>
+                                            </div>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            ))}
+                        </div>
+                    </form>
+
+                    <DialogFooter
+                        className={cn(
+                            isCloud ? "!flex-col" : "flex-row",
+                            "flex w-full !justify-between gap-4",
+                        )}
+                    >
+                        {isCloud ? (
+                            <div className="flex flex-col gap-4 border p-2 rounded-lg">
+                                <span className="text-sm text-muted-foreground">
+                                    Select a server to test the destination. If you do not have a
+                                    server choose the default one.
+                                </span>
+                                <FormField
+                                    control={form.control}
+                                    name="serverId"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel>Server (Optional)</FormLabel>
+                                            <FormControl>
+                                                <Select
+                                                    onValueChange={field.onChange}
+                                                    defaultValue={
+                                                        typeof field.value === "string"
+                                                            ? field.value
+                                                            : undefined
+                                                    }
+                                                >
+                                                    <SelectTrigger className="w-full">
+                                                        <SelectValue placeholder="Select a server" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        <SelectGroup>
+                                                            <SelectLabel>Servers</SelectLabel>
+                                                            {servers?.map((server) => (
+                                                                <SelectItem
+                                                                    key={server.serverId}
+                                                                    value={server.serverId}
+                                                                >
+                                                                    {server.name}
+                                                                </SelectItem>
+                                                            ))}
+                                                            <SelectItem value="none">None</SelectItem>
+                                                        </SelectGroup>
+                                                    </SelectContent>
+                                                </Select>
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    isLoading={isPendingConnection}
+                                    onClick={async () => {
+                                        const value = form.getValues("serverId");
+                                        await handleTestConnection(
+                                            typeof value === "string" ? value : undefined,
+                                        );
+                                    }}
+                                >
+                                    Test Connection
+                                </Button>
+                            </div>
+                        ) : (
+                            <Button
+                                isLoading={isPendingConnection}
+                                type="button"
+                                variant="secondary"
+                                onClick={async () => {
+                                    await handleTestConnection();
+                                }}
+                            >
+                                Test connection
+                            </Button>
+                        )}
+
+                        <Button
+                            isLoading={isPending}
+                            form={`hook-form-destination-${type}`}
+                            type="submit"
+                        >
+                            {destinationId ? "Update" : "Create"}
+                        </Button>
+                    </DialogFooter>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/apps/dokploy/components/dashboard/settings/destination/destination-schema.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/destination-schema.ts
@@ -1,0 +1,172 @@
+import { S3_PROVIDERS } from "./constants";
+
+export type DestinationType = "s3" | "ftp" | "sftp";
+
+export type DestinationProperty = {
+    name: string;
+    type: "text" | "password" | "number" | "select";
+    label: string;
+    description: string;
+    required: boolean;
+    default: string;
+    options?: Array<{
+        key: string;
+        name: string;
+    }>;
+};
+
+export type DestinationSchema = {
+    name: string;
+    type: DestinationType;
+    properties: DestinationProperty[];
+};
+
+export const DESTINATION_SCHEMAS: DestinationSchema[] = [
+    {
+        name: "S3",
+        type: "s3",
+        properties: [
+            {
+                name: "accessKeyId",
+                type: "text",
+                label: "Access Key",
+                description: "Your S3 Access Key",
+                required: true,
+                default: "",
+            },
+            {
+                name: "secretAccessKey",
+                type: "password",
+                label: "Secret Access Key",
+                description: "Your S3 Secret Access Key",
+                required: true,
+                default: "",
+            },
+            {
+                name: "region",
+                type: "text",
+                label: "Region",
+                description: "AWS Region, e.g., us-east-1",
+                required: true,
+                default: "",
+            },
+            {
+                name: "endpoint",
+                type: "text",
+                label: "Endpoint",
+                description: "S3 Endpoint URL",
+                required: true,
+                default: "https://s3.amazonaws.com",
+            },
+            {
+                name: "bucket",
+                type: "text",
+                label: "Bucket Name",
+                description: "Name of the S3 bucket",
+                required: true,
+                default: "",
+            },
+            {
+                name: "provider",
+                type: "select",
+                label: "S3 Provider",
+                description: "Select your S3 provider",
+                required: false,
+                default: "AWS",
+                options: S3_PROVIDERS,
+            },
+        ],
+    },
+    {
+        name: "FTP",
+        type: "ftp",
+        properties: [
+            {
+                name: "host",
+                type: "text",
+                label: "Host",
+                description: "FTP server hostname",
+                required: true,
+                default: "",
+            },
+            {
+                name: "port",
+                type: "number",
+                label: "Port",
+                description: "FTP server port",
+                required: true,
+                default: "21",
+            },
+            {
+                name: "username",
+                type: "text",
+                label: "Username",
+                description: "FTP username",
+                required: true,
+                default: "",
+            },
+            {
+                name: "password",
+                type: "password",
+                label: "Password",
+                description: "FTP password",
+                required: true,
+                default: "",
+            },
+            {
+                name: "path",
+                type: "text",
+                label: "Path",
+                description: "Remote backup path",
+                required: true,
+                default: "/",
+            },
+        ],
+    },
+    {
+        name: "SFTP",
+        type: "sftp",
+        properties: [
+            {
+                name: "host",
+                type: "text",
+                label: "Host",
+                description: "SFTP server hostname",
+                required: true,
+                default: "",
+            },
+            {
+                name: "port",
+                type: "number",
+                label: "Port",
+                description: "SFTP server port",
+                required: true,
+                default: "22",
+            },
+            {
+                name: "username",
+                type: "text",
+                label: "Username",
+                description: "SFTP username",
+                required: true,
+                default: "",
+            },
+            {
+                name: "password",
+                type: "password",
+                label: "Password",
+                description: "SFTP password",
+                required: true,
+                default: "",
+            },
+            {
+                name: "path",
+                type: "text",
+                label: "Path",
+                description: "Remote backup path",
+                required: true,
+                default: "/",
+            },
+        ],
+    },
+];

--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -1,518 +1,80 @@
-import {
-	ADDITIONAL_FLAG_ERROR,
-	ADDITIONAL_FLAG_REGEX,
-} from "@dokploy/server/db/validations/destination";
-import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { PenBoxIcon, PlusIcon, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
-import { toast } from "sonner";
-import { z } from "zod";
-import { AlertBlock } from "@/components/shared/alert-block";
+import { PlusIcon, PenBoxIcon } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
-	Form,
-	FormControl,
-	FormField,
-	FormItem,
-	FormLabel,
-	FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectLabel,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import { cn } from "@/lib/utils";
-import { api } from "@/utils/api";
-import { S3_PROVIDERS } from "./constants";
+    DESTINATION_SCHEMAS,
+    type DestinationType,
+} from "./destination-schema";
+import { DestinationDialog } from "./destination-dialog";
 
-const addDestination = z.object({
-	name: z.string().min(1, "Name is required"),
-	provider: z.string().min(1, "Provider is required"),
-	accessKeyId: z.string().min(1, "Access Key Id is required"),
-	secretAccessKey: z.string().min(1, "Secret Access Key is required"),
-	bucket: z.string().min(1, "Bucket is required"),
-	region: z.string(),
-	endpoint: z.string().min(1, "Endpoint is required"),
-	serverId: z.string().optional(),
-	additionalFlags: z
-		.array(
-			z.object({
-				value: z
-					.string()
-					.min(1, "Flag cannot be empty")
-					.regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR),
-			}),
-		)
-		.optional(),
-});
-
-type AddDestination = z.infer<typeof addDestination>;
+type DestinationDialogType = DestinationType | null;
 
 interface Props {
-	destinationId?: string;
+    destinationId?: string;
+    type?: DestinationDialogType;
 }
 
-export const HandleDestinations = ({ destinationId }: Props) => {
-	const [open, setOpen] = useState(false);
-	const utils = api.useUtils();
-	const { data: servers } = api.server.withSSHKey.useQuery();
-	const { data: isCloud } = api.settings.isCloud.useQuery();
+export const HandleDestinations = ({ destinationId, type: initialType }: Props) => {
+    const [openType, setOpenType] = useState<DestinationDialogType>(null);
 
-	const { mutateAsync, isError, error, isPending } = destinationId
-		? api.destination.update.useMutation()
-		: api.destination.create.useMutation();
+    const handleEdit = () => {
+        setOpenType(initialType || "s3");
+    };
 
-	const { data: destination } = api.destination.one.useQuery(
-		{
-			destinationId: destinationId || "",
-		},
-		{
-			enabled: !!destinationId,
-			refetchOnWindowFocus: false,
-		},
-	);
-	const {
-		mutateAsync: testConnection,
-		isPending: isPendingConnection,
-		error: connectionError,
-		isError: isErrorConnection,
-	} = api.destination.testConnection.useMutation();
+    const destinationOptions = DESTINATION_SCHEMAS.map((schema) => ({
+        type: schema.type,
+        label: schema.type === "s3" ? "S3 Storage" : schema.name,
+    }));
 
-	const form = useForm<AddDestination>({
-		defaultValues: {
-			provider: "",
-			accessKeyId: "",
-			bucket: "",
-			name: "",
-			region: "",
-			secretAccessKey: "",
-			endpoint: "",
-			additionalFlags: [],
-		},
-		resolver: zodResolver(addDestination),
-	});
+    return (
+        <>
+            {destinationId ? (
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="group hover:bg-blue-500/10"
+                    onClick={handleEdit}
+                >
+                    <PenBoxIcon className="size-3.5 text-primary group-hover:text-blue-500" />
+                </Button>
+            ) : (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button className="cursor-pointer space-x-3">
+                            <PlusIcon className="h-4 w-4" />
+                            <span>Add Destination</span>
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-48">
+                        {destinationOptions.map((option) => (
+                            <DropdownMenuItem
+                                key={option.type}
+                                onClick={() => setOpenType(option.type)}
+                            >
+                                {option.label}
+                            </DropdownMenuItem>
+                        ))}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            )}
 
-	const { fields, append, remove } = useFieldArray({
-		control: form.control,
-		name: "additionalFlags",
-	});
-
-	useEffect(() => {
-		if (destination) {
-			form.reset({
-				name: destination.name,
-				provider: destination.provider || "",
-				accessKeyId: destination.accessKey,
-				secretAccessKey: destination.secretAccessKey,
-				bucket: destination.bucket,
-				region: destination.region,
-				endpoint: destination.endpoint,
-				additionalFlags:
-					destination.additionalFlags?.map((f) => ({ value: f })) ?? [],
-			});
-		} else {
-			form.reset();
-		}
-	}, [form, form.reset, form.formState.isSubmitSuccessful, destination]);
-
-	const onSubmit = async (data: AddDestination) => {
-		await mutateAsync({
-			provider: data.provider || "",
-			accessKey: data.accessKeyId,
-			bucket: data.bucket,
-			endpoint: data.endpoint,
-			name: data.name,
-			region: data.region,
-			secretAccessKey: data.secretAccessKey,
-			destinationId: destinationId || "",
-			additionalFlags: data.additionalFlags?.map((f) => f.value) ?? [],
-		})
-			.then(async () => {
-				toast.success(`Destination ${destinationId ? "Updated" : "Created"}`);
-				await utils.destination.all.invalidate();
-				if (destinationId) {
-					await utils.destination.one.invalidate({ destinationId });
-				}
-				setOpen(false);
-			})
-			.catch((e) => {
-				toast.error(
-					`Error ${destinationId ? "Updating" : "Creating"} the Destination`,
-					{
-						description: e.message,
-					},
-				);
-			});
-	};
-
-	const handleTestConnection = async (serverId?: string) => {
-		const result = await form.trigger([
-			"provider",
-			"accessKeyId",
-			"secretAccessKey",
-			"bucket",
-			"endpoint",
-			"additionalFlags",
-		]);
-
-		if (!result) {
-			const errors = form.formState.errors;
-			const errorFields = Object.entries(errors)
-				.map(([field, error]) => `${field}: ${error?.message}`)
-				.filter(Boolean)
-				.join("\n");
-
-			toast.error("Please fill all required fields", {
-				description: errorFields,
-			});
-			return;
-		}
-
-		if (isCloud && !serverId) {
-			toast.error("Please select a server");
-			return;
-		}
-
-		const provider = form.getValues("provider");
-		const accessKey = form.getValues("accessKeyId");
-		const secretKey = form.getValues("secretAccessKey");
-		const bucket = form.getValues("bucket");
-		const endpoint = form.getValues("endpoint");
-		const region = form.getValues("region");
-
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
-
-		await testConnection({
-			provider,
-			accessKey,
-			bucket,
-			endpoint,
-			name: "Test",
-			region,
-			secretAccessKey: secretKey,
-			serverId,
-			additionalFlags:
-				form.getValues("additionalFlags")?.map((f) => f.value) ?? [],
-		})
-			.then(() => {
-				toast.success("Connection Success");
-			})
-			.catch((e) => {
-				toast.error("Error connecting to provider", {
-					description: `${e.message}\n\nTry manually: rclone ls ${connectionString}`,
-				});
-			});
-	};
-
-	return (
-		<Dialog open={open} onOpenChange={setOpen}>
-			<DialogTrigger className="" asChild>
-				{destinationId ? (
-					<Button
-						variant="ghost"
-						size="icon"
-						className="group hover:bg-blue-500/10 "
-					>
-						<PenBoxIcon className="size-3.5  text-primary group-hover:text-blue-500" />
-					</Button>
-				) : (
-					<Button className="cursor-pointer space-x-3">
-						<PlusIcon className="h-4 w-4" />
-						Add Destination
-					</Button>
-				)}
-			</DialogTrigger>
-			<DialogContent className="sm:max-w-2xl">
-				<DialogHeader>
-					<DialogTitle>
-						{destinationId ? "Update" : "Add"} Destination
-					</DialogTitle>
-					<DialogDescription>
-						In this section, you can configure and add new destinations for your
-						backups. Please ensure that you provide the correct information to
-						guarantee secure and efficient storage.
-					</DialogDescription>
-				</DialogHeader>
-				{(isError || isErrorConnection) && (
-					<AlertBlock type="error" className="w-full">
-						{connectionError?.message || error?.message}
-					</AlertBlock>
-				)}
-
-				<Form {...form}>
-					<form
-						id="hook-form-destination-add"
-						onSubmit={form.handleSubmit(onSubmit)}
-						className="grid w-full gap-4 "
-					>
-						<FormField
-							control={form.control}
-							name="name"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Name</FormLabel>
-										<FormControl>
-											<Input placeholder={"S3 Bucket"} {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-						<FormField
-							control={form.control}
-							name="provider"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Provider</FormLabel>
-										<FormControl>
-											<Select
-												onValueChange={field.onChange}
-												defaultValue={field.value}
-												value={field.value}
-											>
-												<FormControl>
-													<SelectTrigger>
-														<SelectValue placeholder="Select a S3 Provider" />
-													</SelectTrigger>
-												</FormControl>
-												<SelectContent>
-													{S3_PROVIDERS.map((s3Provider) => (
-														<SelectItem
-															key={s3Provider.key}
-															value={s3Provider.key}
-														>
-															{s3Provider.name}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-
-						<FormField
-							control={form.control}
-							name="accessKeyId"
-							render={({ field }) => {
-								return (
-									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
-										<FormControl>
-											<Input placeholder={"xcas41dasde"} {...field} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
-						/>
-						<FormField
-							control={form.control}
-							name="secretAccessKey"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"asd123asdasw"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="bucket"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"dokploy-bucket"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="region"
-							render={({ field }) => (
-								<FormItem>
-									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
-									</div>
-									<FormControl>
-										<Input placeholder={"us-east-1"} {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							control={form.control}
-							name="endpoint"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
-									<FormControl>
-										<Input
-											placeholder={"https://us.bucket.aws/s3"}
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<div className="flex flex-col gap-2">
-							<div className="flex items-center justify-between">
-								<FormLabel>Additional Flags (Optional)</FormLabel>
-								<Button
-									type="button"
-									variant="ghost"
-									size="sm"
-									onClick={() => append({ value: "" })}
-								>
-									<PlusIcon className="size-4" />
-									Add Flag
-								</Button>
-							</div>
-							{fields.map((field, index) => (
-								<FormField
-									key={field.id}
-									control={form.control}
-									name={`additionalFlags.${index}.value`}
-									render={({ field }) => (
-										<FormItem>
-											<div className="flex items-center gap-2">
-												<FormControl>
-													<Input
-														placeholder="--s3-sign-accept-encoding=false"
-														{...field}
-													/>
-												</FormControl>
-												<Button
-													type="button"
-													variant="ghost"
-													size="icon"
-													onClick={() => remove(index)}
-												>
-													<Trash2 className="size-4 text-muted-foreground" />
-												</Button>
-											</div>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							))}
-						</div>
-					</form>
-
-					<DialogFooter
-						className={cn(
-							isCloud ? "!flex-col" : "flex-row",
-							"flex w-full  !justify-between gap-4",
-						)}
-					>
-						{isCloud ? (
-							<div className="flex flex-col gap-4 border p-2 rounded-lg">
-								<span className="text-sm text-muted-foreground">
-									Select a server to test the destination. If you don't have a
-									server choose the default one.
-								</span>
-								<FormField
-									control={form.control}
-									name="serverId"
-									render={({ field }) => (
-										<FormItem>
-											<FormLabel>Server (Optional)</FormLabel>
-											<FormControl>
-												<Select
-													onValueChange={field.onChange}
-													defaultValue={field.value}
-												>
-													<SelectTrigger className="w-full">
-														<SelectValue placeholder="Select a server" />
-													</SelectTrigger>
-													<SelectContent>
-														<SelectGroup>
-															<SelectLabel>Servers</SelectLabel>
-															{servers?.map((server) => (
-																<SelectItem
-																	key={server.serverId}
-																	value={server.serverId}
-																>
-																	{server.name}
-																</SelectItem>
-															))}
-															<SelectItem value={"none"}>None</SelectItem>
-														</SelectGroup>
-													</SelectContent>
-												</Select>
-											</FormControl>
-
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-								<Button
-									type="button"
-									variant={"secondary"}
-									isLoading={isPendingConnection}
-									onClick={async () => {
-										await handleTestConnection(form.getValues("serverId"));
-									}}
-								>
-									Test Connection
-								</Button>
-							</div>
-						) : (
-							<Button
-								isLoading={isPendingConnection}
-								type="button"
-								variant="secondary"
-								onClick={async () => {
-									await handleTestConnection();
-								}}
-							>
-								Test connection
-							</Button>
-						)}
-
-						<Button
-							isLoading={isPending}
-							form="hook-form-destination-add"
-							type="submit"
-						>
-							{destinationId ? "Update" : "Create"}
-						</Button>
-					</DialogFooter>
-				</Form>
-			</DialogContent>
-		</Dialog>
-	);
+            {DESTINATION_SCHEMAS.map((schema) => {
+                return (
+                    <DestinationDialog
+                        key={schema.type}
+                        open={openType === schema.type}
+                        onOpenChange={(open: boolean) => !open && setOpenType(null)}
+                        destinationId={destinationId}
+                        type={schema.type}
+                    />
+                );
+            })}
+        </>
+    );
 };

--- a/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
@@ -24,11 +24,10 @@ export const ShowDestinations = () => {
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
 							<Database className="size-6 text-muted-foreground self-center" />
-							S3 Destinations
+							Destinations
 						</CardTitle>
 						<CardDescription>
-							Add your providers like AWS S3, Cloudflare R2, Wasabi,
-							DigitalOcean Spaces etc.
+							Add your providers like FTP, SFTP, and S3.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-2 py-8 border-t">
@@ -71,6 +70,7 @@ export const ShowDestinations = () => {
 														<div className="flex flex-row gap-1">
 															<HandleDestinations
 																destinationId={destination.destinationId}
+																type={destination.type}
 															/>
 															{permissions?.destination.delete && (
 																<DialogAction

--- a/apps/dokploy/drizzle/0166_destination_credentials_json.sql
+++ b/apps/dokploy/drizzle/0166_destination_credentials_json.sql
@@ -1,0 +1,31 @@
+CREATE TYPE "public"."destination_type" AS ENUM('sftp', 'ftp', 's3');
+--> statement-breakpoint
+ALTER TABLE "destination" ADD COLUMN "credentials" jsonb DEFAULT '{}'::jsonb NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "destination" ADD COLUMN "type" "destination_type" DEFAULT 's3' NOT NULL;
+--> statement-breakpoint
+UPDATE "destination"
+SET "credentials" = jsonb_strip_nulls(
+	jsonb_build_object(
+		'provider', "provider",
+		'accessKey', "accessKey",
+		'secretAccessKey', "secretAccessKey",
+		'bucket', "bucket",
+		'region', "region",
+		'endpoint', "endpoint"
+	)
+);
+--> statement-breakpoint
+ALTER TABLE "destination" ALTER COLUMN "type" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "destination" DROP COLUMN "provider";
+--> statement-breakpoint
+ALTER TABLE "destination" DROP COLUMN "accessKey";
+--> statement-breakpoint
+ALTER TABLE "destination" DROP COLUMN "secretAccessKey";
+--> statement-breakpoint
+ALTER TABLE "destination" DROP COLUMN "bucket";
+--> statement-breakpoint
+ALTER TABLE "destination" DROP COLUMN "region";
+--> statement-breakpoint
+ALTER TABLE "destination" DROP COLUMN "endpoint";

--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -31,8 +31,8 @@ import { findDestinationById } from "@dokploy/server/services/destination";
 import { checkServicePermissionAndAccess } from "@dokploy/server/services/permission";
 import { runComposeBackup } from "@dokploy/server/utils/backups/compose";
 import {
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "@dokploy/server/utils/backups/utils";
 import {
 	execAsync,
@@ -461,21 +461,18 @@ export const backupRouter = createTRPCRouter({
 		.query(async ({ input }) => {
 			try {
 				const destination = await findDestinationById(input.destinationId);
-				const rcloneFlags = getS3Credentials(destination);
-				const bucketPath = `:s3:${destination.bucket}`;
 
 				const lastSlashIndex = input.search.lastIndexOf("/");
 				const baseDir =
 					lastSlashIndex !== -1
-						? normalizeS3Path(input.search.slice(0, lastSlashIndex + 1))
+						? normalizePath(input.search.slice(0, lastSlashIndex + 1))
 						: "";
 				const searchTerm =
 					lastSlashIndex !== -1
 						? input.search.slice(lastSlashIndex + 1)
 						: input.search;
 
-				const searchPath = baseDir ? `${bucketPath}/${baseDir}` : bucketPath;
-				const listCommand = `rclone lsjson ${rcloneFlags.join(" ")} "${searchPath}" --no-mimetype --no-modtime 2>/dev/null`;
+				const listCommand = getRcloneCommand(destination, "lsjson", baseDir, `--no-mimetype --no-modtime`) + " 2>/dev/null";
 
 				let stdout = "";
 

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -3,9 +3,12 @@ import {
 	execAsync,
 	execAsyncRemote,
 	findDestinationById,
+	getDestinationAdapter,
 	IS_CLOUD,
 	removeDestinationById,
 	updateDestinationById,
+	apiCreateAnyDestination,
+	apiUpdateAnyDestination,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
 import { TRPCError } from "@trpc/server";
@@ -13,22 +16,26 @@ import { desc, eq } from "drizzle-orm";
 import { createTRPCRouter, withPermission } from "@/server/api/trpc";
 import { audit } from "@/server/api/utils/audit";
 import {
-	apiCreateDestination,
 	apiFindOneDestination,
 	apiRemoveDestination,
-	apiUpdateDestination,
 	destinations,
 } from "@/server/db/schema";
 
 export const destinationRouter = createTRPCRouter({
 	create: withPermission("destination", "create")
-		.input(apiCreateDestination)
+		.input(apiCreateAnyDestination)
 		.mutation(async ({ input, ctx }) => {
 			try {
+				const adapter = getDestinationAdapter(input.type);
+				const credentials = adapter.extractCredentials(input as never);
 				const result = await createDestination(
-					input,
+					{
+						...input,
+						credentials,
+					},
 					ctx.session.activeOrganizationId,
 				);
+
 				await audit(ctx, {
 					action: "create",
 					resourceType: "destination",
@@ -45,38 +52,11 @@ export const destinationRouter = createTRPCRouter({
 			}
 		}),
 	testConnection: withPermission("destination", "create")
-		.input(apiCreateDestination)
+		.input(apiCreateAnyDestination)
 		.mutation(async ({ input }) => {
-			const {
-				secretAccessKey,
-				bucket,
-				region,
-				endpoint,
-				accessKey,
-				provider,
-				additionalFlags,
-			} = input;
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
-				}
-				if (additionalFlags?.length) {
-					rcloneFlags.push(...additionalFlags);
-				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+				const adapter = getDestinationAdapter(input.type);
+				const rcloneCommand = await adapter.testCommand(input as never);
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({
@@ -131,6 +111,7 @@ export const destinationRouter = createTRPCRouter({
 						message: "You are not allowed to delete this destination",
 					});
 				}
+				
 				const result = await removeDestinationById(
 					input.destinationId,
 					ctx.session.activeOrganizationId,
@@ -147,7 +128,7 @@ export const destinationRouter = createTRPCRouter({
 			}
 		}),
 	update: withPermission("destination", "create")
-		.input(apiUpdateDestination)
+		.input(apiUpdateAnyDestination)
 		.mutation(async ({ input, ctx }) => {
 			try {
 				const destination = await findDestinationById(input.destinationId);
@@ -157,10 +138,23 @@ export const destinationRouter = createTRPCRouter({
 						message: "You are not allowed to update this destination",
 					});
 				}
+				
+				if (destination.type !== input.type) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: "Destination type cannot be changed",
+					});
+				}
+
+				const adapter = getDestinationAdapter(destination.type);
+				const credentials = adapter.extractCredentials(input as never);
+				
 				const result = await updateDestinationById(input.destinationId, {
 					...input,
+					credentials,
 					organizationId: ctx.session.activeOrganizationId,
 				});
+
 				await audit(ctx, {
 					action: "update",
 					resourceType: "destination",

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { jsonb, pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { nanoid } from "nanoid";
 import { z } from "zod";
@@ -9,6 +9,8 @@ import {
 } from "../validations/destination";
 import { organization } from "./account";
 import { backups } from "./backups";
+	
+export const destinationTypeEnum = pgEnum("destination_type", ["sftp", "ftp", "s3"]);
 
 export const destinations = pgTable("destination", {
 	destinationId: text("destinationId")
@@ -16,17 +18,16 @@ export const destinations = pgTable("destination", {
 		.primaryKey()
 		.$defaultFn(() => nanoid()),
 	name: text("name").notNull(),
-	provider: text("provider"),
-	accessKey: text("accessKey").notNull(),
-	secretAccessKey: text("secretAccessKey").notNull(),
-	bucket: text("bucket").notNull(),
-	region: text("region").notNull(),
-	endpoint: text("endpoint").notNull(),
+	credentials: jsonb("credentials")
+		.$type<Record<string, unknown>>()
+		.notNull()
+		.default({}),
 	additionalFlags: text("additionalFlags").array(),
 	organizationId: text("organizationId")
 		.notNull()
 		.references(() => organization.id, { onDelete: "cascade" }),
 	createdAt: timestamp("createdAt").notNull().defaultNow(),
+	type: destinationTypeEnum("type").notNull(),
 });
 
 export const destinationsRelations = relations(
@@ -43,27 +44,20 @@ export const destinationsRelations = relations(
 const createSchema = createInsertSchema(destinations, {
 	destinationId: z.string(),
 	name: z.string().min(1),
-	provider: z.string(),
-	accessKey: z.string(),
-	bucket: z.string(),
-	endpoint: z.string(),
-	secretAccessKey: z.string(),
-	region: z.string(),
+	credentials: z.record(z.string(), z.unknown()).default({}),
 	additionalFlags: z
 		.array(z.string().regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR))
 		.default([]),
+	type: z.enum(["s3", "ftp", "sftp"], {
+		error: "Type must be either 's3', 'ftp' or 'sftp'" ,
+	}),
 });
 
 export const apiCreateDestination = createSchema
 	.pick({
 		name: true,
-		provider: true,
-		accessKey: true,
-		bucket: true,
-		region: true,
-		endpoint: true,
-		secretAccessKey: true,
 		additionalFlags: true,
+		type: true,
 	})
 	.required()
 	.extend({
@@ -83,13 +77,7 @@ export const apiRemoveDestination = createSchema
 export const apiUpdateDestination = createSchema
 	.pick({
 		name: true,
-		accessKey: true,
-		bucket: true,
-		region: true,
-		endpoint: true,
-		secretAccessKey: true,
 		destinationId: true,
-		provider: true,
 		additionalFlags: true,
 	})
 	.required()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -16,6 +16,7 @@ export * from "./services/cluster";
 export * from "./services/compose";
 export * from "./services/deployment";
 export * from "./services/destination";
+export * from "./services/destination-adapters";
 export * from "./services/docker";
 export * from "./services/domain";
 export * from "./services/environment";

--- a/packages/server/src/services/destination-adapters.ts
+++ b/packages/server/src/services/destination-adapters.ts
@@ -1,0 +1,269 @@
+import {
+    apiCreateDestination,
+    apiUpdateDestination,
+} from "@dokploy/server/db/schema";
+import { execFileSync } from "node:child_process";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { findDestinationById } from "./destination";
+
+const obscureRclonePassword = (password: string) => {
+    try {
+        return execFileSync("rclone", ["obscure", password], {
+            encoding: "utf8",
+        }).trim();
+    } catch {
+        throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Error obscuring destination password",
+        });
+    }
+};
+
+const ftpCredentialsSchema = z.object({
+    username: z.string().min(1),
+    password: z.string().min(1),
+    host: z.string().min(1),
+    port: z.string().min(1),
+    path: z.string().min(1),
+});
+
+const s3CredentialsSchema = z.object({
+    provider: z.string().optional().nullable(),
+    accessKey: z.string().min(1),
+    secretAccessKey: z.string().min(1),
+    bucket: z.string().min(1),
+    region: z.string(),
+    endpoint: z.string().min(1),
+});
+
+const apiCreateFtpOrSftpDestination = z.object({
+    ...apiCreateDestination.shape,
+    type: z.literal("ftp").or(z.literal("sftp")),
+    ...ftpCredentialsSchema.shape,
+});
+
+const apiCreateS3AnyDestination = z.object({
+    ...apiCreateDestination.shape,
+    type: z.literal("s3"),
+    ...s3CredentialsSchema.shape,
+});
+
+const apiUpdateFtpOrSftpDestination = z.object({
+    ...apiUpdateDestination.shape,
+    type: z.literal("ftp").or(z.literal("sftp")),
+    ...ftpCredentialsSchema.shape,
+});
+
+const apiUpdateS3AnyDestination = z.object({
+    ...apiUpdateDestination.shape,
+    type: z.literal("s3"),
+    ...s3CredentialsSchema.shape,
+});
+
+export const apiCreateAnyDestination = z.discriminatedUnion("type", [
+    apiCreateFtpOrSftpDestination,
+    apiCreateS3AnyDestination,
+]);
+
+export const apiUpdateAnyDestination = z.discriminatedUnion("type", [
+    apiUpdateFtpOrSftpDestination,
+    apiUpdateS3AnyDestination,
+]);
+
+export type DestinationRcloneConfig = {
+    flags: string[];
+    destinationPrefix: string;
+    destinationPathPrefix: string;
+};
+
+export type DestinationCredentials = Record<string, unknown>;
+
+type DestinationType = z.infer<typeof apiCreateAnyDestination>["type"];
+type AnyCreateInput = z.infer<typeof apiCreateAnyDestination>;
+type AnyUpdateInput = z.infer<typeof apiUpdateAnyDestination>;
+type FtpOrSftpCreateInput = Extract<AnyCreateInput, { type: "ftp" | "sftp" }>;
+type S3CreateInput = Extract<AnyCreateInput, { type: "s3" }>;
+type FtpOrSftpUpdateInput = Extract<AnyUpdateInput, { type: "ftp" | "sftp" }>;
+type S3UpdateInput = Extract<AnyUpdateInput, { type: "s3" }>;
+
+type FtpCredentials = z.infer<typeof ftpCredentialsSchema>;
+type S3Credentials = z.infer<typeof s3CredentialsSchema>;
+
+type DestinationAdapter<TType extends DestinationType, TDetails> = {
+    type: TType;
+    create: (
+        input: Extract<AnyCreateInput, { type: TType }>,
+        destinationId: string,
+    ) => Promise<void>;
+    testCommand: (
+        input: Extract<AnyCreateInput, { type: TType }>,
+    ) => Promise<string>;
+    update: (
+        destinationId: string,
+        input: Extract<AnyUpdateInput, { type: TType }>,
+    ) => Promise<void>;
+    getRcloneConfig: (credentials: TDetails) => DestinationRcloneConfig;
+    extractCredentials: (
+        input: Extract<AnyCreateInput | AnyUpdateInput, { type: TType }>,
+    ) => DestinationCredentials;
+};
+
+const destinationAdapters = {
+    ftp: {
+        type: "ftp",
+        create: async () => {},
+        testCommand: async (input: FtpOrSftpCreateInput) => {
+            const obscuredPassword = obscureRclonePassword(input.password);
+            const rcloneFlags = [
+                `--ftp-host="${input.host}"`,
+                `--ftp-port="${input.port}"`,
+                `--ftp-user="${input.username}"`,
+                `--ftp-pass="${obscuredPassword}"`,
+            ];
+            if (input.additionalFlags?.length) {
+                rcloneFlags.push(...input.additionalFlags);
+            }
+            return `rclone lsd ${rcloneFlags.join(" ")} remote:/`;
+        },
+        update: async () => {},
+        getRcloneConfig: (credentials: FtpCredentials) => {
+            const obscuredPassword = obscureRclonePassword(credentials.password);
+            return {
+                flags: [
+                    `--ftp-host="${credentials.host}"`,
+                    `--ftp-port="${credentials.port}"`,
+                    `--ftp-user="${credentials.username}"`,
+                    `--ftp-pass="${obscuredPassword}"`,
+                ],
+                destinationPrefix: "ftp",
+                destinationPathPrefix: credentials.path,
+            };
+        },
+        extractCredentials: (input: FtpOrSftpCreateInput | FtpOrSftpUpdateInput) => ({
+            username: input.username,
+            password: input.password,
+            host: input.host,
+            port: input.port,
+            path: input.path,
+        }),
+    } satisfies DestinationAdapter<"ftp", FtpCredentials>,
+    sftp: {
+        type: "sftp",
+        create: async () => {},
+        testCommand: async (input: FtpOrSftpCreateInput) => {
+            const obscuredPassword = obscureRclonePassword(input.password);
+            const rcloneFlags = [
+                `--sftp-host="${input.host}"`,
+                `--sftp-port="${input.port}"`,
+                `--sftp-user="${input.username}"`,
+                `--sftp-pass="${obscuredPassword}"`,
+            ];
+            if (input.additionalFlags?.length) {
+                rcloneFlags.push(...input.additionalFlags);
+            }
+            return `rclone lsd ${rcloneFlags.join(" ")} remote:/`;
+        },
+        update: async () => {},
+        getRcloneConfig: (credentials: FtpCredentials) => {
+            const obscuredPassword = obscureRclonePassword(credentials.password);
+            return {
+                flags: [
+                    `--sftp-host="${credentials.host}"`,
+                    `--sftp-port="${credentials.port}"`,
+                    `--sftp-user="${credentials.username}"`,
+                    `--sftp-pass="${obscuredPassword}"`,
+                ],
+                destinationPrefix: "sftp",
+                destinationPathPrefix: credentials.path,
+            };
+        },
+        extractCredentials: (input: FtpOrSftpCreateInput | FtpOrSftpUpdateInput) => ({
+            username: input.username,
+            password: input.password,
+            host: input.host,
+            port: input.port,
+            path: input.path,
+        }),
+    } satisfies DestinationAdapter<"sftp", FtpCredentials>,
+    s3: {
+        type: "s3",
+        create: async () => {},
+        testCommand: async (input: S3CreateInput) => {
+            const flags = [
+                `--s3-access-key-id="${input.accessKey}"`,
+                `--s3-secret-access-key="${input.secretAccessKey}"`,
+                `--s3-region="${input.region}"`,
+                `--s3-endpoint="${input.endpoint}"`,
+                "--s3-no-check-bucket",
+                "--s3-force-path-style",
+                "--retries 1",
+                "--low-level-retries 1",
+                "--timeout 10s",
+                "--contimeout 5s",
+            ];
+
+            if (input.provider) {
+                flags.unshift(`--s3-provider="${input.provider}"`);
+            }
+            if (input.additionalFlags?.length) {
+                flags.push(...input.additionalFlags);
+            }
+
+            return `rclone ls ${flags.join(" ")} ":s3:${input.bucket}"`;
+        },
+        update: async () => {},
+        getRcloneConfig: (credentials: S3Credentials) => {
+            const flags = [
+                `--s3-access-key-id="${credentials.accessKey}"`,
+                `--s3-secret-access-key="${credentials.secretAccessKey}"`,
+                `--s3-region="${credentials.region}"`,
+                `--s3-endpoint="${credentials.endpoint}"`,
+                "--s3-no-check-bucket",
+                "--s3-force-path-style",
+            ];
+
+            if (credentials.provider) {
+                flags.unshift(`--s3-provider="${credentials.provider}"`);
+            }
+
+            return {
+                flags,
+                destinationPrefix: "s3",
+                destinationPathPrefix: credentials.bucket,
+            };
+        },
+        extractCredentials: (input: S3CreateInput | S3UpdateInput) => ({
+            provider: input.provider,
+            accessKey: input.accessKey,
+            secretAccessKey: input.secretAccessKey,
+            bucket: input.bucket,
+            region: input.region,
+            endpoint: input.endpoint,
+        }),
+    } satisfies DestinationAdapter<"s3", S3Credentials>,
+};
+
+export type SupportedDestinationType = keyof typeof destinationAdapters;
+export type DestinationDetails = {
+    destination: Awaited<ReturnType<typeof findDestinationById>>;
+} & Record<string, unknown>;
+
+export const getDestinationAdapter = <TType extends SupportedDestinationType>(type: TType) => {
+    const adapter = destinationAdapters[type];
+    if (!adapter) {
+        throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Unsupported destination type: ${type}`,
+        });
+    }
+    return adapter;
+};
+
+export const getDestinationRcloneConfig = (
+    type: SupportedDestinationType,
+    credentials: Record<string, unknown>,
+) => {
+    const adapter = getDestinationAdapter(type);
+    return adapter.getRcloneConfig(credentials as never);
+};

--- a/packages/server/src/services/destination.ts
+++ b/packages/server/src/services/destination.ts
@@ -8,15 +8,19 @@ import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
 
 export type Destination = typeof destinations.$inferSelect;
+type CreateDestinationInput = z.infer<typeof apiCreateDestination> & {
+	credentials?: Record<string, unknown>;
+};
 
 export const createDestination = async (
-	input: z.infer<typeof apiCreateDestination>,
+	input: CreateDestinationInput,
 	organizationId: string,
 ) => {
 	const newDestination = await db
 		.insert(destinations)
 		.values({
 			...input,
+			credentials: input.credentials ?? {},
 			organizationId: organizationId,
 		})
 		.returning()

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -11,8 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "./utils";
 
 export const runComposeBackup = async (
@@ -25,8 +25,8 @@ export const runComposeBackup = async (
 	const { prefix, databaseType, serviceName } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${getBackupTimestamp()}.${databaseType === "mongo" ? "bson" : "sql"}.gz`;
-	const s3AppName = serviceName ? `${appName}_${serviceName}` : appName;
-	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const backupAppName = serviceName ? `${appName}_${serviceName}` : appName;
+	const backupDestination = `${backupAppName}/${normalizePath(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "Compose Backup",
@@ -34,9 +34,7 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = getRcloneCommand(destination, "rcat", backupDestination);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -10,7 +10,7 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import { getRcloneCommand, normalizePath, scheduleBackup } from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -131,17 +131,19 @@ export const keepLatestNBackups = async (
 	if (!backup.keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(backup.destination);
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${backup.destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = `${appName}/${normalizePath(backup.prefix)}`;
 
 		// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
-		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;
+		const rcloneList = getRcloneCommand(backup.destination, "lsf", backupFilesPath) + 
+					`| grep "${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}$"`;
+
 		// when we pipe the above command with this one, we only get the list of files we want to delete
 		const sortAndPickUnwantedBackups = `sort -r | tail -n +$((${backup.keepLatestCount}+1)) | xargs -I{}`;
+
 		// this command deletes the files
 		// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
-		const rcloneDelete = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		const rcloneDelete = getRcloneCommand(backup.destination, "delete", backupFilesPath + "{}") ;
 
 		const rcloneCommand = `${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
 

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -11,8 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "./utils";
 
 export const runLibsqlBackup = async (
@@ -31,12 +31,9 @@ export const runLibsqlBackup = async (
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const bucketDestination = `${appName}/${normalizePath(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = getRcloneCommand(destination, "rcat", bucketDestination);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -11,8 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "./utils";
 
 export const runMariadbBackup = async (
@@ -25,16 +25,14 @@ export const runMariadbBackup = async (
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const bucketDestination = `${appName}/${normalizePath(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "MariaDB Backup",
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = getRcloneCommand(destination, "rcat", bucketDestination);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -11,8 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "./utils";
 
 export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
@@ -22,16 +22,14 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${getBackupTimestamp()}.bson.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const bucketDestination = `${appName}/${normalizePath(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "MongoDB Backup",
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = getRcloneCommand(destination, "rcat", bucketDestination);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -11,8 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "./utils";
 
 export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
@@ -22,7 +22,7 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const bucketDestination = `${appName}/${normalizePath(prefix)}${backupFileName}`;
 	const deployment = await createDeploymentBackup({
 		backupId: backup.backupId,
 		title: "MySQL Backup",
@@ -30,10 +30,7 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = getRcloneCommand(destination, "rcat", bucketDestination);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -11,8 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneCommand,
+	normalizePath,
 } from "./utils";
 
 export const runPostgresBackup = async (
@@ -31,12 +31,9 @@ export const runPostgresBackup = async (
 	const { prefix } = backup;
 	const destination = backup.destination;
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
-	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
+	const bucketDestination = `${appName}/${normalizePath(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = getRcloneCommand(destination, "rcat", bucketDestination);
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -10,6 +10,10 @@ import { runMongoBackup } from "./mongo";
 import { runMySqlBackup } from "./mysql";
 import { runPostgresBackup } from "./postgres";
 import { runWebServerBackup } from "./web-server";
+import {
+	getDestinationRcloneConfig,
+	type SupportedDestinationType,
+} from "@dokploy/server/services/destination-adapters";
 
 export const scheduleBackup = (backup: BackupSchedule) => {
 	const {
@@ -59,14 +63,68 @@ export const removeScheduleBackup = (backupId: string) => {
 export const getBackupTimestamp = () =>
 	new Date().toISOString().replace(/[:.]/g, "-");
 
-export const normalizeS3Path = (prefix: string) => {
+export const normalizePath = (prefix: string) => {
 	// Trim whitespace and remove leading/trailing slashes
 	const normalizedPrefix = prefix.trim().replace(/^\/+|\/+$/g, "");
 	// Return empty string if prefix is empty, otherwise append trailing slash
 	return normalizedPrefix ? `${normalizedPrefix}/` : "";
 };
 
-export const getS3Credentials = (destination: Destination) => {
+export const getRcloneCommand = (destination: Destination, command: string, backupDestination: string, additionalFlags: string = "") => {
+	const config = getDestinationRcloneConfig(
+		destination.type as SupportedDestinationType,
+		destination.credentials ?? {},
+	);
+	let rcloneFlags = [...config.flags];
+	const rcloneDestinationPrefix = config.destinationPrefix;
+	const rcloneDestinationPathPrefix = config.destinationPathPrefix
+		? normalizePath(config.destinationPathPrefix)
+		: "";
+
+	if (destination.additionalFlags?.length) {
+		rcloneFlags.push(...destination.additionalFlags);
+	}
+	const rcloneDestination = `:${rcloneDestinationPrefix}:${rcloneDestinationPathPrefix}${backupDestination}`;
+	const rcloneFlagsString = rcloneFlags.join(" ");
+	const rcloneCommand = `rclone ${command} ${rcloneFlagsString} "${rcloneDestination}" ${additionalFlags}`;
+	return rcloneCommand;
+}
+
+type Path = {
+	path: string;
+	type: "remote" | "local";
+};
+
+export const getRcloneMultiDestinationCommand = (destination: Destination, command: string, sourcePath: Path, destinationPath: Path) => {
+	const config = getDestinationRcloneConfig(
+		destination.type as SupportedDestinationType,
+		destination.credentials ?? {},
+	);
+	let rcloneFlags = [...config.flags];
+	if (destination.additionalFlags?.length) {
+		rcloneFlags.push(...destination.additionalFlags);
+	}
+	const rcloneDestinationPrefix = config.destinationPrefix;
+	const rcloneDestinationPathPrefix = config.destinationPathPrefix
+		? normalizePath(config.destinationPathPrefix)
+		: "";
+	const rcloneSource = sourcePath.type === "remote" ? `:${rcloneDestinationPrefix}:${rcloneDestinationPathPrefix}${sourcePath.path}` : sourcePath.path;
+	const rcloneDestination = destinationPath.type === "remote" ? `:${rcloneDestinationPrefix}:${rcloneDestinationPathPrefix}${destinationPath.path}` : destinationPath.path;
+	const rcloneFlagsString = rcloneFlags.join(" ");
+	const rcloneCommand = `rclone ${command} ${rcloneFlagsString} "${rcloneSource}" "${rcloneDestination}"`;
+	return rcloneCommand;
+}
+
+
+type S3CredentialShape = {
+	provider?: string | null;
+	accessKey: string;
+	secretAccessKey: string;
+	region: string;
+	endpoint: string;
+};
+
+export const getS3Credentials = (destination: S3CredentialShape) => {
 	const { accessKey, secretAccessKey, region, endpoint, provider } =
 		destination;
 	const rcloneFlags = [
@@ -80,10 +138,6 @@ export const getS3Credentials = (destination: Destination) => {
 
 	if (provider) {
 		rcloneFlags.unshift(`--s3-provider="${provider}"`);
-	}
-
-	if (destination.additionalFlags?.length) {
-		rcloneFlags.push(...destination.additionalFlags);
 	}
 
 	return rcloneFlags;

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -11,7 +11,7 @@ import {
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { sendDokployBackupNotifications } from "../notifications/dokploy-backup";
 import { execAsync } from "../process/execAsync";
-import { getBackupTimestamp, getS3Credentials, normalizeS3Path } from "./utils";
+import { getBackupTimestamp, getRcloneMultiDestinationCommand, normalizePath } from "./utils";
 
 function formatBytes(bytes?: number) {
 	if (bytes === undefined) return "Unknown size";
@@ -36,12 +36,12 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 	let computedBackupSize: number | undefined;
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
+
 		const timestamp = getBackupTimestamp();
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const s3Path = `${backup.appName}/${normalizePath(backup.prefix)}${backupFileName}`;
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -98,7 +98,7 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 				// If stat fails, keep undefined
 			}
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${zipPath}" "${s3Path}"`;
+			const uploadCommand = getRcloneMultiDestinationCommand(destination, "copyto", { type: "local", path: zipPath }, { type: "remote", path: s3Path });
 			writeStream.write("Running command to upload backup to S3\n");
 			await execAsync(uploadCommand);
 			writeStream.write("Uploaded backup to S3 ✅\n");

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -23,13 +23,11 @@ export const restoreComposeBackup = async (
 		}
 		const { serverId, appName, composeType } = compose;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		let rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+
+		let rcloneCommand = getRcloneCommand(destination, "cat", backupInput.backupFile) + " | gunzip";
 
 		if (backupInput.metadata?.mongo) {
-			rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+			rcloneCommand = getRcloneCommand(destination, "copy", backupInput.backupFile);
 		}
 
 		let credentials: DatabaseCredentials = {};
@@ -77,7 +75,7 @@ export const restoreComposeBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Backup path: ${backupPath}`);
+		emit(`Backup path: ${backupInput.backupFile}`);
 
 		emit(`Executing command: ${restoreCommand}`);
 

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Libsql } from "@dokploy/server/services/libsql";
 import type { z } from "zod";
-import { getS3Credentials, getServiceContainerCommand } from "../backups/utils";
+import { getRcloneCommand, getServiceContainerCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 
 export const restoreLibsqlBackup = async (
@@ -14,15 +14,10 @@ export const restoreLibsqlBackup = async (
 	try {
 		const { appName, serverId } = libsql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const rcloneCommand = getRcloneCommand(destination, "cat", backupInput.backupFile) + ` | gunzip`;
 
 		emit("Starting restore...");
-		emit(`Backup path: ${backupPath}`);
+		emit(`Backup path: ${backupInput.backupFile}`);
 
 		const containerSearch = getServiceContainerCommand(appName);
 		const restoreCommand = `docker exec -i $CONTAINER_ID sh -c "tar xzf - -C /var/lib/sqld"`;

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mariadb } from "@dokploy/server/services/mariadb";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +15,7 @@ export const restoreMariadbBackup = async (
 	try {
 		const { appName, serverId, databaseUser, databasePassword } = mariadb;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = getRcloneCommand(destination, "cat", backupInput.backupFile) + ` | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mongo } from "@dokploy/server/services/mongo";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,10 +15,7 @@ export const restoreMongoBackup = async (
 	try {
 		const { appName, databasePassword, databaseUser, serverId } = mongo;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		const rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const rcloneCommand = getRcloneCommand(destination, "cat", backupInput.backupFile) + ` | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { MySql } from "@dokploy/server/services/mysql";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +15,7 @@ export const restoreMySqlBackup = async (
 	try {
 		const { appName, databaseRootPassword, serverId } = mysql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = getRcloneCommand(destination, "cat", backupInput.backupFile) + ` | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Postgres } from "@dokploy/server/services/postgres";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,15 +15,10 @@ export const restorePostgresBackup = async (
 	try {
 		const { appName, databaseUser, serverId } = postgres;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = getRcloneCommand(destination, "cat", backupInput.backupFile) + ` | gunzip`;
 
 		emit("Starting restore...");
-		emit(`Backup path: ${backupPath}`);
+		emit(`Backup path: ${backupInput.backupFile}`);
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneMultiDestinationCommand } from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
 export const restoreWebServerBackup = async (
@@ -15,17 +15,21 @@ export const restoreWebServerBackup = async (
 		return;
 	}
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupFile}`;
 		const { BASE_PATH } = paths();
 
 		// Create a temporary directory outside of BASE_PATH
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-restore-"));
 
+		const rcloneCommand = getRcloneMultiDestinationCommand(
+			destination,
+			"copyto",
+			{ type: "remote", path: backupFile },
+			{ type: "local", path: `${tempDir}/${backupFile}` },
+		);
+
 		try {
 			emit("Starting restore...");
-			emit(`Backup path: ${backupPath}`);
+			emit(`Backup path: ${backupFile}`);
 			emit(`Temp directory: ${tempDir}`);
 
 			// Create temp directory
@@ -35,7 +39,7 @@ export const restoreWebServerBackup = async (
 			// Download backup from S3
 			emit("Downloading backup from S3...");
 			await execAsync(
-				`rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${tempDir}/${backupFile}"`,
+				rcloneCommand
 			);
 
 			// List files before extraction

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -4,8 +4,8 @@ import { findComposeById } from "@dokploy/server/services/compose";
 import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
 import {
 	getBackupTimestamp,
-	getS3Credentials,
-	normalizeS3Path,
+	getRcloneMultiDestinationCommand,
+	normalizePath,
 } from "../backups/utils";
 
 export const getVolumeServiceAppName = (
@@ -35,14 +35,18 @@ export const backupVolume = async (
 		volumeBackup.application?.serverId || volumeBackup.compose?.serverId;
 	const { VOLUME_BACKUPS_PATH, VOLUME_BACKUP_LOCK_PATH } = paths(!!serverId);
 	const destination = volumeBackup.destination;
-	const s3AppName = getVolumeServiceAppName(volumeBackup);
+	const appName = getVolumeServiceAppName(volumeBackup);
 	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar`;
-	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
-	const rcloneFlags = getS3Credentials(volumeBackup.destination);
-	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+	const rcloneDestination = `${appName}/${normalizePath(prefix || "")}${backupFileName}`;
+	
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeBackup.appName);
 
-	const rcloneCommand = `rclone copyto ${rcloneFlags.join(" ")} "${volumeBackupPath}/${backupFileName}" "${rcloneDestination}"`;
+	const rcloneCommand = getRcloneMultiDestinationCommand(
+		destination,
+		"copyto",
+		{ type: "local", path: `${volumeBackupPath}/${backupFileName}` },
+		{ type: "remote", path: rcloneDestination },
+	);
 
 	const backupCommand = `
 	set -e

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -3,7 +3,7 @@ import {
 	findApplicationById,
 	findComposeById,
 	findDestinationById,
-	getS3Credentials,
+	getRcloneMultiDestinationCommand,
 	paths,
 } from "../..";
 
@@ -18,12 +18,14 @@ export const restoreVolume = async (
 	const destination = await findDestinationById(destinationId);
 	const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeName);
-	const rcloneFlags = getS3Credentials(destination);
-	const bucketPath = `:s3:${destination.bucket}`;
-	const backupPath = `${bucketPath}/${backupFileName}`;
 
 	// Command to download backup file from S3
-	const downloadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${volumeBackupPath}/${backupFileName}"`;
+	const downloadCommand = getRcloneMultiDestinationCommand(
+		destination,
+		"copyto",
+		{ type: "remote", path: backupFileName },
+		{ type: "local", path: `${volumeBackupPath}/${backupFileName}` },
+	);
 
 	// Base restore command that creates the volume and restores data
 	const baseRestoreCommand = `
@@ -31,7 +33,7 @@ export const restoreVolume = async (
 	echo "Volume name: ${volumeName}"
 	echo "Backup file name: ${backupFileName}"
 	echo "Volume backup path: ${volumeBackupPath}"
-	echo "Downloading backup from S3..."
+	echo "Downloading backup..."
 	mkdir -p ${volumeBackupPath}
 	${downloadCommand}
 	echo "Download completed ✅"

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -10,7 +10,7 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { getS3Credentials, normalizeS3Path } from "../backups/utils";
+import { getRcloneCommand, normalizePath } from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
 
@@ -82,12 +82,11 @@ const cleanupOldVolumeBackups = async (
 	if (!keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const s3AppName = getVolumeServiceAppName(volumeBackup);
-		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
-		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
+		const appName = getVolumeServiceAppName(volumeBackup);
+		const backupFilesPath = `${appName}/${normalizePath(prefix || "")}`;
+		const listCommand = getRcloneCommand(destination, "lsf", backupFilesPath) + `| grep "^${volumeName}-.*\.tar$"`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
-		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		const deleteCommand = getRcloneCommand(destination, "delete", backupFilesPath + "{}") ;	
 		const fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
 
 		if (serverId) {


### PR DESCRIPTION
- Added destination schemas for S3, FTP, and SFTP, including validation and credential extraction.
- Implemented destination adapters for handling different destination types, including connection testing and rclone configuration.
- Introduced a new DestinationDialog component for managing backup destinations with dynamic forms based on selected destination type.
- Replaced direct S3 credential handling with a unified rclone command generation method across various restore utilities (compose, libsql, mariadb, mongo, mysql, postgres, web server).
- Updated database schema to store destination credentials as JSON and added a new destination type enum.

closes #416

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds FTP and SFTP backup destinations via a destination-adapter pattern, migrates S3 credentials into a generic `credentials` jsonb column, and updates all backup/restore utilities to use the new `getRcloneCommand` helper. The architecture is well-structured, but three functional regressions must be fixed before merge:

- **FTP/SFTP test connection always fails**: both adapters use `remote:/` instead of `:ftp:` / `:sftp:`, so "Test Connection" always errors.
- **Standalone mongo restore is broken**: `restore/mongo.ts` was changed to `rclone cat | gunzip`, but `getMongoSpecificCommand` appends `${tempDir}` to that command, producing invalid shell.
- **`keepLatestNBackups` cleanup silently broken**: the grep pattern `.{sql.gz,bson.gz}$` is not valid grep regex, so old backups are never pruned for database types.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — three separate functional regressions affect test connectivity, standalone mongo restore, and backup cleanup.

Three P1 bugs: FTP/SFTP test always fails (wrong `remote:/` remote name), mongo restore broken (wrong rclone sub-command breaks `getMongoSpecificCommand`'s `${tempDir}` append), and `keepLatestNBackups` silently broken (invalid grep pattern). All three affect primary user paths of the new feature.

packages/server/src/services/destination-adapters.ts (lines 127, 165), packages/server/src/utils/restore/mongo.ts (line 18), packages/server/src/utils/backups/index.ts (line 139)

<sub>Reviews (1): Last reviewed commit: ["feat: Refactor backup and restore utilit..."](https://github.com/dokploy/dokploy/commit/26d012f6f7c190adfe7052611134eaf1a285574f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28126138)</sub>

> Greptile also left **6 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->