### PR TITLE
feat: add containers tab to compose services

### DIFF
--- a/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
+++ b/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
@@ -1,0 +1,272 @@
+import { Loader2, MoreHorizontal, RefreshCw } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { api } from "@/utils/api";
+
+const DockerLogsId = dynamic(
+	() =>
+		import("@/components/dashboard/docker/logs/docker-logs-id").then(
+			(e) => e.DockerLogsId,
+		),
+	{
+		ssr: false,
+	},
+);
+
+interface Props {
+	appName: string;
+	serverId?: string;
+	appType: "stack" | "docker-compose";
+}
+
+export const ShowComposeContainers = ({
+	appName,
+	appType,
+	serverId,
+}: Props) => {
+	const { data, isPending, refetch } =
+		api.docker.getContainersByAppNameMatch.useQuery(
+			{
+				appName,
+				appType,
+				serverId,
+			},
+			{
+				enabled: !!appName,
+			},
+		);
+
+	return (
+		<Card className="bg-background">
+			<CardHeader className="flex flex-row items-center justify-between">
+				<div>
+					<CardTitle className="text-xl">Containers</CardTitle>
+					<CardDescription>
+						Inspect each container in this compose and run basic lifecycle
+						actions.
+					</CardDescription>
+				</div>
+				<Button
+					variant="outline"
+					size="icon"
+					onClick={() => refetch()}
+					disabled={isPending}
+				>
+					<RefreshCw
+						className={`h-4 w-4 ${isPending ? "animate-spin" : ""}`}
+					/>
+				</Button>
+			</CardHeader>
+			<CardContent>
+				{isPending ? (
+					<div className="flex items-center justify-center h-[20vh]">
+						<Loader2 className="animate-spin h-6 w-6 text-muted-foreground" />
+					</div>
+				) : !data || data.length === 0 ? (
+					<div className="flex items-center justify-center h-[20vh]">
+						<span className="text-muted-foreground">
+							No containers found. Deploy the compose to see containers here.
+						</span>
+					</div>
+				) : (
+					<div className="rounded-md border">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Name</TableHead>
+									<TableHead>State</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead>Container ID</TableHead>
+									<TableHead className="text-right" />
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{data.map((container) => (
+									<ContainerRow
+										key={container.containerId}
+										container={container}
+										serverId={serverId}
+										onActionComplete={() => refetch()}
+									/>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+};
+
+interface ContainerRowProps {
+	container: {
+		containerId: string;
+		name: string;
+		state: string;
+		status: string;
+	};
+	serverId?: string;
+	onActionComplete: () => void;
+}
+
+const ContainerRow = ({
+	container,
+	serverId,
+	onActionComplete,
+}: ContainerRowProps) => {
+	const [logsOpen, setLogsOpen] = useState(false);
+	const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+	const restartMutation = api.docker.restartContainer.useMutation();
+	const startMutation = api.docker.startContainer.useMutation();
+	const stopMutation = api.docker.stopContainer.useMutation();
+	const killMutation = api.docker.killContainer.useMutation();
+
+	const handleAction = async (
+		action: string,
+		mutationFn: typeof restartMutation,
+	) => {
+		setActionLoading(action);
+		try {
+			await mutationFn.mutateAsync({
+				containerId: container.containerId,
+				serverId,
+			});
+			toast.success(`Container ${action} successfully`);
+			onActionComplete();
+		} catch (error) {
+			toast.error(
+				`Failed to ${action} container: ${error instanceof Error ? error.message : "Unknown error"}`,
+			);
+		} finally {
+			setActionLoading(null);
+		}
+	};
+
+	return (
+		<TableRow>
+			<TableCell className="font-medium">{container.name}</TableCell>
+			<TableCell>
+				<Badge
+					variant={
+						container.state === "running"
+							? "default"
+							: container.state === "exited"
+								? "secondary"
+								: "destructive"
+					}
+				>
+					{container.state}
+				</Badge>
+			</TableCell>
+			<TableCell>{container.status}</TableCell>
+			<TableCell className="font-mono text-sm text-muted-foreground">
+				{container.containerId}
+			</TableCell>
+			<TableCell className="text-right">
+				<Dialog open={logsOpen} onOpenChange={setLogsOpen}>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="ghost" className="h-8 w-8 p-0">
+								{actionLoading ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<MoreHorizontal className="h-4 w-4" />
+								)}
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuLabel>Actions</DropdownMenuLabel>
+							<DialogTrigger asChild>
+								<DropdownMenuItem
+									className="cursor-pointer"
+									onSelect={(e) => e.preventDefault()}
+								>
+									View Logs
+								</DropdownMenuItem>
+							</DialogTrigger>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem
+								className="cursor-pointer"
+								disabled={actionLoading !== null}
+								onClick={() => handleAction("restart", restartMutation)}
+							>
+								Restart
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="cursor-pointer"
+								disabled={actionLoading !== null}
+								onClick={() => handleAction("start", startMutation)}
+							>
+								Start
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="cursor-pointer"
+								disabled={actionLoading !== null}
+								onClick={() => handleAction("stop", stopMutation)}
+							>
+								Stop
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								className="cursor-pointer text-red-500 focus:text-red-600"
+								disabled={actionLoading !== null}
+								onClick={() => handleAction("kill", killMutation)}
+							>
+								Kill
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+					<DialogContent className="sm:max-w-7xl">
+						<DialogHeader>
+							<DialogTitle>View Logs</DialogTitle>
+							<DialogDescription>
+								Logs for {container.name}
+							</DialogDescription>
+						</DialogHeader>
+						<div className="flex flex-col gap-4 pt-2.5">
+							<DockerLogsId
+								containerId={container.containerId}
+								serverId={serverId}
+								runType="native"
+							/>
+						</div>
+					</DialogContent>
+				</Dialog>
+			</TableCell>
+		</TableRow>
+	);
+};

--- a/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
+++ b/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
@@ -86,9 +86,7 @@ export const ShowComposeContainers = ({
 					onClick={() => refetch()}
 					disabled={isPending}
 				>
-					<RefreshCw
-						className={`h-4 w-4 ${isPending ? "animate-spin" : ""}`}
-					/>
+					<RefreshCw className={`h-4 w-4 ${isPending ? "animate-spin" : ""}`} />
 				</Button>
 			</CardHeader>
 			<CardContent>
@@ -253,9 +251,7 @@ const ContainerRow = ({
 					<DialogContent className="sm:max-w-7xl">
 						<DialogHeader>
 							<DialogTitle>View Logs</DialogTitle>
-							<DialogDescription>
-								Logs for {container.name}
-							</DialogDescription>
+							<DialogDescription>Logs for {container.name}</DialogDescription>
 						</DialogHeader>
 						<div className="flex flex-col gap-4 pt-2.5">
 							<DockerLogsId

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -22,9 +22,9 @@ import { ShowSchedules } from "@/components/dashboard/application/schedules/show
 import { ShowVolumeBackups } from "@/components/dashboard/application/volume-backups/show-volume-backups";
 import { AddCommandCompose } from "@/components/dashboard/compose/advanced/add-command";
 import { IsolatedDeploymentTab } from "@/components/dashboard/compose/advanced/add-isolation";
+import { ShowComposeContainers } from "@/components/dashboard/compose/containers/show-compose-containers";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
 import { ShowGeneralCompose } from "@/components/dashboard/compose/general/show";
-import { ShowComposeContainers } from "@/components/dashboard/compose/containers/show-compose-containers";
 import { ShowDockerLogsCompose } from "@/components/dashboard/compose/logs/show";
 import { ShowDockerLogsStack } from "@/components/dashboard/compose/logs/show-stack";
 import { UpdateCompose } from "@/components/dashboard/compose/update-compose";

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -234,9 +234,7 @@ const Service = (
 												</TabsTrigger>
 											)}
 											{permissions?.docker.read && (
-												<TabsTrigger value="containers">
-													Containers
-												</TabsTrigger>
+												<TabsTrigger value="containers">Containers</TabsTrigger>
 											)}
 											{permissions?.service.create && (
 												<TabsTrigger value="backups">Backups</TabsTrigger>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -307,7 +307,7 @@ const Service = (
 										<TabsContent value="containers">
 											<div className="flex flex-col gap-4 pt-2.5">
 												<ShowComposeContainers
-													serverId={data?.serverId || ""}
+													serverId={data?.serverId || undefined}
 													appName={data?.appName || ""}
 													appType={data?.composeType || "docker-compose"}
 												/>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -233,7 +233,7 @@ const Service = (
 													Deployments
 												</TabsTrigger>
 											)}
-											{permissions?.docker.read && (
+											{permissions?.service.read && (
 												<TabsTrigger value="containers">Containers</TabsTrigger>
 											)}
 											{permissions?.service.create && (
@@ -303,7 +303,7 @@ const Service = (
 											</div>
 										</TabsContent>
 									)}
-									{permissions?.docker.read && (
+									{permissions?.service.read && (
 										<TabsContent value="containers">
 											<div className="flex flex-col gap-4 pt-2.5">
 												<ShowComposeContainers

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -24,6 +24,7 @@ import { AddCommandCompose } from "@/components/dashboard/compose/advanced/add-c
 import { IsolatedDeploymentTab } from "@/components/dashboard/compose/advanced/add-isolation";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
 import { ShowGeneralCompose } from "@/components/dashboard/compose/general/show";
+import { ShowComposeContainers } from "@/components/dashboard/compose/containers/show-compose-containers";
 import { ShowDockerLogsCompose } from "@/components/dashboard/compose/logs/show";
 import { ShowDockerLogsStack } from "@/components/dashboard/compose/logs/show-stack";
 import { UpdateCompose } from "@/components/dashboard/compose/update-compose";
@@ -60,6 +61,7 @@ type TabState =
 	| "advanced"
 	| "deployments"
 	| "domains"
+	| "containers"
 	| "monitoring"
 	| "volumeBackups";
 
@@ -231,6 +233,11 @@ const Service = (
 													Deployments
 												</TabsTrigger>
 											)}
+											{permissions?.docker.read && (
+												<TabsTrigger value="containers">
+													Containers
+												</TabsTrigger>
+											)}
 											{permissions?.service.create && (
 												<TabsTrigger value="backups">Backups</TabsTrigger>
 											)}
@@ -298,6 +305,18 @@ const Service = (
 											</div>
 										</TabsContent>
 									)}
+									{permissions?.docker.read && (
+										<TabsContent value="containers">
+											<div className="flex flex-col gap-4 pt-2.5">
+												<ShowComposeContainers
+													serverId={data?.serverId || ""}
+													appName={data?.appName || ""}
+													appType={data?.composeType || "docker-compose"}
+												/>
+											</div>
+										</TabsContent>
+									)}
+
 									{permissions?.monitoring.read && (
 										<TabsContent value="monitoring">
 											<div className="pt-2.5">

--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -135,7 +135,7 @@ export const dockerRouter = createTRPCRouter({
 			}
 			await containerKill(input.containerId, input.serverId);
 			await audit(ctx, {
-				action: "stop",
+				action: "kill",
 				resourceType: "docker",
 				resourceId: input.containerId,
 				resourceName: input.containerId,

--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -1,6 +1,9 @@
 import {
+	containerKill,
 	containerRemove,
 	containerRestart,
+	containerStart,
+	containerStop,
 	findServerById,
 	getConfig,
 	getContainers,
@@ -42,17 +45,101 @@ export const dockerRouter = createTRPCRouter({
 					.string()
 					.min(1)
 					.regex(containerIdRegex, "Invalid container id."),
+				serverId: z.string().optional(),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			const result = await containerRestart(input.containerId);
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			await containerRestart(input.containerId, input.serverId);
 			await audit(ctx, {
 				action: "start",
 				resourceType: "docker",
 				resourceId: input.containerId,
 				resourceName: input.containerId,
 			});
-			return result;
+		}),
+
+	startContainer: withPermission("docker", "read")
+		.input(
+			z.object({
+				containerId: z
+					.string()
+					.min(1)
+					.regex(containerIdRegex, "Invalid container id."),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			await containerStart(input.containerId, input.serverId);
+			await audit(ctx, {
+				action: "start",
+				resourceType: "docker",
+				resourceId: input.containerId,
+				resourceName: input.containerId,
+			});
+		}),
+
+	stopContainer: withPermission("docker", "read")
+		.input(
+			z.object({
+				containerId: z
+					.string()
+					.min(1)
+					.regex(containerIdRegex, "Invalid container id."),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			await containerStop(input.containerId, input.serverId);
+			await audit(ctx, {
+				action: "stop",
+				resourceType: "docker",
+				resourceId: input.containerId,
+				resourceName: input.containerId,
+			});
+		}),
+
+	killContainer: withPermission("docker", "read")
+		.input(
+			z.object({
+				containerId: z
+					.string()
+					.min(1)
+					.regex(containerIdRegex, "Invalid container id."),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			await containerKill(input.containerId, input.serverId);
+			await audit(ctx, {
+				action: "stop",
+				resourceType: "docker",
+				resourceId: input.containerId,
+				resourceName: input.containerId,
+			});
 		}),
 
 	removeContainer: withPermission("docker", "read")

--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -38,7 +38,7 @@ export const dockerRouter = createTRPCRouter({
 			return await getContainers(input.serverId);
 		}),
 
-	restartContainer: withPermission("docker", "read")
+	restartContainer: withPermission("service", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -64,7 +64,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	startContainer: withPermission("docker", "read")
+	startContainer: withPermission("service", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -90,7 +90,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	stopContainer: withPermission("docker", "read")
+	stopContainer: withPermission("service", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -116,7 +116,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	killContainer: withPermission("docker", "read")
+	killContainer: withPermission("service", "read")
 		.input(
 			z.object({
 				containerId: z

--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -135,7 +135,7 @@ export const dockerRouter = createTRPCRouter({
 			}
 			await containerKill(input.containerId, input.serverId);
 			await audit(ctx, {
-				action: "kill",
+				action: "stop",
 				resourceType: "docker",
 				resourceId: input.containerId,
 				resourceName: input.containerId,

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -447,10 +447,7 @@ export const containerStart = async (
 	}
 };
 
-export const containerStop = async (
-	containerId: string,
-	serverId?: string,
-) => {
+export const containerStop = async (containerId: string, serverId?: string) => {
 	const command = `docker container stop ${containerId}`;
 	const { stderr } = serverId
 		? await execAsyncRemote(serverId, command)
@@ -462,10 +459,7 @@ export const containerStop = async (
 	}
 };
 
-export const containerKill = async (
-	containerId: string,
-	serverId?: string,
-) => {
+export const containerKill = async (containerId: string, serverId?: string) => {
 	const command = `docker container kill ${containerId}`;
 	const { stderr } = serverId
 		? await execAsyncRemote(serverId, command)

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -417,21 +417,64 @@ export const getContainerLogs = async (
 	}
 };
 
-export const containerRestart = async (containerId: string) => {
-	try {
-		const { stdout, stderr } = await execAsync(
-			`docker container restart ${containerId}`,
-		);
+export const containerRestart = async (
+	containerId: string,
+	serverId?: string,
+) => {
+	const command = `docker container restart ${containerId}`;
+	const { stderr } = serverId
+		? await execAsyncRemote(serverId, command)
+		: await execAsync(command);
 
-		if (stderr) {
-			console.error(`Error: ${stderr}`);
-			return;
-		}
+	if (stderr) {
+		console.error(`Error: ${stderr}`);
+		throw new Error(stderr);
+	}
+};
 
-		const config = JSON.parse(stdout);
+export const containerStart = async (
+	containerId: string,
+	serverId?: string,
+) => {
+	const command = `docker container start ${containerId}`;
+	const { stderr } = serverId
+		? await execAsyncRemote(serverId, command)
+		: await execAsync(command);
 
-		return config;
-	} catch {}
+	if (stderr) {
+		console.error(`Error: ${stderr}`);
+		throw new Error(stderr);
+	}
+};
+
+export const containerStop = async (
+	containerId: string,
+	serverId?: string,
+) => {
+	const command = `docker container stop ${containerId}`;
+	const { stderr } = serverId
+		? await execAsyncRemote(serverId, command)
+		: await execAsync(command);
+
+	if (stderr) {
+		console.error(`Error: ${stderr}`);
+		throw new Error(stderr);
+	}
+};
+
+export const containerKill = async (
+	containerId: string,
+	serverId?: string,
+) => {
+	const command = `docker container kill ${containerId}`;
+	const { stderr } = serverId
+		? await execAsyncRemote(serverId, command)
+		: await execAsync(command);
+
+	if (stderr) {
+		console.error(`Error: ${stderr}`);
+		throw new Error(stderr);
+	}
 };
 
 export const containerRemove = async (


### PR DESCRIPTION
## What is this PR about?

Adds a **Containers** tab to the compose service page, allowing users to inspect each container in a compose deployment and run basic lifecycle actions (View Logs, Restart, Start, Stop, Kill) directly from the UI.

### Changes

- **`packages/server/src/services/docker.ts`** — Added `containerStart`, `containerStop`, `containerKill` functions with remote server support. Updated `containerRestart` to also support `serverId`.
- **`apps/dokploy/server/api/routers/docker.ts`** — Added `startContainer`, `stopContainer`, `killContainer` tRPC procedures with server ownership checks and audit logging. Updated `restartContainer` to accept `serverId`.
- **`apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx`** — New component with a table showing container name, state (badge), status, and container ID. Each row has a dropdown menu with lifecycle actions and a View Logs dialog.
- **`apps/dokploy/pages/.../compose/[composeId].tsx`** — Added the Containers tab between Deployments and Backups, gated by `docker.read` permission.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a **Containers** tab to compose service pages, letting users inspect running containers and trigger lifecycle actions (start, stop, restart, kill) directly from the UI. The server-side service functions are well-structured, correctly supporting both local and remote server execution, and the old silent-error-swallowing in `containerRestart` is properly fixed.

- `killContainer` audit log records `action: \"stop\"` instead of `\"kill\"`, making kill events indistinguishable from stop events in the audit trail.
- `startContainer`, `stopContainer`, and `killContainer` are gated by `docker.read` permission — consistent with the pre-existing pattern for `restartContainer`/`removeContainer`, but worth revisiting so read-only roles cannot mutate container state via the API.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor cleanup; no functional regressions introduced.

All findings are P2: the wrong audit action label for kill, the empty-string serverId, and the read-permission-for-write-mutations concern (which follows the existing codebase pattern). None block the primary user path. Score is 4 rather than 5 to flag the permission model concern as worth addressing before the pattern spreads further.

apps/dokploy/server/api/routers/docker.ts — audit action label for killContainer and permission level for mutation procedures.

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/ddf570a8078d7b4a54ffbf21ad6d5d60b7c110ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28295527)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->