### PR TITLE
fix(ai): allow Ollama Cloud API key in AI settings

### DIFF
--- a/apps/dokploy/components/dashboard/settings/handle-ai.tsx
+++ b/apps/dokploy/components/dashboard/settings/handle-ai.tsx
@@ -131,7 +131,10 @@ export const HandleAi = ({ aiId }: Props) => {
 	const apiUrl = form.watch("apiUrl");
 	const apiKey = form.watch("apiKey");
 
-	const isOllama = apiUrl.includes(":11434") || apiUrl.includes("ollama");
+	// Any Ollama instance on the default port 11434 is treated as no-auth
+	// (covers localhost and self-hosted LAN deployments). Ollama Cloud
+	// (ollama.com on 443) falls through and requires an API key.
+	const isLocalOllama = apiUrl.includes(":11434");
 	const {
 		data: models,
 		isFetching: isLoadingServerModels,
@@ -142,7 +145,7 @@ export const HandleAi = ({ aiId }: Props) => {
 			apiKey: apiKey ?? "",
 		},
 		{
-			enabled: !!apiUrl && (isOllama || !!apiKey),
+			enabled: !!apiUrl && (isLocalOllama || !!apiKey),
 		},
 	);
 
@@ -275,7 +278,7 @@ export const HandleAi = ({ aiId }: Props) => {
 							)}
 						/>
 
-						{!isOllama && (
+						{!isLocalOllama && (
 							<FormField
 								control={form.control}
 								name="apiKey"

--- a/packages/server/src/utils/ai/select-ai-provider.ts
+++ b/packages/server/src/utils/ai/select-ai-provider.ts
@@ -74,8 +74,10 @@ export function selectAIProvider(config: { apiUrl: string; apiKey: string }) {
 			});
 		case "ollama":
 			return createOllama({
-				// optional settings, e.g.
 				baseURL: config.apiUrl,
+				headers: config.apiKey
+					? { Authorization: `Bearer ${config.apiKey}` }
+					: undefined,
 			});
 		case "deepinfra":
 			return createDeepInfra({


### PR DESCRIPTION
## Summary

The Ollama provider detection in AI Settings matches any URL containing the substring `ollama`, which hides the **API Key** input for Ollama Cloud (`ollama.com`) and drops the key from the `createOllama()` client. As a result, Ollama Cloud cannot be used — requests go out unauthenticated and fail.

This PR:

- Narrows the "no API key needed" rule to **local** Ollama only (`localhost:11434` / `127.0.0.1:11434`), so the API Key field is visible for Ollama Cloud and any self-hosted Ollama behind an auth proxy.
- Forwards the API key as an `Authorization: Bearer ...` header to `createOllama`, using the `headers` option supported by `ai-sdk-ollama` v3.7.

The `getModels` ollama branch in the AI router already builds its headers via `getProviderHeaders(apiUrl, apiKey)`, so once the key reaches the backend it authenticates `/api/tags` correctly — no router change needed.

## Repro (before fix)

1. Settings → AI → Add AI, select **Ollama**
2. Change API URL to an Ollama Cloud endpoint (hostname contains `ollama`)
3. API Key input is hidden — cannot be entered or saved
4. Requests to Ollama Cloud fail auth

## After fix

- API Key field is shown for any non-local Ollama URL
- Key is sent as `Authorization: Bearer <key>` on both model listing and completion requests

## Files changed

- `apps/dokploy/components/dashboard/settings/handle-ai.tsx` — replace `isOllama` substring check with `isLocalOllama` (localhost-only)
- `packages/server/src/utils/ai/select-ai-provider.ts` — pass `headers` with Bearer token to `createOllama`

## Test plan

- [ ] Local Ollama (`http://localhost:11434`) still works with no API key entered
- [ ] Ollama Cloud URL shows the API Key field
- [ ] Ollama Cloud with valid key lists models and runs completions
- [ ] Other providers (OpenAI, Anthropic, Gemini, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Ollama Cloud authentication by narrowing the "no API key needed" detection from any URL containing `ollama` or `:11434` to strictly `localhost`/`127.0.0.1` on port 11434, and forwards the API key as a `Bearer` header to `createOllama`.

- **Regression**: The `enabled` gate on the `getModels` query (`isLocalOllama || !!apiKey`) now blocks model listing for any non-localhost Ollama that has no API key (e.g. `http://192.168.1.100:11434`). Those instances don't need auth but will silently get no models in the dropdown.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary Ollama Cloud use case, but introduces a regression for unauthenticated non-localhost Ollama instances.

The core fix (showing the API key field for Ollama Cloud and forwarding it as a Bearer token) is correct. However, the `enabled` gate for model listing now blocks model fetching for unauthenticated Ollama instances that aren't on localhost (e.g. LAN or remote Ollama without auth), which is a real UX regression from the previous behavior.

apps/dokploy/components/dashboard/settings/handle-ai.tsx — specifically the `enabled` condition on the `getModels` query

<sub>Reviews (1): Last reviewed commit: ["fix(ai): allow Ollama Cloud API key in A..."](https://github.com/dokploy/dokploy/commit/9f3736c9c1b1bb3078547bdf2f3129ce4a8edab2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28937134)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->