### PR TITLE
fix: prevent serverIp from being overwritten on every user registration

### DIFF
--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -196,7 +196,7 @@ const { handler, api } = betterAuth({
 						where: eq(schema.member.role, "owner"),
 					});
 
-					if (!IS_CLOUD) {
+					if (!IS_CLOUD && !isAdminPresent) {
 						await updateWebServerSettings({
 							serverIp: await getPublicIpWithFallback(),
 						});


### PR DESCRIPTION
Fixes #4215

### Summary

- Add `!isAdminPresent` guard to the `updateWebServerSettings({ serverIp })` call in `databaseHooks.user.create.after` so the public IP is only auto-set during the very first admin registration, not on every subsequent user creation.

### Changes

```diff
- if (!IS_CLOUD) {
+ if (!IS_CLOUD && !isAdminPresent) {
      await updateWebServerSettings({
          serverIp: await getPublicIpWithFallback(),
      });
  }
```

`isAdminPresent` is already queried in the same scope (checks if an owner role exists in the `member` table). On first setup no owner exists yet, so the IP is auto-detected as before. On all subsequent user creations an owner already exists, so the block is skipped and the stored IP is preserved.

### Impact

- 1 line changed, 1 file -- minimal, safe diff.
- No effect on the manual "Update Server IP" dialog -- admins can still change the IP at any time.
- No effect on license validation -- it calls `getPublicIpWithFallback()` directly without writing to `webServerSettings`.
- No effect on cloud deployments -- the `IS_CLOUD` guard already skips this code path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `!isAdminPresent` guard to the `updateWebServerSettings({ serverIp })` call in the `databaseHooks.user.create.after` handler so the server IP is only auto-detected during the very first admin registration rather than on every subsequent user creation. The fix is minimal and correct — `isAdminPresent` is already queried at the top of the `after` hook (line 195) before the `member` insert transaction, so it accurately reflects whether an owner already exists at the time each user is created.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line guard change with correct logic and no side effects on other code paths.

The fix is logically sound: `isAdminPresent` is queried before the owner `member` record is inserted, so it's `null` on first-admin setup and truthy thereafter. All guarded code paths (IS_CLOUD, manual IP update, license validation) are unaffected. No P0 or P1 findings.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: prevent serverIp from being overwri..."](https://github.com/dokploy/dokploy/commit/9f07f8e9e1a128e27a7473ee228f8bc76352648f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28234700)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->