### PR TITLE
feat(preview-deployments): variable templates and settings overhaul

### DIFF
--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-deployments.tsx
@@ -81,9 +81,7 @@ export const ShowPreviewDeployments = ({ applicationId }: Props) => {
 					<CardTitle className="text-xl">Preview Deployments</CardTitle>
 					<CardDescription>See all the preview deployments</CardDescription>
 				</div>
-				{data?.isPreviewDeploymentsActive && (
-					<ShowPreviewSettings applicationId={applicationId} />
-				)}
+				<ShowPreviewSettings applicationId={applicationId} />
 			</CardHeader>
 			<CardContent className="flex flex-col gap-4">
 				{data?.isPreviewDeploymentsActive ? (
@@ -303,7 +301,6 @@ export const ShowPreviewDeployments = ({ applicationId }: Props) => {
 							Preview deployments are disabled for this application, please
 							enable it
 						</span>
-						<ShowPreviewSettings applicationId={applicationId} />
 					</div>
 				)}
 			</CardContent>

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -54,6 +54,14 @@ import { api } from "@/utils/api";
 
 const PREVIEW_VARIABLES = ["appname", "branch", "pr", "hash"] as const;
 
+const findUnknownTokens = (value: string) => {
+	const matches = value.match(/\{(\w+)\}/g) ?? [];
+	return matches.filter((m) => {
+		const key = m.slice(1, -1).toLowerCase();
+		return !(PREVIEW_VARIABLES as readonly string[]).includes(key);
+	});
+};
+
 const schema = z
 	.object({
 		env: z.string(),
@@ -78,6 +86,22 @@ const schema = z
 				code: z.ZodIssueCode.custom,
 				path: ["previewCustomCertResolver"],
 				message: "Required",
+			});
+		}
+		const unknownDomainTokens = findUnknownTokens(input.wildcardDomain);
+		if (unknownDomainTokens.length) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["wildcardDomain"],
+				message: `Unknown variable${unknownDomainTokens.length > 1 ? "s" : ""} ${unknownDomainTokens.join(", ")}. Supported: {appname}, {branch}, {pr}, {hash}.`,
+			});
+		}
+		const unknownPathTokens = findUnknownTokens(input.previewPath);
+		if (unknownPathTokens.length) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["previewPath"],
+				message: `Unknown variable${unknownPathTokens.length > 1 ? "s" : ""} ${unknownPathTokens.join(", ")}. Supported: {appname}, {branch}, {pr}, {hash}.`,
 			});
 		}
 	});
@@ -139,52 +163,62 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 	const watchedPreviewPath = form.watch("previewPath");
 	const isTraefikMeDomain = wildcardDomain?.includes("traefik.me") || false;
 	const isTemplateMode = isPreviewTemplateMode(wildcardDomain || "");
-	const previewDomainExample = (() => {
-		if (!wildcardDomain) return "";
+	const previewExample = (() => {
+		if (!wildcardDomain) return { url: "", error: "" };
 		const sampleAppName = `preview-${data?.appName ?? "app"}-a1b2c3`;
 		const slugIp = (data?.server?.ipAddress || "127.0.0.1").replaceAll(
 			".",
 			"-",
 		);
+		let host: string;
 		try {
 			if (isTemplateMode) {
-				const host = resolvePreviewDomainTemplate(wildcardDomain, {
-					appName: sampleAppName,
-					branch: "feat/new-login",
-					pr: "42",
-					hash: "a1b2c3",
-				});
-				return injectDynamicDnsIp(host, slugIp);
+				host = injectDynamicDnsIp(
+					resolvePreviewDomainTemplate(wildcardDomain, {
+						appName: sampleAppName,
+						branch: "feat/new-login",
+						pr: "42",
+						hash: "a1b2c3",
+					}),
+					slugIp,
+				);
+			} else if (wildcardDomain.includes("*")) {
+				host = resolveWildcardDomain(wildcardDomain, sampleAppName, slugIp);
+			} else {
+				host = injectDynamicDnsIp(wildcardDomain, slugIp);
 			}
-			if (wildcardDomain.includes("*")) {
-				return resolveWildcardDomain(wildcardDomain, sampleAppName, slugIp);
-			}
-			return injectDynamicDnsIp(wildcardDomain, slugIp);
-		} catch {
-			return "";
+		} catch (err) {
+			return {
+				url: "",
+				error: err instanceof Error ? err.message : "Invalid domain template",
+			};
 		}
-	})();
-	const previewUrlExample = (() => {
-		if (!previewDomainExample) return "";
+
 		const scheme = previewHttps && !isTraefikMeDomain ? "https://" : "http://";
 		let resolvedPath: string;
 		try {
 			resolvedPath = resolvePreviewPathTemplate(
 				watchedPreviewPath?.trim() || "/",
 				{
-					appName: `preview-${data?.appName ?? "app"}-a1b2c3`,
+					appName: sampleAppName,
 					branch: "feat/new-login",
 					pr: "42",
 					hash: "a1b2c3",
 				},
 			);
-		} catch {
-			return "";
+		} catch (err) {
+			return {
+				url: "",
+				error: err instanceof Error ? err.message : "Invalid path template",
+			};
 		}
 		const path = resolvedPath.startsWith("/")
 			? resolvedPath
 			: `/${resolvedPath}`;
-		return `${scheme}${previewDomainExample}${path === "/" ? "" : path}`;
+		return {
+			url: `${scheme}${host}${path === "/" ? "" : path}`,
+			error: "",
+		};
 	})();
 
 	useEffect(() => {
@@ -243,7 +277,8 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 			previewRequireCollaboratorPermissions:
 				formData.previewRequireCollaboratorPermissions,
 		})
-			.then(() => {
+			.then(async () => {
+				await refetch();
 				toast.success("Preview Deployments settings updated");
 				setIsOpen(false);
 			})
@@ -422,20 +457,29 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 											</FormItem>
 										)}
 									/>
-									{previewUrlExample && (
+									{previewExample.error ? (
+										<div className="md:col-span-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2">
+											<div className="text-xs font-medium uppercase tracking-wide text-destructive">
+												Invalid template
+											</div>
+											<div className="mt-1 text-sm text-destructive break-words">
+												{previewExample.error}
+											</div>
+										</div>
+									) : previewExample.url ? (
 										<div className="md:col-span-2 rounded-md border bg-muted/40 px-3 py-2">
 											<div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
 												Example preview URL
 											</div>
 											<div className="mt-1 font-mono text-sm break-all text-foreground">
-												{previewUrlExample}
+												{previewExample.url}
 											</div>
 											<div className="mt-1 text-xs text-muted-foreground">
 												Using sample values <code>branch=feat/new-login</code>,{" "}
 												<code>pr=42</code>, <code>hash=a1b2c3</code>.
 											</div>
 										</div>
-									)}
+									) : null}
 									<FormField
 										control={form.control}
 										name="port"

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -88,6 +88,17 @@ const schema = z
 				message: "Required",
 			});
 		}
+		if (
+			input.wildcardDomain.includes("*") &&
+			input.wildcardDomain.includes("{")
+		) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["wildcardDomain"],
+				message:
+					'Use either a wildcard "*" or {variables}, not both. Mixed templates leave unresolved tokens in the generated URL.',
+			});
+		}
 		const unknownDomainTokens = findUnknownTokens(input.wildcardDomain);
 		if (unknownDomainTokens.length) {
 			ctx.addIssue({

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -3,6 +3,7 @@ import {
 	isPreviewTemplateMode,
 	resolvePreviewDomainTemplate,
 	resolvePreviewPathTemplate,
+	resolveWildcardDomain,
 } from "@dokploy/server/utils/traefik/preview-domain";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { HelpCircle, Plus, Settings2, X } from "lucide-react";
@@ -145,33 +146,41 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 			".",
 			"-",
 		);
-		let host: string;
-		if (isTemplateMode) {
-			host = resolvePreviewDomainTemplate(wildcardDomain, {
-				appName: sampleAppName,
-				branch: "feat/new-login",
-				pr: "42",
-				hash: "a1b2c3",
-			});
-		} else if (wildcardDomain.includes("*")) {
-			host = wildcardDomain.replace("*", sampleAppName);
-		} else {
-			host = wildcardDomain;
+		try {
+			if (isTemplateMode) {
+				const host = resolvePreviewDomainTemplate(wildcardDomain, {
+					appName: sampleAppName,
+					branch: "feat/new-login",
+					pr: "42",
+					hash: "a1b2c3",
+				});
+				return injectDynamicDnsIp(host, slugIp);
+			}
+			if (wildcardDomain.includes("*")) {
+				return resolveWildcardDomain(wildcardDomain, sampleAppName, slugIp);
+			}
+			return injectDynamicDnsIp(wildcardDomain, slugIp);
+		} catch {
+			return "";
 		}
-		return injectDynamicDnsIp(host, slugIp);
 	})();
 	const previewUrlExample = (() => {
 		if (!previewDomainExample) return "";
 		const scheme = previewHttps && !isTraefikMeDomain ? "https://" : "http://";
-		const resolvedPath = resolvePreviewPathTemplate(
-			watchedPreviewPath?.trim() || "/",
-			{
-				appName: `preview-${data?.appName ?? "app"}-a1b2c3`,
-				branch: "feat/new-login",
-				pr: "42",
-				hash: "a1b2c3",
-			},
-		);
+		let resolvedPath: string;
+		try {
+			resolvedPath = resolvePreviewPathTemplate(
+				watchedPreviewPath?.trim() || "/",
+				{
+					appName: `preview-${data?.appName ?? "app"}-a1b2c3`,
+					branch: "feat/new-login",
+					pr: "42",
+					hash: "a1b2c3",
+				},
+			);
+		} catch {
+			return "";
+		}
 		const path = resolvedPath.startsWith("/")
 			? resolvedPath
 			: `/${resolvedPath}`;

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -1,6 +1,13 @@
+import {
+	injectDynamicDnsIp,
+	isPreviewTemplateMode,
+	resolvePreviewDomainTemplate,
+	resolvePreviewPathTemplate,
+} from "@dokploy/server/utils/traefik/preview-domain";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { HelpCircle, Plus, Settings2, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -41,7 +48,10 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
+
+const PREVIEW_VARIABLES = ["appname", "branch", "pr", "hash"] as const;
 
 const schema = z
 	.object({
@@ -100,16 +110,94 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 		resolver: zodResolver(schema),
 	});
 
+	const wildcardDomainInputRef = useRef<HTMLInputElement | null>(null);
+	const previewPathInputRef = useRef<HTMLInputElement | null>(null);
+	const insertVariable = (
+		fieldName: "wildcardDomain" | "previewPath",
+		input: HTMLInputElement | null,
+		name: string,
+	) => {
+		const current = form.getValues(fieldName) ?? "";
+		const token = `{${name}}`;
+		const start = input?.selectionStart ?? current.length;
+		const end = input?.selectionEnd ?? current.length;
+		const next = current.slice(0, start) + token + current.slice(end);
+		form.setValue(fieldName, next, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+		const cursor = start + token.length;
+		queueMicrotask(() => {
+			input?.focus();
+			input?.setSelectionRange(cursor, cursor);
+		});
+	};
+
 	const previewHttps = form.watch("previewHttps");
 	const wildcardDomain = form.watch("wildcardDomain");
+	const watchedPreviewPath = form.watch("previewPath");
 	const isTraefikMeDomain = wildcardDomain?.includes("traefik.me") || false;
+	const isTemplateMode = isPreviewTemplateMode(wildcardDomain || "");
+	const previewDomainExample = (() => {
+		if (!wildcardDomain) return "";
+		const sampleAppName = `preview-${data?.appName ?? "app"}-a1b2c3`;
+		const slugIp = (data?.server?.ipAddress || "127.0.0.1").replaceAll(
+			".",
+			"-",
+		);
+		let host: string;
+		if (isTemplateMode) {
+			host = resolvePreviewDomainTemplate(wildcardDomain, {
+				appName: sampleAppName,
+				branch: "feat/new-login",
+				pr: "42",
+				hash: "a1b2c3",
+			});
+		} else if (wildcardDomain.includes("*")) {
+			host = wildcardDomain.replace("*", sampleAppName);
+		} else {
+			host = wildcardDomain;
+		}
+		return injectDynamicDnsIp(host, slugIp);
+	})();
+	const previewUrlExample = (() => {
+		if (!previewDomainExample) return "";
+		const scheme = previewHttps && !isTraefikMeDomain ? "https://" : "http://";
+		const resolvedPath = resolvePreviewPathTemplate(
+			watchedPreviewPath?.trim() || "/",
+			{
+				appName: `preview-${data?.appName ?? "app"}-a1b2c3`,
+				branch: "feat/new-login",
+				pr: "42",
+				hash: "a1b2c3",
+			},
+		);
+		const path = resolvedPath.startsWith("/")
+			? resolvedPath
+			: `/${resolvedPath}`;
+		return `${scheme}${previewDomainExample}${path === "/" ? "" : path}`;
+	})();
 
 	useEffect(() => {
 		setIsEnabled(data?.isPreviewDeploymentsActive || false);
 	}, [data?.isPreviewDeploymentsActive]);
 
 	useEffect(() => {
-		if (data) {
+		if (isTraefikMeDomain && form.getValues("previewHttps")) {
+			form.setValue("previewHttps", false, { shouldDirty: true });
+		}
+	}, [isTraefikMeDomain, form]);
+
+	// Only seed the form from server state once per modal open — otherwise
+	// toggling `Enable preview deployments` (which refetches `data`) would wipe
+	// any in-progress edits.
+	const hasSeededForm = useRef(false);
+	useEffect(() => {
+		if (!isOpen) {
+			hasSeededForm.current = false;
+			return;
+		}
+		if (data && !hasSeededForm.current) {
 			form.reset({
 				env: data.previewEnv || "",
 				buildArgs: data.previewBuildArgs || "",
@@ -125,8 +213,9 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 				previewRequireCollaboratorPermissions:
 					data.previewRequireCollaboratorPermissions ?? true,
 			});
+			hasSeededForm.current = true;
 		}
-	}, [data]);
+	}, [isOpen, data, form]);
 
 	const onSubmit = async (formData: Schema) => {
 		updateApplication({
@@ -147,6 +236,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 		})
 			.then(() => {
 				toast.success("Preview Deployments settings updated");
+				setIsOpen(false);
 			})
 			.catch((error) => {
 				toast.error(error.message);
@@ -170,30 +260,108 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 							rules.
 						</DialogDescription>
 					</DialogHeader>
-					<div className="grid gap-4">
-						{isTraefikMeDomain && (
+					<div className="grid gap-6 max-h-[75vh] overflow-y-auto pr-1">
+						<div className="flex flex-row items-center justify-between rounded-lg border p-4">
+							<div className="space-y-0.5">
+								<div className="text-base font-medium leading-none">
+									Enable preview deployments
+								</div>
+								<p className="text-sm text-muted-foreground">
+									Enable or disable preview deployments for this application.
+								</p>
+							</div>
+							<Switch
+								checked={isEnabled}
+								onCheckedChange={(checked) => {
+									updateApplication({
+										isPreviewDeploymentsActive: checked,
+										applicationId,
+									})
+										.then(() => {
+											refetch();
+											toast.success(
+												checked
+													? "Preview deployments enabled"
+													: "Preview deployments disabled",
+											);
+										})
+										.catch((error) => {
+											toast.error(error.message);
+										});
+								}}
+							/>
+						</div>
+						{!isEnabled && (
 							<AlertBlock type="info">
-								<strong>Note:</strong> traefik.me is a public HTTP service and
-								does not support SSL/HTTPS. HTTPS and certificate options will
-								not have any effect.
+								Preview deployments are disabled. Enable them above to configure
+								settings, then press Save.
 							</AlertBlock>
 						)}
 						<Form {...form}>
 							<form
 								onSubmit={form.handleSubmit(onSubmit)}
 								id="hook-form-delete-application"
-								className="grid w-full gap-4"
+								className={cn(
+									"grid w-full gap-4 transition-opacity",
+									!isEnabled && "opacity-50 pointer-events-none select-none",
+								)}
+								aria-disabled={!isEnabled}
 							>
 								<div className="grid gap-4 lg:grid-cols-2">
+									<div className="md:col-span-2 space-y-1">
+										<h3 className="text-sm font-semibold">Routing</h3>
+										<p className="text-xs text-muted-foreground">
+											Configure the hostname, path, and port for each generated
+											preview.
+										</p>
+									</div>
 									<FormField
 										control={form.control}
 										name="wildcardDomain"
 										render={({ field }) => (
 											<FormItem>
-												<FormLabel>Wildcard Domain</FormLabel>
+												<FormLabel>Domain Template</FormLabel>
 												<FormControl>
-													<Input placeholder="*.traefik.me" {...field} />
+													<Input
+														placeholder="*.traefik.me"
+														{...field}
+														ref={(el) => {
+															field.ref(el);
+															wildcardDomainInputRef.current = el;
+														}}
+													/>
 												</FormControl>
+												<FormDescription className="space-y-2">
+													<span className="block">
+														Use <code>*</code> for the legacy wildcard, or{" "}
+														<code>{"{variables}"}</code> for a custom pattern.
+													</span>
+													<span className="flex flex-wrap items-center gap-1.5">
+														<span className="text-xs text-muted-foreground">
+															Insert:
+														</span>
+														{PREVIEW_VARIABLES.map((name) => (
+															<Badge
+																key={name}
+																variant="secondary"
+																className="cursor-pointer font-mono text-xs hover:bg-secondary/80"
+																onClick={() =>
+																	insertVariable(
+																		"wildcardDomain",
+																		wildcardDomainInputRef.current,
+																		name,
+																	)
+																}
+															>
+																{`{${name}}`}
+															</Badge>
+														))}
+													</span>
+													<span className="block text-xs">
+														Dynamic DNS auto-detected for traefik.me, nip.io,
+														sslip.io, backname.io.
+													</span>
+												</FormDescription>
 												<FormMessage />
 											</FormItem>
 										)}
@@ -203,14 +371,62 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 										name="previewPath"
 										render={({ field }) => (
 											<FormItem>
-												<FormLabel>Preview Path</FormLabel>
+												<FormLabel>Path</FormLabel>
 												<FormControl>
-													<Input placeholder="/" {...field} />
+													<Input
+														placeholder="/"
+														{...field}
+														ref={(el) => {
+															field.ref(el);
+															previewPathInputRef.current = el;
+														}}
+													/>
 												</FormControl>
+												<FormDescription className="space-y-2">
+													<span className="block">
+														Supports the same <code>{"{variables}"}</code> —
+														e.g. <code>/pr-{"{pr}"}/</code>.
+													</span>
+													<span className="flex flex-wrap items-center gap-1.5">
+														<span className="text-xs text-muted-foreground">
+															Insert:
+														</span>
+														{PREVIEW_VARIABLES.map((name) => (
+															<Badge
+																key={name}
+																variant="secondary"
+																className="cursor-pointer font-mono text-xs hover:bg-secondary/80"
+																onClick={() =>
+																	insertVariable(
+																		"previewPath",
+																		previewPathInputRef.current,
+																		name,
+																	)
+																}
+															>
+																{`{${name}}`}
+															</Badge>
+														))}
+													</span>
+												</FormDescription>
 												<FormMessage />
 											</FormItem>
 										)}
 									/>
+									{previewUrlExample && (
+										<div className="md:col-span-2 rounded-md border bg-muted/40 px-3 py-2">
+											<div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+												Example preview URL
+											</div>
+											<div className="mt-1 font-mono text-sm break-all text-foreground">
+												{previewUrlExample}
+											</div>
+											<div className="mt-1 text-xs text-muted-foreground">
+												Using sample values <code>branch=feat/new-login</code>,{" "}
+												<code>pr=42</code>, <code>hash=a1b2c3</code>.
+											</div>
+										</div>
+									)}
 									<FormField
 										control={form.control}
 										name="port"
@@ -221,6 +437,57 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 													<NumberInput placeholder="3000" {...field} />
 												</FormControl>
 												<FormMessage />
+												<FormDescription>
+													The container port that your application listens on.
+												</FormDescription>
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={form.control}
+										name="previewLimit"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Preview Limit</FormLabel>
+												<FormControl>
+													<NumberInput placeholder="3" {...field} />
+												</FormControl>
+												<FormDescription>
+													Max concurrent preview deployments for this
+													application.
+												</FormDescription>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<div className="md:col-span-2 space-y-1 mt-2">
+										<h3 className="text-sm font-semibold">Triggers & Access</h3>
+										<p className="text-xs text-muted-foreground">
+											Control which pull requests spawn a preview and who can
+											trigger one.
+										</p>
+									</div>
+									<FormField
+										control={form.control}
+										name="previewRequireCollaboratorPermissions"
+										render={({ field }) => (
+											<FormItem className="md:col-span-2 flex flex-row items-center justify-between p-3 border rounded-lg shadow-sm">
+												<div className="space-y-0.5">
+													<FormLabel>
+														Require Collaborator Permissions
+													</FormLabel>
+													<FormDescription>
+														Only collaborators with the Admin, Maintain, or
+														Write role in your GitHub Repository can trigger
+														preview deployments.
+													</FormDescription>
+												</div>
+												<FormControl>
+													<Switch
+														checked={field.value}
+														onCheckedChange={field.onChange}
+													/>
+												</FormControl>
 											</FormItem>
 										)}
 									/>
@@ -308,35 +575,43 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 											</FormItem>
 										)}
 									/>
-									<FormField
-										control={form.control}
-										name="previewLimit"
-										render={({ field }) => (
-											<FormItem>
-												<FormLabel>Preview Limit</FormLabel>
-												<FormControl>
-													<NumberInput placeholder="3000" {...field} />
-												</FormControl>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
+									<div className="md:col-span-2 space-y-1 mt-2">
+										<h3 className="text-sm font-semibold">
+											HTTPS &amp; Certificates
+										</h3>
+										<p className="text-xs text-muted-foreground">
+											Choose how SSL is provisioned for preview domains.
+										</p>
+									</div>
+									{isTraefikMeDomain && (
+										<div className="md:col-span-2">
+											<AlertBlock type="info">
+												<strong>Note:</strong> traefik.me is a public HTTP
+												service and does not support SSL/HTTPS. HTTPS and
+												certificate options are disabled while this domain is in
+												use. To use HTTPS, change your wildcard domain to a
+												supported dynamic DNS provider (e.g.{" "}
+												<code>*.sslip.io</code>) or a custom domain.
+											</AlertBlock>
+										</div>
+									)}
 									<FormField
 										control={form.control}
 										name="previewHttps"
 										render={({ field }) => (
-											<FormItem className="flex flex-row items-center justify-between p-3 mt-4 border rounded-lg shadow-sm">
+											<FormItem className="md:col-span-2 flex flex-row items-center justify-between p-3 border rounded-lg shadow-sm">
 												<div className="space-y-0.5">
 													<FormLabel>HTTPS</FormLabel>
 													<FormDescription>
-														Automatically provision SSL Certificate.
+														Automatically provision an SSL certificate.
 													</FormDescription>
 													<FormMessage />
 												</div>
 												<FormControl>
 													<Switch
-														checked={field.value}
+														checked={field.value && !isTraefikMeDomain}
 														onCheckedChange={field.onChange}
+														disabled={isTraefikMeDomain}
 													/>
 												</FormControl>
 											</FormItem>
@@ -347,7 +622,13 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 											control={form.control}
 											name="previewCertificateType"
 											render={({ field }) => (
-												<FormItem>
+												<FormItem
+													className={
+														form.watch("previewCertificateType") === "custom"
+															? ""
+															: "md:col-span-2"
+													}
+												>
 													<FormLabel>Certificate Provider</FormLabel>
 													<Select
 														onValueChange={field.onChange}
@@ -358,7 +639,6 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 																<SelectValue placeholder="Select a certificate provider" />
 															</SelectTrigger>
 														</FormControl>
-
 														<SelectContent>
 															<SelectItem value="none">None</SelectItem>
 															<SelectItem value={"letsencrypt"}>
@@ -367,94 +647,46 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 															<SelectItem value={"custom"}>Custom</SelectItem>
 														</SelectContent>
 													</Select>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									)}
-
-									{form.watch("previewCertificateType") === "custom" && (
-										<FormField
-											control={form.control}
-											name="previewCustomCertResolver"
-											render={({ field }) => (
-												<FormItem>
-													<FormLabel>Certificate Provider</FormLabel>
-													<FormControl>
-														<Input
-															placeholder="my-custom-resolver"
-															{...field}
-														/>
-													</FormControl>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									)}
-								</div>
-								<div className="grid gap-4 lg:grid-cols-2">
-									<div className="flex flex-row items-center justify-between rounded-lg border p-4 col-span-2">
-										<div className="space-y-0.5">
-											<FormLabel className="text-base">
-												Enable preview deployments
-											</FormLabel>
-											<FormDescription>
-												Enable or disable preview deployments for this
-												application.
-											</FormDescription>
-										</div>
-										<Switch
-											checked={isEnabled}
-											onCheckedChange={(checked) => {
-												updateApplication({
-													isPreviewDeploymentsActive: checked,
-													applicationId,
-												})
-													.then(() => {
-														refetch();
-														toast.success(
-															checked
-																? "Preview deployments enabled"
-																: "Preview deployments disabled",
-														);
-													})
-													.catch((error) => {
-														toast.error(error.message);
-													});
-											}}
-										/>
-									</div>
-								</div>
-
-								<div className="grid gap-4 lg:grid-cols-2">
-									<FormField
-										control={form.control}
-										name="previewRequireCollaboratorPermissions"
-										render={({ field }) => (
-											<FormItem className="flex flex-row items-center justify-between p-3 mt-4 border rounded-lg shadow-sm col-span-2">
-												<div className="space-y-0.5">
-													<FormLabel>
-														Require Collaborator Permissions
-													</FormLabel>
 													<FormDescription>
-														Require collaborator permissions to preview
-														deployments, valid roles are:
-														<ul>
-															<li>Admin</li>
-															<li>Maintain</li>
-															<li>Write</li>
-														</ul>
+														Manage providers under{" "}
+														<Link
+															href="/dashboard/settings/certificates"
+															target="_blank"
+															className="text-primary underline-offset-2 hover:underline"
+														>
+															Settings → Certificates
+														</Link>
+														.
 													</FormDescription>
-												</div>
-												<FormControl>
-													<Switch
-														checked={field.value}
-														onCheckedChange={field.onChange}
-													/>
-												</FormControl>
-											</FormItem>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									)}
+
+									{previewHttps &&
+										form.watch("previewCertificateType") === "custom" && (
+											<FormField
+												control={form.control}
+												name="previewCustomCertResolver"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Custom Certificate Resolver</FormLabel>
+														<FormControl>
+															<Input
+																placeholder="my-custom-resolver"
+																{...field}
+															/>
+														</FormControl>
+														<FormDescription>
+															Name of a Traefik resolver defined in your Dokploy
+															configuration.
+														</FormDescription>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
 										)}
-									/>
 								</div>
 
 								<FormField
@@ -538,6 +770,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 							isLoading={isPending}
 							form="hook-form-delete-application"
 							type="submit"
+							disabled={!isEnabled}
 						>
 							Save
 						</Button>

--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -14,6 +14,14 @@ import { removeDirectoryCode } from "../utils/filesystem/directory";
 import { authGithub } from "../utils/providers/github";
 import { removeTraefikConfig } from "../utils/traefik/application";
 import { manageDomain } from "../utils/traefik/domain";
+import {
+	injectDynamicDnsIp,
+	isDynamicDnsHost,
+	isPreviewTemplateMode,
+	type PreviewDomainContext,
+	resolvePreviewDomainTemplate,
+	resolvePreviewPathTemplate,
+} from "../utils/traefik/preview-domain";
 import { findApplicationById } from "./application";
 import { removeDeploymentsByPreviewDeploymentId } from "./deployment";
 import { createDomain } from "./domain";
@@ -130,16 +138,27 @@ export const createPreviewDeployment = async (
 	schema: z.infer<typeof apiCreatePreviewDeployment>,
 ) => {
 	const application = await findApplicationById(schema.applicationId);
-	const appName = `preview-${application.appName}-${generatePassword(6)}`;
+	const hash = generatePassword(6);
+	const appName = `preview-${application.appName}-${hash}`;
 
 	const org = await db.query.organization.findFirst({
 		where: eq(organization.id, application.environment.project.organizationId),
 	});
+	const domainContext: PreviewDomainContext = {
+		appName,
+		branch: schema.branch,
+		pr: schema.pullRequestNumber,
+		hash,
+	};
 	const generateDomain = await generateWildcardDomain(
 		application.previewWildcard || "*.traefik.me",
-		appName,
+		domainContext,
 		application.server?.ipAddress || "",
 		org?.ownerId || "",
+	);
+	const resolvedPath = resolvePreviewPathTemplate(
+		application.previewPath || "/",
+		domainContext,
 	);
 
 	const octokit = authGithub(application?.github as Github);
@@ -176,7 +195,7 @@ export const createPreviewDeployment = async (
 
 	const newDomain = await createDomain({
 		host: generateDomain,
-		path: application.previewPath,
+		path: resolvedPath,
 		port: application.previewPort,
 		https: application.previewHttps,
 		certificateType: application.previewCertificateType,
@@ -228,38 +247,42 @@ export const findPreviewDeploymentByApplicationId = async (
 	return previewDeploymentResult;
 };
 
+const resolveDynamicDnsIpSlug = async (serverIp: string): Promise<string> => {
+	let ip = "";
+	if (process.env.NODE_ENV === "development") {
+		ip = "127.0.0.1";
+	}
+	if (serverIp) {
+		ip = serverIp;
+	}
+	if (!ip) {
+		const settings = await getWebServerSettings();
+		ip = settings?.serverIp || "";
+	}
+	return ip.replaceAll(".", "-");
+};
+
 const generateWildcardDomain = async (
 	baseDomain: string,
-	appName: string,
+	context: PreviewDomainContext,
 	serverIp: string,
 	_userId: string,
 ): Promise<string> => {
-	if (!baseDomain.startsWith("*.")) {
-		throw new Error('The base domain must start with "*."');
-	}
-	const hash = `${appName}`;
-	if (baseDomain.includes("traefik.me")) {
-		let ip = "";
-
-		if (process.env.NODE_ENV === "development") {
-			ip = "127.0.0.1";
+	let host: string;
+	if (isPreviewTemplateMode(baseDomain)) {
+		host = resolvePreviewDomainTemplate(baseDomain, context);
+	} else {
+		if (!baseDomain.startsWith("*.")) {
+			throw new Error(
+				'The base domain must start with "*." or use {variables}',
+			);
 		}
-
-		if (serverIp) {
-			ip = serverIp;
-		}
-
-		if (!ip) {
-			const settings = await getWebServerSettings();
-			ip = settings?.serverIp || "";
-		}
-
-		const slugIp = ip.replaceAll(".", "-");
-		return baseDomain.replace(
-			"*",
-			`${hash}${slugIp === "" ? "" : `-${slugIp}`}`,
-		);
+		host = baseDomain.replace("*", context.appName);
 	}
 
-	return baseDomain.replace("*", hash);
+	if (isDynamicDnsHost(host)) {
+		const slugIp = await resolveDynamicDnsIpSlug(serverIp);
+		return injectDynamicDnsIp(host, slugIp);
+	}
+	return host;
 };

--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -21,6 +21,7 @@ import {
 	type PreviewDomainContext,
 	resolvePreviewDomainTemplate,
 	resolvePreviewPathTemplate,
+	resolveWildcardDomain,
 } from "../utils/traefik/preview-domain";
 import { findApplicationById } from "./application";
 import { removeDeploymentsByPreviewDeploymentId } from "./deployment";
@@ -268,21 +269,21 @@ const generateWildcardDomain = async (
 	serverIp: string,
 	_userId: string,
 ): Promise<string> => {
-	let host: string;
 	if (isPreviewTemplateMode(baseDomain)) {
-		host = resolvePreviewDomainTemplate(baseDomain, context);
-	} else {
-		if (!baseDomain.startsWith("*.")) {
-			throw new Error(
-				'The base domain must start with "*." or use {variables}',
-			);
+		const host = resolvePreviewDomainTemplate(baseDomain, context);
+		if (isDynamicDnsHost(host)) {
+			const slugIp = await resolveDynamicDnsIpSlug(serverIp);
+			return injectDynamicDnsIp(host, slugIp);
 		}
-		host = baseDomain.replace("*", context.appName);
+		return host;
 	}
 
-	if (isDynamicDnsHost(host)) {
-		const slugIp = await resolveDynamicDnsIpSlug(serverIp);
-		return injectDynamicDnsIp(host, slugIp);
+	if (!baseDomain.startsWith("*.")) {
+		throw new Error('The base domain must start with "*." or use {variables}');
 	}
-	return host;
+
+	const slugIp = isDynamicDnsHost(baseDomain)
+		? await resolveDynamicDnsIpSlug(serverIp)
+		: "";
+	return resolveWildcardDomain(baseDomain, context.appName, slugIp);
 };

--- a/packages/server/src/utils/traefik/preview-domain.ts
+++ b/packages/server/src/utils/traefik/preview-domain.ts
@@ -1,0 +1,78 @@
+export type PreviewDomainContext = {
+	appName: string;
+	branch: string;
+	pr: string;
+	hash: string;
+};
+
+const MAX_LABEL_LENGTH = 63;
+
+const slugifyLabel = (value: string) =>
+	value
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/g, "-")
+		.replace(/-{2,}/g, "-")
+		.replace(/^-+|-+$/g, "");
+
+const capLabel = (label: string) =>
+	label.length <= MAX_LABEL_LENGTH
+		? label
+		: label.slice(0, MAX_LABEL_LENGTH).replace(/-+$/, "");
+
+const substitute = (template: string, vars: Record<string, string>): string =>
+	template.replace(/\{(\w+)\}/g, (_match, key) => {
+		const lower = key.toLowerCase();
+		return Object.hasOwn(vars, lower) ? (vars[lower] ?? "") : "";
+	});
+
+export const resolvePreviewDomainTemplate = (
+	template: string,
+	context: PreviewDomainContext,
+): string => {
+	const substituted = substitute(template, {
+		appname: context.appName,
+		branch: slugifyLabel(context.branch),
+		pr: slugifyLabel(context.pr),
+		hash: slugifyLabel(context.hash),
+	});
+
+	return substituted
+		.split(".")
+		.map((label) => capLabel(slugifyLabel(label)))
+		.filter(Boolean)
+		.join(".");
+};
+
+export const resolvePreviewPathTemplate = (
+	template: string,
+	context: PreviewDomainContext,
+): string =>
+	substitute(template, {
+		appname: context.appName,
+		branch: slugifyLabel(context.branch),
+		pr: context.pr,
+		hash: context.hash,
+	});
+
+export const isPreviewTemplateMode = (template: string) =>
+	!template.includes("*") && template.includes("{");
+
+export const DYNAMIC_DNS_SUFFIXES = [
+	".traefik.me",
+	".nip.io",
+	".sslip.io",
+	".backname.io",
+] as const;
+
+export const detectDynamicDnsSuffix = (host: string): string | undefined =>
+	DYNAMIC_DNS_SUFFIXES.find((s) => host.endsWith(s));
+
+export const isDynamicDnsHost = (host: string): boolean =>
+	detectDynamicDnsSuffix(host) !== undefined;
+
+export const injectDynamicDnsIp = (host: string, slugIp: string): string => {
+	const suffix = detectDynamicDnsSuffix(host);
+	if (!suffix || !slugIp) return host;
+	const base = host.slice(0, -suffix.length);
+	return base ? `${base}.${slugIp}${suffix}` : `${slugIp}${suffix}`;
+};

--- a/packages/server/src/utils/traefik/preview-domain.ts
+++ b/packages/server/src/utils/traefik/preview-domain.ts
@@ -95,6 +95,11 @@ export const resolveWildcardDomain = (
 	appName: string,
 	slugIp: string,
 ): string => {
+	if (baseDomain.includes("{")) {
+		throw new Error(
+			`Preview domain "${baseDomain}" mixes wildcard "*" with {variables}. Use one or the other.`,
+		);
+	}
 	const suffix = detectDynamicDnsSuffix(baseDomain);
 	if (suffix && slugIp) {
 		const label = `${appName}-${slugIp}`;

--- a/packages/server/src/utils/traefik/preview-domain.ts
+++ b/packages/server/src/utils/traefik/preview-domain.ts
@@ -20,21 +20,31 @@ const capLabel = (label: string) =>
 		: label.slice(0, MAX_LABEL_LENGTH).replace(/-+$/, "");
 
 const substitute = (template: string, vars: Record<string, string>): string =>
-	template.replace(/\{(\w+)\}/g, (_match, key) => {
+	template.replace(/\{(\w+)\}/g, (match, key) => {
 		const lower = key.toLowerCase();
-		return Object.hasOwn(vars, lower) ? (vars[lower] ?? "") : "";
+		return Object.hasOwn(vars, lower) ? (vars[lower] ?? "") : match;
 	});
+
+const assertNoUnresolvedTokens = (resolved: string, template: string) => {
+	const leftover = resolved.match(/\{\w+\}/g);
+	if (leftover?.length) {
+		throw new Error(
+			`Unknown variable${leftover.length > 1 ? "s" : ""} in preview template "${template}": ${leftover.join(", ")}. Supported: {appname}, {branch}, {pr}, {hash}.`,
+		);
+	}
+};
 
 export const resolvePreviewDomainTemplate = (
 	template: string,
 	context: PreviewDomainContext,
 ): string => {
 	const substituted = substitute(template, {
-		appname: context.appName,
+		appname: slugifyLabel(context.appName),
 		branch: slugifyLabel(context.branch),
 		pr: slugifyLabel(context.pr),
 		hash: slugifyLabel(context.hash),
 	});
+	assertNoUnresolvedTokens(substituted, template);
 
 	return substituted
 		.split(".")
@@ -46,13 +56,16 @@ export const resolvePreviewDomainTemplate = (
 export const resolvePreviewPathTemplate = (
 	template: string,
 	context: PreviewDomainContext,
-): string =>
-	substitute(template, {
-		appname: context.appName,
+): string => {
+	const substituted = substitute(template, {
+		appname: slugifyLabel(context.appName),
 		branch: slugifyLabel(context.branch),
 		pr: context.pr,
 		hash: context.hash,
 	});
+	assertNoUnresolvedTokens(substituted, template);
+	return substituted;
+};
 
 export const isPreviewTemplateMode = (template: string) =>
 	!template.includes("*") && template.includes("{");
@@ -75,4 +88,18 @@ export const injectDynamicDnsIp = (host: string, slugIp: string): string => {
 	if (!suffix || !slugIp) return host;
 	const base = host.slice(0, -suffix.length);
 	return base ? `${base}.${slugIp}${suffix}` : `${slugIp}${suffix}`;
+};
+
+export const resolveWildcardDomain = (
+	baseDomain: string,
+	appName: string,
+	slugIp: string,
+): string => {
+	const suffix = detectDynamicDnsSuffix(baseDomain);
+	if (suffix && slugIp) {
+		const label = `${appName}-${slugIp}`;
+		return baseDomain.replace("*", label);
+	}
+	const host = baseDomain.replace("*", appName);
+	return injectDynamicDnsIp(host, slugIp);
 };


### PR DESCRIPTION
## What is this PR about?

Overhauls the Preview Deployment settings experience. Adds `{variable}` URL templates, support for four dynamic-DNS providers, and a redesigned settings modal. Preview domains and paths can now use `{appname}`, `{branch}`, `{pr}`, `{hash}` placeholders alongside the legacy `*.domain.com` wildcard — no more long hashed subdomains unless you want them.

## Key features

- **New variables supported in preview deployment URLs** — `{appname}`, `{branch}`, `{pr}`, `{hash}` (case-insensitive) for both the Domain Template and Path fields. Example: `pr-{pr}.preview.example.com` with path `/pr-{pr}/`.
- **New dynamic DNS providers supported** — traefik.me, nip.io, sslip.io, backname.io are auto-detected and the server IP is injected in the format each service requires (position differs per service).
- **Complete UI overhaul for easier use** — Sectioned layout (Routing, HTTPS & Certificates, Triggers & Access), clickable variable chips that insert tokens at the cursor, live preview of the resolved URL, and a clear greyed-out state when the feature is off.
- **Turning on preview deployments no longer closes the modal** — The enable toggle lives at the top of the modal and no longer unmounts the settings on flip, preventing in-progress changes being lost across the resulting refetch.
- **HTTPS gets disabled for dynamic DNS options that do not support HTTPS** — Currently just traefik.me. When such a domain is entered the HTTPS switch is forced off and locked with an inline explanation.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)
<img width="1052" height="727" alt="image" src="https://github.com/user-attachments/assets/bbbf0d53-089f-424f-aaad-d8bb05221ba2" />
<img width="1046" height="720" alt="image" src="https://github.com/user-attachments/assets/807b11f7-63e4-4516-8035-2ac23f6d0a6a" />
<img width="1063" height="726" alt="image" src="https://github.com/user-attachments/assets/8761748f-e6e2-46a5-b170-836845162cf0" />
<img width="1005" height="328" alt="image" src="https://github.com/user-attachments/assets/22fdacda-2919-42a2-9750-ef1c66adc7aa" />
<img width="500" height="328" alt="image" src="https://github.com/user-attachments/assets/d10887fa-8e58-4758-a16a-0f4ec457a78d" />
<img width="496" height="323" alt="image" src="https://github.com/user-attachments/assets/51325d33-e0d1-418d-97ff-0c40ca4e01f3" />
<img width="992" height="155" alt="image" src="https://github.com/user-attachments/assets/b13eb38c-cb9a-4bff-85c7-c63797b7d3e1" />
HTTPS is not force disabled when using other non-traefik.me providers, and the warning disappears.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR overhauls the Preview Deployment settings UI — adding `{variable}` URL templates, four dynamic-DNS provider integrations (traefik.me, nip.io, sslip.io, backname.io), variable-chip insertion, a live URL preview, and a sectioned modal layout. All three previously-flagged concerns are now resolved: unknown tokens are preserved by `substitute` and rejected by `assertNoUnresolvedTokens`, mixed `*`/`{…}` templates are caught by both the zod superRefine and `resolveWildcardDomain`, and the wildcard path retains the original `appName-slugIp` single-label format so existing traefik.me URLs are not broken.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all previously flagged P1s are addressed and only a cosmetic IP preview discrepancy remains.

All prior P1 issues (silent unknown-token substitution, mixed wildcard+template acceptance, unslugified appname, URL format change for existing traefik.me users) are definitively resolved in this revision. The one remaining finding is a P2 UI discrepancy in the example URL when server.ipAddress is unset, which does not affect actual deployment logic.

No files require special attention.

<sub>Reviews (4): Last reviewed commit: ["fix: dont allow wildcard and variables i..."](https://github.com/dokploy/dokploy/commit/640bb6e4acd3873168181443abd6c055282cd663) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29437119)</sub>

<!-- /greptile_comment -->