### PR TITLE
feat(logs): add copy button to AI log analysis result

### DIFF
--- a/apps/dokploy/components/dashboard/docker/logs/analyze-logs.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/analyze-logs.tsx
@@ -1,5 +1,13 @@
 "use client";
-import { Bot, Loader2, RotateCcw, Settings, X } from "lucide-react";
+import {
+	Bot,
+	Check,
+	Copy,
+	Loader2,
+	RotateCcw,
+	Settings,
+	X,
+} from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
@@ -30,6 +38,7 @@ const MAX_LOG_LINES = 200;
 export function AnalyzeLogs({ logs, context }: Props) {
 	const [open, setOpen] = useState(false);
 	const [aiId, setAiId] = useState<string>("");
+	const [copied, setCopied] = useState(false);
 	const { data: providers } = api.ai.getEnabledProviders.useQuery(undefined, {
 		enabled: open,
 	});
@@ -50,6 +59,17 @@ export function AnalyzeLogs({ logs, context }: Props) {
 			.join("\n");
 
 		mutate({ aiId, logs: logsText, context });
+	};
+
+	const handleCopy = async () => {
+		if (!data?.analysis) return;
+		try {
+			await navigator.clipboard.writeText(data.analysis);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			toast.error("Failed to copy to clipboard");
+		}
 	};
 
 	return (
@@ -167,6 +187,18 @@ export function AnalyzeLogs({ logs, context }: Props) {
 										<RotateCcw className="mr-2 h-3.5 w-3.5" />
 									)}
 									Re-analyze
+								</Button>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={handleCopy}
+									title="Copy analysis"
+								>
+									{copied ? (
+										<Check className="h-3.5 w-3.5" />
+									) : (
+										<Copy className="h-3.5 w-3.5" />
+									)}
 								</Button>
 								<Button
 									size="sm"


### PR DESCRIPTION
## Summary

The AI Log Analysis popover renders the AI response as Markdown but provides no
way to copy it. This adds a one-click Copy button to the result action row that
copies the raw Markdown to the clipboard. Same change covers both call sites
(Deployments view and container Logs view) since they share the
`AnalyzeLogs` component.

## Changes

- `apps/dokploy/components/dashboard/docker/logs/analyze-logs.tsx`
  - Add `Copy` and `Check` icons to the lucide-react import.
  - Track a `copied` boolean state.
  - `handleCopy` writes `data.analysis` to the clipboard, flips the icon
    to `Check` for 2s, falls back to a sonner error toast if the
    clipboard API rejects.
  - New icon-only Button placed between Re-analyze and the
    provider-reset X.

## Test plan

- [x] Build context (Deployments → View → AI → Analyze → Copy) — Markdown
  preserved when pasted.
- [x] Runtime context (Logs tab → container AI button) — same.
- [x] Light + dark mode visual check.
- [x] Clipboard rejection path shows a "Failed to copy to clipboard" toast.
- [x] `pnpm lint` + `pnpm typecheck` clean.

## Notes

Mirrors the existing copy-button pattern already used in
`show-deployment.tsx`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a Copy button to the `AnalyzeLogs` popover so users can copy the raw Markdown analysis to the clipboard. The implementation is clean and follows the existing pattern in the codebase — the button is correctly scoped to the `data?.analysis` branch, uses a 2-second visual confirmation state, and provides a fallback error toast. Two minor P2 items: the icon-only button uses `title` but is missing `aria-label` for screen-reader accessibility, and the `setTimeout` handle is not cleared on unmount.

<h3>Confidence Score: 4/5</h3>

Safe to merge — only P2 style/accessibility findings, no logic or security issues.

All findings are P2 (missing aria-label, uncleared setTimeout). The core logic is correct, the button is properly conditionally rendered, and the clipboard API usage is standard.

No files require special attention beyond the two P2 suggestions in analyze-logs.tsx.

<sub>Reviews (1): Last reviewed commit: ["feat(logs): add copy button to AI log an..."](https://github.com/dokploy/dokploy/commit/94d3792c739be0cee6c1c36235a6e6946d205ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30251083)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->