### PR TITLE
fix(webhook): return 401 when signature header is missing

### DIFF
--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -53,10 +53,7 @@ export default async function handler(
 		secret: githubResult.githubWebhookSecret,
 	});
 
-	const verified = await webhooks.verify(
-		JSON.stringify(githubBody),
-		signature,
-	);
+	const verified = await webhooks.verify(JSON.stringify(githubBody), signature);
 
 	if (!verified) {
 		res.status(401).json({ message: "Unauthorized" });

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -53,7 +53,10 @@ export default async function handler(
 		secret: githubResult.githubWebhookSecret,
 	});
 
-	const verified = await webhooks.verify(JSON.stringify(githubBody), signature as string);
+	const verified = await webhooks.verify(
+		JSON.stringify(githubBody),
+		signature as string,
+	);
 
 	if (!verified) {
 		res.status(401).json({ message: "Unauthorized" });

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -53,7 +53,7 @@ export default async function handler(
 		secret: githubResult.githubWebhookSecret,
 	});
 
-	const verified = await webhooks.verify(JSON.stringify(githubBody), signature);
+	const verified = await webhooks.verify(JSON.stringify(githubBody), signature as string);
 
 	if (!verified) {
 		res.status(401).json({ message: "Unauthorized" });

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -24,6 +24,11 @@ export default async function handler(
 	res: NextApiResponse,
 ) {
 	const signature = req.headers["x-hub-signature-256"];
+	if (!signature) {
+		res.status(401).json({ message: "Missing signature header" });
+		return;
+	}
+
 	const githubBody = req.body;
 
 	if (!githubBody?.installation?.id) {
@@ -50,7 +55,7 @@ export default async function handler(
 
 	const verified = await webhooks.verify(
 		JSON.stringify(githubBody),
-		signature as string,
+		signature,
 	);
 
 	if (!verified) {


### PR DESCRIPTION
Fixes #4275

When the signature header is absent, webhooks.verify() receives undefined and throws, causing a 500. Now we check for the header early and return 401 with a clear message.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an early `!signature` guard to return 401 when the `x-hub-signature-256` header is absent, fixing the 500 thrown by `webhooks.verify(body, undefined)`. Also removes the `as string` type cast at the `verify` call site.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core fix is correct and the remaining note is minor.

The 401 early-return for a missing signature is clearly correct and consistent with the existing 401 for a bad signature. The only concern (handling `string[]` header values) is pre-existing behaviour that was previously hidden by the `as string` cast, and GitHub realistically never sends multiple signature headers.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/8fb517152a63b6dc98514df1d747b422a143d746) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29197784)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->