### PR TITLE
fix: filter requests by hostname instead of path

### DIFF
--- a/apps/dokploy/components/dashboard/requests/requests-table.tsx
+++ b/apps/dokploy/components/dashboard/requests/requests-table.tsx
@@ -185,7 +185,7 @@ export const RequestsTable = ({ dateRange }: RequestsTableProps) => {
 					<div className="flex flex-col gap-4  w-full overflow-auto">
 						<div className="flex items-center gap-2 max-sm:flex-wrap">
 							<Input
-								placeholder="Filter by name..."
+								placeholder="Filter by hostname..."
 								value={search}
 								onChange={(event) => setSearch(event.target.value)}
 								className="md:max-w-sm"

--- a/packages/server/src/utils/access-log/utils.ts
+++ b/packages/server/src/utils/access-log/utils.ts
@@ -120,7 +120,7 @@ export function parseRawConfig(
 
 		if (search) {
 			parsedLogs = parsedLogs.filter((log) =>
-				log.RequestPath.toLowerCase().includes(search.toLowerCase()),
+				log.RequestHost.toLowerCase().includes(search.toLowerCase()),
 			);
 		}
 


### PR DESCRIPTION
## Summary

- The search filter on the Requests tab was matching against `RequestPath` (the URL path) instead of `RequestHost` (the hostname)
- Updated `parseRawConfig` in `packages/server/src/utils/access-log/utils.ts` to filter by `log.RequestHost`
- Updated the input placeholder from "Filter by name..." to "Filter by hostname..." to accurately reflect what is being filtered

## Test plan

- [ ] Go to the Requests tab in Dokploy
- [ ] Type a hostname (e.g. `myapp.example.com`) in the filter input — results should filter by hostname now
- [ ] Verify that typing a URL path (e.g. `/dashboard`) no longer matches unrelated hostnames

Fixes #4249

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the search filter on the Requests tab was incorrectly matching against `RequestPath` (the URL path) instead of `RequestHost` (the hostname). The server-side filter in `parseRawConfig` is updated to use `log.RequestHost`, and the UI input placeholder is updated from "Filter by name..." to "Filter by hostname..." to match.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line targeted bug fix with no side effects.

`RequestHost` is confirmed as a valid field in the `LogEntry` type, the change is minimal and correct, and the placeholder update accurately reflects the new behavior.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: filter requests by hostname instead..."](https://github.com/dokploy/dokploy/commit/598fae0e92e5bd9941f78170d26ac6b6a088e9cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28897114)</sub>

<!-- /greptile_comment -->