### PR TITLE
fix: fallback to DownstreamStatus when OriginStatus is 0 in requests table

### DIFF
--- a/apps/dokploy/components/dashboard/requests/columns.tsx
+++ b/apps/dokploy/components/dashboard/requests/columns.tsx
@@ -79,8 +79,8 @@ export const columns: ColumnDef<LogEntry>[] = [
 							: log.RequestPath}
 					</div>
 					<div className="flex flex-row gap-3 w-full">
-						<Badge variant={getStatusColor(log.OriginStatus)}>
-							Status: {formatStatusLabel(log.OriginStatus)}
+						<Badge variant={getStatusColor(log.OriginStatus || log.DownstreamStatus)}>
+							Status: {formatStatusLabel(log.OriginStatus || log.DownstreamStatus)}
 						</Badge>
 						<Badge variant={"secondary"}>
 							Exec Time: {formatDuration(log.Duration)}


### PR DESCRIPTION
## Summary

- Fixes the requests table showing "Status: 0" or "Status: N/A" when the upstream server doesn't respond
- When `OriginStatus` is 0, falls back to `DownstreamStatus` which always reflects the status code returned to the client by Traefik (e.g. 502, 404)

Closes #4250

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the requests table displaying "Status: 0" or "Status: N/A" when the upstream server doesn't respond, by falling back to `DownstreamStatus` whenever `OriginStatus` is `0`. The change is small and correctly leverages JavaScript's `||` operator since `OriginStatus: number` is typed as `0` (falsy) in the no-response case, and `DownstreamStatus` is always set to the HTTP status Traefik returned to the client.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line, well-scoped fallback that correctly handles the 0-status edge case.

Only a P2 style observation (duplicated expression) with no logic or security concerns. The fallback logic is correct and both OriginStatus and DownstreamStatus are typed as number in the backend types, so there is no risk of undefined values.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: fallback to DownstreamStatus when O..."](https://github.com/dokploy/dokploy/commit/e9fdc19b9615dfd6dc832e52b1fcda4e2e39cd86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29692507)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->