### PR TITLE
fix(sidebar): close mobile sidebar on navigation

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -868,6 +868,19 @@ function SidebarLogo() {
 	);
 }
 
+function MobileCloser() {
+	const pathname = usePathname();
+	const { setOpenMobile, isMobile } = useSidebar();
+
+	useEffect(() => {
+		if (isMobile) {
+			setOpenMobile(false);
+		}
+	}, [pathname, isMobile, setOpenMobile]);
+
+	return null;
+}
+
 export default function Page({ children }: Props) {
 	const [defaultOpen, setDefaultOpen] = useState<boolean | undefined>(
 		undefined,
@@ -933,6 +946,7 @@ export default function Page({ children }: Props) {
 				} as React.CSSProperties
 			}
 		>
+			<MobileCloser />
 			<Sidebar collapsible="icon" variant="floating">
 				<SidebarHeader>
 					{/* <SidebarMenuButton


### PR DESCRIPTION
## Summary

- Adds a `MobileCloser` component inside `SidebarProvider` that listens to pathname changes and calls `setOpenMobile(false)` when on mobile
- Fixes the sidebar staying open after navigating to a different page on mobile devices

Closes #4340