### PR TITLE
fix: preview deployments broken on v0.29.0 — postgres 100-arg limit

### DIFF
--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -30,13 +30,9 @@ export const findPreviewDeploymentById = async (
 		with: {
 			domain: true,
 			application: {
-				with: {
-					server: true,
-					environment: {
-						with: {
-							project: true,
-						},
-					},
+				columns: {
+					applicationId: true,
+					serverId: true,
 				},
 			},
 		},


### PR DESCRIPTION
## What's happening

On v0.29.0, preview deployments are completely broken. A PR triggers the preview creation flow, the GitHub comment appears with "Building", but nothing ever actually builds — no container is created, and every action on the preview card (Delete, Rebuild, Logs, Deployments) fails. The server log shows:

```
PostgresError: cannot pass more than 100 arguments to a function
```

## Why

The `application` table grew to 99 columns in v0.29.0 (adding Swarm config, Railpack, Heroku, multi-provider git fields, etc.). Drizzle's relational query in `findPreviewDeploymentById` hydrates the `application` relation by passing every column to `json_build_array(...)`, plus two extra blobs for the nested `server` and `environment → project` relations. That's 99 + 2 = 101 arguments — one over Postgres's hard-compiled `FUNC_MAX_ARGS = 100` limit (error code `54023`).

Every call to `findPreviewDeploymentById` crashes. Since that function is on the hot path for the GitHub webhook and every UI action on a preview card, nothing works.

## The fix

In `findPreviewDeploymentById`, switch the `application` relation from selecting all columns + nested joins to an explicit `columns` selector with only what's actually used:

```diff
- application: {
-   with: {
-     server: true,
-     environment: {
-       with: {
-         project: true,
-       },
-     },
-   },
- },
+ application: {
+   columns: {
+     applicationId: true,
+     serverId: true,
+   },
+ },
```

The `server` and `environment.project` nested relations were never accessed from the return value of this function anywhere in the codebase — callers that need full application data call `findApplicationById` separately. The only field actually pulled off the nested `application` object is `serverId` (in the deployment log path).

This brings the `json_build_array` argument count from 101 down to 2.

## Affected file

`packages/server/src/services/preview-deployment.ts`

Fixes #4256

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression in v0.29.0 where preview deployments were completely broken due to PostgreSQL's 100-argument limit for `json_build_array`. The `application` table grew to 99 columns, causing Drizzle's relational query in `findPreviewDeploymentById` to exceed the limit when it also included two nested blob arguments for `server` and `environment → project`.

The fix replaces the broad `with` clause with a narrow `columns` selector exposing only `applicationId` and `serverId`. All call sites have been verified: the only consumer of `application.*` from this function's return value is in `deployment.ts`, which reads `previewDeployment?.application?.serverId` — still present after the change. All other callers only use top-level `previewDeployment` fields or call `findApplicationById` separately for full application data.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no regressions identified across all call sites.

The change is a one-file, minimal diff that directly addresses a confirmed production crash (PostgreSQL error code 54023). All callers of `findPreviewDeploymentById` were checked: no caller accesses the previously included `server` or `environment.project` nested fields from the return value, and the only field read from `application` (`serverId`) is still included in the new `columns` selector. TypeScript types would surface any missed access at compile time. No P0 or P1 issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: limit application columns in findPr..."](https://github.com/dokploy/dokploy/commit/54417ca8e73ad7ff26558fc305256abf45208587) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28898324)</sub>

<!-- /greptile_comment -->