### PR TITLE
fix: remove leftover debug console.log statements

### DIFF
--- a/apps/dokploy/components/dashboard/database/backups/restore-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/restore-backup.tsx
@@ -288,7 +288,6 @@ export const RestoreBackup = ({
 			toast.error("Please select a database type");
 			return;
 		}
-		console.log({ data });
 		setIsDeploying(true);
 	};
 

--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -632,7 +632,6 @@ export const AddDatabase = ({ environmentId, projectName }: Props) => {
 										control={form.control}
 										name="enableNamespaces"
 										render={({ field }) => {
-											console.log(field.value);
 											return (
 												<FormItem>
 													<FormLabel>Enable Namespaces</FormLabel>

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -856,8 +856,6 @@ export const projectRouter = createTRPCRouter({
 							ctx.session.activeOrganizationId,
 						).then((value) => value.environment);
 
-				console.log("targetProject", targetProject);
-
 				if (input.includeServices) {
 					const servicesToDuplicate = input.selectedServices || [];
 


### PR DESCRIPTION
Three stray debug `console.log` calls were left behind in production code paths. This PR removes them.

**Removals:**

- `apps/dokploy/components/dashboard/database/backups/restore-backup.tsx`
  Logged the full form-submission payload (`{ data }`) on every backup restore submit.

- `apps/dokploy/components/dashboard/project/add-database.tsx`
  Logged `field.value` for the libsql `enableNamespaces` field from **inside the `render` callback**, so it fired on every re-render of the parent form (every keystroke that re-rendered).

- `apps/dokploy/server/api/routers/project.ts`
  Server-side log of the freshly-created `targetProject` row in the `duplicateProject` mutation, leaking a DB object into production logs on every duplicate.

**Why these and not others:** I deliberately kept `console.log` / `console.error` calls that look intentional (server boot logs in `server.ts`, error paths in `catch` blocks, BullMQ queue lifecycle messages). Only the three above had no surrounding intentional-logging context and were clearly leftover from local debugging.

**Risk:** zero behaviour change — strictly removes log noise. No tests touch these specific lines.
