### PR TITLE
style: Fix typo in custom entrypoint description

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -666,7 +666,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 											<div className="space-y-0.5">
 												<FormLabel>Custom Entrypoint</FormLabel>
 												<FormDescription>
-													Use custom entrypoint for domina
+													Use custom entrypoint for domain
 													<br />
 													"web" and/or "websecure" is used by default.
 												</FormDescription>


### PR DESCRIPTION
## What is this PR about?
Minimal typo fix

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Screenshots (if applicable)
Currently:
<img width="752" height="148" alt="image" src="https://github.com/user-attachments/assets/669653eb-5c38-4fbc-8a8d-a655ef2e0ef7" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a single-word typo in the `Custom Entrypoint` form field description inside `handle-domain.tsx`, changing `"domina"` to `"domain"`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-character typo correction with no logic or behaviour changes.

The change is a trivial one-word spelling fix in a UI description string; no logic, data, or security implications exist.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["Fix typo in custom entrypoint descriptio..."](https://github.com/dokploy/dokploy/commit/f7b576cbf3a9fa6be5b9e262950bee4a3c5f9c6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28834380)</sub>

<!-- /greptile_comment -->