### PR TITLE
fix: enforce 255-char max length on forgot password email field

### DIFF
--- a/apps/dokploy/pages/send-reset-password.tsx
+++ b/apps/dokploy/pages/send-reset-password.tsx
@@ -30,6 +30,9 @@ const loginSchema = z.object({
 		.min(1, {
 			message: "Email is required",
 		})
+		.max(255, {
+			message: "Email must be at most 255 characters",
+		})
 		.email({
 			message: "Email must be a valid email",
 		}),
@@ -118,7 +121,7 @@ export default function Home() {
 												<FormItem>
 													<FormLabel>Email</FormLabel>
 													<FormControl>
-														<Input placeholder="Email" {...field} />
+														<Input placeholder="Email" maxLength={255} {...field} />
 													</FormControl>
 													<FormMessage />
 												</FormItem>

--- a/apps/dokploy/pages/send-reset-password.tsx
+++ b/apps/dokploy/pages/send-reset-password.tsx
@@ -121,7 +121,11 @@ export default function Home() {
 												<FormItem>
 													<FormLabel>Email</FormLabel>
 													<FormControl>
-														<Input placeholder="Email" maxLength={255} {...field} />
+														<Input
+															placeholder="Email"
+															maxLength={255}
+															{...field}
+														/>
 													</FormControl>
 													<FormMessage />
 												</FormItem>


### PR DESCRIPTION
## Summary

- Added `.max(255)` to the Zod schema in `send-reset-password.tsx` so emails over 255 characters are rejected before reaching the server
- Added `maxLength={255}` to the `<Input>` element to enforce the limit at the browser level as well

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 255-character maximum length constraint to the email field on the forgot-password page, both at the Zod schema level (server-side form validation) and as a native `maxLength` HTML attribute on the `<Input>` element.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped change with no logic issues.

The change is a two-line addition: a Zod .max(255) validator and a matching maxLength={255} HTML attribute. Both layers are consistent, the ordering in the Zod chain is correct, and no existing logic is affected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/34564aec84cf13b76d0445bf81a03f11790cad6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30106366)</sub>

<!-- /greptile_comment -->