### PR TITLE
fix: enforce docker:read on container start/stop/kill/restart mutations

### DIFF
--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -38,7 +38,7 @@ export const dockerRouter = createTRPCRouter({
 			return await getContainers(input.serverId);
 		}),
 
-	restartContainer: withPermission("service", "read")
+	restartContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -64,7 +64,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	startContainer: withPermission("service", "read")
+	startContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -90,7 +90,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	stopContainer: withPermission("service", "read")
+	stopContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -116,7 +116,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	killContainer: withPermission("service", "read")
+	killContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z


### PR DESCRIPTION
## Summary

- Four Docker mutation endpoints (`docker.startContainer`,
  `docker.stopContainer`, `docker.killContainer`,
  `docker.restartContainer`) were gated by `withPermission("service", "read")`,
  which the default member role grants. Any authenticated org member
  with an API key could change the state of any container in the
  organization — regardless of `canAccessToDocker` or
  `accessedServices` scope. Read-only endpoints and `removeContainer`
  were already correctly gated on `docker:read`.
- Switch the four mutations to `withPermission("docker", "read")`,
  matching `removeContainer`, `getConfig` and `getContainers`. Member
  callers now need `canAccessToDocker=true` (legacy override in
  `getLegacyOverrides`) or an explicit `docker:read` grant via a
  custom role.

## Severity

Privilege escalation inside an organization — a member could DoS
production containers (DBs, Traefik, app/compose services) and cycle
them in a loop. No audit log in OSS, so recovery is via host-level
docker logs only.

## Reproduction (before fix)

With a member API key where `canAccessToDocker=false` and the target
container is outside `accessedServices`/`accessedProjects`:

```bash
curl -X POST -H "x-api-key: $KEY_MEMBER" \
  -H 'Content-Type: application/json' \
  -d "{\"containerId\":\"$CID\"}" \
  "$HOST/api/docker.killContainer"
# before: HTTP 200, container is killed
# after:  HTTP 401, body {"message":"unauthorized to access resource \"docker\"",...}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a privilege escalation vulnerability where four Docker mutation endpoints (`restartContainer`, `startContainer`, `stopContainer`, `killContainer`) were gated by `withPermission("service", "read")` instead of `withPermission("docker", "read")`. Since the `memberRole` grants `service: ["read"]` but `docker: []`, any authenticated org member could mutate container state without needing `canAccessToDocker=true` or a custom role granting docker access. The fix aligns all destructive docker endpoints with `removeContainer`, `getConfig`, and `getContainers`, which were already correctly gated on `docker:read`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no regressions.

The change is a four-line permission string swap, each line verified against the access-control statements (`docker` only defines `"read"`, and `memberRole` grants `docker: []`). The fix is consistent with the pre-existing pattern used by `removeContainer`, `getConfig`, and `getContainers`. No logic, schema, or API surface is changed beyond the permission gate.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fix: gate docker container lifecycle mut..."](https://github.com/dokploy/dokploy/commit/40e1e38a4d15bd5d906153e15734c8923789dd24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30305795)</sub>

<!-- /greptile_comment -->

Issue: https://github.com/Dokploy/dokploy/issues/4486