### PR TITLE
feat: add basic auth middleware UI under Traefik Dynamic

### DIFF
--- a/apps/dokploy/components/dashboard/file-system/handle-basic-auth-middleware.tsx
+++ b/apps/dokploy/components/dashboard/file-system/handle-basic-auth-middleware.tsx
@@ -1,0 +1,174 @@
+import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { PlusIcon } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { api } from "@/utils/api";
+
+const BasicAuthMiddlewareSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Name is required")
+		.regex(
+			/^[a-zA-Z0-9_-]+$/,
+			"Only letters, numbers, dashes and underscores are allowed",
+		),
+	username: z.string().min(1, "Username is required"),
+	password: z.string().min(1, "Password is required"),
+});
+
+type BasicAuthMiddleware = z.infer<typeof BasicAuthMiddlewareSchema>;
+
+interface Props {
+	serverId?: string;
+	children?: React.ReactNode;
+}
+
+export const HandleBasicAuthMiddleware = ({
+	serverId,
+	children = <PlusIcon className="h-4 w-4" />,
+}: Props) => {
+	const utils = api.useUtils();
+	const [isOpen, setIsOpen] = useState(false);
+
+	const { mutateAsync, isPending, error, isError } =
+		api.settings.createBasicAuthMiddleware.useMutation();
+
+	const form = useForm<BasicAuthMiddleware>({
+		defaultValues: {
+			name: "",
+			username: "",
+			password: "",
+		},
+		resolver: zodResolver(BasicAuthMiddlewareSchema),
+	});
+
+	const onSubmit = async (values: BasicAuthMiddleware) => {
+		await mutateAsync({
+			...values,
+			serverId,
+		})
+			.then(async () => {
+				toast.success("Middleware created");
+				await utils.settings.listBasicAuthMiddlewares.invalidate({ serverId });
+				form.reset();
+				setIsOpen(false);
+			})
+			.catch((err) => {
+				toast.error(err?.message ?? "Error creating middleware");
+			});
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={setIsOpen}>
+			<DialogTrigger asChild>
+				<Button>{children}</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Basic Auth Middleware</DialogTitle>
+					<DialogDescription>
+						Creates an entry in <code className="text-xs">middlewares.yml</code>
+						. Reference it in a Docker Compose label or on a domain's
+						Middlewares field as{" "}
+						<code className="text-xs">{"<name>@file"}</code>.
+					</DialogDescription>
+				</DialogHeader>
+				{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
+
+				<Form {...form}>
+					<form
+						id="hook-form-add-basic-auth-middleware"
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="grid w-full gap-4"
+					>
+						<div className="flex flex-col gap-4">
+							<FormField
+								control={form.control}
+								name="name"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Name</FormLabel>
+										<FormControl>
+											<Input placeholder="auth-alloy" {...field} />
+										</FormControl>
+										<FormDescription>
+											Used as the Traefik middleware key. Will be referenced as{" "}
+											<code className="text-xs">
+												{field.value ? `${field.value}@file` : "<name>@file"}
+											</code>
+											.
+										</FormDescription>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="username"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Username</FormLabel>
+										<FormControl>
+											<Input placeholder="admin" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="password"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Password</FormLabel>
+										<FormControl>
+											<Input type="password" {...field} />
+										</FormControl>
+										<FormDescription>
+											Stored bcrypt-hashed in{" "}
+											<code className="text-xs">middlewares.yml</code>.
+										</FormDescription>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+					</form>
+
+					<DialogFooter>
+						<Button
+							isLoading={isPending}
+							form="hook-form-add-basic-auth-middleware"
+							type="submit"
+						>
+							Create
+						</Button>
+					</DialogFooter>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/file-system/show-basic-auth-middlewares.tsx
+++ b/apps/dokploy/components/dashboard/file-system/show-basic-auth-middlewares.tsx
@@ -34,10 +34,10 @@ export const ShowBasicAuthMiddlewares = ({ serverId }: Props) => {
 							Basic Auth Middlewares
 						</CardTitle>
 						<CardDescription>
-							Create reusable basic auth middlewares in{" "}
-							{"'middlewares.yml'"}. Reference one in a Docker Compose label or
-							on a domain's Middlewares field as{" "}
-							<code className="text-xs">name@file</code>, then redeploy.
+							Create reusable basic auth middlewares in {"'middlewares.yml'"}.
+							Reference one in a Docker Compose label or on a domain's
+							Middlewares field as <code className="text-xs">name@file</code>,
+							then redeploy.
 						</CardDescription>
 					</div>
 

--- a/apps/dokploy/components/dashboard/file-system/show-basic-auth-middlewares.tsx
+++ b/apps/dokploy/components/dashboard/file-system/show-basic-auth-middlewares.tsx
@@ -1,5 +1,6 @@
 import copy from "copy-to-clipboard";
 import { Copy, LockKeyhole, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { DialogAction } from "@/components/shared/dialog-action";
 import { Button } from "@/components/ui/button";
@@ -21,8 +22,10 @@ export const ShowBasicAuthMiddlewares = ({ serverId }: Props) => {
 	const { data, refetch, isLoading } =
 		api.settings.listBasicAuthMiddlewares.useQuery({ serverId });
 
-	const { mutateAsync: deleteMiddleware, isPending: isRemoving } =
+	const { mutateAsync: deleteMiddleware } =
 		api.settings.deleteBasicAuthMiddleware.useMutation();
+
+	const [deletingName, setDeletingName] = useState<string | null>(null);
 
 	return (
 		<Card className="bg-sidebar p-2.5 rounded-xl">
@@ -98,6 +101,7 @@ export const ShowBasicAuthMiddlewares = ({ serverId }: Props) => {
 											description={`Are you sure you want to delete "${middleware.name}"? Any compose services or domains referencing it will stop authenticating until redeployed.`}
 											type="destructive"
 											onClick={async () => {
+												setDeletingName(middleware.name);
 												await deleteMiddleware({
 													name: middleware.name,
 													serverId,
@@ -110,6 +114,9 @@ export const ShowBasicAuthMiddlewares = ({ serverId }: Props) => {
 														toast.error(
 															error?.message ?? "Error deleting middleware",
 														);
+													})
+													.finally(() => {
+														setDeletingName(null);
 													});
 											}}
 										>
@@ -117,7 +124,7 @@ export const ShowBasicAuthMiddlewares = ({ serverId }: Props) => {
 												variant="ghost"
 												size="icon"
 												className="group hover:bg-red-500/10"
-												isLoading={isRemoving}
+												isLoading={deletingName === middleware.name}
 											>
 												<Trash2 className="size-4 text-primary group-hover:text-red-500" />
 											</Button>

--- a/apps/dokploy/components/dashboard/file-system/show-basic-auth-middlewares.tsx
+++ b/apps/dokploy/components/dashboard/file-system/show-basic-auth-middlewares.tsx
@@ -1,0 +1,134 @@
+import copy from "copy-to-clipboard";
+import { Copy, LockKeyhole, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { DialogAction } from "@/components/shared/dialog-action";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { api } from "@/utils/api";
+import { HandleBasicAuthMiddleware } from "./handle-basic-auth-middleware";
+
+interface Props {
+	serverId?: string;
+}
+
+export const ShowBasicAuthMiddlewares = ({ serverId }: Props) => {
+	const { data, refetch, isLoading } =
+		api.settings.listBasicAuthMiddlewares.useQuery({ serverId });
+
+	const { mutateAsync: deleteMiddleware, isPending: isRemoving } =
+		api.settings.deleteBasicAuthMiddleware.useMutation();
+
+	return (
+		<Card className="bg-sidebar p-2.5 rounded-xl">
+			<div className="rounded-xl bg-background shadow-md">
+				<CardHeader className="flex flex-row justify-between flex-wrap gap-4">
+					<div>
+						<CardTitle className="text-xl flex flex-row gap-2">
+							<LockKeyhole className="size-6 text-muted-foreground self-center" />
+							Basic Auth Middlewares
+						</CardTitle>
+						<CardDescription>
+							Create reusable basic auth middlewares in{" "}
+							{"'middlewares.yml'"}. Reference one in a Docker Compose label or
+							on a domain's Middlewares field as{" "}
+							<code className="text-xs">name@file</code>, then redeploy.
+						</CardDescription>
+					</div>
+
+					{data && data.length > 0 && (
+						<HandleBasicAuthMiddleware serverId={serverId}>
+							Add Middleware
+						</HandleBasicAuthMiddleware>
+					)}
+				</CardHeader>
+				<CardContent className="flex flex-col gap-4 py-6 border-t">
+					{isLoading ? (
+						<div className="flex w-full flex-col items-center justify-center gap-3 py-10">
+							<span className="text-muted-foreground text-sm">Loading...</span>
+						</div>
+					) : !data || data.length === 0 ? (
+						<div className="flex w-full flex-col items-center justify-center gap-3 py-10">
+							<LockKeyhole className="size-8 text-muted-foreground" />
+							<span className="text-base text-muted-foreground">
+								No basic auth middlewares configured
+							</span>
+							<HandleBasicAuthMiddleware serverId={serverId}>
+								Add Middleware
+							</HandleBasicAuthMiddleware>
+						</div>
+					) : (
+						<div className="flex flex-col gap-4">
+							{data.map((middleware) => {
+								const reference = `${middleware.name}@file`;
+								return (
+									<div
+										key={middleware.name}
+										className="flex flex-col md:flex-row md:items-center justify-between gap-4 border rounded-lg p-4"
+									>
+										<div className="flex flex-col gap-2">
+											<div className="flex items-center gap-2">
+												<span className="font-medium">{middleware.name}</span>
+												<Button
+													variant="ghost"
+													size="icon"
+													className="size-6"
+													onClick={() => {
+														copy(reference);
+														toast.success(`Copied "${reference}"`);
+													}}
+													title={`Copy "${reference}"`}
+												>
+													<Copy className="size-3.5 text-muted-foreground" />
+												</Button>
+											</div>
+											<span className="text-xs text-muted-foreground">
+												{middleware.users.length > 0
+													? `Users: ${middleware.users.join(", ")}`
+													: "No users"}
+											</span>
+										</div>
+										<DialogAction
+											title="Delete Middleware"
+											description={`Are you sure you want to delete "${middleware.name}"? Any compose services or domains referencing it will stop authenticating until redeployed.`}
+											type="destructive"
+											onClick={async () => {
+												await deleteMiddleware({
+													name: middleware.name,
+													serverId,
+												})
+													.then(() => {
+														refetch();
+														toast.success("Middleware deleted");
+													})
+													.catch((error) => {
+														toast.error(
+															error?.message ?? "Error deleting middleware",
+														);
+													});
+											}}
+										>
+											<Button
+												variant="ghost"
+												size="icon"
+												className="group hover:bg-red-500/10"
+												isLoading={isRemoving}
+											>
+												<Trash2 className="size-4 text-primary group-hover:text-red-500" />
+											</Button>
+										</DialogAction>
+									</div>
+								);
+							})}
+						</div>
+					)}
+				</CardContent>
+			</div>
+		</Card>
+	);
+};

--- a/apps/dokploy/pages/dashboard/traefik.tsx
+++ b/apps/dokploy/pages/dashboard/traefik.tsx
@@ -4,12 +4,18 @@ import { createServerSideHelpers } from "@trpc/react-query/server";
 import type { GetServerSidePropsContext } from "next";
 import type { ReactElement } from "react";
 import superjson from "superjson";
+import { ShowBasicAuthMiddlewares } from "@/components/dashboard/file-system/show-basic-auth-middlewares";
 import { ShowTraefikSystem } from "@/components/dashboard/file-system/show-traefik-system";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { appRouter } from "@/server/api/root";
 
 const Dashboard = () => {
-	return <ShowTraefikSystem />;
+	return (
+		<div className="flex flex-col gap-4">
+			<ShowBasicAuthMiddlewares />
+			<ShowTraefikSystem />
+		</div>
+	);
 };
 
 export default Dashboard;

--- a/apps/dokploy/pages/dashboard/traefik.tsx
+++ b/apps/dokploy/pages/dashboard/traefik.tsx
@@ -12,8 +12,8 @@ import { appRouter } from "@/server/api/root";
 const Dashboard = () => {
 	return (
 		<div className="flex flex-col gap-4">
-			<ShowBasicAuthMiddlewares />
 			<ShowTraefikSystem />
+			<ShowBasicAuthMiddlewares />
 		</div>
 	);
 };

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -525,7 +525,7 @@ export const settingsRouter = createTRPCRouter({
 			if (IS_CLOUD) {
 				return [];
 			}
-			let config: FileConfig;
+			let config: FileConfig | null;
 			try {
 				config = input?.serverId
 					? await loadRemoteMiddlewares(input.serverId)
@@ -563,14 +563,15 @@ export const settingsRouter = createTRPCRouter({
 			if (IS_CLOUD) {
 				return true;
 			}
-			let config: FileConfig;
+			let config: FileConfig | null;
 			try {
 				config = input.serverId
 					? await loadRemoteMiddlewares(input.serverId)
 					: loadMiddlewares<FileConfig>();
 			} catch {
-				config = { http: { middlewares: {} } };
+				config = null;
 			}
+			if (!config) config = { http: { middlewares: {} } };
 			if (!config.http) config.http = { middlewares: {} };
 			if (!config.http.middlewares) config.http.middlewares = {};
 
@@ -626,7 +627,7 @@ export const settingsRouter = createTRPCRouter({
 			if (IS_CLOUD) {
 				return true;
 			}
-			let config: FileConfig;
+			let config: FileConfig | null;
 			try {
 				config = input.serverId
 					? await loadRemoteMiddlewares(input.serverId)
@@ -635,8 +636,8 @@ export const settingsRouter = createTRPCRouter({
 				return true;
 			}
 
-			const entry = config.http?.middlewares?.[input.name];
-			if (!entry || !("basicAuth" in entry)) {
+			const entry = config?.http?.middlewares?.[input.name];
+			if (!config || !entry || !("basicAuth" in entry)) {
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: `Basic auth middleware "${input.name}" not found`,

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -21,6 +21,8 @@ import {
 	getUpdateData,
 	getWebServerSettings,
 	IS_CLOUD,
+	loadMiddlewares,
+	loadRemoteMiddlewares,
 	parseRawConfig,
 	paths,
 	prepareEnvironmentVariables,
@@ -45,9 +47,13 @@ import {
 	updateWebServerSettings,
 	writeConfig,
 	writeMainConfig,
+	writeMiddleware,
 	writeTraefikConfigInPath,
+	writeTraefikConfigRemote,
 	writeTraefikSetup,
 } from "@dokploy/server";
+import type { FileConfig } from "@dokploy/server";
+import * as bcrypt from "bcrypt";
 import { db } from "@dokploy/server/db";
 import { checkPermission } from "@dokploy/server/services/permission";
 import { generateOpenApiDocument } from "@dokploy/trpc-openapi";
@@ -509,6 +515,159 @@ export const settingsRouter = createTRPCRouter({
 				action: "update",
 				resourceType: "settings",
 				resourceName: "middleware-traefik-config",
+			});
+			return true;
+		}),
+
+	listBasicAuthMiddlewares: adminProcedure
+		.input(apiServerSchema)
+		.query(async ({ input }) => {
+			if (IS_CLOUD) {
+				return [];
+			}
+			let config: FileConfig;
+			try {
+				config = input?.serverId
+					? await loadRemoteMiddlewares(input.serverId)
+					: loadMiddlewares<FileConfig>();
+			} catch {
+				return [];
+			}
+			const middlewares = config?.http?.middlewares ?? {};
+			return Object.entries(middlewares)
+				.filter(([, value]) => !!value && "basicAuth" in value)
+				.map(([name, value]) => ({
+					name,
+					users: (
+						(value as { basicAuth: { users?: string[] } }).basicAuth.users ?? []
+					).map((entry) => entry.split(":")[0] ?? ""),
+				}));
+		}),
+
+	createBasicAuthMiddleware: adminProcedure
+		.input(
+			z.object({
+				name: z
+					.string()
+					.min(1, "Name is required")
+					.regex(
+						/^[a-zA-Z0-9_-]+$/,
+						"Only letters, numbers, dashes and underscores are allowed",
+					),
+				username: z.string().min(1, "Username is required"),
+				password: z.string().min(1, "Password is required"),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (IS_CLOUD) {
+				return true;
+			}
+			let config: FileConfig;
+			try {
+				config = input.serverId
+					? await loadRemoteMiddlewares(input.serverId)
+					: loadMiddlewares<FileConfig>();
+			} catch {
+				config = { http: { middlewares: {} } };
+			}
+			if (!config.http) config.http = { middlewares: {} };
+			if (!config.http.middlewares) config.http.middlewares = {};
+
+			const existing = config.http.middlewares[input.name];
+			if (existing && !("basicAuth" in existing)) {
+				throw new TRPCError({
+					code: "CONFLICT",
+					message: `A middleware named "${input.name}" already exists and is not a basic auth middleware`,
+				});
+			}
+
+			const user = `${input.username}:${await bcrypt.hash(input.password, 10)}`;
+
+			if (existing && "basicAuth" in existing) {
+				const basicAuth = (existing as { basicAuth: { users?: string[] } })
+					.basicAuth;
+				const otherUsers = (basicAuth.users ?? []).filter(
+					(entry) => entry.split(":")[0] !== input.username,
+				);
+				basicAuth.users = [...otherUsers, user];
+			} else {
+				config.http.middlewares[input.name] = {
+					basicAuth: {
+						removeHeader: true,
+						users: [user],
+					},
+				};
+			}
+
+			if (input.serverId) {
+				await writeTraefikConfigRemote(config, "middlewares", input.serverId);
+			} else {
+				writeMiddleware(config);
+			}
+
+			await audit(ctx, {
+				action: "create",
+				resourceType: "settings",
+				resourceName: "basic-auth-middleware",
+			});
+			return true;
+		}),
+
+	deleteBasicAuthMiddleware: adminProcedure
+		.input(
+			z.object({
+				name: z.string().min(1),
+				username: z.string().optional(),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (IS_CLOUD) {
+				return true;
+			}
+			let config: FileConfig;
+			try {
+				config = input.serverId
+					? await loadRemoteMiddlewares(input.serverId)
+					: loadMiddlewares<FileConfig>();
+			} catch {
+				return true;
+			}
+
+			const entry = config.http?.middlewares?.[input.name];
+			if (!entry || !("basicAuth" in entry)) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Basic auth middleware "${input.name}" not found`,
+				});
+			}
+
+			if (input.username) {
+				const basicAuth = (entry as { basicAuth: { users?: string[] } })
+					.basicAuth;
+				const remaining = (basicAuth.users ?? []).filter(
+					(u) => u.split(":")[0] !== input.username,
+				);
+				if (remaining.length === 0) {
+					delete config.http!.middlewares![input.name];
+				} else {
+					basicAuth.users = remaining;
+				}
+			} else {
+				delete config.http!.middlewares![input.name];
+			}
+
+			if (input.serverId) {
+				await writeTraefikConfigRemote(config, "middlewares", input.serverId);
+			} else {
+				writeMiddleware(config);
+			}
+
+			await audit(ctx, {
+				action: "delete",
+				resourceType: "settings",
+				resourceName: "basic-auth-middleware",
 			});
 			return true;
 		}),


### PR DESCRIPTION
Lets users create and delete Traefik basicAuth middlewares from the Traefik dashboard, so compose services can reference them as `<name>@file` via labels without hand-editing middlewares.yml.

## What is this PR about?

Adds a **Basic Auth Middlewares** card to the Traefik dashboard page (`/dashboard/traefik`) that lets users create and delete Traefik `basicAuth` middlewares directly in `middlewares.yml` from the UI.

Today, Applications can manage basic auth via Advanced → Security, but Compose apps (and anyone wanting a standalone basic auth middleware) have to SSH into the host and hand-edit YAML plus bcrypt hashes. This PR closes that gap with a generic, app-agnostic middleware manager.

The generated middleware is referenced manually as `<name>@file` — either in compose labels or in a domain's Middlewares field — followed by a user-initiated redeploy. Traefik picks up the YAML change live.

## Checklist

Before submitting this PR, please make sure that:

- [x] I created a dedicated branch based on the `canary` branch (`feat/traefik-basic-auth-middleware-ui`).
- [x] I have read the suggestions in the [CONTRIBUTING.md](https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request) file.
- [x] I have tested this PR in my local instance.

## Issues related (if applicable)

closes #4284 

## Screenshots (if applicable)

<img width="1401" height="843" alt="Screenshot 2026-04-23 at 08 50 26" src="https://github.com/user-attachments/assets/b5bb33ba-a1e3-40d3-8142-cef278bc334c" />

<img width="1010" height="834" alt="Screenshot 2026-04-23 at 08 52 57" src="https://github.com/user-attachments/assets/5885d477-282f-4361-ab41-4a26cb57829c" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Basic Auth Middlewares UI to the Traefik dashboard, letting users create and delete `basicAuth` entries in `middlewares.yml` without hand-editing YAML. The approach is consistent with how the rest of the codebase manages Traefik dynamic config.

- **P1 — null-config crash**: `loadMiddlewares()` returns `null` for an empty `middlewares.yml` (no exception is thrown, so the `catch` is bypassed). Both `createBasicAuthMiddleware` and `deleteBasicAuthMiddleware` then dereference that `null` value without guarding against it, causing an unhandled `TypeError` on the server.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the null-config crash in the two new mutations.

One P1 defect: both mutating endpoints crash with a TypeError if middlewares.yml exists but is empty, because loadMiddlewares() returns null without throwing. The rest of the implementation follows existing codebase patterns and introduces no security regressions.

apps/dokploy/server/api/routers/settings.ts — null guard after loadMiddlewares() in both createBasicAuthMiddleware and deleteBasicAuthMiddleware

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/39dad1a5596fdb1a8f508816aed2ee8f4f6c9a0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29267160)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->