### PR TITLE
fix(ui): prevent layout shift in log counter using tabular-nums

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployment.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployment.tsx
@@ -148,7 +148,7 @@ export const ShowDeployment = ({
 					<DialogDescription className="flex items-center gap-2">
 						<span className="flex items-center gap-2">
 							See all the details of this deployment |{" "}
-							<Badge variant="blank" className="text-xs">
+							<Badge variant="blank" className="text-xs tabular-nums">
 								{filteredLogs.length} lines
 							</Badge>
 						</span>


### PR DESCRIPTION
## Fix: prevent layout shift in log counter

### Summary
Add `tabular-nums` to the log lines counter to avoid horizontal layout shift when the number of digits changes.

### Before

https://github.com/user-attachments/assets/e433d640-a7a5-478a-84c4-635d18f6e531

### Changes
- Apply `tabular-nums` to the counter badge in deployment dialog

### Type of change
- [x] Bug fix

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `tabular-nums` to the Tailwind class on the log-lines `Badge` in `show-deployment.tsx`, ensuring digits use fixed-width slots and eliminating the horizontal layout shift when the digit count changes during a live deployment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-character CSS utility addition with no logic changes.

The change is a one-word Tailwind utility added to a className string. It has no impact on logic, data, or security, and directly fixes the described visual jitter.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(ui): prevent layout shift in log cou..."](https://github.com/dokploy/dokploy/commit/bb0c59fc5c30fe0168f53a02b47ee0893f654416) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29865191)</sub>

<!-- /greptile_comment -->