### PR TITLE
Fix/ghsa f8wj 5c4w frhg cross org idor

### DIFF
--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -458,9 +458,26 @@ export const backupRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
 			try {
 				const destination = await findDestinationById(input.destinationId);
+				if (destination.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this destination.",
+					});
+				}
+				if (input.serverId) {
+					const targetServer = await findServerById(input.serverId);
+					if (
+						targetServer.organizationId !== ctx.session.activeOrganizationId
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this server.",
+						});
+					}
+				}
 				const rcloneFlags = getS3Credentials(destination);
 				const bucketPath = `:s3:${destination.bucket}`;
 

--- a/apps/dokploy/server/api/routers/cluster.ts
+++ b/apps/dokploy/server/api/routers/cluster.ts
@@ -11,20 +11,6 @@ import { audit } from "@/server/api/utils/audit";
 import { getLocalServerIp } from "@/server/wss/terminal";
 import { createTRPCRouter, withPermission } from "../trpc";
 
-const assertServerBelongsToOrg = async (
-	serverId: string | undefined,
-	activeOrganizationId: string,
-) => {
-	if (!serverId) return;
-	const targetServer = await findServerById(serverId);
-	if (targetServer.organizationId !== activeOrganizationId) {
-		throw new TRPCError({
-			code: "UNAUTHORIZED",
-			message: "You don't have access to this server.",
-		});
-	}
-};
-
 export const clusterRouter = createTRPCRouter({
 	getNodes: withPermission("server", "read")
 		.input(
@@ -33,10 +19,15 @@ export const clusterRouter = createTRPCRouter({
 			}),
 		)
 		.query(async ({ input, ctx }) => {
-			await assertServerBelongsToOrg(
-				input.serverId,
-				ctx.session.activeOrganizationId,
-			);
+			if (input.serverId) {
+				const targetServer = await findServerById(input.serverId);
+				if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this server.",
+					});
+				}
+			}
 			const docker = await getRemoteDocker(input.serverId);
 			const workers: DockerNode[] = await docker.listNodes();
 			return workers;
@@ -50,10 +41,15 @@ export const clusterRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			await assertServerBelongsToOrg(
-				input.serverId,
-				ctx.session.activeOrganizationId,
-			);
+			if (input.serverId) {
+				const targetServer = await findServerById(input.serverId);
+				if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this server.",
+					});
+				}
+			}
 			try {
 				const drainCommand = `docker node update --availability drain ${input.nodeId}`;
 				const removeCommand = `docker node rm ${input.nodeId} --force`;
@@ -88,10 +84,15 @@ export const clusterRouter = createTRPCRouter({
 			}),
 		)
 		.query(async ({ input, ctx }) => {
-			await assertServerBelongsToOrg(
-				input.serverId,
-				ctx.session.activeOrganizationId,
-			);
+			if (input.serverId) {
+				const targetServer = await findServerById(input.serverId);
+				if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this server.",
+					});
+				}
+			}
 			const docker = await getRemoteDocker(input.serverId);
 			const result = await docker.swarmInspect();
 			const docker_version = await docker.version();
@@ -115,10 +116,15 @@ export const clusterRouter = createTRPCRouter({
 			}),
 		)
 		.query(async ({ input, ctx }) => {
-			await assertServerBelongsToOrg(
-				input.serverId,
-				ctx.session.activeOrganizationId,
-			);
+			if (input.serverId) {
+				const targetServer = await findServerById(input.serverId);
+				if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this server.",
+					});
+				}
+			}
 			const docker = await getRemoteDocker(input.serverId);
 			const result = await docker.swarmInspect();
 			const docker_version = await docker.version();

--- a/apps/dokploy/server/api/routers/cluster.ts
+++ b/apps/dokploy/server/api/routers/cluster.ts
@@ -11,6 +11,20 @@ import { audit } from "@/server/api/utils/audit";
 import { getLocalServerIp } from "@/server/wss/terminal";
 import { createTRPCRouter, withPermission } from "../trpc";
 
+const assertServerBelongsToOrg = async (
+	serverId: string | undefined,
+	activeOrganizationId: string,
+) => {
+	if (!serverId) return;
+	const targetServer = await findServerById(serverId);
+	if (targetServer.organizationId !== activeOrganizationId) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "You don't have access to this server.",
+		});
+	}
+};
+
 export const clusterRouter = createTRPCRouter({
 	getNodes: withPermission("server", "read")
 		.input(
@@ -18,7 +32,11 @@ export const clusterRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await assertServerBelongsToOrg(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			const docker = await getRemoteDocker(input.serverId);
 			const workers: DockerNode[] = await docker.listNodes();
 			return workers;
@@ -32,6 +50,10 @@ export const clusterRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
+			await assertServerBelongsToOrg(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			try {
 				const drainCommand = `docker node update --availability drain ${input.nodeId}`;
 				const removeCommand = `docker node rm ${input.nodeId} --force`;
@@ -65,7 +87,11 @@ export const clusterRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await assertServerBelongsToOrg(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			const docker = await getRemoteDocker(input.serverId);
 			const result = await docker.swarmInspect();
 			const docker_version = await docker.version();
@@ -88,7 +114,11 @@ export const clusterRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await assertServerBelongsToOrg(
+				input.serverId,
+				ctx.session.activeOrganizationId,
+			);
 			const docker = await getRemoteDocker(input.serverId);
 			const result = await docker.swarmInspect();
 			const docker_version = await docker.version();

--- a/apps/dokploy/server/api/routers/deployment.ts
+++ b/apps/dokploy/server/api/routers/deployment.ts
@@ -16,6 +16,7 @@ import {
 	checkServicePermissionAndAccess,
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
+import { findServerById } from "@dokploy/server/services/server";
 import { TRPCError } from "@trpc/server";
 import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -52,7 +53,14 @@ export const deploymentRouter = createTRPCRouter({
 		}),
 	allByServer: withPermission("deployment", "read")
 		.input(apiFindAllByServer)
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const targetServer = await findServerById(input.serverId);
+			if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You don't have access to this server.",
+				});
+			}
 			return await findAllDeploymentsByServerId(input.serverId);
 		}),
 	allCentralized: withPermission("deployment", "read").query(

--- a/apps/dokploy/server/api/routers/volume-backups.ts
+++ b/apps/dokploy/server/api/routers/volume-backups.ts
@@ -15,7 +15,9 @@ import {
 	updateVolumeBackupSchema,
 	volumeBackups,
 } from "@dokploy/server/db/schema";
+import { findDestinationById } from "@dokploy/server/services/destination";
 import { checkServicePermissionAndAccess } from "@dokploy/server/services/permission";
+import { findServerById } from "@dokploy/server/services/server";
 import {
 	execAsyncRemote,
 	execAsyncStream,
@@ -265,7 +267,23 @@ export const volumeBackupsRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.subscription(async ({ input }) => {
+		.subscription(async ({ input, ctx }) => {
+			const destination = await findDestinationById(input.destinationId);
+			if (destination.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You don't have access to this destination.",
+				});
+			}
+			if (input.serverId) {
+				const targetServer = await findServerById(input.serverId);
+				if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this server.",
+					});
+				}
+			}
 			return observable<string>((emit) => {
 				const runRestore = async () => {
 					try {

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -85,6 +85,11 @@ export const setupDockerContainerLogsWebSocketServer = (
 			if (serverId) {
 				const server = await findServerById(serverId);
 
+				if (server.organizationId !== session.activeOrganizationId) {
+					ws.close();
+					return;
+				}
+
 				if (!server.sshKeyId) return;
 				const client = new Client();
 				client

--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -61,6 +61,12 @@ export const setupDockerContainerTerminalWebSocketServer = (
 		try {
 			if (serverId) {
 				const server = await findServerById(serverId);
+
+				if (server.organizationId !== session.activeOrganizationId) {
+					ws.close();
+					return;
+				}
+
 				if (!server.sshKeyId)
 					throw new Error("No SSH key available for this server");
 

--- a/apps/dokploy/server/wss/listen-deployment.ts
+++ b/apps/dokploy/server/wss/listen-deployment.ts
@@ -57,6 +57,11 @@ export const setupDeploymentLogsWebSocketServer = (
 			if (serverId) {
 				const server = await findServerById(serverId);
 
+				if (server.organizationId !== session.activeOrganizationId) {
+					ws.close();
+					return;
+				}
+
 				if (!server.sshKeyId) {
 					ws.close();
 					return;

--- a/apps/dokploy/server/wss/terminal.ts
+++ b/apps/dokploy/server/wss/terminal.ts
@@ -154,6 +154,11 @@ export const setupTerminalWebSocketServer = (
 				return;
 			}
 
+			if (server.organizationId !== session.activeOrganizationId) {
+				ws.close();
+				return;
+			}
+
 			const { ipAddress: host, port, username, sshKey, sshKeyId } = server;
 
 			if (!sshKeyId) {

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -481,8 +481,10 @@ export const validateRequest = async (request: IncomingMessage) => {
 				};
 			}
 
-			const organizationId = JSON.parse(
-				apiKeyRecord.metadata || "{}",
+			const organizationId = (
+				JSON.parse(apiKeyRecord.metadata || "{}") as {
+					organizationId?: string;
+				}
 			).organizationId;
 
 			if (!organizationId) {


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cross-organization IDOR vulnerability (GHSA-f8wj-5c4w-frhg) by adding `organizationId` ownership checks on server and destination resources across several tRPC routers and WebSocket handlers. The fix pattern is consistent and correct: fetch the target resource, compare its `organizationId` to `ctx.session.activeOrganizationId`, and reject unauthorized access.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the security fix is sound with only minor P2 quality issues.

The IDOR fix is correct and consistently applied across all affected endpoints. The only findings are P2: a minor resource leak (ping interval not cleared on early WebSocket exit) and a redundant DB call in the cluster router. No P0 or P1 issues found.

apps/dokploy/server/wss/docker-container-logs.ts (ping interval leak on early return), apps/dokploy/server/api/routers/cluster.ts (double findServerById call in addWorker/addManager)

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/dokploy/server/api/routers/cluster.ts`, line 87-110 ([link](https://github.com/dokploy/dokploy/blob/232ccc913967e28d58635a989a80cd77733d9f96/apps/dokploy/server/api/routers/cluster.ts#L87-L110)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`findServerById` called twice for the same `serverId`**

   In `addWorker` (and `addManager`), the server record is already fetched into `targetServer` during the organization check, but then `findServerById(input.serverId)` is called a second time just to obtain `ipAddress`. The result from the first call can be reused directly.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat: add organization-level authorizati..."](https://github.com/dokploy/dokploy/commit/232ccc913967e28d58635a989a80cd77733d9f96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29645497)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->