### PR TITLE
fix: use temporary redirects for auth checks in getServerSideProps

### DIFF
--- a/apps/dokploy/pages/dashboard/deployments.tsx
+++ b/apps/dokploy/pages/dashboard/deployments.tsx
@@ -84,7 +84,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/home.tsx
+++ b/apps/dokploy/pages/dashboard/home.tsx
@@ -24,7 +24,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/monitoring.tsx
+++ b/apps/dokploy/pages/dashboard/monitoring.tsx
@@ -95,7 +95,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -104,7 +104,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -1827,7 +1827,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -451,7 +451,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -455,7 +455,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -307,7 +307,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -336,7 +336,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -340,7 +340,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -318,7 +318,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -324,7 +324,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -329,7 +329,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/projects.tsx
+++ b/apps/dokploy/pages/dashboard/projects.tsx
@@ -56,7 +56,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/requests.tsx
+++ b/apps/dokploy/pages/dashboard/requests.tsx
@@ -17,7 +17,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -26,7 +26,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/schedules.tsx
+++ b/apps/dokploy/pages/dashboard/schedules.tsx
@@ -34,7 +34,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -43,7 +43,7 @@ export async function getServerSideProps(
 	if (!user || (user.role !== "owner" && user.role !== "admin")) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/ai.tsx
+++ b/apps/dokploy/pages/dashboard/settings/ai.tsx
@@ -45,7 +45,7 @@ export async function getServerSideProps(
 	if (!user || user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/audit-logs.tsx
+++ b/apps/dokploy/pages/dashboard/settings/audit-logs.tsx
@@ -27,7 +27,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
 	if (!user) {
 		return {
-			redirect: { destination: "/", permanent: true },
+			redirect: { destination: "/", permanent: false },
 		};
 	}
 

--- a/apps/dokploy/pages/dashboard/settings/billing.tsx
+++ b/apps/dokploy/pages/dashboard/settings/billing.tsx
@@ -23,7 +23,7 @@ export async function getServerSideProps(
 	if (!IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -33,7 +33,7 @@ export async function getServerSideProps(
 	if (!user || user.role !== "owner") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/certificates.tsx
+++ b/apps/dokploy/pages/dashboard/settings/certificates.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(
 	if (!user || user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/cluster.tsx
+++ b/apps/dokploy/pages/dashboard/settings/cluster.tsx
@@ -27,7 +27,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -36,7 +36,7 @@ export async function getServerSideProps(
 	if (!user || user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/destinations.tsx
+++ b/apps/dokploy/pages/dashboard/settings/destinations.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(
 	if (!user || user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/git-providers.tsx
+++ b/apps/dokploy/pages/dashboard/settings/git-providers.tsx
@@ -27,7 +27,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -53,7 +53,7 @@ export async function getServerSideProps(
 		if (!userPermissions?.gitProviders.read) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};

--- a/apps/dokploy/pages/dashboard/settings/invoices.tsx
+++ b/apps/dokploy/pages/dashboard/settings/invoices.tsx
@@ -23,7 +23,7 @@ export async function getServerSideProps(
 	if (!IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -33,7 +33,7 @@ export async function getServerSideProps(
 	if (!user || user.role !== "owner") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/license.tsx
+++ b/apps/dokploy/pages/dashboard/settings/license.tsx
@@ -38,7 +38,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -46,7 +46,7 @@ export async function getServerSideProps(
 	if (user.role !== "owner") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/settings/profile",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/notifications.tsx
+++ b/apps/dokploy/pages/dashboard/settings/notifications.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(
 	if (!user || user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/profile.tsx
+++ b/apps/dokploy/pages/dashboard/settings/profile.tsx
@@ -54,7 +54,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/registry.tsx
+++ b/apps/dokploy/pages/dashboard/settings/registry.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(
 	if (!user || user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/server.tsx
+++ b/apps/dokploy/pages/dashboard/settings/server.tsx
@@ -44,7 +44,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -53,7 +53,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -61,7 +61,7 @@ export async function getServerSideProps(
 	if (user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/settings/profile",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/servers.tsx
+++ b/apps/dokploy/pages/dashboard/settings/servers.tsx
@@ -28,7 +28,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -36,7 +36,7 @@ export async function getServerSideProps(
 	if (user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/settings/profile",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/ssh-keys.tsx
+++ b/apps/dokploy/pages/dashboard/settings/ssh-keys.tsx
@@ -27,7 +27,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -54,7 +54,7 @@ export async function getServerSideProps(
 		if (!userPermissions?.sshKeys.read) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};

--- a/apps/dokploy/pages/dashboard/settings/sso.tsx
+++ b/apps/dokploy/pages/dashboard/settings/sso.tsx
@@ -46,7 +46,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -54,7 +54,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (user.role === "member") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/settings/profile",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/settings/tags.tsx
+++ b/apps/dokploy/pages/dashboard/settings/tags.tsx
@@ -47,7 +47,7 @@ export async function getServerSideProps(
 		if (!userPermissions?.tag.read) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};

--- a/apps/dokploy/pages/dashboard/settings/users.tsx
+++ b/apps/dokploy/pages/dashboard/settings/users.tsx
@@ -39,7 +39,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -66,7 +66,7 @@ export async function getServerSideProps(
 		if (!userPermissions?.member.read) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};

--- a/apps/dokploy/pages/dashboard/settings/whitelabeling.tsx
+++ b/apps/dokploy/pages/dashboard/settings/whitelabeling.tsx
@@ -46,7 +46,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -54,7 +54,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (user.role !== "owner") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/settings/profile",
 			},
 		};

--- a/apps/dokploy/pages/dashboard/swarm.tsx
+++ b/apps/dokploy/pages/dashboard/swarm.tsx
@@ -45,7 +45,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -54,7 +54,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -80,7 +80,7 @@ export async function getServerSideProps(
 		if (!userPermissions?.docker.read) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};

--- a/apps/dokploy/pages/dashboard/traefik.tsx
+++ b/apps/dokploy/pages/dashboard/traefik.tsx
@@ -23,7 +23,7 @@ export async function getServerSideProps(
 	if (IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};
@@ -32,7 +32,7 @@ export async function getServerSideProps(
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -58,7 +58,7 @@ export async function getServerSideProps(
 		if (!userPermissions?.traefikFiles.read) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};

--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -407,7 +407,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 			if (user) {
 				return {
 					redirect: {
-						permanent: true,
+						permanent: false,
 						destination: "/dashboard/home",
 					},
 				};
@@ -425,7 +425,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	if (!hasAdmin) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/register",
 			},
 		};
@@ -436,7 +436,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	if (user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/dashboard/home",
 			},
 		};

--- a/apps/dokploy/pages/invitation.tsx
+++ b/apps/dokploy/pages/invitation.tsx
@@ -333,7 +333,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	// if (IS_CLOUD) {
 	// 	return {
 	// 		redirect: {
-	// 			permanent: true,
+	// 			permanent: false,
 	// 			destination: "/",
 	// 		},
 	// 	};
@@ -342,7 +342,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	if (typeof token !== "string") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -365,7 +365,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 		if (invitation.isExpired) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/",
 				},
 			};
@@ -382,7 +382,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 		console.log("error", error);
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/register.tsx
+++ b/apps/dokploy/pages/register.tsx
@@ -302,7 +302,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 		if (user) {
 			return {
 				redirect: {
-					permanent: true,
+					permanent: false,
 					destination: "/dashboard/home",
 				},
 			};

--- a/apps/dokploy/pages/reset-password.tsx
+++ b/apps/dokploy/pages/reset-password.tsx
@@ -190,7 +190,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	if (!IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -200,7 +200,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	if (typeof token !== "string") {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/send-reset-password.tsx
+++ b/apps/dokploy/pages/send-reset-password.tsx
@@ -168,7 +168,7 @@ export async function getServerSideProps(_context: GetServerSidePropsContext) {
 	if (!IS_CLOUD) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};

--- a/apps/dokploy/pages/swagger.tsx
+++ b/apps/dokploy/pages/swagger.tsx
@@ -82,7 +82,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	if (!user) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};
@@ -103,7 +103,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	if (!userPermissions?.api.read) {
 		return {
 			redirect: {
-				permanent: true,
+				permanent: false,
 				destination: "/",
 			},
 		};


### PR DESCRIPTION
## Summary

- All `getServerSideProps` auth checks used `permanent: true` (HTTP 301), which browsers cache indefinitely
- After logout, the browser cached the unauthenticated redirect (`/dashboard/home → /`), so the next `router.push("/dashboard/home")` after login was intercepted by the cached 301 and sent back to the login page
- Users had to manually refresh (F5) to clear the cache and access the dashboard
- Changed all auth-related redirects to `permanent: false` (HTTP 302) so the browser always checks with the server

Fixes #4220