### PR TITLE
fix: Tiny docker build cache optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ RUN corepack enable
 RUN corepack prepare pnpm@10.22.0 --activate
 
 FROM base AS build
-COPY . /usr/src/app
-WORKDIR /usr/src/app
 
 RUN apt-get update && apt-get install -y python3 make g++ git python3-pip pkg-config libsecret-1-dev && rm -rf /var/lib/apt/lists/*
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
 
 # Install dependencies
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

This is a tiny 2 line change that moves where & when the build layer in docker installs the changes, this should make development a bit faster as you are able to at least cache the apt changes.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)


## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorders the `apt-get install` step in the `build` stage to appear before `COPY . /usr/src/app`, so the system-dependency layer is cached and not rebuilt on every source change. The reordering is correct and the Dockerfile remains valid.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a correct and standard Dockerfile layer-ordering optimization with no functional impact.

Only finding is a P2 suggestion for a deeper cache optimization (copy manifests before full source). The change as written is correct, builds will not break, and the cache benefit is real.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: Reorder when apt updates and instal..."](https://github.com/dokploy/dokploy/commit/b811e617097fb32a0ab9695f91c203b9624a7f27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29240459)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->