### PR TITLE
feat: add copy button to AI log analysis result

### DIFF
--- a/apps/dokploy/components/dashboard/docker/logs/analyze-logs.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/analyze-logs.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { Bot, Loader2, RotateCcw, Settings, X } from "lucide-react";
+import copy from "copy-to-clipboard";
+import { Bot, Check, Copy, Loader2, RotateCcw, Settings, X } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
@@ -30,6 +31,7 @@ const MAX_LOG_LINES = 200;
 export function AnalyzeLogs({ logs, context }: Props) {
 	const [open, setOpen] = useState(false);
 	const [aiId, setAiId] = useState<string>("");
+	const [copied, setCopied] = useState(false);
 	const { data: providers } = api.ai.getEnabledProviders.useQuery(undefined, {
 		enabled: open,
 	});
@@ -50,6 +52,15 @@ export function AnalyzeLogs({ logs, context }: Props) {
 			.join("\n");
 
 		mutate({ aiId, logs: logsText, context });
+	};
+
+	const handleCopy = () => {
+		if (!data?.analysis) return;
+		const success = copy(data.analysis);
+		if (success) {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
 	};
 
 	return (
@@ -167,6 +178,18 @@ export function AnalyzeLogs({ logs, context }: Props) {
 										<RotateCcw className="mr-2 h-3.5 w-3.5" />
 									)}
 									Re-analyze
+								</Button>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={handleCopy}
+									title="Copy analysis to clipboard"
+								>
+									{copied ? (
+										<Check className="h-3.5 w-3.5" />
+									) : (
+										<Copy className="h-3.5 w-3.5" />
+									)}
 								</Button>
 								<Button
 									size="sm"


### PR DESCRIPTION
## What is this PR about?

Adds a copy-to-clipboard button to the AI log analysis popover in `AnalyzeLogs`. After the AI generates an analysis of build or runtime logs, users can now copy the markdown result with a single click to send it to their coding agents.

I didn't get a chance to test it locally, so I would appreciate it if someone else could.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a copy-to-clipboard button to the AI log analysis result popover using the existing `copy-to-clipboard` library. The implementation is straightforward and consistent with how the library is used elsewhere in the codebase.

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, isolated feature addition with no edge cases or regressions.

The change is minimal: one new state variable, one handler, and one button. The `copy-to-clipboard` library is already a dependency used in 20+ other components. The button is gated behind `data?.analysis`, so it only appears when relevant. No security, logic, or correctness issues were found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["feat: add copy button to AI log analysis..."](https://github.com/dokploy/dokploy/commit/ad490dca3fc60aee4470a669d886bfd2149f462f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29646115)</sub>

<!-- /greptile_comment -->