### PR TITLE
fix(databases): update default Redis version from 7 to 8

### DIFF
--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -62,7 +62,7 @@ const dockerImageDefaultPlaceholder: Record<DbType, string> = {
 	mariadb: "mariadb:11",
 	mysql: "mysql:8",
 	postgres: "postgres:18",
-	redis: "redis:7",
+	redis: "redis:8",
 };
 
 const databasesUserDefaultPlaceholder: Record<

--- a/packages/server/src/services/ai.ts
+++ b/packages/server/src/services/ai.ts
@@ -198,12 +198,12 @@ export const suggestVariants = async ({
 		    1. ALWAYS use 'image:' field, NEVER use 'build:' field
 		    2. NEVER use 'build: .' or any build directive - we don't have local Dockerfiles
 		    3. Use images from Docker Hub or other public registries (e.g., docker.io, ghcr.io, quay.io)
-		    4. For dependencies (databases, redis, etc.), use official images (e.g., postgres:16, redis:7, etc.)
+		    4. For dependencies (databases, redis, etc.), use official images (e.g., postgres:16, redis:8, etc.)
 		    5. Always specify image tags - avoid using 'latest' tag, use specific versions when possible
 		    6. Examples of correct image usage:
 		       - image: sendingtk/chatwoot:develop
 		       - image: postgres:16-alpine
-		       - image: redis:7-alpine
+		       - image: redis:8-alpine
 		    7. Examples of INCORRECT usage (DO NOT USE):
 		       - build: .
 		       - build: ./app

--- a/packages/server/src/setup/redis-setup.ts
+++ b/packages/server/src/setup/redis-setup.ts
@@ -3,7 +3,7 @@ import { docker } from "../constants";
 import { pullImage } from "../utils/docker/utils";
 
 export const initializeRedis = async () => {
-	const imageName = "redis:7";
+	const imageName = "redis:8";
 	const containerName = "dokploy-redis";
 
 	const settings: CreateServiceOptions = {


### PR DESCRIPTION
## Summary

Update Redis default image from `redis:7` to `redis:8` in:
- `packages/server/src/setup/redis-setup.ts` (internal Redis setup)
- `packages/server/src/services/ai.ts` (AI service template examples)
- `apps/dokploy/components/dashboard/project/add-database.tsx` (UI default)

Redis 8 provides better performance according to benchmarks while maintaining stability.

Closes #4172

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the default Redis image from `redis:7` to `redis:8` across the UI placeholder, AI prompt template, and the internal Dokploy Redis setup. Redis 8 has been GA since May 2025 and is available on Docker Hub. The db schema (`packages/server/src/db/schema/redis.ts`) was already at `redis:8` before this PR, so the three changes here bring the rest of the codebase in sync — no `redis:7` references remain.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — clean version bump with no remaining redis:7 references and no logic changes.
- All three changes are straightforward string replacements. Redis 8 is confirmed GA and available on Docker Hub. The db schema was already at redis:8 before this PR, so these changes are consistent. No functional logic is altered and no redis:7 references remain in the codebase.
- No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(databases): update default Redis ver..."](https://github.com/dokploy/dokploy/commit/ee53cc12b375e165f6ba988bd632f2a5c4b1e7ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28330325)</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->