### PR TITLE
Feat/env var form layout

### DIFF
--- a/apps/dokploy/components/dashboard/projects/project-environment.tsx
+++ b/apps/dokploy/components/dashboard/projects/project-environment.tsx
@@ -5,7 +5,6 @@ import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { AlertBlock } from "@/components/shared/alert-block";
-import { CodeEditor } from "@/components/shared/code-editor";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -17,6 +16,7 @@ import {
 	DialogTrigger,
 } from "@/components/ui/dialog";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { EnvEditor } from "@/components/ui/env-editor";
 import {
 	Form,
 	FormControl,
@@ -148,16 +148,12 @@ export const ProjectEnvironment = ({ projectId, children }: Props) => {
 										<FormItem>
 											<FormLabel>Environment variables</FormLabel>
 											<FormControl>
-												<CodeEditor
-													lineWrapping
-													language="properties"
-													readOnly={!canWrite}
-													wrapperClassName="h-[35rem] font-mono"
-													placeholder={`NODE_ENV=production
-PORT=3000
-
-                                                    `}
-													{...field}
+												<EnvEditor
+													value={field.value ?? ""}
+													onChange={field.onChange}
+													disabled={!canWrite}
+													rawClassName="h-[35rem]"
+													placeholder={"NODE_ENV=production\nPORT=3000"}
 												/>
 											</FormControl>
 

--- a/apps/dokploy/components/ui/env-editor.tsx
+++ b/apps/dokploy/components/ui/env-editor.tsx
@@ -40,6 +40,15 @@ const createId = () =>
 		? crypto.randomUUID()
 		: `row-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
+const unquoteDouble = (raw: string): string =>
+	// Inside double quotes, backslash escapes `"` and `\` (and \n / \r / \t for convenience).
+	raw.replace(/\\(["\\nrt])/g, (_match, ch: string) => {
+		if (ch === "n") return "\n";
+		if (ch === "r") return "\r";
+		if (ch === "t") return "\t";
+		return ch;
+	});
+
 const parseEnv = (text: string): Row[] => {
 	if (!text) return [];
 	const rows: Row[] = [];
@@ -55,9 +64,17 @@ const parseEnv = (text: string): Row[] => {
 		let value = line.slice(eq + 1).trim();
 		if (key.startsWith("export ")) key = key.slice(7).trim();
 		if (
-			(value.startsWith('"') && value.endsWith('"')) ||
-			(value.startsWith("'") && value.endsWith("'"))
+			value.length >= 2 &&
+			value.startsWith('"') &&
+			value.endsWith('"')
 		) {
+			value = unquoteDouble(value.slice(1, -1));
+		} else if (
+			value.length >= 2 &&
+			value.startsWith("'") &&
+			value.endsWith("'")
+		) {
+			// POSIX-style single quotes: content is literal, no escape processing.
 			value = value.slice(1, -1);
 		}
 		rows.push({ id: createId(), key, value });
@@ -65,10 +82,33 @@ const parseEnv = (text: string): Row[] => {
 	return rows;
 };
 
+const needsQuoting = (value: string): boolean => {
+	if (value === "") return false;
+	// Quote whenever the value has whitespace, a leading/trailing space, a
+	// comment marker, quotes, backslash, `$`, or backtick — anything a shell
+	// or dotenv parser could reinterpret if left bare.
+	if (/[\s#"'\\$`]/.test(value)) return true;
+	if (value !== value.trim()) return true;
+	return false;
+};
+
+const quoteValue = (value: string): string => {
+	const escaped = value
+		.replace(/\\/g, "\\\\")
+		.replace(/"/g, '\\"')
+		.replace(/\n/g, "\\n")
+		.replace(/\r/g, "\\r");
+	return `"${escaped}"`;
+};
+
 const serializeRows = (rows: Row[]): string =>
 	rows
 		.filter((r) => r.key.trim() !== "")
-		.map((r) => `${r.key.trim()}=${r.value}`)
+		.map((r) => {
+			const key = r.key.trim();
+			const value = needsQuoting(r.value) ? quoteValue(r.value) : r.value;
+			return `${key}=${value}`;
+		})
 		.join("\n");
 
 const looksLikeEnvPaste = (text: string) => {

--- a/apps/dokploy/components/ui/env-editor.tsx
+++ b/apps/dokploy/components/ui/env-editor.tsx
@@ -1,0 +1,395 @@
+import {
+	CodeIcon,
+	EyeIcon,
+	EyeOffIcon,
+	GripVerticalIcon,
+	PlusIcon,
+	Rows3Icon,
+	Trash2Icon,
+} from "lucide-react";
+import {
+	type ClipboardEvent,
+	type CSSProperties,
+	type DragEvent,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
+import { CodeEditor } from "@/components/shared/code-editor";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Toggle } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
+
+type ViewMode = "raw" | "rows";
+type Row = { id: string; key: string; value: string };
+
+export interface EnvEditorProps {
+	value: string;
+	onChange: (value: string) => void;
+	placeholder?: string;
+	disabled?: boolean;
+	rawClassName?: string;
+	className?: string;
+}
+
+const createId = () =>
+	typeof crypto !== "undefined" && "randomUUID" in crypto
+		? crypto.randomUUID()
+		: `row-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const parseEnv = (text: string): Row[] => {
+	if (!text) return [];
+	const rows: Row[] = [];
+	for (const line of text.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = line.indexOf("=");
+		if (eq === -1) {
+			rows.push({ id: createId(), key: trimmed, value: "" });
+			continue;
+		}
+		let key = line.slice(0, eq).trim();
+		let value = line.slice(eq + 1).trim();
+		if (key.startsWith("export ")) key = key.slice(7).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		rows.push({ id: createId(), key, value });
+	}
+	return rows;
+};
+
+const serializeRows = (rows: Row[]): string =>
+	rows
+		.filter((r) => r.key.trim() !== "")
+		.map((r) => `${r.key.trim()}=${r.value}`)
+		.join("\n");
+
+const looksLikeEnvPaste = (text: string) => {
+	if (!text.includes("=")) return false;
+	if (/\r?\n/.test(text)) return true;
+	return (text.match(/=/g) ?? []).length >= 1;
+};
+
+export const EnvEditor = ({
+	value,
+	onChange,
+	placeholder,
+	disabled = false,
+	rawClassName = "h-96",
+	className,
+}: EnvEditorProps) => {
+	const [isObscured, setIsObscured] = useState(true);
+	const [viewMode, setViewMode] = useState<ViewMode>("raw");
+	const [rows, setRows] = useState<Row[]>([]);
+	const [draggingId, setDraggingId] = useState<string | null>(null);
+	const lastSerializedRef = useRef<string>("");
+	const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+	const prevRectsRef = useRef<Map<string, DOMRect>>(new Map());
+
+	const setRowRef = useCallback(
+		(id: string) => (el: HTMLDivElement | null) => {
+			if (el) rowRefs.current.set(id, el);
+			else rowRefs.current.delete(id);
+		},
+		[],
+	);
+
+	useLayoutEffect(() => {
+		if (viewMode !== "rows") {
+			prevRectsRef.current.clear();
+			return;
+		}
+		const prev = prevRectsRef.current;
+		const next = new Map<string, DOMRect>();
+		rowRefs.current.forEach((el, id) => {
+			next.set(id, el.getBoundingClientRect());
+		});
+		prev.forEach((prevRect, id) => {
+			const nextRect = next.get(id);
+			const el = rowRefs.current.get(id);
+			if (!el || !nextRect) return;
+			const dy = prevRect.top - nextRect.top;
+			if (Math.abs(dy) < 0.5) return;
+			el.style.transition = "none";
+			el.style.transform = `translateY(${dy}px)`;
+			requestAnimationFrame(() => {
+				el.style.transition =
+					"transform 220ms cubic-bezier(0.22, 1, 0.36, 1)";
+				el.style.transform = "";
+			});
+		});
+		prevRectsRef.current = next;
+	}, [rows, viewMode]);
+
+	useEffect(() => {
+		if (viewMode !== "rows") return;
+		if (value === lastSerializedRef.current) return;
+		const parsed = parseEnv(value);
+		setRows(parsed);
+		lastSerializedRef.current = serializeRows(parsed);
+	}, [value, viewMode]);
+
+	const commitRows = (next: Row[]) => {
+		setRows(next);
+		const serialized = serializeRows(next);
+		lastSerializedRef.current = serialized;
+		onChange(serialized);
+	};
+
+	const handleKeyChange = (id: string, key: string) => {
+		commitRows(rows.map((r) => (r.id === id ? { ...r, key } : r)));
+	};
+
+	const handleValueChange = (id: string, nextValue: string) => {
+		commitRows(rows.map((r) => (r.id === id ? { ...r, value: nextValue } : r)));
+	};
+
+	const handleRemove = (id: string) => {
+		commitRows(rows.filter((r) => r.id !== id));
+	};
+
+	const handleAdd = () => {
+		commitRows([...rows, { id: createId(), key: "", value: "" }]);
+	};
+
+	const handleDragStart =
+		(id: string) => (e: DragEvent<HTMLButtonElement>) => {
+			if (disabled) return;
+			setDraggingId(id);
+			e.dataTransfer.effectAllowed = "move";
+			try {
+				e.dataTransfer.setData("text/plain", id);
+			} catch {
+				// Safari can throw in rare cases; the drag still works.
+			}
+		};
+
+	const handleDragEnd = () => setDraggingId(null);
+
+	const handleDragOver =
+		(id: string) => (e: DragEvent<HTMLDivElement>) => {
+			if (!draggingId || disabled) return;
+			e.preventDefault();
+			e.dataTransfer.dropEffect = "move";
+			if (draggingId === id) return;
+			const rect = e.currentTarget.getBoundingClientRect();
+			const isAbove = e.clientY < rect.top + rect.height / 2;
+			const fromIdx = rows.findIndex((r) => r.id === draggingId);
+			const targetIdx = rows.findIndex((r) => r.id === id);
+			if (fromIdx === -1 || targetIdx === -1) return;
+			let newIdx = isAbove ? targetIdx : targetIdx + 1;
+			if (fromIdx < newIdx) newIdx -= 1;
+			if (fromIdx === newIdx) return;
+			const next = [...rows];
+			const [moved] = next.splice(fromIdx, 1);
+			if (!moved) return;
+			next.splice(newIdx, 0, moved);
+			commitRows(next);
+		};
+
+	const handlePaste = (id: string, e: ClipboardEvent<HTMLInputElement>) => {
+		if (disabled) return;
+		const text = e.clipboardData.getData("text");
+		if (!looksLikeEnvPaste(text)) return;
+		const parsed = parseEnv(text);
+		if (parsed.length === 0) return;
+		e.preventDefault();
+
+		// Collapse duplicates within the pasted content (last occurrence wins).
+		const incomingByKey = new Map<string, Row>();
+		for (const row of parsed) {
+			incomingByKey.set(row.key.trim(), row);
+		}
+
+		const idx = rows.findIndex((r) => r.id === id);
+		const target = rows[idx];
+		const isTargetEmpty =
+			target && target.key.trim() === "" && target.value === "";
+		const base = isTargetEmpty
+			? [...rows.slice(0, idx), ...rows.slice(idx + 1)]
+			: [...rows];
+
+		// Merge: overwrite existing rows with matching keys, append the rest.
+		const result = base.map((r) => ({ ...r }));
+		for (const incoming of incomingByKey.values()) {
+			const key = incoming.key.trim();
+			if (!key) continue;
+			const existingIdx = result.findIndex((r) => r.key.trim() === key);
+			const existing = existingIdx >= 0 ? result[existingIdx] : undefined;
+			if (existing) {
+				result[existingIdx] = {
+					id: existing.id,
+					key: existing.key,
+					value: incoming.value,
+				};
+			} else {
+				result.push(incoming);
+			}
+		}
+		commitRows(result);
+	};
+
+	return (
+		<div className={cn("flex w-full flex-col gap-3", className)}>
+			<div className="flex items-center justify-end gap-2">
+				<div
+					className="inline-flex items-center rounded-md border border-input p-0.5"
+					role="radiogroup"
+					aria-label="Editor view"
+				>
+					<button
+						type="button"
+						role="radio"
+						aria-checked={viewMode === "raw"}
+						aria-label="Raw editor"
+						onClick={() => setViewMode("raw")}
+						className={cn(
+							"flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+							viewMode === "raw"
+								? "bg-accent text-accent-foreground"
+								: "text-muted-foreground hover:bg-muted",
+						)}
+					>
+						<CodeIcon className="h-4 w-4" />
+					</button>
+					<button
+						type="button"
+						role="radio"
+						aria-checked={viewMode === "rows"}
+						aria-label="Rows editor"
+						onClick={() => setViewMode("rows")}
+						className={cn(
+							"flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+							viewMode === "rows"
+								? "bg-accent text-accent-foreground"
+								: "text-muted-foreground hover:bg-muted",
+						)}
+					>
+						<Rows3Icon className="h-4 w-4" />
+					</button>
+				</div>
+				<Toggle
+					aria-label="Toggle value visibility"
+					pressed={isObscured}
+					onPressedChange={setIsObscured}
+				>
+					{isObscured ? (
+						<EyeOffIcon className="h-4 w-4 text-muted-foreground" />
+					) : (
+						<EyeIcon className="h-4 w-4 text-muted-foreground" />
+					)}
+				</Toggle>
+			</div>
+
+			{viewMode === "raw" ? (
+				<CodeEditor
+					style={
+						{
+							WebkitTextSecurity: isObscured ? "disc" : null,
+						} as CSSProperties
+					}
+					language="properties"
+					disabled={isObscured || disabled}
+					lineWrapping
+					placeholder={placeholder}
+					className={cn("font-mono", rawClassName)}
+					value={value}
+					onChange={(next) => onChange(next)}
+				/>
+			) : (
+				<div className="space-y-2">
+					{rows.length === 0 ? (
+						<div className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+							No variables yet. Add one below, or paste an .env file into a
+							row to import multiple at once.
+						</div>
+					) : (
+						<div className="space-y-2">
+							{rows.map((row) => (
+								<div
+									key={row.id}
+									ref={setRowRef(row.id)}
+									onDragOver={handleDragOver(row.id)}
+									className={cn(
+										"grid grid-cols-[auto_1fr_1fr_auto] items-center gap-2 will-change-transform",
+										draggingId === row.id && "opacity-40",
+									)}
+								>
+									<button
+										type="button"
+										draggable={!disabled}
+										onDragStart={handleDragStart(row.id)}
+										onDragEnd={handleDragEnd}
+										aria-label="Drag to reorder"
+										tabIndex={-1}
+										disabled={disabled}
+										className="flex h-10 w-6 cursor-grab items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50"
+									>
+										<GripVerticalIcon className="h-4 w-4" />
+									</button>
+									<Input
+										className="font-mono"
+										placeholder="KEY"
+										autoComplete="off"
+										spellCheck={false}
+										readOnly={disabled}
+										value={row.key}
+										onChange={(e) =>
+											handleKeyChange(row.id, e.target.value)
+										}
+										onPaste={(e) => handlePaste(row.id, e)}
+									/>
+									<Input
+										className="font-mono"
+										placeholder="VALUE"
+										autoComplete="off"
+										spellCheck={false}
+										readOnly={disabled}
+										style={
+											{
+												WebkitTextSecurity: isObscured ? "disc" : null,
+											} as CSSProperties
+										}
+										value={row.value}
+										onChange={(e) =>
+											handleValueChange(row.id, e.target.value)
+										}
+										onPaste={(e) => handlePaste(row.id, e)}
+									/>
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon"
+										aria-label="Remove variable"
+										disabled={disabled}
+										onClick={() => handleRemove(row.id)}
+									>
+										<Trash2Icon className="h-4 w-4 text-muted-foreground" />
+									</Button>
+								</div>
+							))}
+						</div>
+					)}
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={handleAdd}
+						disabled={disabled}
+						className="w-full"
+					>
+						<PlusIcon className="mr-2 h-4 w-4" />
+						Add variable
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/apps/dokploy/components/ui/env-editor.tsx
+++ b/apps/dokploy/components/ui/env-editor.tsx
@@ -85,7 +85,7 @@ export const EnvEditor = ({
 	rawClassName = "h-96",
 	className,
 }: EnvEditorProps) => {
-	const [isObscured, setIsObscured] = useState(true);
+	const [isObscured, setIsObscured] = useState(false);
 	const [viewMode, setViewMode] = useState<ViewMode>("raw");
 	const [rows, setRows] = useState<Row[]>([]);
 	const [draggingId, setDraggingId] = useState<string | null>(null);

--- a/apps/dokploy/components/ui/env-editor.tsx
+++ b/apps/dokploy/components/ui/env-editor.tsx
@@ -73,8 +73,7 @@ const serializeRows = (rows: Row[]): string =>
 
 const looksLikeEnvPaste = (text: string) => {
 	if (!text.includes("=")) return false;
-	if (/\r?\n/.test(text)) return true;
-	return (text.match(/=/g) ?? []).length >= 1;
+	return /\r?\n/.test(text);
 };
 
 export const EnvEditor = ({

--- a/apps/dokploy/components/ui/secrets.tsx
+++ b/apps/dokploy/components/ui/secrets.tsx
@@ -1,7 +1,26 @@
-import { EyeIcon, EyeOffIcon } from "lucide-react";
-import { type CSSProperties, type ReactNode, useState } from "react";
+import {
+	CodeIcon,
+	EyeIcon,
+	EyeOffIcon,
+	GripVerticalIcon,
+	PlusIcon,
+	Rows3Icon,
+	Trash2Icon,
+} from "lucide-react";
+import {
+	type ClipboardEvent,
+	type CSSProperties,
+	type DragEvent,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from "react";
 import { useFormContext } from "react-hook-form";
 import { CodeEditor } from "@/components/shared/code-editor";
+import { Button } from "@/components/ui/button";
 import {
 	CardContent,
 	CardDescription,
@@ -14,7 +33,9 @@ import {
 	FormItem,
 	FormMessage,
 } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { Toggle } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
 
 interface Props {
 	name: string;
@@ -23,9 +44,205 @@ interface Props {
 	placeholder: string;
 }
 
+type ViewMode = "raw" | "rows";
+type Row = { id: string; key: string; value: string };
+
+const createId = () =>
+	typeof crypto !== "undefined" && "randomUUID" in crypto
+		? crypto.randomUUID()
+		: `row-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+const parseEnv = (text: string): Row[] => {
+	if (!text) return [];
+	const rows: Row[] = [];
+	for (const line of text.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		const eq = line.indexOf("=");
+		if (eq === -1) {
+			rows.push({ id: createId(), key: trimmed, value: "" });
+			continue;
+		}
+		let key = line.slice(0, eq).trim();
+		let value = line.slice(eq + 1).trim();
+		if (key.startsWith("export ")) key = key.slice(7).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		rows.push({ id: createId(), key, value });
+	}
+	return rows;
+};
+
+const serializeRows = (rows: Row[]): string =>
+	rows
+		.filter((r) => r.key.trim() !== "")
+		.map((r) => `${r.key.trim()}=${r.value}`)
+		.join("\n");
+
+const looksLikeEnvPaste = (text: string) => {
+	if (!text.includes("=")) return false;
+	if (/\r?\n/.test(text)) return true;
+	return (text.match(/=/g) ?? []).length >= 1;
+};
+
 export const Secrets = (props: Props) => {
 	const [isVisible, setIsVisible] = useState(true);
+	const [viewMode, setViewMode] = useState<ViewMode>("raw");
+	const [rows, setRows] = useState<Row[]>([]);
+	const [draggingId, setDraggingId] = useState<string | null>(null);
+	const lastSerializedRef = useRef<string>("");
+	const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+	const prevRectsRef = useRef<Map<string, DOMRect>>(new Map());
 	const form = useFormContext<Record<string, string>>();
+	const fieldValue = form.watch(props.name) ?? "";
+
+	const setRowRef = useCallback(
+		(id: string) => (el: HTMLDivElement | null) => {
+			if (el) rowRefs.current.set(id, el);
+			else rowRefs.current.delete(id);
+		},
+		[],
+	);
+
+	useLayoutEffect(() => {
+		if (viewMode !== "rows") {
+			prevRectsRef.current.clear();
+			return;
+		}
+		const prev = prevRectsRef.current;
+		const next = new Map<string, DOMRect>();
+		rowRefs.current.forEach((el, id) => {
+			next.set(id, el.getBoundingClientRect());
+		});
+		prev.forEach((prevRect, id) => {
+			const nextRect = next.get(id);
+			const el = rowRefs.current.get(id);
+			if (!el || !nextRect) return;
+			const dy = prevRect.top - nextRect.top;
+			if (Math.abs(dy) < 0.5) return;
+			el.style.transition = "none";
+			el.style.transform = `translateY(${dy}px)`;
+			requestAnimationFrame(() => {
+				el.style.transition =
+					"transform 220ms cubic-bezier(0.22, 1, 0.36, 1)";
+				el.style.transform = "";
+			});
+		});
+		prevRectsRef.current = next;
+	}, [rows, viewMode]);
+
+	useEffect(() => {
+		if (viewMode !== "rows") return;
+		if (fieldValue === lastSerializedRef.current) return;
+		const parsed = parseEnv(fieldValue);
+		setRows(parsed);
+		lastSerializedRef.current = serializeRows(parsed);
+	}, [fieldValue, viewMode]);
+
+	const commitRows = (next: Row[]) => {
+		setRows(next);
+		const serialized = serializeRows(next);
+		lastSerializedRef.current = serialized;
+		form.setValue(props.name, serialized, {
+			shouldDirty: true,
+			shouldTouch: true,
+		});
+	};
+
+	const handleKeyChange = (id: string, key: string) => {
+		commitRows(rows.map((r) => (r.id === id ? { ...r, key } : r)));
+	};
+
+	const handleValueChange = (id: string, value: string) => {
+		commitRows(rows.map((r) => (r.id === id ? { ...r, value } : r)));
+	};
+
+	const handleRemove = (id: string) => {
+		commitRows(rows.filter((r) => r.id !== id));
+	};
+
+	const handleAdd = () => {
+		commitRows([...rows, { id: createId(), key: "", value: "" }]);
+	};
+
+	const handleDragStart =
+		(id: string) => (e: DragEvent<HTMLButtonElement>) => {
+			setDraggingId(id);
+			e.dataTransfer.effectAllowed = "move";
+			try {
+				e.dataTransfer.setData("text/plain", id);
+			} catch {
+				// Safari can throw in rare cases; the drag still works.
+			}
+		};
+
+	const handleDragEnd = () => setDraggingId(null);
+
+	const handleDragOver =
+		(id: string) => (e: DragEvent<HTMLDivElement>) => {
+			if (!draggingId) return;
+			e.preventDefault();
+			e.dataTransfer.dropEffect = "move";
+			if (draggingId === id) return;
+			const rect = e.currentTarget.getBoundingClientRect();
+			const isAbove = e.clientY < rect.top + rect.height / 2;
+			const fromIdx = rows.findIndex((r) => r.id === draggingId);
+			const targetIdx = rows.findIndex((r) => r.id === id);
+			if (fromIdx === -1 || targetIdx === -1) return;
+			let newIdx = isAbove ? targetIdx : targetIdx + 1;
+			if (fromIdx < newIdx) newIdx -= 1;
+			if (fromIdx === newIdx) return;
+			const next = [...rows];
+			const [moved] = next.splice(fromIdx, 1);
+			if (!moved) return;
+			next.splice(newIdx, 0, moved);
+			commitRows(next);
+		};
+
+	const handlePaste = (id: string, e: ClipboardEvent<HTMLInputElement>) => {
+		const text = e.clipboardData.getData("text");
+		if (!looksLikeEnvPaste(text)) return;
+		const parsed = parseEnv(text);
+		if (parsed.length === 0) return;
+		e.preventDefault();
+
+		// Collapse duplicates within the pasted content (last occurrence wins).
+		const incomingByKey = new Map<string, Row>();
+		for (const row of parsed) {
+			incomingByKey.set(row.key.trim(), row);
+		}
+
+		const idx = rows.findIndex((r) => r.id === id);
+		const target = rows[idx];
+		const isTargetEmpty =
+			target && target.key.trim() === "" && target.value === "";
+		const base = isTargetEmpty
+			? [...rows.slice(0, idx), ...rows.slice(idx + 1)]
+			: [...rows];
+
+		// Merge: overwrite existing rows with matching keys, append the rest.
+		const result = base.map((r) => ({ ...r }));
+		for (const incoming of incomingByKey.values()) {
+			const key = incoming.key.trim();
+			if (!key) continue;
+			const existingIdx = result.findIndex((r) => r.key.trim() === key);
+			const existing = existingIdx >= 0 ? result[existingIdx] : undefined;
+			if (existing) {
+				result[existingIdx] = {
+					id: existing.id,
+					key: existing.key,
+					value: incoming.value,
+				};
+			} else {
+				result.push(incoming);
+			}
+		}
+		commitRows(result);
+	};
 
 	return (
 		<>
@@ -35,44 +252,166 @@ export const Secrets = (props: Props) => {
 					<CardDescription>{props.description}</CardDescription>
 				</div>
 
-				<Toggle
-					aria-label="Toggle bold"
-					pressed={isVisible}
-					onPressedChange={setIsVisible}
-				>
-					{isVisible ? (
-						<EyeOffIcon className="h-4 w-4 text-muted-foreground" />
-					) : (
-						<EyeIcon className="h-4 w-4 text-muted-foreground" />
-					)}
-				</Toggle>
+				<div className="flex items-center gap-2">
+					<div
+						className="inline-flex items-center rounded-md border border-input p-0.5"
+						role="radiogroup"
+						aria-label="Editor view"
+					>
+						<button
+							type="button"
+							role="radio"
+							aria-checked={viewMode === "raw"}
+							aria-label="Raw editor"
+							onClick={() => setViewMode("raw")}
+							className={cn(
+								"flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+								viewMode === "raw"
+									? "bg-accent text-accent-foreground"
+									: "text-muted-foreground hover:bg-muted",
+							)}
+						>
+							<CodeIcon className="h-4 w-4" />
+						</button>
+						<button
+							type="button"
+							role="radio"
+							aria-checked={viewMode === "rows"}
+							aria-label="Rows editor"
+							onClick={() => setViewMode("rows")}
+							className={cn(
+								"flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+								viewMode === "rows"
+									? "bg-accent text-accent-foreground"
+									: "text-muted-foreground hover:bg-muted",
+							)}
+						>
+							<Rows3Icon className="h-4 w-4" />
+						</button>
+					</div>
+
+					<Toggle
+						aria-label="Toggle value visibility"
+						pressed={isVisible}
+						onPressedChange={setIsVisible}
+					>
+						{isVisible ? (
+							<EyeOffIcon className="h-4 w-4 text-muted-foreground" />
+						) : (
+							<EyeIcon className="h-4 w-4 text-muted-foreground" />
+						)}
+					</Toggle>
+				</div>
 			</CardHeader>
 			<CardContent className="w-full space-y-4 p-0">
-				<FormField
-					control={form.control}
-					name={props.name}
-					render={({ field }) => (
-						<FormItem className="w-full">
-							<FormControl>
-								<CodeEditor
-									style={
-										{
-											WebkitTextSecurity: isVisible ? "disc" : null,
-										} as CSSProperties
-									}
-									language="properties"
-									disabled={isVisible}
-									lineWrapping
-									placeholder={props.placeholder}
-									className="h-96 font-mono"
-									{...field}
-								/>
-							</FormControl>
+				{viewMode === "raw" ? (
+					<FormField
+						control={form.control}
+						name={props.name}
+						render={({ field }) => (
+							<FormItem className="w-full">
+								<FormControl>
+									<CodeEditor
+										style={
+											{
+												WebkitTextSecurity: isVisible ? "disc" : null,
+											} as CSSProperties
+										}
+										language="properties"
+										disabled={isVisible}
+										lineWrapping
+										placeholder={props.placeholder}
+										className="h-96 font-mono"
+										{...field}
+									/>
+								</FormControl>
 
-							<FormMessage />
-						</FormItem>
-					)}
-				/>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				) : (
+					<div className="space-y-2">
+						{rows.length === 0 ? (
+							<div className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+								No variables yet. Add one below, or paste an .env file into a
+								row to import multiple at once.
+							</div>
+						) : (
+							<div className="space-y-2">
+								{rows.map((row) => (
+									<div
+										key={row.id}
+										ref={setRowRef(row.id)}
+										onDragOver={handleDragOver(row.id)}
+										className={cn(
+											"grid grid-cols-[auto_1fr_1fr_auto] items-center gap-2 will-change-transform",
+											draggingId === row.id && "opacity-40",
+										)}
+									>
+										<button
+											type="button"
+											draggable
+											onDragStart={handleDragStart(row.id)}
+											onDragEnd={handleDragEnd}
+											aria-label="Drag to reorder"
+											tabIndex={-1}
+											className="flex h-10 w-6 cursor-grab items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing"
+										>
+											<GripVerticalIcon className="h-4 w-4" />
+										</button>
+										<Input
+											className="font-mono"
+											placeholder="KEY"
+											autoComplete="off"
+											spellCheck={false}
+											value={row.key}
+											onChange={(e) =>
+												handleKeyChange(row.id, e.target.value)
+											}
+											onPaste={(e) => handlePaste(row.id, e)}
+										/>
+										<Input
+											className="font-mono"
+											placeholder="VALUE"
+											autoComplete="off"
+											spellCheck={false}
+											style={
+												{
+													WebkitTextSecurity: isVisible ? "disc" : null,
+												} as CSSProperties
+											}
+											value={row.value}
+											onChange={(e) =>
+												handleValueChange(row.id, e.target.value)
+											}
+											onPaste={(e) => handlePaste(row.id, e)}
+										/>
+										<Button
+											type="button"
+											variant="ghost"
+											size="icon"
+											aria-label="Remove variable"
+											onClick={() => handleRemove(row.id)}
+										>
+											<Trash2Icon className="h-4 w-4 text-muted-foreground" />
+										</Button>
+									</div>
+								))}
+							</div>
+						)}
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={handleAdd}
+							className="w-full"
+						>
+							<PlusIcon className="mr-2 h-4 w-4" />
+							Add variable
+						</Button>
+					</div>
+				)}
 			</CardContent>
 		</>
 	);

--- a/apps/dokploy/components/ui/secrets.tsx
+++ b/apps/dokploy/components/ui/secrets.tsx
@@ -1,41 +1,18 @@
-import {
-	CodeIcon,
-	EyeIcon,
-	EyeOffIcon,
-	GripVerticalIcon,
-	PlusIcon,
-	Rows3Icon,
-	Trash2Icon,
-} from "lucide-react";
-import {
-	type ClipboardEvent,
-	type CSSProperties,
-	type DragEvent,
-	type ReactNode,
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from "react";
+import type { ReactNode } from "react";
 import { useFormContext } from "react-hook-form";
-import { CodeEditor } from "@/components/shared/code-editor";
-import { Button } from "@/components/ui/button";
 import {
 	CardContent,
 	CardDescription,
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { EnvEditor } from "@/components/ui/env-editor";
 import {
 	FormControl,
 	FormField,
 	FormItem,
 	FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Toggle } from "@/components/ui/toggle";
-import { cn } from "@/lib/utils";
 
 interface Props {
 	name: string;
@@ -44,205 +21,8 @@ interface Props {
 	placeholder: string;
 }
 
-type ViewMode = "raw" | "rows";
-type Row = { id: string; key: string; value: string };
-
-const createId = () =>
-	typeof crypto !== "undefined" && "randomUUID" in crypto
-		? crypto.randomUUID()
-		: `row-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-const parseEnv = (text: string): Row[] => {
-	if (!text) return [];
-	const rows: Row[] = [];
-	for (const line of text.split(/\r?\n/)) {
-		const trimmed = line.trim();
-		if (!trimmed || trimmed.startsWith("#")) continue;
-		const eq = line.indexOf("=");
-		if (eq === -1) {
-			rows.push({ id: createId(), key: trimmed, value: "" });
-			continue;
-		}
-		let key = line.slice(0, eq).trim();
-		let value = line.slice(eq + 1).trim();
-		if (key.startsWith("export ")) key = key.slice(7).trim();
-		if (
-			(value.startsWith('"') && value.endsWith('"')) ||
-			(value.startsWith("'") && value.endsWith("'"))
-		) {
-			value = value.slice(1, -1);
-		}
-		rows.push({ id: createId(), key, value });
-	}
-	return rows;
-};
-
-const serializeRows = (rows: Row[]): string =>
-	rows
-		.filter((r) => r.key.trim() !== "")
-		.map((r) => `${r.key.trim()}=${r.value}`)
-		.join("\n");
-
-const looksLikeEnvPaste = (text: string) => {
-	if (!text.includes("=")) return false;
-	if (/\r?\n/.test(text)) return true;
-	return (text.match(/=/g) ?? []).length >= 1;
-};
-
 export const Secrets = (props: Props) => {
-	const [isVisible, setIsVisible] = useState(true);
-	const [viewMode, setViewMode] = useState<ViewMode>("raw");
-	const [rows, setRows] = useState<Row[]>([]);
-	const [draggingId, setDraggingId] = useState<string | null>(null);
-	const lastSerializedRef = useRef<string>("");
-	const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
-	const prevRectsRef = useRef<Map<string, DOMRect>>(new Map());
 	const form = useFormContext<Record<string, string>>();
-	const fieldValue = form.watch(props.name) ?? "";
-
-	const setRowRef = useCallback(
-		(id: string) => (el: HTMLDivElement | null) => {
-			if (el) rowRefs.current.set(id, el);
-			else rowRefs.current.delete(id);
-		},
-		[],
-	);
-
-	useLayoutEffect(() => {
-		if (viewMode !== "rows") {
-			prevRectsRef.current.clear();
-			return;
-		}
-		const prev = prevRectsRef.current;
-		const next = new Map<string, DOMRect>();
-		rowRefs.current.forEach((el, id) => {
-			next.set(id, el.getBoundingClientRect());
-		});
-		prev.forEach((prevRect, id) => {
-			const nextRect = next.get(id);
-			const el = rowRefs.current.get(id);
-			if (!el || !nextRect) return;
-			const dy = prevRect.top - nextRect.top;
-			if (Math.abs(dy) < 0.5) return;
-			el.style.transition = "none";
-			el.style.transform = `translateY(${dy}px)`;
-			requestAnimationFrame(() => {
-				el.style.transition =
-					"transform 220ms cubic-bezier(0.22, 1, 0.36, 1)";
-				el.style.transform = "";
-			});
-		});
-		prevRectsRef.current = next;
-	}, [rows, viewMode]);
-
-	useEffect(() => {
-		if (viewMode !== "rows") return;
-		if (fieldValue === lastSerializedRef.current) return;
-		const parsed = parseEnv(fieldValue);
-		setRows(parsed);
-		lastSerializedRef.current = serializeRows(parsed);
-	}, [fieldValue, viewMode]);
-
-	const commitRows = (next: Row[]) => {
-		setRows(next);
-		const serialized = serializeRows(next);
-		lastSerializedRef.current = serialized;
-		form.setValue(props.name, serialized, {
-			shouldDirty: true,
-			shouldTouch: true,
-		});
-	};
-
-	const handleKeyChange = (id: string, key: string) => {
-		commitRows(rows.map((r) => (r.id === id ? { ...r, key } : r)));
-	};
-
-	const handleValueChange = (id: string, value: string) => {
-		commitRows(rows.map((r) => (r.id === id ? { ...r, value } : r)));
-	};
-
-	const handleRemove = (id: string) => {
-		commitRows(rows.filter((r) => r.id !== id));
-	};
-
-	const handleAdd = () => {
-		commitRows([...rows, { id: createId(), key: "", value: "" }]);
-	};
-
-	const handleDragStart =
-		(id: string) => (e: DragEvent<HTMLButtonElement>) => {
-			setDraggingId(id);
-			e.dataTransfer.effectAllowed = "move";
-			try {
-				e.dataTransfer.setData("text/plain", id);
-			} catch {
-				// Safari can throw in rare cases; the drag still works.
-			}
-		};
-
-	const handleDragEnd = () => setDraggingId(null);
-
-	const handleDragOver =
-		(id: string) => (e: DragEvent<HTMLDivElement>) => {
-			if (!draggingId) return;
-			e.preventDefault();
-			e.dataTransfer.dropEffect = "move";
-			if (draggingId === id) return;
-			const rect = e.currentTarget.getBoundingClientRect();
-			const isAbove = e.clientY < rect.top + rect.height / 2;
-			const fromIdx = rows.findIndex((r) => r.id === draggingId);
-			const targetIdx = rows.findIndex((r) => r.id === id);
-			if (fromIdx === -1 || targetIdx === -1) return;
-			let newIdx = isAbove ? targetIdx : targetIdx + 1;
-			if (fromIdx < newIdx) newIdx -= 1;
-			if (fromIdx === newIdx) return;
-			const next = [...rows];
-			const [moved] = next.splice(fromIdx, 1);
-			if (!moved) return;
-			next.splice(newIdx, 0, moved);
-			commitRows(next);
-		};
-
-	const handlePaste = (id: string, e: ClipboardEvent<HTMLInputElement>) => {
-		const text = e.clipboardData.getData("text");
-		if (!looksLikeEnvPaste(text)) return;
-		const parsed = parseEnv(text);
-		if (parsed.length === 0) return;
-		e.preventDefault();
-
-		// Collapse duplicates within the pasted content (last occurrence wins).
-		const incomingByKey = new Map<string, Row>();
-		for (const row of parsed) {
-			incomingByKey.set(row.key.trim(), row);
-		}
-
-		const idx = rows.findIndex((r) => r.id === id);
-		const target = rows[idx];
-		const isTargetEmpty =
-			target && target.key.trim() === "" && target.value === "";
-		const base = isTargetEmpty
-			? [...rows.slice(0, idx), ...rows.slice(idx + 1)]
-			: [...rows];
-
-		// Merge: overwrite existing rows with matching keys, append the rest.
-		const result = base.map((r) => ({ ...r }));
-		for (const incoming of incomingByKey.values()) {
-			const key = incoming.key.trim();
-			if (!key) continue;
-			const existingIdx = result.findIndex((r) => r.key.trim() === key);
-			const existing = existingIdx >= 0 ? result[existingIdx] : undefined;
-			if (existing) {
-				result[existingIdx] = {
-					id: existing.id,
-					key: existing.key,
-					value: incoming.value,
-				};
-			} else {
-				result.push(incoming);
-			}
-		}
-		commitRows(result);
-	};
 
 	return (
 		<>
@@ -251,167 +31,24 @@ export const Secrets = (props: Props) => {
 					<CardTitle className="text-xl">{props.title}</CardTitle>
 					<CardDescription>{props.description}</CardDescription>
 				</div>
-
-				<div className="flex items-center gap-2">
-					<div
-						className="inline-flex items-center rounded-md border border-input p-0.5"
-						role="radiogroup"
-						aria-label="Editor view"
-					>
-						<button
-							type="button"
-							role="radio"
-							aria-checked={viewMode === "raw"}
-							aria-label="Raw editor"
-							onClick={() => setViewMode("raw")}
-							className={cn(
-								"flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
-								viewMode === "raw"
-									? "bg-accent text-accent-foreground"
-									: "text-muted-foreground hover:bg-muted",
-							)}
-						>
-							<CodeIcon className="h-4 w-4" />
-						</button>
-						<button
-							type="button"
-							role="radio"
-							aria-checked={viewMode === "rows"}
-							aria-label="Rows editor"
-							onClick={() => setViewMode("rows")}
-							className={cn(
-								"flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
-								viewMode === "rows"
-									? "bg-accent text-accent-foreground"
-									: "text-muted-foreground hover:bg-muted",
-							)}
-						>
-							<Rows3Icon className="h-4 w-4" />
-						</button>
-					</div>
-
-					<Toggle
-						aria-label="Toggle value visibility"
-						pressed={isVisible}
-						onPressedChange={setIsVisible}
-					>
-						{isVisible ? (
-							<EyeOffIcon className="h-4 w-4 text-muted-foreground" />
-						) : (
-							<EyeIcon className="h-4 w-4 text-muted-foreground" />
-						)}
-					</Toggle>
-				</div>
 			</CardHeader>
 			<CardContent className="w-full space-y-4 p-0">
-				{viewMode === "raw" ? (
-					<FormField
-						control={form.control}
-						name={props.name}
-						render={({ field }) => (
-							<FormItem className="w-full">
-								<FormControl>
-									<CodeEditor
-										style={
-											{
-												WebkitTextSecurity: isVisible ? "disc" : null,
-											} as CSSProperties
-										}
-										language="properties"
-										disabled={isVisible}
-										lineWrapping
-										placeholder={props.placeholder}
-										className="h-96 font-mono"
-										{...field}
-									/>
-								</FormControl>
-
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-				) : (
-					<div className="space-y-2">
-						{rows.length === 0 ? (
-							<div className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
-								No variables yet. Add one below, or paste an .env file into a
-								row to import multiple at once.
-							</div>
-						) : (
-							<div className="space-y-2">
-								{rows.map((row) => (
-									<div
-										key={row.id}
-										ref={setRowRef(row.id)}
-										onDragOver={handleDragOver(row.id)}
-										className={cn(
-											"grid grid-cols-[auto_1fr_1fr_auto] items-center gap-2 will-change-transform",
-											draggingId === row.id && "opacity-40",
-										)}
-									>
-										<button
-											type="button"
-											draggable
-											onDragStart={handleDragStart(row.id)}
-											onDragEnd={handleDragEnd}
-											aria-label="Drag to reorder"
-											tabIndex={-1}
-											className="flex h-10 w-6 cursor-grab items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing"
-										>
-											<GripVerticalIcon className="h-4 w-4" />
-										</button>
-										<Input
-											className="font-mono"
-											placeholder="KEY"
-											autoComplete="off"
-											spellCheck={false}
-											value={row.key}
-											onChange={(e) =>
-												handleKeyChange(row.id, e.target.value)
-											}
-											onPaste={(e) => handlePaste(row.id, e)}
-										/>
-										<Input
-											className="font-mono"
-											placeholder="VALUE"
-											autoComplete="off"
-											spellCheck={false}
-											style={
-												{
-													WebkitTextSecurity: isVisible ? "disc" : null,
-												} as CSSProperties
-											}
-											value={row.value}
-											onChange={(e) =>
-												handleValueChange(row.id, e.target.value)
-											}
-											onPaste={(e) => handlePaste(row.id, e)}
-										/>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											aria-label="Remove variable"
-											onClick={() => handleRemove(row.id)}
-										>
-											<Trash2Icon className="h-4 w-4 text-muted-foreground" />
-										</Button>
-									</div>
-								))}
-							</div>
-						)}
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={handleAdd}
-							className="w-full"
-						>
-							<PlusIcon className="mr-2 h-4 w-4" />
-							Add variable
-						</Button>
-					</div>
-				)}
+				<FormField
+					control={form.control}
+					name={props.name}
+					render={({ field }) => (
+						<FormItem className="w-full">
+							<FormControl>
+								<EnvEditor
+									value={field.value ?? ""}
+									onChange={field.onChange}
+									placeholder={props.placeholder}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
 			</CardContent>
 		</>
 	);


### PR DESCRIPTION
## What is this PR about?

Added a toggle in the env editors to toggle between code editor and vercel style editor for env variables.
Pasting a copied env file content will automatically populate env variables
Variables can be reordered just by dragging

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

none

## Screenshots (if applicable)

Without anything inside
<img width="1104" height="718" alt="Screenshot 2026-04-21 alle 09 25 52" src="https://github.com/user-attachments/assets/07d66e9c-5a1f-4cbe-a233-c3b35a61c5ff" />

After pasting the .env.example
<img width="1104" height="718" alt="Screenshot 2026-04-21 alle 09 26 02" src="https://github.com/user-attachments/assets/cb19d8ab-c54d-4132-8b01-5eb2768acedc" />

Reordering
<img width="1104" height="718" alt="Screenshot 2026-04-21 alle 09 26 14" src="https://github.com/user-attachments/assets/01623e82-8891-4694-9af2-e42561ab1e14" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `EnvEditor` component that wraps the existing `CodeEditor` and introduces a toggleable rows-based view (Vercel-style) with drag-to-reorder and smart paste. The component replaces the raw `CodeEditor` in both `project-environment.tsx` and `secrets.tsx`.

- **Raw editor disabled on first load**: `isObscured` defaults to `true`, which also sets `disabled={isObscured || disabled}` on the raw `CodeEditor`. Any user with write access will find the raw editor completely uneditable until they click the eye toggle — a clear regression from the previous behaviour.
- **Paste interception breaks values containing `=`**: `looksLikeEnvPaste` returns `true` for any single-line text that includes `=`, so pasting a URL with query params, a Base64 string, or similar into a VALUE field will be silently intercepted and split on `=` instead of inserted as a literal string.
- **Silent data loss on round-trip**: `parseEnv` strips surrounding quotes from values but `serializeRows` never re-adds them, permanently altering quoted values (e.g. those containing spaces) after one save in rows mode.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — three P1 defects will affect all users of the new component.

Three distinct P1 issues exist in the new EnvEditor: the raw editor is disabled on first load blocking normal editing, single-line paste interception corrupts values containing =, and a parse/serialize asymmetry silently drops quotes from values causing data loss. All three are present on the changed code path and will affect real users.

apps/dokploy/components/ui/env-editor.tsx requires attention on the default isObscured state, looksLikeEnvPaste logic, and the parseEnv/serializeRows quote handling.

<sub>Reviews (1): Last reviewed commit: ["feat: replace CodeEditor with EnvEditor ..."](https://github.com/dokploy/dokploy/commit/a3ce1f0fbe4fe0bfa04b952818780e81d5ed83a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29094437)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->