### PR TITLE
fix(schedule): add authz checks for server and host-level schedules

### DIFF
--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -7,19 +7,25 @@ import {
 	updateScheduleSchema,
 } from "@dokploy/server/db/schema/schedule";
 import { runCommand } from "@dokploy/server/index";
-import { checkServicePermissionAndAccess } from "@dokploy/server/services/permission";
+import {
+	checkPermission,
+	checkServicePermissionAndAccess,
+	findMemberByUserId,
+} from "@dokploy/server/services/permission";
 import {
 	createSchedule,
 	deleteSchedule,
 	findScheduleById,
 	updateSchedule,
 } from "@dokploy/server/services/schedule";
+import { findServerById } from "@dokploy/server/services/server";
 import { TRPCError } from "@trpc/server";
 import { asc, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
 import { removeJob, schedule } from "@/server/utils/backup";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
+
 export const scheduleRouter = createTRPCRouter({
 	create: protectedProcedure
 		.input(createScheduleSchema)
@@ -29,6 +35,45 @@ export const scheduleRouter = createTRPCRouter({
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["create"],
 				});
+			} else {
+				if (input.scheduleType === "dokploy-server" && IS_CLOUD) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message:
+							"Host-level schedules are not available in the cloud version.",
+					});
+				}
+
+				await checkPermission(ctx, { schedule: ["create"] });
+
+				if (
+					input.scheduleType === "server" ||
+					input.scheduleType === "dokploy-server"
+				) {
+					const member = await findMemberByUserId(
+						ctx.user.id,
+						ctx.session.activeOrganizationId,
+					);
+					if (member.role !== "owner" && member.role !== "admin") {
+						throw new TRPCError({
+							code: "FORBIDDEN",
+							message:
+								"Only owners and admins can manage server-level schedules.",
+						});
+					}
+				}
+
+				if (input.scheduleType === "server" && input.serverId) {
+					const targetServer = await findServerById(input.serverId);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this server.",
+						});
+					}
+				}
 			}
 			const newSchedule = await createSchedule(input);
 
@@ -57,12 +102,77 @@ export const scheduleRouter = createTRPCRouter({
 		.input(updateScheduleSchema)
 		.mutation(async ({ input, ctx }) => {
 			const existingSchedule = await findScheduleById(input.scheduleId);
+
+			if (
+				IS_CLOUD &&
+				input.scheduleType &&
+				input.scheduleType !== existingSchedule.scheduleType
+			) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Changing scheduleType is not allowed in the cloud version.",
+				});
+			}
+
 			const serviceId =
 				existingSchedule.applicationId || existingSchedule.composeId;
 			if (serviceId) {
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["update"],
 				});
+			} else {
+				if (existingSchedule.scheduleType === "dokploy-server" && IS_CLOUD) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message:
+							"Host-level schedules are not available in the cloud version.",
+					});
+				}
+
+				await checkPermission(ctx, { schedule: ["update"] });
+
+				if (
+					existingSchedule.scheduleType === "server" ||
+					existingSchedule.scheduleType === "dokploy-server"
+				) {
+					const member = await findMemberByUserId(
+						ctx.user.id,
+						ctx.session.activeOrganizationId,
+					);
+					if (member.role !== "owner" && member.role !== "admin") {
+						throw new TRPCError({
+							code: "FORBIDDEN",
+							message:
+								"Only owners and admins can manage server-level schedules.",
+						});
+					}
+				}
+
+				if (
+					existingSchedule.scheduleType === "server" &&
+					existingSchedule.serverId
+				) {
+					const targetServer = await findServerById(existingSchedule.serverId);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this server.",
+						});
+					}
+				}
+
+				if (
+					existingSchedule.scheduleType === "dokploy-server" &&
+					existingSchedule.userId &&
+					existingSchedule.userId !== ctx.user.id
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You can only manage your own host-level schedules.",
+					});
+				}
 			}
 			const updatedSchedule = await updateSchedule(input);
 
@@ -107,6 +217,56 @@ export const scheduleRouter = createTRPCRouter({
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["delete"],
 				});
+			} else {
+				if (scheduleItem.scheduleType === "dokploy-server" && IS_CLOUD) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message:
+							"Host-level schedules are not available in the cloud version.",
+					});
+				}
+
+				await checkPermission(ctx, { schedule: ["delete"] });
+
+				if (
+					scheduleItem.scheduleType === "server" ||
+					scheduleItem.scheduleType === "dokploy-server"
+				) {
+					const member = await findMemberByUserId(
+						ctx.user.id,
+						ctx.session.activeOrganizationId,
+					);
+					if (member.role !== "owner" && member.role !== "admin") {
+						throw new TRPCError({
+							code: "FORBIDDEN",
+							message:
+								"Only owners and admins can manage server-level schedules.",
+						});
+					}
+				}
+
+				if (scheduleItem.scheduleType === "server" && scheduleItem.serverId) {
+					const targetServer = await findServerById(scheduleItem.serverId);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this server.",
+						});
+					}
+				}
+
+				if (
+					scheduleItem.scheduleType === "dokploy-server" &&
+					scheduleItem.userId &&
+					scheduleItem.userId !== ctx.user.id
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You can only manage your own host-level schedules.",
+					});
+				}
 			}
 			await deleteSchedule(input.scheduleId);
 
@@ -148,6 +308,30 @@ export const scheduleRouter = createTRPCRouter({
 				await checkServicePermissionAndAccess(ctx, input.id, {
 					schedule: ["read"],
 				});
+			} else {
+				await checkPermission(ctx, { schedule: ["read"] });
+
+				if (input.scheduleType === "server") {
+					const targetServer = await findServerById(input.id);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this server.",
+						});
+					}
+				}
+
+				if (
+					input.scheduleType === "dokploy-server" &&
+					input.id !== ctx.user.id
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You can only list your own host-level schedules.",
+					});
+				}
 			}
 			const where = {
 				application: eq(schedules.applicationId, input.id),
@@ -178,6 +362,31 @@ export const scheduleRouter = createTRPCRouter({
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["read"],
 				});
+			} else {
+				await checkPermission(ctx, { schedule: ["read"] });
+
+				if (schedule.scheduleType === "server" && schedule.serverId) {
+					const targetServer = await findServerById(schedule.serverId);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this schedule.",
+						});
+					}
+				}
+
+				if (
+					schedule.scheduleType === "dokploy-server" &&
+					schedule.userId &&
+					schedule.userId !== ctx.user.id
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this schedule.",
+					});
+				}
 			}
 			return schedule;
 		}),
@@ -191,6 +400,56 @@ export const scheduleRouter = createTRPCRouter({
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["create"],
 				});
+			} else {
+				if (scheduleItem.scheduleType === "dokploy-server" && IS_CLOUD) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message:
+							"Host-level schedules are not available in the cloud version.",
+					});
+				}
+
+				await checkPermission(ctx, { schedule: ["create"] });
+
+				if (
+					scheduleItem.scheduleType === "server" ||
+					scheduleItem.scheduleType === "dokploy-server"
+				) {
+					const member = await findMemberByUserId(
+						ctx.user.id,
+						ctx.session.activeOrganizationId,
+					);
+					if (member.role !== "owner" && member.role !== "admin") {
+						throw new TRPCError({
+							code: "FORBIDDEN",
+							message:
+								"Only owners and admins can manage server-level schedules.",
+						});
+					}
+				}
+
+				if (scheduleItem.scheduleType === "server" && scheduleItem.serverId) {
+					const targetServer = await findServerById(scheduleItem.serverId);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this server.",
+						});
+					}
+				}
+
+				if (
+					scheduleItem.scheduleType === "dokploy-server" &&
+					scheduleItem.userId &&
+					scheduleItem.userId !== ctx.user.id
+				) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You can only manage your own host-level schedules.",
+					});
+				}
 			}
 			try {
 				await runCommand(input.scheduleId);


### PR DESCRIPTION
## Summary
- Adds authorization checks to the schedule router so non-service schedules (`server`, `dokploy-server`) enforce owner/admin role, org ownership of the target server, and self-user ownership for host-level schedules.
- Blocks `dokploy-server` schedules entirely in cloud (no shared host) and prevents changing `scheduleType` on update in cloud.
- Keeps the existing inline check style per endpoint instead of extracting a shared helper, to stay close to the original flow.

Addresses GHSA-7wmr-57mg-h5q6.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds authorization guards to `create`, `update`, `delete`, `list`, `one`, and `runManually` for server-level and host-level (`dokploy-server`) schedules, including role checks, org ownership of the target server, and user self-ownership for host schedules. One bypassable gap remains: the `scheduleType` change guard in `update` is `IS_CLOUD`-only, leaving self-hosted deployments exposed to privilege escalation via a service → server type mutation.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until the self-hosted scheduleType escalation path is closed.

The new auth checks are otherwise sound and correctly address the reported advisory, but the IS_CLOUD-only guard on scheduleType mutation leaves a live privilege-escalation path in self-hosted deployments.

apps/dokploy/server/api/routers/schedule.ts — specifically the update handler's scheduleType change guard.

<details open><summary><h3>Security Review</h3></summary>

- **scheduleType privilege escalation (self-hosted)**: The `update` endpoint only restricts `scheduleType` changes under `IS_CLOUD`. On self-hosted instances, a user with service-level schedule access can mutate `scheduleType` to `"server"` or `"dokploy-server"` while clearing `applicationId`/`composeId`, bypassing the owner/admin check that would otherwise block the elevation. The cron runner has no additional auth layer, so the escalated schedule executes at server level.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: enhance schedule management with p..."](https://github.com/dokploy/dokploy/commit/c3fa638a566e77dc4d71d9b49de84a1942e1f824) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29224936)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->