### PR TITLE
fix(ai): add nullable() to configFiles schema to support OpenAI stric…

### DIFF
--- a/packages/server/src/services/ai.ts
+++ b/packages/server/src/services/ai.ts
@@ -136,7 +136,7 @@ export const suggestVariants = async ({
 								filePath: z.string(),
 							}),
 						)
-						.optional(),
+						.nullable().optional(),
 				}),
 			),
 		});


### PR DESCRIPTION
…t mode

OpenAI strict mode requires all keys in `properties` to also appear in `required`. The `configFiles` field was marked as `.optional()` in the Zod schema, which generates a JSON Schema where `configFiles` is in `properties` but not in `required`, causing the error:

"Invalid schema for response_format 'response': In context=('properties', 'suggestions', 'items'), 'required' is required to be supplied and to be an array including every key in properties. Missing 'configFiles'."

Adding `.nullable()` before `.optional()` generates an `anyOf: [{...}, {type: 'null'}]` pattern while keeping `configFiles` in `required`, which is compatible with OpenAI strict mode.

Fixes #4267

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an OpenAI strict-mode schema incompatibility by adding `.nullable()` before `.optional()` on the `configFiles` Zod field. When using the Vercel AI SDK's OpenAI provider, `zod-to-json-schema` transforms `.nullable().optional()` fields into required-but-nullable properties (adding them to `required` with an `anyOf: [{…}, {type: "null"}]` type), satisfying the constraint that every key in `properties` must appear in `required`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line fix with no runtime risk and all consumers already guard against falsy values.

The fix is correct and well-targeted. All callers use truthy checks or optional chaining, so a null value returned by the model is handled safely. The only remaining note is a minor TypeScript type inconsistency in the DockerOutput interface that has no production impact.

No files require special attention.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/server/src/services/ai.ts`, line 27 ([link](https://github.com/dokploy/dokploy/blob/448eb186df141c484eb6711b59002b9b1a1a3fe6/packages/server/src/services/ai.ts#L27)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`DockerOutput` interface not updated for `null`**

   The `configFiles` field in `DockerOutput` is typed as `Array<...> | undefined` (via `?:`), but the Zod schema now also allows `null`. At runtime the AI model could return `null` for this field, which would be mis-typed. All current consumers use truthy/optional-chaining guards so there is no runtime breakage, but a strict TypeScript assignment (`const f: typeof item.configFiles = item.configFiles`) could silently accept a `null` value. Keeping the interface in sync avoids confusion.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ai): add nullable() to configFiles s..."](https://github.com/dokploy/dokploy/commit/448eb186df141c484eb6711b59002b9b1a1a3fe6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29075621)</sub>

<!-- /greptile_comment -->