### PR TITLE
feat: resend verification email on sign-in and improve template

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -82,6 +82,16 @@ export default function Home({ IS_CLOUD }: Props) {
 			});
 
 			if (error) {
+				const isEmailNotVerified =
+					error.code === "EMAIL_NOT_VERIFIED" ||
+					error.message?.toLowerCase().includes("email not verified");
+				if (isEmailNotVerified) {
+					const msg =
+						"Your email is not verified. We've sent a new verification link to your email.";
+					toast.info(msg);
+					setError(msg);
+					return;
+				}
 				toast.error(error.message);
 				setError(error.message || "An error occurred while logging in");
 				return;

--- a/packages/server/src/emails/emails/verify-email.tsx
+++ b/packages/server/src/emails/emails/verify-email.tsx
@@ -1,0 +1,104 @@
+import {
+	Body,
+	Button,
+	Container,
+	Head,
+	Heading,
+	Html,
+	Img,
+	Link,
+	Preview,
+	Section,
+	Tailwind,
+	Text,
+} from "@react-email/components";
+
+export type TemplateProps = {
+	userName: string;
+	verificationUrl: string;
+};
+
+export const VerifyEmailTemplate = ({
+	userName = "User",
+	verificationUrl = "https://app.dokploy.com/verify",
+}: TemplateProps) => {
+	const previewText = "Verify your email address to get started with Dokploy";
+	return (
+		<Html>
+			<Head />
+			<Preview>{previewText}</Preview>
+			<Tailwind
+				config={{
+					theme: {
+						extend: {
+							colors: {
+								brand: "#007291",
+							},
+						},
+					},
+				}}
+			>
+				<Body className="bg-[#f4f4f5] my-auto mx-auto font-sans">
+					<Container className="my-[40px] mx-auto max-w-[520px]">
+						{/* Header */}
+						<Section className="bg-[#09090b] rounded-t-xl px-[40px] py-[32px] text-center">
+							<Img
+								src="https://raw.githubusercontent.com/Dokploy/website/refs/heads/main/apps/docs/public/logo-dokploy-blackpng.png"
+								width="190"
+								height="120"
+								alt="Dokploy"
+								className="my-0 mx-auto"
+							/>
+						</Section>
+
+						{/* Body */}
+						<Section className="bg-white px-[40px] py-[32px]">
+							<Heading className="text-[#09090b] text-[22px] font-semibold m-0 mb-[8px]">
+								Verify Your Email
+							</Heading>
+							<Text className="text-[#71717a] text-[14px] leading-[22px] m-0 mb-[24px]">
+								Hello {userName}, thank you for signing up for Dokploy. Please
+								verify your email address to activate your account.
+							</Text>
+
+							{/* CTA Button */}
+							<Section className="text-center mb-[24px]">
+								<Button
+									href={verificationUrl}
+									className="bg-[#09090b] rounded-lg text-white text-[14px] font-semibold no-underline text-center px-[24px] py-[12px]"
+								>
+									Verify Email Address
+								</Button>
+							</Section>
+
+							<Text className="text-[#a1a1aa] text-[13px] leading-[20px] m-0 text-center mb-[16px]">
+								If the button above doesn't work, copy and paste the following
+								link into your browser:
+							</Text>
+							<Text className="text-[#71717a] text-[12px] leading-[18px] m-0 text-center break-all">
+								{verificationUrl}
+							</Text>
+						</Section>
+
+						{/* Footer */}
+						<Section className="bg-[#fafafa] rounded-b-xl px-[40px] py-[24px] text-center border-t border-solid border-[#e4e4e7]">
+							<Text className="text-[#a1a1aa] text-[12px] leading-[18px] m-0">
+								This is an automated email from{" "}
+								<Link
+									href="https://dokploy.com"
+									className="text-[#71717a] underline"
+								>
+									Dokploy Cloud
+								</Link>
+								. If you didn't create an account, you can safely ignore this
+								email.
+							</Text>
+						</Section>
+					</Container>
+				</Body>
+			</Tailwind>
+		</Html>
+	);
+};
+
+export default VerifyEmailTemplate;

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -76,7 +76,7 @@ const { handler, api } = betterAuth({
 		},
 	},
 	logger: {
-		disabled: false,
+		disabled: process.env.NODE_ENV === "production",
 	},
 	async trustedOrigins() {
 		try {

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -21,7 +21,10 @@ import {
 	updateWebServerSettings,
 } from "../services/web-server-settings";
 import { getHubSpotUTK, submitToHubSpot } from "../utils/tracking/hubspot";
-import { sendEmail } from "../verification/send-verification-email";
+import {
+	sendEmail,
+	sendVerificationEmail,
+} from "../verification/send-verification-email";
 import { getPublicIpWithFallback } from "../wss/utils";
 import { ac, adminRole, memberRole, ownerRole } from "./access-control";
 
@@ -73,7 +76,7 @@ const { handler, api } = betterAuth({
 		},
 	},
 	logger: {
-		disabled: process.env.NODE_ENV === "production",
+		disabled: false,
 	},
 	async trustedOrigins() {
 		try {
@@ -106,14 +109,13 @@ const { handler, api } = betterAuth({
 	emailVerification: {
 		sendOnSignUp: true,
 		autoSignInAfterVerification: true,
+		sendOnSignIn: true,
 		sendVerificationEmail: async ({ user, url }) => {
 			if (IS_CLOUD) {
-				await sendEmail({
+				await sendVerificationEmail({
+					userName: user.name || "User",
 					email: user.email,
-					subject: "Verify your email",
-					text: `
-				<p>Click the link to verify your email: <a href="${url}">Verify Email</a></p>
-				`,
+					verificationUrl: url,
 				});
 			}
 		},

--- a/packages/server/src/verification/send-verification-email.tsx
+++ b/packages/server/src/verification/send-verification-email.tsx
@@ -1,4 +1,7 @@
+import { renderAsync } from "@react-email/components";
+import VerifyEmailTemplate from "../emails/emails/verify-email";
 import { sendEmailNotification } from "../utils/notifications/utils";
+
 export const sendEmail = async ({
 	email,
 	subject,
@@ -25,4 +28,26 @@ export const sendEmail = async ({
 	);
 
 	return true;
+};
+
+export const sendVerificationEmail = async ({
+	userName,
+	email,
+	verificationUrl,
+}: {
+	userName: string;
+	email: string;
+	verificationUrl: string;
+}) => {
+	const html = await renderAsync(
+		VerifyEmailTemplate({
+			userName: userName || "User",
+			verificationUrl,
+		}),
+	);
+	await sendEmail({
+		email,
+		subject: "Verify your email",
+		text: html,
+	});
 };


### PR DESCRIPTION
## Summary
- Add `sendOnSignIn: true` to `emailVerification` config — unverified users now receive a new verification email when they attempt to sign in
- Create styled verification email template (matching invoice email design with Dokploy branding)
- Extract `sendVerificationEmail` helper function to `send-verification-email.tsx`
- Frontend detects `EMAIL_NOT_VERIFIED` error and shows a friendly message instead of the raw error

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `sendOnSignIn: true` to the email verification config so unverified users receive a new verification link on sign-in, introduces a styled React Email verification template matching Dokploy's branding, and shows a friendly frontend message instead of the raw auth error.

- **P1 – logger regression**: `logger.disabled` was changed from `process.env.NODE_ENV === "production"` to `false`, unconditionally enabling auth logs in production and potentially exposing session/token data in server logs.

<h3>Confidence Score: 4/5</h3>

Safe to merge after reverting the logger change; all other changes are well-scoped and correct.

One P1 issue remains: the auth logger was unintentionally set to always-on (`disabled: false`), which enables verbose auth logs in production and should be reverted before merging. All other changes — the email template, the `sendVerificationEmail` helper, and the frontend error handling — are correct and well-implemented.

packages/server/src/lib/auth.ts — logger configuration regression at line 79.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/server/src/lib/auth.ts`, line 79 ([link](https://github.com/dokploy/dokploy/blob/fda367b2c51bbe6930823cf711883899cdf95494/packages/server/src/lib/auth.ts#L79)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Logger always enabled in production**

   Setting `disabled: false` unconditionally re-enables the auth library logger in production, reverting the previous intentional guard (`process.env.NODE_ENV === "production"`). Better-auth's logger can emit session tokens, user IDs, and request details — having it always on in production creates unnecessary log noise and risks leaking sensitive auth data.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: update logger configuration to disa..."](https://github.com/dokploy/dokploy/commit/fda367b2c51bbe6930823cf711883899cdf95494) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28817274)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->