### PR TITLE
feat: copy server IP to clipboard

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server.tsx
@@ -1,8 +1,4 @@
-import { 
-	Check,
-	Copy,
-	ServerIcon,
-} from "lucide-react";
+import { Check, Copy, ServerIcon } from "lucide-react";
 import {
 	Card,
 	CardContent,

--- a/apps/dokploy/components/dashboard/settings/web-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server.tsx
@@ -1,4 +1,8 @@
-import { ServerIcon } from "lucide-react";
+import { 
+	Check,
+	Copy,
+	ServerIcon,
+} from "lucide-react";
 import {
 	Card,
 	CardContent,
@@ -6,6 +10,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import React from "react";
 import { api } from "@/utils/api";
 import { ShowDokployActions } from "./servers/actions/show-dokploy-actions";
 import { ShowStorageActions } from "./servers/actions/show-storage-actions";
@@ -18,6 +23,14 @@ export const WebServer = () => {
 		api.settings.getWebServerSettings.useQuery();
 
 	const { data: dokployVersion } = api.settings.getDokployVersion.useQuery();
+
+	const [copied, setCopied] = React.useState(false);
+
+	const handleCopy = async () => {
+		await navigator.clipboard.writeText(webServerSettings?.serverIp || "");
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
 
 	return (
 		<div className="w-full">
@@ -49,9 +62,22 @@ export const WebServer = () => {
 						</div>
 
 						<div className="flex items-center flex-wrap justify-between gap-4">
-							<span className="text-sm text-muted-foreground">
-								Server IP: {webServerSettings?.serverIp}
-							</span>
+							<div className="flex items-center gap-2">
+								<span className="text-sm text-muted-foreground">
+									Server IP: {webServerSettings?.serverIp}
+								</span>
+								<button
+									onClick={handleCopy}
+									className="text-muted-foreground"
+									title="Copy IP to clipboard"
+								>
+									{copied ? (
+										<Check className="size-3.5" />
+									) : (
+										<Copy className="size-3.5" />
+									)}
+								</button>
+							</div>
 							<span className="text-sm text-muted-foreground">
 								Version: {dokployVersion}
 							</span>


### PR DESCRIPTION
## What is this PR about?

Added a copy to clipboard button next to the Server IP field in the Web Server settings.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #3982

## Screenshots (if applicable)

<img width="1036" height="332" alt="Screenshot 2026-04-20 at 11 18 19" src="https://github.com/user-attachments/assets/16c7ae09-3357-4a3b-8fca-26a827bf30b2" />
<img width="1043" height="344" alt="Screenshot 2026-04-20 at 11 19 05" src="https://github.com/user-attachments/assets/bf114593-a9c0-43f2-a18e-c6556cf5239f" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a copy-to-clipboard button next to the Server IP field in the Web Server settings card, using the browser Clipboard API with a 2-second visual toggle between `Copy` and `Check` icons. The implementation is straightforward and isolated to a single component with no state-management or API changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, self-contained, and all remaining findings are P2 style suggestions.

No P0 or P1 issues. The two comments flag an unhandled async rejection (best-practice hardening) and a minor import style preference, neither of which blocks correct operation.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/components/dashboard/settings/web-server.tsx`, line 13 ([link](https://github.com/dokploy/dokploy/blob/093d9a06d227f10f6d4dc2fe9c4b5bdf4d18802c/apps/dokploy/components/dashboard/settings/web-server.tsx#L13)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Prefer named React import**

   The default `React` import is only used for `React.useState`. With the modern JSX transform already in use across this codebase, you can use the named import instead, which is the pattern used in sibling components.

   

   Then replace `React.useState` with `useState` on line 27.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/093d9a06d227f10f6d4dc2fe9c4b5bdf4d18802c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28956027)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->