### PR TITLE
feat: add dashboard home page

### DIFF
--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -163,8 +163,8 @@ export const ShowHome = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar p-2.5 rounded-xl">
-				<div className="rounded-xl bg-background shadow-md p-6 flex flex-col gap-6">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl min-h-[85vh]">
+				<div className="rounded-xl bg-background shadow-md p-6 flex flex-col gap-6 h-full">
 					<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
 						<h1 className="text-3xl font-semibold tracking-tight">
 							{firstName ? `Welcome back, ${firstName}` : "Welcome back"}

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -1,0 +1,223 @@
+import { formatDistanceToNow } from "date-fns";
+import { Plus, Rocket } from "lucide-react";
+import Link from "next/link";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { api } from "@/utils/api";
+
+type DeploymentStatus = "idle" | "running" | "done" | "error";
+
+const statusDotClass: Record<string, string> = {
+	done: "bg-muted-foreground/60",
+	running: "bg-amber-500",
+	error: "bg-red-500",
+	idle: "bg-muted-foreground/30",
+};
+
+function getServiceInfo(d: any) {
+	const app = d.application;
+	const comp = d.compose;
+	if (app?.environment?.project && app.environment) {
+		return {
+			name: app.name as string,
+			environment: app.environment.name as string,
+			projectName: app.environment.project.name as string,
+			href: `/dashboard/project/${app.environment.project.projectId}/environment/${app.environment.environmentId}/services/application/${app.applicationId}`,
+		};
+	}
+	if (comp?.environment?.project && comp.environment) {
+		return {
+			name: comp.name as string,
+			environment: comp.environment.name as string,
+			projectName: comp.environment.project.name as string,
+			href: `/dashboard/project/${comp.environment.project.projectId}/environment/${comp.environment.environmentId}/services/compose/${comp.composeId}`,
+		};
+	}
+	return null;
+}
+
+function StatCard({
+	label,
+	value,
+	delta,
+}: {
+	label: string;
+	value: string;
+	delta?: string;
+}) {
+	return (
+		<div className="rounded-xl border bg-background p-5 min-h-[120px] flex flex-col justify-between">
+			<span className="text-xs uppercase tracking-wider text-muted-foreground">
+				{label}
+			</span>
+			<div className="flex flex-col gap-1">
+				<span className="text-3xl font-semibold tracking-tight">{value}</span>
+				{delta && (
+					<span className="text-xs text-muted-foreground">
+						{delta}
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export const ShowHome = () => {
+	const { data: auth } = api.user.get.useQuery();
+	const { data: projects } = api.project.all.useQuery();
+	const { data: servers } = api.server.all.useQuery();
+	const { data: permissions } = api.user.getPermissions.useQuery();
+	const canReadDeployments = !!permissions?.deployment.read;
+	const { data: deployments } = api.deployment.allCentralized.useQuery(
+		undefined,
+		{
+			enabled: canReadDeployments,
+			refetchInterval: 10000,
+		},
+	);
+
+	const firstName = auth?.user?.firstName?.trim();
+
+	const { totals, serverCount } = useMemo(() => {
+		let applications = 0;
+		let compose = 0;
+		let databases = 0;
+		const dbKeys = [
+			"postgres",
+			"mysql",
+			"mariadb",
+			"mongo",
+			"redis",
+			"libsql",
+		] as const;
+		for (const p of projects ?? []) {
+			for (const env of p.environments ?? []) {
+				applications += env.applications?.length ?? 0;
+				compose += env.compose?.length ?? 0;
+				for (const key of dbKeys) {
+					databases += (env as any)[key]?.length ?? 0;
+				}
+			}
+		}
+		return {
+			totals: {
+				projects: projects?.length ?? 0,
+				applications,
+				compose,
+				databases,
+				services: applications + compose + databases,
+			},
+			serverCount: servers?.length ?? 0,
+		};
+	}, [projects, servers]);
+
+	const recentDeployments = useMemo(() => {
+		if (!deployments) return [];
+		return [...deployments]
+			.sort(
+				(a, b) =>
+					new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+			)
+			.slice(0, 10);
+	}, [deployments]);
+
+	return (
+		<div className="w-full flex flex-col gap-6">
+			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+				<div className="flex flex-col gap-1">
+					<h1 className="text-3xl font-semibold tracking-tight">
+						{firstName ? `Welcome back, ${firstName}` : "Welcome back"}
+					</h1>
+					<p className="text-sm text-muted-foreground">
+						{totals.services} services across {serverCount}{" "}
+						{serverCount === 1 ? "server" : "servers"} · {totals.projects}{" "}
+						{totals.projects === 1 ? "project" : "projects"}
+					</p>
+				</div>
+				<Button asChild className="w-fit">
+					<Link href="/dashboard/projects">
+						<Plus className="size-4" />
+						New project
+					</Link>
+				</Button>
+			</div>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+				<StatCard
+					label="Deploys / 24h"
+					value={String(recentDeployments.length)}
+					delta="placeholder"
+				/>
+				<StatCard label="Avg build" value="—" delta="placeholder" />
+				<StatCard label="CPU" value="—" delta="placeholder" />
+				<StatCard label="Memory" value="—" delta="placeholder" />
+			</div>
+
+			<div className="rounded-xl border bg-background">
+				<div className="flex items-center justify-between px-5 py-4 border-b">
+					<div className="flex items-center gap-2">
+						<Rocket className="size-4 text-muted-foreground" />
+						<h2 className="text-sm font-semibold">Recent deployments</h2>
+					</div>
+					{canReadDeployments && (
+						<Link
+							href="/dashboard/deployments"
+							className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+						>
+							view all →
+						</Link>
+					)}
+				</div>
+				{!canReadDeployments ? (
+					<div className="p-10 text-center text-sm text-muted-foreground">
+						You do not have permission to view deployments.
+					</div>
+				) : recentDeployments.length === 0 ? (
+					<div className="p-10 text-center text-sm text-muted-foreground">
+						No deployments yet.
+					</div>
+				) : (
+					<ul className="divide-y">
+						{recentDeployments.map((d) => {
+							const info = getServiceInfo(d);
+							if (!info) return null;
+							const status = (d.status ?? "idle") as DeploymentStatus;
+							return (
+								<li key={d.deploymentId}>
+									<Link
+										href={info.href}
+										className="flex items-center gap-4 px-5 py-4 hover:bg-muted/40 transition-colors"
+									>
+										<span
+											className={`size-2 rounded-full shrink-0 ${statusDotClass[status] ?? statusDotClass.idle}`}
+											aria-hidden
+										/>
+										<div className="flex flex-col min-w-0 flex-1">
+											<span className="text-sm truncate">
+												{info.name}
+											</span>
+											<span className="text-xs text-muted-foreground truncate">
+												{info.projectName} · {info.environment}
+											</span>
+										</div>
+										<span className="text-xs text-muted-foreground w-20 text-right hidden sm:inline">
+											{status}
+										</span>
+										<span className="text-xs text-muted-foreground w-24 text-right hidden md:inline">
+											{formatDistanceToNow(new Date(d.createdAt), {
+												addSuffix: true,
+											})}
+										</span>
+										<span className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+											logs →
+										</span>
+									</Link>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -95,8 +95,7 @@ function StatusListCard({
 
 export const ShowHome = () => {
 	const { data: auth } = api.user.get.useQuery();
-	const { data: projects } = api.project.all.useQuery();
-	const { data: servers } = api.server.all.useQuery();
+	const { data: homeStats } = api.project.homeStats.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const canReadDeployments = !!permissions?.deployment.read;
 	const { data: deployments } = api.deployment.allCentralized.useQuery(
@@ -109,53 +108,19 @@ export const ShowHome = () => {
 
 	const firstName = auth?.user?.firstName?.trim();
 
-	const { totals, statusBreakdown } = useMemo(() => {
-		let applications = 0;
-		let compose = 0;
-		let databases = 0;
-		let environments = 0;
-		const breakdown = { running: 0, error: 0, idle: 0 };
-		const dbKeys = [
-			"postgres",
-			"mysql",
-			"mariadb",
-			"mongo",
-			"redis",
-			"libsql",
-		] as const;
-		const bump = (status?: string) => {
-			if (status === "done") breakdown.running++;
-			else if (status === "error") breakdown.error++;
-			else breakdown.idle++;
-		};
-		for (const p of projects ?? []) {
-			for (const env of p.environments ?? []) {
-				environments++;
-				applications += env.applications?.length ?? 0;
-				compose += env.compose?.length ?? 0;
-				for (const a of env.applications ?? []) bump(a.applicationStatus);
-				for (const c of env.compose ?? []) bump((c as any).composeStatus);
-				for (const key of dbKeys) {
-					const list = ((env as any)[key] ?? []) as Array<{
-						applicationStatus?: string;
-					}>;
-					databases += list.length;
-					for (const s of list) bump(s.applicationStatus);
-				}
-			}
-		}
-		return {
-			totals: {
-				projects: projects?.length ?? 0,
-				environments,
-				applications,
-				compose,
-				databases,
-				services: applications + compose + databases,
-			},
-			statusBreakdown: breakdown,
-		};
-	}, [projects, servers]);
+	const totals = homeStats ?? {
+		projects: 0,
+		environments: 0,
+		applications: 0,
+		compose: 0,
+		databases: 0,
+		services: 0,
+	};
+	const statusBreakdown = homeStats?.status ?? {
+		running: 0,
+		error: 0,
+		idle: 0,
+	};
 
 	const recentDeployments = useMemo(() => {
 		if (!deployments) return [];

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -1,27 +1,31 @@
 import { formatDistanceToNow } from "date-fns";
-import { Plus, Rocket } from "lucide-react";
+import { ArrowRight, Rocket, Server } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { api } from "@/utils/api";
 
 type DeploymentStatus = "idle" | "running" | "done" | "error";
 
 const statusDotClass: Record<string, string> = {
-	done: "bg-muted-foreground/60",
+	done: "bg-emerald-500",
 	running: "bg-amber-500",
 	error: "bg-red-500",
-	idle: "bg-muted-foreground/30",
+	idle: "bg-muted-foreground/40",
 };
 
 function getServiceInfo(d: any) {
 	const app = d.application;
 	const comp = d.compose;
+	const serverName: string =
+		d.server?.name ?? app?.server?.name ?? comp?.server?.name ?? "Dokploy";
 	if (app?.environment?.project && app.environment) {
 		return {
 			name: app.name as string,
 			environment: app.environment.name as string,
 			projectName: app.environment.project.name as string,
+			serverName,
 			href: `/dashboard/project/${app.environment.project.projectId}/environment/${app.environment.environmentId}/services/application/${app.applicationId}`,
 		};
 	}
@@ -30,6 +34,7 @@ function getServiceInfo(d: any) {
 			name: comp.name as string,
 			environment: comp.environment.name as string,
 			projectName: comp.environment.project.name as string,
+			serverName,
 			href: `/dashboard/project/${comp.environment.project.projectId}/environment/${comp.environment.environmentId}/services/compose/${comp.composeId}`,
 		};
 	}
@@ -46,7 +51,7 @@ function StatCard({
 	delta?: string;
 }) {
 	return (
-		<div className="rounded-xl border bg-background p-5 min-h-[120px] flex flex-col justify-between">
+		<div className="rounded-xl border bg-background p-5 min-h-[140px] flex flex-col justify-between">
 			<span className="text-xs uppercase tracking-wider text-muted-foreground">
 				{label}
 			</span>
@@ -56,6 +61,34 @@ function StatCard({
 					<span className="text-xs text-muted-foreground">{delta}</span>
 				)}
 			</div>
+		</div>
+	);
+}
+
+function StatusListCard({
+	label,
+	items,
+}: {
+	label: string;
+	items: { dotClass: string; label: string; count: number }[];
+}) {
+	return (
+		<div className="rounded-xl border bg-background p-5 min-h-[140px] flex flex-col gap-3">
+			<span className="text-xs uppercase tracking-wider text-muted-foreground">
+				{label}
+			</span>
+			<ul className="flex flex-col gap-1.5">
+				{items.map((item) => (
+					<li key={item.label} className="flex items-center gap-2.5 text-sm">
+						<span
+							className={`size-2 rounded-full shrink-0 ${item.dotClass}`}
+							aria-hidden
+						/>
+						<span className="font-semibold tabular-nums w-8">{item.count}</span>
+						<span className="text-muted-foreground">{item.label}</span>
+					</li>
+				))}
+			</ul>
 		</div>
 	);
 }
@@ -76,10 +109,12 @@ export const ShowHome = () => {
 
 	const firstName = auth?.user?.firstName?.trim();
 
-	const { totals, serverCount } = useMemo(() => {
+	const { totals, statusBreakdown } = useMemo(() => {
 		let applications = 0;
 		let compose = 0;
 		let databases = 0;
+		let environments = 0;
+		const breakdown = { running: 0, error: 0, idle: 0 };
 		const dbKeys = [
 			"postgres",
 			"mysql",
@@ -88,24 +123,37 @@ export const ShowHome = () => {
 			"redis",
 			"libsql",
 		] as const;
+		const bump = (status?: string) => {
+			if (status === "done") breakdown.running++;
+			else if (status === "error") breakdown.error++;
+			else breakdown.idle++;
+		};
 		for (const p of projects ?? []) {
 			for (const env of p.environments ?? []) {
+				environments++;
 				applications += env.applications?.length ?? 0;
 				compose += env.compose?.length ?? 0;
+				for (const a of env.applications ?? []) bump(a.applicationStatus);
+				for (const c of env.compose ?? []) bump((c as any).composeStatus);
 				for (const key of dbKeys) {
-					databases += (env as any)[key]?.length ?? 0;
+					const list = ((env as any)[key] ?? []) as Array<{
+						applicationStatus?: string;
+					}>;
+					databases += list.length;
+					for (const s of list) bump(s.applicationStatus);
 				}
 			}
 		}
 		return {
 			totals: {
 				projects: projects?.length ?? 0,
+				environments,
 				applications,
 				compose,
 				databases,
 				services: applications + compose + databases,
 			},
-			serverCount: servers?.length ?? 0,
+			statusBreakdown: breakdown,
 		};
 	}, [projects, servers]);
 
@@ -119,101 +167,160 @@ export const ShowHome = () => {
 			.slice(0, 10);
 	}, [deployments]);
 
+	const deployStats = useMemo(() => {
+		const now = Date.now();
+		const weekMs = 7 * 24 * 60 * 60 * 1000;
+		const lastStart = now - weekMs;
+		const prevStart = now - 2 * weekMs;
+
+		const last: NonNullable<typeof deployments> = [];
+		const prev: NonNullable<typeof deployments> = [];
+		for (const d of deployments ?? []) {
+			const t = new Date(d.createdAt).getTime();
+			if (t >= lastStart) last.push(d);
+			else if (t >= prevStart) prev.push(d);
+		}
+
+		const lastCount = last.length;
+		const prevCount = prev.length;
+		let delta: string | undefined;
+		if (prevCount > 0) {
+			const pct = Math.round(((lastCount - prevCount) / prevCount) * 100);
+			delta = `${pct >= 0 ? "+" : ""}${pct}% vs prev 7d`;
+		} else if (lastCount > 0) {
+			delta = "no prior data";
+		} else {
+			delta = "no activity yet";
+		}
+
+		return { value: String(lastCount), delta };
+	}, [deployments]);
+
 	return (
-		<div className="w-full flex flex-col gap-6">
-			<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-				<div className="flex flex-col gap-1">
-					<h1 className="text-3xl font-semibold tracking-tight">
-						{firstName ? `Welcome back, ${firstName}` : "Welcome back"}
-					</h1>
-					<p className="text-sm text-muted-foreground">
-						{totals.services} services across {serverCount}{" "}
-						{serverCount === 1 ? "server" : "servers"} · {totals.projects}{" "}
-						{totals.projects === 1 ? "project" : "projects"}
-					</p>
-				</div>
-				<Button asChild className="w-fit">
-					<Link href="/dashboard/projects">
-						<Plus className="size-4" />
-						New project
-					</Link>
-				</Button>
-			</div>
+		<div className="w-full">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl">
+				<div className="rounded-xl bg-background shadow-md p-6 flex flex-col gap-6">
+					<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+						<h1 className="text-3xl font-semibold tracking-tight">
+							{firstName ? `Welcome back, ${firstName}` : "Welcome back"}
+						</h1>
+						<Button asChild variant="secondary" className="w-fit">
+							<Link href="/dashboard/projects">
+								Go to projects
+								<ArrowRight className="size-4" />
+							</Link>
+						</Button>
+					</div>
 
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-				<StatCard
-					label="Deploys / 24h"
-					value={String(recentDeployments.length)}
-					delta="placeholder"
-				/>
-				<StatCard label="Avg build" value="—" delta="placeholder" />
-				<StatCard label="CPU" value="—" delta="placeholder" />
-				<StatCard label="Memory" value="—" delta="placeholder" />
-			</div>
+					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+						<StatCard
+							label="Projects"
+							value={String(totals.projects)}
+							delta={`${totals.environments} ${totals.environments === 1 ? "environment" : "environments"}`}
+						/>
+						<StatCard
+							label="Services"
+							value={String(totals.services)}
+							delta={`${totals.applications} apps · ${totals.compose} compose · ${totals.databases} db`}
+						/>
+						<StatCard
+							label="Deploys / 7d"
+							value={deployStats.value}
+							delta={deployStats.delta}
+						/>
+						<StatusListCard
+							label="Status"
+							items={[
+								{
+									dotClass: "bg-emerald-500",
+									label: "running",
+									count: statusBreakdown.running,
+								},
+								{
+									dotClass: "bg-red-500",
+									label: "errored",
+									count: statusBreakdown.error,
+								},
+								{
+									dotClass: "bg-muted-foreground/40",
+									label: "idle",
+									count: statusBreakdown.idle,
+								},
+							]}
+						/>
+					</div>
 
-			<div className="rounded-xl border bg-background">
-				<div className="flex items-center justify-between px-5 py-4 border-b">
-					<div className="flex items-center gap-2">
-						<Rocket className="size-4 text-muted-foreground" />
-						<h2 className="text-sm font-semibold">Recent deployments</h2>
+					<div className="rounded-xl border bg-background">
+						<div className="flex items-center justify-between px-5 py-4 border-b">
+							<div className="flex items-center gap-2">
+								<Rocket className="size-4 text-muted-foreground" />
+								<h2 className="text-sm font-semibold">Recent deployments</h2>
+							</div>
+							{canReadDeployments && (
+								<Link
+									href="/dashboard/deployments"
+									className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+								>
+									view all →
+								</Link>
+							)}
+						</div>
+						{!canReadDeployments ? (
+							<div className="min-h-[400px] flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground p-10">
+								<Rocket className="size-8 opacity-40" />
+								<span>You do not have permission to view deployments.</span>
+							</div>
+						) : recentDeployments.length === 0 ? (
+							<div className="min-h-[400px] flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground p-10">
+								<Rocket className="size-8 opacity-40" />
+								<span>No deployments yet.</span>
+							</div>
+						) : (
+							<ul className="divide-y">
+								{recentDeployments.map((d) => {
+									const info = getServiceInfo(d);
+									if (!info) return null;
+									const status = (d.status ?? "idle") as DeploymentStatus;
+									return (
+										<li key={d.deploymentId}>
+											<Link
+												href={info.href}
+												className="flex items-center gap-4 px-5 py-4 hover:bg-muted/40 transition-colors"
+											>
+												<span
+													className={`size-2 rounded-full shrink-0 ${statusDotClass[status] ?? statusDotClass.idle}`}
+													aria-hidden
+												/>
+												<div className="flex flex-col min-w-0 flex-1">
+													<span className="text-sm truncate">{info.name}</span>
+													<span className="text-xs text-muted-foreground truncate">
+														{info.projectName} · {info.environment}
+													</span>
+												</div>
+												<span className="text-xs text-muted-foreground w-36 hidden lg:flex items-center justify-end gap-1.5 truncate">
+													<Server className="size-3 shrink-0" />
+													<span className="truncate">{info.serverName}</span>
+												</span>
+												<span className="text-xs text-muted-foreground w-20 text-right hidden sm:inline">
+													{status}
+												</span>
+												<span className="text-xs text-muted-foreground w-24 text-right hidden md:inline">
+													{formatDistanceToNow(new Date(d.createdAt), {
+														addSuffix: true,
+													})}
+												</span>
+												<span className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+													logs →
+												</span>
+											</Link>
+										</li>
+									);
+								})}
+							</ul>
+						)}
 					</div>
-					{canReadDeployments && (
-						<Link
-							href="/dashboard/deployments"
-							className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-						>
-							view all →
-						</Link>
-					)}
 				</div>
-				{!canReadDeployments ? (
-					<div className="p-10 text-center text-sm text-muted-foreground">
-						You do not have permission to view deployments.
-					</div>
-				) : recentDeployments.length === 0 ? (
-					<div className="p-10 text-center text-sm text-muted-foreground">
-						No deployments yet.
-					</div>
-				) : (
-					<ul className="divide-y">
-						{recentDeployments.map((d) => {
-							const info = getServiceInfo(d);
-							if (!info) return null;
-							const status = (d.status ?? "idle") as DeploymentStatus;
-							return (
-								<li key={d.deploymentId}>
-									<Link
-										href={info.href}
-										className="flex items-center gap-4 px-5 py-4 hover:bg-muted/40 transition-colors"
-									>
-										<span
-											className={`size-2 rounded-full shrink-0 ${statusDotClass[status] ?? statusDotClass.idle}`}
-											aria-hidden
-										/>
-										<div className="flex flex-col min-w-0 flex-1">
-											<span className="text-sm truncate">{info.name}</span>
-											<span className="text-xs text-muted-foreground truncate">
-												{info.projectName} · {info.environment}
-											</span>
-										</div>
-										<span className="text-xs text-muted-foreground w-20 text-right hidden sm:inline">
-											{status}
-										</span>
-										<span className="text-xs text-muted-foreground w-24 text-right hidden md:inline">
-											{formatDistanceToNow(new Date(d.createdAt), {
-												addSuffix: true,
-											})}
-										</span>
-										<span className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-											logs →
-										</span>
-									</Link>
-								</li>
-							);
-						})}
-					</ul>
-				)}
-			</div>
+			</Card>
 		</div>
 	);
 };

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -53,9 +53,7 @@ function StatCard({
 			<div className="flex flex-col gap-1">
 				<span className="text-3xl font-semibold tracking-tight">{value}</span>
 				{delta && (
-					<span className="text-xs text-muted-foreground">
-						{delta}
-					</span>
+					<span className="text-xs text-muted-foreground">{delta}</span>
 				)}
 			</div>
 		</div>
@@ -193,9 +191,7 @@ export const ShowHome = () => {
 											aria-hidden
 										/>
 										<div className="flex flex-col min-w-0 flex-1">
-											<span className="text-sm truncate">
-												{info.name}
-											</span>
+											<span className="text-sm truncate">{info.name}</span>
 											<span className="text-xs text-muted-foreground truncate">
 												{info.projectName} · {info.environment}
 											</span>

--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -166,6 +166,7 @@ export const ShowProjects = () => {
 						return (
 							total +
 							(env.applications?.length || 0) +
+							(env.libsql?.length || 0) +
 							(env.mariadb?.length || 0) +
 							(env.mongo?.length || 0) +
 							(env.mysql?.length || 0) +
@@ -178,6 +179,7 @@ export const ShowProjects = () => {
 						return (
 							total +
 							(env.applications?.length || 0) +
+							(env.libsql?.length || 0) +
 							(env.mariadb?.length || 0) +
 							(env.mongo?.length || 0) +
 							(env.mysql?.length || 0) +

--- a/apps/dokploy/components/dashboard/search-command.tsx
+++ b/apps/dokploy/components/dashboard/search-command.tsx
@@ -167,7 +167,7 @@ export const SearchCommand = () => {
 					<CommandGroup heading={"Application"} hidden={true}>
 						<CommandItem
 							onSelect={() => {
-								router.push("/dashboard/projects");
+								router.push("/dashboard/home");
 								setOpen(false);
 							}}
 						>

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/welcome-subscription.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/welcome-subscription.tsx
@@ -425,7 +425,7 @@ export const WelcomeSubscription = () => {
 								onClick={() => {
 									if (stepper.isLast) {
 										setIsOpen(false);
-										push("/dashboard/projects");
+										push("/dashboard/home");
 									} else {
 										stepper.next();
 									}

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -19,6 +19,7 @@ import {
 	Forward,
 	GalleryVerticalEnd,
 	GitBranch,
+	House,
 	Key,
 	KeyRound,
 	Loader2,
@@ -148,6 +149,12 @@ type Menu = {
 // The `isEnabled` function is called to determine if the item should be displayed
 const MENU: Menu = {
 	home: [
+		{
+			isSingle: true,
+			title: "Home",
+			url: "/dashboard/home",
+			icon: House,
+		},
 		{
 			isSingle: true,
 			title: "Projects",

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -80,7 +80,7 @@ export const UserNav = () => {
 					<DropdownMenuItem
 						className="cursor-pointer"
 						onClick={() => {
-							router.push("/dashboard/projects");
+							router.push("/dashboard/home");
 						}}
 					>
 						Projects

--- a/apps/dokploy/components/proprietary/sso/sign-in-with-sso.tsx
+++ b/apps/dokploy/components/proprietary/sso/sign-in-with-sso.tsx
@@ -44,7 +44,7 @@ export function SignInWithSSO({ children }: SignInWithSSOProps) {
 		try {
 			const { data, error } = await authClient.signIn.sso({
 				email: values.email,
-				callbackURL: "/dashboard/projects",
+				callbackURL: "/dashboard/home",
 			});
 			if (error) {
 				toast.error(error.message ?? "Failed to sign in with SSO");

--- a/apps/dokploy/pages/_error.tsx
+++ b/apps/dokploy/pages/_error.tsx
@@ -53,7 +53,7 @@ export default function Custom404({ statusCode, error }: Props) {
 
 						<div className="mt-5 flex flex-col justify-center items-center gap-2 sm:flex-row sm:gap-3">
 							<Link
-								href="/dashboard/projects"
+								href="/dashboard/home"
 								className={buttonVariants({
 									variant: "secondary",
 									className: "flex flex-row gap-2",

--- a/apps/dokploy/pages/dashboard/deployments.tsx
+++ b/apps/dokploy/pages/dashboard/deployments.tsx
@@ -102,7 +102,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 		return {
 			redirect: {
 				permanent: false,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/docker.tsx
+++ b/apps/dokploy/pages/dashboard/docker.tsx
@@ -24,7 +24,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/home.tsx
+++ b/apps/dokploy/pages/dashboard/home.tsx
@@ -1,36 +1,27 @@
-import { IS_CLOUD } from "@dokploy/server/constants";
 import { validateRequest } from "@dokploy/server/lib/auth";
 import { createServerSideHelpers } from "@trpc/react-query/server";
 import type { GetServerSidePropsContext } from "next";
 import type { ReactElement } from "react";
 import superjson from "superjson";
-import { ShowBillingInvoices } from "@/components/dashboard/settings/billing/show-billing-invoices";
+import { ShowHome } from "@/components/dashboard/home/show-home";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { appRouter } from "@/server/api/root";
 
-const Page = () => {
-	return <ShowBillingInvoices />;
+const Home = () => {
+	return <ShowHome />;
 };
 
-export default Page;
+export default Home;
 
-Page.getLayout = (page: ReactElement) => {
-	return <DashboardLayout metaName="Invoices">{page}</DashboardLayout>;
+Home.getLayout = (page: ReactElement) => {
+	return <DashboardLayout>{page}</DashboardLayout>;
 };
-export async function getServerSideProps(
-	ctx: GetServerSidePropsContext<{ serviceId: string }>,
-) {
-	if (!IS_CLOUD) {
-		return {
-			redirect: {
-				permanent: true,
-				destination: "/dashboard/home",
-			},
-		};
-	}
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	const { req, res } = ctx;
 	const { user, session } = await validateRequest(req);
-	if (!user || user.role !== "owner") {
+
+	if (!user) {
 		return {
 			redirect: {
 				permanent: true,
@@ -51,9 +42,8 @@ export async function getServerSideProps(
 		transformer: superjson,
 	});
 
-	await helpers.user.get.prefetch();
-
 	await helpers.settings.isCloud.prefetch();
+	await helpers.user.get.prefetch();
 
 	return {
 		props: {

--- a/apps/dokploy/pages/dashboard/monitoring.tsx
+++ b/apps/dokploy/pages/dashboard/monitoring.tsx
@@ -96,7 +96,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}
@@ -122,7 +122,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: false,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -36,7 +36,7 @@ import { AddTemplate } from "@/components/dashboard/project/add-template";
 import { AdvancedEnvironmentSelector } from "@/components/dashboard/project/advanced-environment-selector";
 import { DuplicateProject } from "@/components/dashboard/project/duplicate-project";
 import { EnvironmentVariables } from "@/components/dashboard/project/environment-variables";
-import { ProjectEnvironment } from "@/components/dashboard/projects/project-environment";
+import { ProjectEnvironment } from "@/components/dashboard/home/project-environment";
 import {
 	LibsqlIcon,
 	MariadbIcon,
@@ -1856,7 +1856,7 @@ export async function getServerSideProps(
 				return {
 					redirect: {
 						permanent: false,
-						destination: "/dashboard/projects",
+						destination: "/dashboard/home",
 					},
 				};
 			}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -36,7 +36,7 @@ import { AddTemplate } from "@/components/dashboard/project/add-template";
 import { AdvancedEnvironmentSelector } from "@/components/dashboard/project/advanced-environment-selector";
 import { DuplicateProject } from "@/components/dashboard/project/duplicate-project";
 import { EnvironmentVariables } from "@/components/dashboard/project/environment-variables";
-import { ProjectEnvironment } from "@/components/dashboard/home/project-environment";
+import { ProjectEnvironment } from "@/components/dashboard/projects/project-environment";
 import {
 	LibsqlIcon,
 	MariadbIcon,
@@ -509,6 +509,14 @@ const EnvironmentPage = (
 		deploy: api.mongo.deploy.useMutation(),
 	};
 
+	const libsqlActions = {
+		start: api.libsql.start.useMutation(),
+		stop: api.libsql.stop.useMutation(),
+		move: api.libsql.move.useMutation(),
+		delete: api.libsql.remove.useMutation(),
+		deploy: api.libsql.deploy.useMutation(),
+	};
+
 	const handleBulkStart = async () => {
 		let success = 0;
 		setIsBulkActionLoading(true);
@@ -540,6 +548,9 @@ const EnvironmentPage = (
 						break;
 					case "mongo":
 						await mongoActions.start.mutateAsync({ mongoId: serviceId });
+						break;
+					case "libsql":
+						await libsqlActions.start.mutateAsync({ libsqlId: serviceId });
 						break;
 				}
 				success++;
@@ -587,6 +598,9 @@ const EnvironmentPage = (
 						break;
 					case "mongo":
 						await mongoActions.stop.mutateAsync({ mongoId: serviceId });
+						break;
+					case "libsql":
+						await libsqlActions.stop.mutateAsync({ libsqlId: serviceId });
 						break;
 				}
 				success++;
@@ -664,6 +678,12 @@ const EnvironmentPage = (
 							targetEnvironmentId: selectedTargetEnvironment,
 						});
 						break;
+					case "libsql":
+						await libsqlActions.move.mutateAsync({
+							libsqlId: serviceId,
+							targetEnvironmentId: selectedTargetEnvironment,
+						});
+						break;
 				}
 				await utils.environment.one.invalidate({
 					environmentId,
@@ -733,6 +753,11 @@ const EnvironmentPage = (
 							mongoId: serviceId,
 						});
 						break;
+					case "libsql":
+						await libsqlActions.delete.mutateAsync({
+							libsqlId: serviceId,
+						});
+						break;
 				}
 				await utils.environment.one.invalidate({
 					environmentId,
@@ -797,6 +822,11 @@ const EnvironmentPage = (
 					case "mongo":
 						await mongoActions.deploy.mutateAsync({
 							mongoId: serviceId,
+						});
+						break;
+					case "libsql":
+						await libsqlActions.deploy.mutateAsync({
+							libsqlId: serviceId,
 						});
 						break;
 				}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -490,7 +490,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -492,7 +492,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -343,7 +343,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -372,7 +372,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -376,7 +376,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -353,7 +353,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -360,7 +360,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -363,7 +363,7 @@ export async function getServerSideProps(
 			return {
 				redirect: {
 					permanent: false,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/pages/dashboard/requests.tsx
+++ b/apps/dokploy/pages/dashboard/requests.tsx
@@ -18,7 +18,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/schedules.tsx
+++ b/apps/dokploy/pages/dashboard/schedules.tsx
@@ -35,7 +35,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/settings/billing.tsx
+++ b/apps/dokploy/pages/dashboard/settings/billing.tsx
@@ -24,7 +24,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/settings/cluster.tsx
+++ b/apps/dokploy/pages/dashboard/settings/cluster.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/settings/server.tsx
+++ b/apps/dokploy/pages/dashboard/settings/server.tsx
@@ -45,7 +45,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/swarm.tsx
+++ b/apps/dokploy/pages/dashboard/swarm.tsx
@@ -46,7 +46,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/dashboard/traefik.tsx
+++ b/apps/dokploy/pages/dashboard/traefik.tsx
@@ -24,7 +24,7 @@ export async function getServerSideProps(
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -106,7 +106,7 @@ export default function Home({ IS_CLOUD }: Props) {
 			}
 
 			toast.success("Logged in successfully");
-			router.push("/dashboard/projects");
+			router.push("/dashboard/home");
 		} catch {
 			toast.error("An error occurred while logging in");
 		} finally {
@@ -133,7 +133,7 @@ export default function Home({ IS_CLOUD }: Props) {
 			}
 
 			toast.success("Logged in successfully");
-			router.push("/dashboard/projects");
+			router.push("/dashboard/home");
 		} catch {
 			toast.error("An error occurred while verifying 2FA code");
 		} finally {
@@ -163,7 +163,7 @@ export default function Home({ IS_CLOUD }: Props) {
 			}
 
 			toast.success("Logged in successfully");
-			router.push("/dashboard/projects");
+			router.push("/dashboard/home");
 		} catch {
 			toast.error("An error occurred while verifying backup code");
 		} finally {
@@ -408,7 +408,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 				return {
 					redirect: {
 						permanent: true,
-						destination: "/dashboard/projects",
+						destination: "/dashboard/home",
 					},
 				};
 			}
@@ -437,7 +437,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 		return {
 			redirect: {
 				permanent: true,
-				destination: "/dashboard/projects",
+				destination: "/dashboard/home",
 			},
 		};
 	}

--- a/apps/dokploy/pages/invitation.tsx
+++ b/apps/dokploy/pages/invitation.tsx
@@ -139,7 +139,7 @@ const Invitation = ({
 			});
 
 			toast.success("Account created successfully");
-			router.push("/dashboard/projects");
+			router.push("/dashboard/home");
 		} catch {
 			toast.error("An error occurred while creating your account");
 		}

--- a/apps/dokploy/pages/register.tsx
+++ b/apps/dokploy/pages/register.tsx
@@ -303,7 +303,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 			return {
 				redirect: {
 					permanent: true,
-					destination: "/dashboard/projects",
+					destination: "/dashboard/home",
 				},
 			};
 		}

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -487,6 +487,149 @@ export const projectRouter = createTRPCRouter({
 		},
 	),
 
+	homeStats: protectedProcedure.query(async ({ ctx }) => {
+		const isPrivileged =
+			ctx.user.role === "owner" || ctx.user.role === "admin";
+
+		let accessedProjects: string[] = [];
+		let accessedEnvironments: string[] = [];
+		let accessedServices: string[] = [];
+
+		if (!isPrivileged) {
+			const member = await findMemberByUserId(
+				ctx.user.id,
+				ctx.session.activeOrganizationId,
+			);
+			accessedProjects = member.accessedProjects;
+			accessedEnvironments = member.accessedEnvironments;
+			accessedServices = member.accessedServices;
+
+			if (accessedProjects.length === 0) {
+				return {
+					projects: 0,
+					environments: 0,
+					applications: 0,
+					compose: 0,
+					databases: 0,
+					services: 0,
+					status: { running: 0, error: 0, idle: 0 },
+				};
+			}
+		}
+
+		const projectIdFilter = isPrivileged
+			? eq(projects.organizationId, ctx.session.activeOrganizationId)
+			: and(
+					sql`${projects.projectId} IN (${sql.join(
+						accessedProjects.map((id) => sql`${id}`),
+						sql`, `,
+					)})`,
+					eq(projects.organizationId, ctx.session.activeOrganizationId),
+				);
+
+		const environmentFilter = isPrivileged
+			? undefined
+			: accessedEnvironments.length === 0
+				? sql`false`
+				: sql`${environments.environmentId} IN (${sql.join(
+						accessedEnvironments.map((envId) => sql`${envId}`),
+						sql`, `,
+					)})`;
+
+		const applyFilter = (col: AnyPgColumn) =>
+			isPrivileged ? undefined : buildServiceFilter(col, accessedServices);
+
+		const rows = await db.query.projects.findMany({
+			where: projectIdFilter,
+			columns: { projectId: true },
+			with: {
+				environments: {
+					where: environmentFilter,
+					columns: { environmentId: true },
+					with: {
+						applications: {
+							where: applyFilter(applications.applicationId),
+							columns: { applicationStatus: true },
+						},
+						compose: {
+							where: applyFilter(compose.composeId),
+							columns: { composeStatus: true },
+						},
+						libsql: {
+							where: applyFilter(libsql.libsqlId),
+							columns: { applicationStatus: true },
+						},
+						mariadb: {
+							where: applyFilter(mariadb.mariadbId),
+							columns: { applicationStatus: true },
+						},
+						mongo: {
+							where: applyFilter(mongo.mongoId),
+							columns: { applicationStatus: true },
+						},
+						mysql: {
+							where: applyFilter(mysql.mysqlId),
+							columns: { applicationStatus: true },
+						},
+						postgres: {
+							where: applyFilter(postgres.postgresId),
+							columns: { applicationStatus: true },
+						},
+						redis: {
+							where: applyFilter(redis.redisId),
+							columns: { applicationStatus: true },
+						},
+					},
+				},
+			},
+		});
+
+		let applicationsCount = 0;
+		let composeCount = 0;
+		let databasesCount = 0;
+		let environmentsCount = 0;
+		const status = { running: 0, error: 0, idle: 0 };
+		const bump = (s?: string | null) => {
+			if (s === "done") status.running++;
+			else if (s === "error") status.error++;
+			else status.idle++;
+		};
+
+		for (const project of rows) {
+			for (const env of project.environments) {
+				environmentsCount++;
+				applicationsCount += env.applications.length;
+				composeCount += env.compose.length;
+				databasesCount +=
+					env.libsql.length +
+					env.mariadb.length +
+					env.mongo.length +
+					env.mysql.length +
+					env.postgres.length +
+					env.redis.length;
+
+				for (const a of env.applications) bump(a.applicationStatus);
+				for (const c of env.compose) bump(c.composeStatus);
+				for (const s of env.libsql) bump(s.applicationStatus);
+				for (const s of env.mariadb) bump(s.applicationStatus);
+				for (const s of env.mongo) bump(s.applicationStatus);
+				for (const s of env.mysql) bump(s.applicationStatus);
+				for (const s of env.postgres) bump(s.applicationStatus);
+				for (const s of env.redis) bump(s.applicationStatus);
+			}
+		}
+
+		return {
+			projects: rows.length,
+			environments: environmentsCount,
+			applications: applicationsCount,
+			compose: composeCount,
+			databases: databasesCount,
+			services: applicationsCount + composeCount + databasesCount,
+			status,
+		};
+	}),
+
 	search: protectedProcedure
 		.input(
 			z.object({

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -488,8 +488,7 @@ export const projectRouter = createTRPCRouter({
 	),
 
 	homeStats: protectedProcedure.query(async ({ ctx }) => {
-		const isPrivileged =
-			ctx.user.role === "owner" || ctx.user.role === "admin";
+		const isPrivileged = ctx.user.role === "owner" || ctx.user.role === "admin";
 
 		let accessedProjects: string[] = [];
 		let accessedEnvironments: string[] = [];


### PR DESCRIPTION
## Summary
- New `/dashboard/home` page with welcome header, KPI cards (deploys/24h, build, CPU, memory placeholders) and recent deployments list (last 10).
- Home added to sidebar above Projects with a House icon.
- Post-login landing and permission fallback redirects across the app now point to `/dashboard/home`. Projects remains accessible from the sidebar.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `/dashboard/home` page as the new post-login landing, with a welcome header, four KPI stat cards, and a recent deployments list. All redirect destinations across auth flows and permission fallbacks are updated from `/dashboard/projects` to `/dashboard/home`.

- **\"Deploys / 24h\" stat is wrong**: the value is `recentDeployments.length` (the last 10 deployments by date, capped at 10), not a 24-hour filtered count — users with many deployments will always see \"10\".
- **All four stat cards render literal `\"placeholder\"` text** via the `delta` prop, which is unconditionally displayed in `StatCard`; this is visible in production.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two P1 bugs in the primary new feature cause incorrect data and visible placeholder text in production.

The redirect and sidebar changes are clean, but the centrepiece ShowHome component has two distinct P1 regressions: a mislabeled/incorrectly-computed Deploys/24h KPI and hardcoded placeholder delta strings that render visibly in every user's dashboard. These need to be fixed before the page ships.

apps/dokploy/components/dashboard/home/show-home.tsx (wrong KPI logic + visible placeholder text)

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/components/dashboard/settings/servers/welcome-stripe/welcome-subscription.tsx`, line 87 ([link](https://github.com/dokploy/dokploy/blob/e7859395b166442a385ddab366f0085ef5a1d897/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/welcome-subscription.tsx#L87)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Leftover debug expression**

   `{showConfetti ?? "Flaso"}` is a debugging artifact. Because `showConfetti` is a `boolean` (never `null`/`undefined`), the `??` fallback never activates and nothing renders — but the expression will confuse future readers. It should be removed entirely.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/e7859395b166442a385ddab366f0085ef5a1d897) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28847215)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->