### PR TITLE
feat: add view mounts, config, and terminal to container actions

### DIFF
--- a/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
+++ b/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
@@ -36,6 +36,9 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { api } from "@/utils/api";
+import { ShowContainerConfig } from "@/components/dashboard/docker/config/show-container-config";
+import { ShowContainerMounts } from "@/components/dashboard/docker/mounts/show-container-mounts";
+import { DockerTerminalModal } from "@/components/dashboard/docker/terminal/docker-terminal-modal";
 
 const DockerLogsId = dynamic(
 	() =>
@@ -217,6 +220,20 @@ const ContainerRow = ({
 									View Logs
 								</DropdownMenuItem>
 							</DialogTrigger>
+							<ShowContainerConfig
+								containerId={container.containerId}
+								serverId={serverId || ""}
+							/>
+							<ShowContainerMounts
+								containerId={container.containerId}
+								serverId={serverId || ""}
+							/>
+							<DockerTerminalModal
+								containerId={container.containerId}
+								serverId={serverId || ""}
+							>
+								Terminal
+							</DockerTerminalModal>
 							<DropdownMenuSeparator />
 							<DropdownMenuItem
 								className="cursor-pointer"

--- a/apps/dokploy/components/dashboard/docker/mounts/show-container-mounts.tsx
+++ b/apps/dokploy/components/dashboard/docker/mounts/show-container-mounts.tsx
@@ -1,0 +1,112 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { api } from "@/utils/api";
+
+interface Props {
+	containerId: string;
+	serverId?: string;
+}
+
+interface Mount {
+	Type: string;
+	Source: string;
+	Destination: string;
+	Mode: string;
+	RW: boolean;
+	Propagation: string;
+	Name?: string;
+	Driver?: string;
+}
+
+export const ShowContainerMounts = ({ containerId, serverId }: Props) => {
+	const { data } = api.docker.getConfig.useQuery(
+		{
+			containerId,
+			serverId,
+		},
+		{
+			enabled: !!containerId,
+		},
+	);
+
+	const mounts: Mount[] = data?.Mounts ?? [];
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<DropdownMenuItem
+					className="w-full cursor-pointer"
+					onSelect={(e) => e.preventDefault()}
+				>
+					View Mounts
+				</DropdownMenuItem>
+			</DialogTrigger>
+			<DialogContent className="w-full md:w-[70vw] min-w-[70vw]">
+				<DialogHeader>
+					<DialogTitle>Container Mounts</DialogTitle>
+					<DialogDescription>
+						Volume and bind mounts for this container
+					</DialogDescription>
+				</DialogHeader>
+				<div className="overflow-auto max-h-[70vh]">
+					{mounts.length === 0 ? (
+						<div className="text-center text-muted-foreground py-8">
+							No mounts found for this container.
+						</div>
+					) : (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Type</TableHead>
+									<TableHead>Source</TableHead>
+									<TableHead>Destination</TableHead>
+									<TableHead>Mode</TableHead>
+									<TableHead>Read/Write</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{mounts.map((mount, index) => (
+									<TableRow key={index}>
+										<TableCell>
+											<Badge variant="outline">{mount.Type}</Badge>
+										</TableCell>
+										<TableCell className="font-mono text-xs max-w-[250px] truncate">
+											{mount.Name || mount.Source}
+										</TableCell>
+										<TableCell className="font-mono text-xs max-w-[250px] truncate">
+											{mount.Destination}
+										</TableCell>
+										<TableCell className="text-xs">
+											{mount.Mode || "-"}
+										</TableCell>
+										<TableCell>
+											<Badge variant={mount.RW ? "default" : "secondary"}>
+												{mount.RW ? "RW" : "RO"}
+											</Badge>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/docker/show/columns.tsx
+++ b/apps/dokploy/components/dashboard/docker/show/columns.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ShowContainerConfig } from "../config/show-container-config";
 import { ShowDockerModalLogs } from "../logs/show-docker-modal-logs";
+import { ShowContainerMounts } from "../mounts/show-container-mounts";
 import { RemoveContainerDialog } from "../remove/remove-container";
 import { DockerTerminalModal } from "../terminal/docker-terminal-modal";
 import { UploadFileModal } from "../upload/upload-file-modal";
@@ -120,6 +121,10 @@ export const columns: ColumnDef<Container>[] = [
 							View Logs
 						</ShowDockerModalLogs>
 						<ShowContainerConfig
+							containerId={container.containerId}
+							serverId={container.serverId || ""}
+						/>
+						<ShowContainerMounts
 							containerId={container.containerId}
 							serverId={container.serverId || ""}
 						/>


### PR DESCRIPTION
## Summary
- Add a new **View Mounts** action to the container dropdown that displays volume and bind mounts in a clean table (type, source, destination, mode, read/write)
- Add **View Config**, **View Mounts**, and **Terminal** actions to compose containers tab, which previously only had logs and lifecycle actions
- Reuses existing `docker inspect` query — no new API endpoints needed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds **View Mounts**, **View Config**, and **Terminal** actions to the compose containers tab, and adds **View Mounts** to the standalone Docker containers table — all by reusing the existing `api.docker.getConfig` query with no new API endpoints. The implementation is consistent with the patterns already established by `ShowContainerConfig` and `DockerTerminalModal`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the single finding is a minor UX polish item (missing loading indicator) that does not affect correctness.
- No P0 or P1 issues found. The new `ShowContainerMounts` component correctly reuses the existing `getConfig` query (React Query deduplicates it with `ShowContainerConfig`), nesting inside Radix dialogs is safe given the outer logs-dialog is always closed when the new modals are triggered, and the rest of the changes are straightforward drop-ins following established patterns.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat: add view mounts, view config, and ..."](https://github.com/dokploy/dokploy/commit/9af745ce6701f712461635ca50e2d2a442661b0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28302099)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->