### PR TITLE
fix: stop leaking Drizzle SQL queries in webhook error responses (#4276)

### DIFF
--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -13,6 +13,15 @@ import { myQueue } from "@/server/queues/queueSetup";
 import { deploy } from "@/server/utils/deploy";
 
 /**
+ * Log a webhook handler error server-side without leaking its shape to the HTTP
+ * response. Drizzle errors carry the raw SQL query, column list and parameters,
+ * so we never forward the error object to the client.
+ */
+export const logWebhookError = (context: string, error: unknown) => {
+	console.error(context, error);
+};
+
+/**
  * Helper function to get package_version from registry_package events
  */
 const getPackageVersion = (headers: any, body: any) => {
@@ -262,14 +271,15 @@ export default async function handler(
 				);
 			}
 		} catch (error) {
-			res.status(400).json({ message: "Error deploying Application", error });
+			logWebhookError("Error deploying Application:", error);
+			res.status(400).json({ message: "Error deploying Application" });
 			return;
 		}
 
 		res.status(200).json({ message: "Application deployed successfully" });
 	} catch (error) {
-		console.log(error);
-		res.status(400).json({ message: "Error deploying Application", error });
+		logWebhookError("Error deploying Application:", error);
+		res.status(400).json({ message: "Error deploying Application" });
 	}
 }
 

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -12,6 +12,7 @@ import {
 	extractCommittedPaths,
 	extractHash,
 	getProviderByHeader,
+	logWebhookError,
 } from "../[refreshToken]";
 
 export default async function handler(
@@ -195,13 +196,14 @@ export default async function handler(
 				);
 			}
 		} catch (error) {
-			res.status(400).json({ message: "Error deploying Compose", error });
+			logWebhookError("Error deploying Compose:", error);
+			res.status(400).json({ message: "Error deploying Compose" });
 			return;
 		}
 
 		res.status(200).json({ message: "Compose deployed successfully" });
 	} catch (error) {
-		console.log(error);
-		res.status(400).json({ message: "Error deploying Compose", error });
+		logWebhookError("Error deploying Compose:", error);
+		res.status(400).json({ message: "Error deploying Compose" });
 	}
 }

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -17,7 +17,11 @@ import { applications, compose, github } from "@/server/db/schema";
 import type { DeploymentJob } from "@/server/queues/queue-types";
 import { myQueue } from "@/server/queues/queueSetup";
 import { deploy } from "@/server/utils/deploy";
-import { extractCommitMessage, extractHash } from "./[refreshToken]";
+import {
+	extractCommitMessage,
+	extractHash,
+	logWebhookError,
+} from "./[refreshToken]";
 
 export default async function handler(
 	req: NextApiRequest,
@@ -197,10 +201,8 @@ export default async function handler(
 			});
 			return;
 		} catch (error) {
-			console.error("Error deploying applications on tag:", error);
-			res
-				.status(400)
-				.json({ message: "Error deploying applications on tag", error });
+			logWebhookError("Error deploying applications on tag:", error);
+			res.status(400).json({ message: "Error deploying applications on tag" });
 			return;
 		}
 	}
@@ -322,7 +324,8 @@ export default async function handler(
 			}
 			res.status(200).json({ message: `Deployed ${totalApps} apps` });
 		} catch (error) {
-			res.status(400).json({ message: "Error deploying Application", error });
+			logWebhookError("Error deploying Application:", error);
+			res.status(400).json({ message: "Error deploying Application" });
 		}
 	} else if (req.headers["x-github-event"] === "pull_request") {
 		const prId = githubBody?.pull_request?.id;


### PR DESCRIPTION
## What is this PR about?

Deploy webhook endpoints (/api/deploy/github, /api/deploy/[refreshToken], /api/deploy/compose/[refreshToken]) were spreading the raw caught error into the JSON body, leaking Drizzle's full SQL query, column list and parameters — including secret-bearing column names (password, buildSecrets, refreshToken, etc.) and internal IDs.

Adds a shared logWebhookError helper: full error goes to the server log, clients get only the generic message.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4276

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security-relevant information-disclosure issue where raw Drizzle ORM errors (containing full SQL queries, column names, and parameters including sensitive ones like `password`, `refreshToken`, and `buildSecrets`) were being spread directly into webhook HTTP error responses. The fix introduces a `logWebhookError` helper that logs the full error server-side via `console.error` and returns only a generic message to the client, applied consistently across all three affected webhook endpoints.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal, correct, and directly addresses the reported information-disclosure issue with no regressions introduced.

All remaining findings are P2 style suggestions (a missed console.log that doesn't expose data to clients, and a code-organization note about where logWebhookError lives). Neither blocks correctness or security.

No files require special attention; all three changed files apply the fix consistently.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/pages/api/deploy/github.ts`, line 344-346 ([link](https://github.com/dokploy/dokploy/blob/f8c6c8f7ccee57ac16b5d13cba398a967b92706d/apps/dokploy/pages/api/deploy/github.ts#L344-L346)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missed `console.log` in pull_request closed handler**

   This catch block still uses `console.log(error)` instead of `console.error` or `logWebhookError`. While there's no HTTP response leakage here (the error isn't forwarded to the client), the PR upgraded every other similar pattern in this file and the sibling files to use `logWebhookError`, leaving this one inconsistent and at a lower log severity than intended.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: stop leaking Drizzle SQL queries in..."](https://github.com/dokploy/dokploy/commit/f8c6c8f7ccee57ac16b5d13cba398a967b92706d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29241883)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->