### PR TITLE
fix: align card footers to bottom on project and service cards

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -344,7 +344,7 @@ export const ShowProjects = () => {
 															}
 														}}
 													>
-														<Card className="group relative w-full h-full bg-transparent transition-colors hover:bg-border">
+														<Card className="group relative w-full h-full bg-transparent transition-colors hover:bg-border flex flex-col">
 															<CardHeader>
 																<CardTitle className="flex items-center justify-between gap-2 overflow-clip">
 																	<span className="flex flex-col gap-1.5 ">
@@ -491,7 +491,7 @@ export const ShowProjects = () => {
 																	</div>
 																</CardTitle>
 															</CardHeader>
-															<CardFooter className="pt-4">
+															<CardFooter className="pt-4 mt-auto">
 																<div className="space-y-1 text-xs flex flex-row justify-between max-sm:flex-wrap w-full gap-2 sm:gap-4">
 																	<DateTooltip date={project.createdAt}>
 																		Created

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId].tsx
@@ -1620,9 +1620,9 @@ const EnvironmentPage = (
 														<ContextMenuTrigger asChild>
 															<Link
 																href={`/dashboard/project/${projectId}/environment/${environmentId}/services/${service.type}/${service.id}`}
-																className="block"
+																className="block h-full"
 															>
-																<Card className="flex flex-col group relative cursor-pointer bg-transparent transition-colors hover:bg-border">
+																<Card className="flex flex-col h-full group relative cursor-pointer bg-transparent transition-colors hover:bg-border">
 																	{service.serverId && (
 																		<div className="absolute -left-1 -top-2">
 																			<ServerIcon className="size-4 text-muted-foreground" />


### PR DESCRIPTION
## What is this PR about?

Fixes misaligned card footers ("Created at" timestamp and service count) on the Projects page and the Services page. When one card has a description and another doesn't, the footer text was not sticking to the bottom of the card, causing visual misalignment across cards in the same grid row.

**Changes:**

- **Projects page** (`show.tsx`): Added `flex flex-col` to the Card and `mt-auto` to CardFooter so the footer is always pushed to the bottom.
- **Services page** (`[environmentId].tsx`): Added `h-full` to the Link wrapper and Card so they stretch to fill the grid cell, allowing the existing `mt-auto` on CardFooter to work correctly.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots (if applicable)

**Before:** 
<img width="1494" height="684" alt="image" src="https://github.com/user-attachments/assets/6a518475-7844-473b-ba34-6a84438b1102" />
<img width="1510" height="752" alt="image" src="https://github.com/user-attachments/assets/c7ef2791-bb43-4d12-92d4-38cbe1cc0e45" />


**After:** 
<img width="1508" height="728" alt="image" src="https://github.com/user-attachments/assets/daac4503-2c86-43e6-9d53-0fe5d5a28a85" />
<img width="1514" height="762" alt="image" src="https://github.com/user-attachments/assets/4810d72b-e7d0-4516-8dca-cf890569656c" />
