### PR TITLE
fix: reduce healthcheck frequency to lower memory pressure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ COPY --from=buildpacksio/pack:0.39.1 /usr/local/bin/pack /usr/local/bin/pack
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=10s --timeout=3s --retries=10 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=5 \
   CMD curl -fs http://localhost:3000/api/trpc/settings.health || exit 1
 
   CMD ["sh", "-c", "pnpm run wait-for-postgres && exec pnpm start"]


### PR DESCRIPTION
Closes #3909

The `HEALTHCHECK` was configured with `--interval=10s`, which triggered a real PostgreSQL query (`SELECT 1`) 360 times/hour. This kept the Node.js heap under constant pressure, preventing the GC from reclaiming memory efficiently — causing ~350MB of extra memory usage compared to baseline.

## Changes

- `--interval`: `10s` → `30s` (3x fewer DB queries)
- `--timeout`: `3s` → `5s` (more margin under load)
- `--start-period`: added `60s` (avoids false failures during Next.js startup)
- `--retries`: `10` → `5` (was excessive)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tunes the `HEALTHCHECK` instruction in the Dockerfile to reduce the frequency of health queries, lowering constant pressure on the Node.js heap. The four parameter changes (`--interval` 10s→30s, `--timeout` 3s→5s, new `--start-period=60s`, `--retries` 10→5) are individually sensible and collectively reasonable for a Next.js + Postgres container that takes time to boot. No issues were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line Dockerfile change with no logic or security implications.

The only change is adjusting HEALTHCHECK timing parameters, which is a well-justified, low-risk tweak. No new code paths, no security surface changes, and no behavioral regressions are introduced.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: reduce healthcheck frequency to low..."](https://github.com/dokploy/dokploy/commit/8f3d824ea6e4573472206af6ff3ef0a8fcac0754) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30108071)</sub>

<!-- /greptile_comment -->