### PR TITLE
fix(docker): add tls=true label when certificateType is 'none'

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -337,6 +337,8 @@ export const createDomainLabels = (
 			labels.push(
 				`traefik.http.routers.${routerName}.tls.certresolver=${customCertResolver}`,
 			);
+		} else if (certificateType === "none") {
+			labels.push(`traefik.http.routers.${routerName}.tls=true`);
 		}
 	}
 


### PR DESCRIPTION
## Summary

When configuring HTTPS with certificateType='none' in Docker Compose applications, Traefik was not generating the tls=true label on the websecure router, causing HTTPS requests to return 404.

This fix adds the missing  label for certificateType='none', allowing Traefik to properly handle TLS termination.

### Fix

In , added the missing  branch that pushes the tls=true label.

Closes #4018

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `traefik.http.routers.${routerName}.tls=true` label in `createDomainLabels` when `certificateType === "none"` on a websecure (or custom HTTPS) entrypoint, fixing HTTPS 404s for Docker Compose apps that rely on a default/pre-installed certificate rather than Let's Encrypt or a named cert resolver.

- The equivalent non-Compose path in `packages/server/src/utils/traefik/domain.ts` sets `routerConfig.tls = undefined` for the same case, which means the `tls` key is omitted from the Traefik file config entirely. This could produce the same 404 in regular (non-Compose) application deployments with `certificateType === "none"`, and may be worth aligning in a follow-up.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; the one-line fix is correct and the only open finding is a pre-existing inconsistency in a different code path.
- The change is minimal, correctly scoped, and directly fixes the reported HTTPS 404 for Docker Compose apps with certificateType='none'. No regressions are introduced. The P2 comment flags a pre-existing inconsistency in traefik/domain.ts that is out of scope for this PR.
- packages/server/src/utils/traefik/domain.ts — same certificateType === "none" branch may need `tls = {}` for consistency, but this is pre-existing and not a blocker.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/server/src/utils/traefik/domain.ts`, line 198-200 ([link](https://github.com/dokploy/dokploy/blob/03be19f23e2f67a429a451e35ccf884dabd14577/packages/server/src/utils/traefik/domain.ts#L198-L200)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent `certificateType === "none"` behavior vs Docker fix**

   This PR correctly adds `tls=true` for `certificateType === "none"` in Docker Compose labels, but the parallel non-Compose path here explicitly sets `routerConfig.tls = undefined`, which means no `tls` key appears in the serialized Traefik file config. Per the `HttpRouter` type definition (line 285 in `file-types.ts`): "When a TLS section is specified, it instructs Traefik that the current router is dedicated to HTTPS requests only." Without it, regular application deployments with `certificateType === "none"` may exhibit the same 404 on HTTPS described in #4018. Consider aligning this with `routerConfig.tls = {}` for consistency.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(docker): add tls=true label when cer..."](https://github.com/dokploy/dokploy/commit/03be19f23e2f67a429a451e35ccf884dabd14577) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28331499)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->