### PR TITLE
fix: share global schedules across org admins/owners

### DIFF
--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -1,5 +1,6 @@
 import { IS_CLOUD, removeScheduleJob, scheduleJob } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import { member } from "@dokploy/server/db/schema";
 import { deployments } from "@dokploy/server/db/schema/deployment";
 import {
 	createScheduleSchema,
@@ -20,7 +21,7 @@ import {
 } from "@dokploy/server/services/schedule";
 import { findServerById } from "@dokploy/server/services/server";
 import { TRPCError } from "@trpc/server";
-import { asc, desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
 import { removeJob, schedule } from "@/server/utils/backup";
@@ -163,16 +164,26 @@ export const scheduleRouter = createTRPCRouter({
 					}
 				}
 
-				if (
-					existingSchedule.scheduleType === "dokploy-server" &&
-					existingSchedule.userId &&
-					existingSchedule.userId !== ctx.user.id
-				) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You can only manage your own host-level schedules.",
-					});
+			if (
+				existingSchedule.scheduleType === "dokploy-server" &&
+				existingSchedule.userId &&
+				existingSchedule.userId !== ctx.user.id
+			) {
+				// Admin/owner role already verified above.
+				// Don't use findMemberByUserId here — it would throw if the
+				// schedule owner left the org, making the schedule unmanageable.
+				const scheduleOwnerInOrg = await db.query.member.findFirst({
+					where: and(
+						eq(member.userId, existingSchedule.userId),
+						eq(member.organizationId, ctx.session.activeOrganizationId),
+					),
+					columns: { id: true },
+				});
+				if (scheduleOwnerInOrg) {
+					// Owner is still in org — allowed.
 				}
+				// If owner left the org, still allow the admin/owner to manage it.
+			}
 			}
 			const updatedSchedule = await updateSchedule(input);
 
@@ -262,10 +273,18 @@ export const scheduleRouter = createTRPCRouter({
 					scheduleItem.userId &&
 					scheduleItem.userId !== ctx.user.id
 				) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You can only manage your own host-level schedules.",
+					// Admin/owner role already verified above.
+					// Don't throw if the schedule owner left the org.
+					const scheduleOwnerInOrg = await db.query.member.findFirst({
+						where: and(
+							eq(member.userId, scheduleItem.userId),
+							eq(member.organizationId, ctx.session.activeOrganizationId),
+						),
+						columns: { id: true },
 					});
+					if (scheduleOwnerInOrg) {
+						// Owner is still in org — allowed.
+					}
 				}
 			}
 			await deleteSchedule(input.scheduleId);
@@ -322,36 +341,54 @@ export const scheduleRouter = createTRPCRouter({
 						});
 					}
 				}
-
-				if (
-					input.scheduleType === "dokploy-server" &&
-					input.id !== ctx.user.id
-				) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You can only list your own host-level schedules.",
-					});
-				}
 			}
+
+		let listWhere;
+		if (input.scheduleType === "dokploy-server") {
+			const currentMember = await findMemberByUserId(
+				ctx.user.id,
+				ctx.session.activeOrganizationId,
+			);
+			if (
+				currentMember.role === "owner" ||
+				currentMember.role === "admin"
+			) {
+				const orgMembers = await db.query.member.findMany({
+					where: eq(member.organizationId, ctx.session.activeOrganizationId),
+					columns: { userId: true },
+				});
+				const userIds = orgMembers.map((m) => m.userId);
+				if (userIds.length === 0) {
+					return [];
+				}
+				listWhere = and(
+					eq(schedules.scheduleType, "dokploy-server"),
+					inArray(schedules.userId, userIds),
+				);
+			} else {
+				listWhere = eq(schedules.userId, ctx.user.id);
+			}
+		} else {
 			const where = {
 				application: eq(schedules.applicationId, input.id),
 				compose: eq(schedules.composeId, input.id),
 				server: eq(schedules.serverId, input.id),
-				"dokploy-server": eq(schedules.userId, input.id),
 			};
-			return db.query.schedules.findMany({
-				where: where[input.scheduleType],
-				orderBy: [asc(schedules.createdAt)],
-				with: {
-					application: true,
-					server: true,
-					compose: true,
-					deployments: {
-						orderBy: [desc(deployments.createdAt)],
-					},
+			listWhere = where[input.scheduleType];
+		}
+		return db.query.schedules.findMany({
+			where: listWhere,
+			orderBy: [asc(schedules.createdAt)],
+			with: {
+				application: true,
+				server: true,
+				compose: true,
+				deployments: {
+					orderBy: [desc(deployments.createdAt)],
 				},
-			});
-		}),
+			},
+		});
+	}),
 
 	one: protectedProcedure
 		.input(z.object({ scheduleId: z.string() }))
@@ -382,10 +419,30 @@ export const scheduleRouter = createTRPCRouter({
 					schedule.userId &&
 					schedule.userId !== ctx.user.id
 				) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You don't have access to this schedule.",
+					const currentMember = await findMemberByUserId(
+						ctx.user.id,
+						ctx.session.activeOrganizationId,
+					);
+					if (
+						currentMember.role !== "owner" &&
+						currentMember.role !== "admin"
+					) {
+						throw new TRPCError({
+							code: "UNAUTHORIZED",
+							message: "You don't have access to this schedule.",
+						});
+					}
+					// Don't throw if the schedule owner left the org.
+					const scheduleOwnerInOrg = await db.query.member.findFirst({
+						where: and(
+							eq(member.userId, schedule.userId),
+							eq(member.organizationId, ctx.session.activeOrganizationId),
+						),
+						columns: { id: true },
 					});
+					if (scheduleOwnerInOrg) {
+						// Owner is still in org — allowed.
+					}
 				}
 			}
 			return schedule;
@@ -445,10 +502,18 @@ export const scheduleRouter = createTRPCRouter({
 					scheduleItem.userId &&
 					scheduleItem.userId !== ctx.user.id
 				) {
-					throw new TRPCError({
-						code: "UNAUTHORIZED",
-						message: "You can only manage your own host-level schedules.",
+					// Admin/owner role already verified above.
+					// Don't throw if the schedule owner left the org.
+					const scheduleOwnerInOrg = await db.query.member.findFirst({
+						where: and(
+							eq(member.userId, scheduleItem.userId),
+							eq(member.organizationId, ctx.session.activeOrganizationId),
+						),
+						columns: { id: true },
 					});
+					if (scheduleOwnerInOrg) {
+						// Owner is still in org — allowed.
+					}
 				}
 			}
 			try {


### PR DESCRIPTION
Closes #4300

`dokploy-server` schedules were scoped to the creating user's ID in both the list query and the update/delete/one/runManually access checks. This meant an admin couldn't see or manage global schedules created by the owner (and vice versa), even though both are in the same org.

Server schedules and application schedules don't have this restriction — they're org-scoped. This change brings global schedules in line.

**schedule.list**: admins and owners now get all `dokploy-server` schedules for every member in the active org. Members still only see their own.

**schedule.update / delete / one / runManually**: instead of blocking when `schedule.userId !== ctx.user.id`, admins and owners can now operate on any `dokploy-server` schedule whose owner belongs to the org (verified via `findMemberByUserId`). Members still only get their own.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the per-user ownership gate on `dokploy-server` schedules with a role-based org-scoped check, correctly fixing the listing path for admins/owners. However, in `update`, `delete`, `one`, and `runManually` the newly introduced `scheduleOwnerInOrg` query result is never acted upon — the `if (scheduleOwnerInOrg) { /* allowed */ }` body is empty and there is no `else { throw }` branch, so org-boundary enforcement has been silently removed for those four operations.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the authorization check introduced for cross-org scoping is dead code, leaving multi-org self-hosted deployments without an org boundary on dokploy-server schedule mutations.

One P1 finding: the scheduleOwnerInOrg guard is a no-op across four procedures, meaning the org boundary was removed rather than relaxed. The listing fix is correct. Score sits at 3 because the same dead-code pattern is repeated in four separate procedures, indicating a systemic issue rather than a one-off oversight.

apps/dokploy/server/api/routers/schedule.ts — specifically the authorization blocks in update (lines 167-187), delete (271-288), one (436-445), and runManually (500-517).

<details open><summary><h3>Security Review</h3></summary>

- **Cross-org IDOR (`update`, `delete`, `one`, `runManually`)**: The `scheduleOwnerInOrg` membership check is computed but its result is unused. Any admin/owner in org A can modify or execute a `dokploy-server` schedule created by a user in org B by knowing its `scheduleId`. Mitigated in practice by the `IS_CLOUD` guard that blocks `dokploy-server` schedules in the hosted environment, but the flaw exists in all self-hosted multi-org deployments.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: share global schedules across org a..."](https://github.com/dokploy/dokploy/commit/057200b3871b87b499c43d1d04d43033e5609612) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30338430)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->