### PR TITLE
fix(git-provider): honor sharedWithOrganization in application/compose detail views

### DIFF
--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -4,8 +4,8 @@ import {
 	deleteAllMiddlewares,
 	findApplicationById,
 	findEnvironmentById,
-	findGitProviderById,
 	findProjectById,
+	getAccessibleGitProviderIds,
 	getAccessibleServerIds,
 	getApplicationStats,
 	getContainerLogs,
@@ -169,13 +169,8 @@ export const applicationRouter = createTRPCRouter({
 			const gitProviderId = getGitProviderId();
 
 			if (gitProviderId) {
-				try {
-					const gitProvider = await findGitProviderById(gitProviderId);
-					if (gitProvider.userId !== ctx.session.userId) {
-						hasGitProviderAccess = false;
-						unauthorizedProvider = application.sourceType;
-					}
-				} catch {
+				const accessibleIds = await getAccessibleGitProviderIds(ctx.session);
+				if (!accessibleIds.has(gitProviderId)) {
 					hasGitProviderAccess = false;
 					unauthorizedProvider = application.sourceType;
 				}

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -13,9 +13,9 @@ import {
 	findComposeById,
 	findDomainsByComposeId,
 	findEnvironmentById,
-	findGitProviderById,
 	findProjectById,
 	findServerById,
+	getAccessibleGitProviderIds,
 	getAccessibleServerIds,
 	getComposeContainer,
 	getContainerLogs,
@@ -169,13 +169,8 @@ export const composeRouter = createTRPCRouter({
 			const gitProviderId = getGitProviderId();
 
 			if (gitProviderId) {
-				try {
-					const gitProvider = await findGitProviderById(gitProviderId);
-					if (gitProvider.userId !== ctx.session.userId) {
-						hasGitProviderAccess = false;
-						unauthorizedProvider = compose.sourceType;
-					}
-				} catch {
+				const accessibleIds = await getAccessibleGitProviderIds(ctx.session);
+				if (!accessibleIds.has(gitProviderId)) {
 					hasGitProviderAccess = false;
 					unauthorizedProvider = compose.sourceType;
 				}


### PR DESCRIPTION
## Summary

The application/compose detail pages still display "Repository connection through unauthorized provider" for git providers shared with the organization (or accessible via owner/admin role / Enterprise per-user assignment), even though the listing endpoints correctly grant access.

Root cause: `application.one` and `compose.one` compute `hasGitProviderAccess` with a hand-rolled check (`gitProvider.userId !== ctx.session.userId`) that pre-dates the sharing feature added in #4135. The other five call sites (`git-provider.getAll`, `github.githubProviders`, `gitlab.gitlabProviders`, `bitbucket.bitbucketProviders`, `gitea.giteaProviders`) all use `getAccessibleGitProviderIds(ctx.session)`, which returns the full set of accessible provider ids (creator + `sharedWithOrganization` + owner/admin + per-user assignment).

This PR replaces the `userId` check in both `application.one` and `compose.one` with `getAccessibleGitProviderIds`, bringing the detail-view access check in line with every other call site.

The previous `try/catch` around `findGitProviderById` is no longer needed: a missing/orphaned provider simply isn't in the returned set, producing the same "no access" UI without an exception.

## Reproduction

1. As user A, connect a GitHub git provider and toggle "Share with organization" on.
2. As user B, open any application or compose using that provider.
3. Expected: form renders normally. Actual (before this PR): "Repository connection through unauthorized provider" banner.

<img width="2198" height="424" alt="image" src="https://github.com/user-attachments/assets/ff692f20-981f-4a9e-aaac-89026bd7e03f" />


## Test plan

- [x] Manually reproduced the bug on v0.29.2 with a shared GitHub provider.
- [x] Patched bundle deployed to a self-hosted instance and verified the banner is gone for non-creator org members on a shared provider.
- [x] Biome check passes (no new warnings introduced).

## Checklist

- [x] Branch is based on `canary`.
- [x] Read CONTRIBUTING.md.
- [x] Conventional Commits message.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `application.one` and `compose.one` used a hand-rolled `gitProvider.userId !== ctx.session.userId` check that predated the organization-sharing feature, causing shared/admin-accessible git providers to be incorrectly flagged as unauthorized. Both endpoints now call `getAccessibleGitProviderIds(ctx.session)`, aligning them with the five other call sites that already use this helper.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is a targeted, correct replacement of a stale access check with the existing shared helper already used by all other call sites.

The change is minimal (two identical hunks), uses a well-tested existing function, correctly handles all access scenarios (owner/admin, sharedWithOrganization, per-user assignment, and missing providers), and introduces no new code paths. No P0 or P1 issues found.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix(git-provider): honor sharedWithOrgan..."](https://github.com/dokploy/dokploy/commit/38e5ca2b63688989e8f250b20d5bf5821740d02d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30015208)</sub>

<!-- /greptile_comment -->