### PR TITLE
fix: tooltip incorrectly lists volumes among Daily Cleanup targets

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
@@ -70,7 +70,7 @@ export const ToggleDockerCleanup = ({ serverId }: Props) => {
 					<TooltipContent side="top" className="max-w-sm">
 						<p>
 							Runs a full Docker cleanup daily, pruning stopped containers,
-							unused images, volumes, build cache, and system resources. This
+							unused images, build cache, and system resources. This
 							may remove images built for Compose services that run on-demand
 							(backup runners, cron jobs, one-off tasks).
 						</p>


### PR DESCRIPTION
The Daily Docker Cleanup tooltip lists `volumes` among pruned resources, but `cleanupAll` in `packages/server/src/utils/docker/utils.ts` excludes the volume prune via `excludedCleanupAllCommands` (added in #3267).

Removes `volumes` from the tooltip to match actual behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `volumes` from the Daily Docker Cleanup tooltip to match the actual behavior of `cleanupAll`, which explicitly skips volume pruning via `excludedCleanupAllCommands` (intentionally excluded since #3267 to prevent accidental data loss from stopped containers).

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line tooltip copy fix with no logic changes.

The change is a one-line documentation/UI fix that correctly aligns tooltip text with verified server-side behavior. No logic, no risk.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: tooltip incorrectly lists volumes a..."](https://github.com/dokploy/dokploy/commit/403289517653371f36e9b0ae8eeea7a64c8b5483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30139418)</sub>

<!-- /greptile_comment -->