### PR TITLE
feat: show modal when switching to incompatible providers

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/confirmable-provider-save.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/confirmable-provider-save.tsx
@@ -1,0 +1,93 @@
+import { type ReactNode, useState } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+	onConfirm: () => void;
+	needsConfirmation: boolean;
+	onValidate?: () => Promise<boolean> | boolean;
+	isLoading?: boolean;
+	disabled?: boolean;
+	children?: ReactNode;
+}
+
+export const ConfirmableProviderSave = ({
+	onConfirm,
+	needsConfirmation,
+	onValidate,
+	isLoading,
+	disabled,
+	children = "Save",
+}: Props) => {
+	const [open, setOpen] = useState(false);
+
+	if (!needsConfirmation) {
+		return (
+			<Button
+				type="submit"
+				className="w-fit"
+				isLoading={isLoading}
+				disabled={disabled}
+			>
+				{children}
+			</Button>
+		);
+	}
+
+	const handleClick = async () => {
+		if (onValidate) {
+			const valid = await onValidate();
+			if (!valid) return;
+		}
+		setOpen(true);
+	};
+
+	return (
+		<>
+			<Button
+				type="button"
+				className="w-fit"
+				isLoading={isLoading}
+				disabled={disabled}
+				onClick={handleClick}
+			>
+				{children}
+			</Button>
+			<AlertDialog open={open} onOpenChange={setOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							Switch provider and disable preview deployments?
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							Preview deployments only run on the GitHub provider. Switching
+							will disable preview deployments for this application; existing
+							previews will stop receiving updates.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							onClick={() => {
+								setOpen(false);
+								onConfirm();
+							}}
+						>
+							Confirm
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
+};

--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -71,9 +71,10 @@ interface Props {
 }
 
 export const SaveBitbucketProvider = ({ applicationId }: Props) => {
+	const utils = api.useUtils();
 	const { data: bitbucketProviders } =
 		api.bitbucket.bitbucketProviders.useQuery();
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const { data } = api.application.one.useQuery({ applicationId });
 
 	const { mutateAsync, isPending: isSavingBitbucketProvider } =
 		api.application.saveBitbucketProvider.useMutation();
@@ -159,7 +160,7 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Service Provider Saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the Bitbucket provider");

--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
+import { ConfirmableProviderSave } from "./confirmable-provider-save";
 
 const BitbucketProviderSchema = z.object({
 	buildPath: z.string().min(1, "Path is required").default("/"),
@@ -500,13 +501,17 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 						/>
 					</div>
 					<div className="flex w-full justify-end">
-						<Button
+						<ConfirmableProviderSave
+							needsConfirmation={
+								data?.sourceType === "github" &&
+								data?.isPreviewDeploymentsActive === true
+							}
 							isLoading={isSavingBitbucketProvider}
-							type="submit"
-							className="w-fit"
+							onValidate={() => form.trigger()}
+							onConfirm={form.handleSubmit(onSubmit)}
 						>
 							Save
-						</Button>
+						</ConfirmableProviderSave>
 					</div>
 				</form>
 			</Form>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -31,7 +31,8 @@ interface Props {
 }
 
 export const SaveDockerProvider = ({ applicationId }: Props) => {
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const utils = api.useUtils();
+	const { data } = api.application.one.useQuery({ applicationId });
 
 	const { mutateAsync } = api.application.saveDockerProvider.useMutation();
 	const form = useForm<DockerProvider>({
@@ -65,7 +66,7 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Docker Provider Saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the Docker provider");

--- a/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-docker-provider.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-import { Button } from "@/components/ui/button";
 import {
 	Form,
 	FormControl,
@@ -14,6 +13,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { api } from "@/utils/api";
+import { ConfirmableProviderSave } from "./confirmable-provider-save";
 
 const DockerProviderSchema = z.object({
 	dockerImage: z.string().min(1, {
@@ -149,13 +149,17 @@ export const SaveDockerProvider = ({ applicationId }: Props) => {
 				</div>
 
 				<div className="flex flex-row justify-end">
-					<Button
-						type="submit"
-						className="w-fit"
+					<ConfirmableProviderSave
+						needsConfirmation={
+							data?.sourceType === "github" &&
+							data?.isPreviewDeploymentsActive === true
+						}
 						isLoading={form.formState.isSubmitting}
+						onValidate={() => form.trigger()}
+						onConfirm={form.handleSubmit(onSubmit)}
 					>
-						Save{" "}
-					</Button>
+						Save
+					</ConfirmableProviderSave>
 				</div>
 			</form>
 		</Form>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-drag-n-drop.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-drag-n-drop.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { api } from "@/utils/api";
 import { type UploadFile, uploadFileSchema } from "@/utils/schema";
+import { ConfirmableProviderSave } from "./confirmable-provider-save";
 
 interface Props {
 	applicationId: string;
@@ -126,14 +127,18 @@ export const SaveDragNDrop = ({ applicationId }: Props) => {
 				</div>
 
 				<div className="flex flex-row justify-end">
-					<Button
-						type="submit"
-						className="w-fit"
+					<ConfirmableProviderSave
+						needsConfirmation={
+							data?.sourceType === "github" &&
+							data?.isPreviewDeploymentsActive === true
+						}
 						isLoading={isPending}
 						disabled={!zip || isPending}
+						onValidate={() => form.trigger()}
+						onConfirm={form.handleSubmit(onSubmit)}
 					>
-						Deploy{" "}
-					</Button>
+						Deploy
+					</ConfirmableProviderSave>
 				</div>
 			</form>
 		</Form>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-drag-n-drop.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-drag-n-drop.tsx
@@ -23,7 +23,8 @@ interface Props {
 }
 
 export const SaveDragNDrop = ({ applicationId }: Props) => {
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const utils = api.useUtils();
+	const { data } = api.application.one.useQuery({ applicationId });
 
 	const { mutateAsync, isPending } =
 		api.application.dropDeployment.useMutation();
@@ -54,7 +55,7 @@ export const SaveDragNDrop = ({ applicationId }: Props) => {
 		await mutateAsync(formData)
 			.then(async () => {
 				toast.success("Deployment saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the deployment");

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -35,6 +35,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { api } from "@/utils/api";
+import { ConfirmableProviderSave } from "./confirmable-provider-save";
 
 const GitProviderSchema = z.object({
 	buildPath: z.string().min(1, "Path is required").default("/"),
@@ -315,9 +316,17 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 				</div>
 
 				<div className="flex flex-row justify-end">
-					<Button type="submit" className="w-fit" isLoading={isPending}>
+					<ConfirmableProviderSave
+						needsConfirmation={
+							data?.sourceType === "github" &&
+							data?.isPreviewDeploymentsActive === true
+						}
+						isLoading={isPending}
+						onValidate={() => form.trigger()}
+						onConfirm={form.handleSubmit(onSubmit)}
+					>
 						Save
-					</Button>
+					</ConfirmableProviderSave>
 				</div>
 			</form>
 		</Form>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -55,7 +55,8 @@ interface Props {
 }
 
 export const SaveGitProvider = ({ applicationId }: Props) => {
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const utils = api.useUtils();
+	const { data } = api.application.one.useQuery({ applicationId });
 	const { data: sshKeys } = api.sshKey.allForApps.useQuery();
 	const router = useRouter();
 
@@ -99,7 +100,7 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Git Provider Saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the Git provider");

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
+import { ConfirmableProviderSave } from "./confirmable-provider-save";
 
 interface GiteaRepository {
 	name: string;
@@ -527,13 +528,17 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 						/>
 					</div>
 					<div className="flex w-full justify-end">
-						<Button
+						<ConfirmableProviderSave
+							needsConfirmation={
+								data?.sourceType === "github" &&
+								data?.isPreviewDeploymentsActive === true
+							}
 							isLoading={isSavingGiteaProvider}
-							type="submit"
-							className="w-fit"
+							onValidate={() => form.trigger()}
+							onConfirm={form.handleSubmit(onSubmit)}
 						>
 							Save
-						</Button>
+						</ConfirmableProviderSave>
 					</div>
 				</form>
 			</Form>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
@@ -86,8 +86,9 @@ interface Props {
 }
 
 export const SaveGiteaProvider = ({ applicationId }: Props) => {
+	const utils = api.useUtils();
 	const { data: giteaProviders } = api.gitea.giteaProviders.useQuery();
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const { data } = api.application.one.useQuery({ applicationId });
 
 	const { mutateAsync, isPending: isSavingGiteaProvider } =
 		api.application.saveGiteaProvider.useMutation();
@@ -174,7 +175,7 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Service Provider Saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the Gitea provider");

--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -69,8 +69,9 @@ interface Props {
 }
 
 export const SaveGithubProvider = ({ applicationId }: Props) => {
+	const utils = api.useUtils();
 	const { data: githubProviders } = api.github.githubProviders.useQuery();
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const { data } = api.application.one.useQuery({ applicationId });
 
 	const { mutateAsync, isPending: isSavingGithubProvider } =
 		api.application.saveGithubProvider.useMutation();
@@ -150,7 +151,7 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Service Provider Saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the github provider");

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
+import { ConfirmableProviderSave } from "./confirmable-provider-save";
 
 const GitlabProviderSchema = z.object({
 	buildPath: z.string().min(1, "Path is required").default("/"),
@@ -520,13 +521,17 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 						/>
 					</div>
 					<div className="flex w-full justify-end">
-						<Button
+						<ConfirmableProviderSave
+							needsConfirmation={
+								data?.sourceType === "github" &&
+								data?.isPreviewDeploymentsActive === true
+							}
 							isLoading={isSavingGitlabProvider}
-							type="submit"
-							className="w-fit"
+							onValidate={() => form.trigger()}
+							onConfirm={form.handleSubmit(onSubmit)}
 						>
 							Save
-						</Button>
+						</ConfirmableProviderSave>
 					</div>
 				</form>
 			</Form>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -72,8 +72,9 @@ interface Props {
 }
 
 export const SaveGitlabProvider = ({ applicationId }: Props) => {
+	const utils = api.useUtils();
 	const { data: gitlabProviders } = api.gitlab.gitlabProviders.useQuery();
-	const { data, refetch } = api.application.one.useQuery({ applicationId });
+	const { data } = api.application.one.useQuery({ applicationId });
 
 	const { mutateAsync, isPending: isSavingGitlabProvider } =
 		api.application.saveGitlabProvider.useMutation();
@@ -169,7 +170,7 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 		})
 			.then(async () => {
 				toast.success("Service Provider Saved");
-				await refetch();
+				await utils.application.one.invalidate({ applicationId });
 			})
 			.catch(() => {
 				toast.error("Error saving the gitlab provider");

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -245,11 +245,12 @@ const Service = (
 													Deployments
 												</TabsTrigger>
 											)}
-											{permissions?.deployment.read && (
-												<TabsTrigger value="preview-deployments">
-													Preview Deployments
-												</TabsTrigger>
-											)}
+											{permissions?.deployment.read &&
+												data?.sourceType === "github" && (
+													<TabsTrigger value="preview-deployments">
+														Preview Deployments
+													</TabsTrigger>
+												)}
 											{permissions?.schedule.read && (
 												<TabsTrigger value="schedules">Schedules</TabsTrigger>
 											)}
@@ -385,13 +386,19 @@ const Service = (
 											</div>
 										</TabsContent>
 									)}
-									{permissions?.deployment.read && (
-										<TabsContent value="preview-deployments" className="w-full">
-											<div className="flex flex-col gap-4 pt-2.5">
-												<ShowPreviewDeployments applicationId={applicationId} />
-											</div>
-										</TabsContent>
-									)}
+									{permissions?.deployment.read &&
+										data?.sourceType === "github" && (
+											<TabsContent
+												value="preview-deployments"
+												className="w-full"
+											>
+												<div className="flex flex-col gap-4 pt-2.5">
+													<ShowPreviewDeployments
+														applicationId={applicationId}
+													/>
+												</div>
+											</TabsContent>
+										)}
 									{permissions?.domain.read && (
 										<TabsContent value="domains" className="w-full">
 											<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -457,6 +457,7 @@ export const applicationRouter = createTRPCRouter({
 				gitlabPathNamespace: input.gitlabPathNamespace,
 				watchPaths: input.watchPaths,
 				enableSubmodules: input.enableSubmodules,
+				isPreviewDeploymentsActive: false,
 			});
 			const application = await findApplicationById(input.applicationId);
 			await audit(ctx, {
@@ -484,6 +485,7 @@ export const applicationRouter = createTRPCRouter({
 				bitbucketId: input.bitbucketId,
 				watchPaths: input.watchPaths,
 				enableSubmodules: input.enableSubmodules,
+				isPreviewDeploymentsActive: false,
 			});
 			const application = await findApplicationById(input.applicationId);
 			await audit(ctx, {
@@ -510,6 +512,7 @@ export const applicationRouter = createTRPCRouter({
 				giteaId: input.giteaId,
 				watchPaths: input.watchPaths,
 				enableSubmodules: input.enableSubmodules,
+				isPreviewDeploymentsActive: false,
 			});
 			const application = await findApplicationById(input.applicationId);
 			await audit(ctx, {
@@ -533,6 +536,7 @@ export const applicationRouter = createTRPCRouter({
 				sourceType: "docker",
 				applicationStatus: "idle",
 				registryUrl: input.registryUrl,
+				isPreviewDeploymentsActive: false,
 			});
 			const application = await findApplicationById(input.applicationId);
 			await audit(ctx, {
@@ -558,6 +562,7 @@ export const applicationRouter = createTRPCRouter({
 				applicationStatus: "idle",
 				watchPaths: input.watchPaths,
 				enableSubmodules: input.enableSubmodules,
+				isPreviewDeploymentsActive: false,
 			});
 			const application = await findApplicationById(input.applicationId);
 			await audit(ctx, {
@@ -813,6 +818,7 @@ export const applicationRouter = createTRPCRouter({
 			await updateApplication(applicationId, {
 				sourceType: "drop",
 				dropBuildPath: dropBuildPath || "",
+				isPreviewDeploymentsActive: false,
 			});
 
 			await unzipDrop(zipFile, app);

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -92,7 +92,7 @@ const { handler, api } = betterAuth({
 				process.env.NODE_ENV === "development"
 					? [
 							"http://localhost:3000",
-							"https://absolutely-handy-falcon.ngrok-free.app",
+							"https://select-stuffed-andrea-timeline.trycloudflare.com",
 						]
 					: [];
 			return [

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -92,7 +92,7 @@ const { handler, api } = betterAuth({
 				process.env.NODE_ENV === "development"
 					? [
 							"http://localhost:3000",
-							"https://select-stuffed-andrea-timeline.trycloudflare.com",
+							"https://absolutely-handy-falcon.ngrok-free.app",
 						]
 					: [];
 			return [


### PR DESCRIPTION
## What is this PR about?
This commit shows a modal after validating the form data with Zod to confirm that the user intends to switch providers after being told that the preview deployments feature will disabled, as it's only compatible with one of the available application source types.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

None, new feature

## Screenshots (if applicable)

Runs Zod validation checks BEFORE showing the modal to prevent confusion
<img width="1125" height="451" alt="image" src="https://github.com/user-attachments/assets/70121073-98d6-42a9-b16d-242b550f7e5f" />

Shows a modal if the change is valid to make sure the user wants to disable the preview deployments feature (only triggers if `sourceType = 'github'` and `previewDeployments` are enabled as a feature on the application)
<img width="2212" height="822" alt="image" src="https://github.com/user-attachments/assets/1ac98ec2-a7c5-4cf6-a043-239396865fe1" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a confirmation modal when a user saves a non-GitHub provider (Bitbucket, GitLab, Gitea, Docker, plain Git, drag-and-drop) while the application currently has GitHub + preview deployments active. It also hides the "Preview Deployments" tab for non-GitHub source types, and consistently sets `isPreviewDeploymentsActive: false` on the server for every non-GitHub save mutation. The `refetch` → `utils.application.one.invalidate` change is a minor cache-management improvement bundled in.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct, server-side enforcement is consistent, and no critical issues remain.

The confirmation guard fires when and only when it should (sourceType === 'github' + isPreviewDeploymentsActive). Server mutations independently set isPreviewDeploymentsActive: false for every non-GitHub provider, so correctness doesn't depend solely on the UI path. The double-validation in the confirmation path is harmless. Previous P1 concerns have been addressed or acknowledged. All remaining observations are P2 or lower.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["fix: use application document invalidate..."](https://github.com/dokploy/dokploy/commit/d9039c822c5648f90a45119a8b08488d6dc72abf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29328974)</sub>

<!-- /greptile_comment -->