### PR TITLE
fix: docker cleanup

### DIFF
--- a/apps/dokploy/__test__/traefik/server/update-server-config.test.ts
+++ b/apps/dokploy/__test__/traefik/server/update-server-config.test.ts
@@ -24,7 +24,7 @@ const baseSettings: WebServerSettings = {
 	serverIp: null,
 	letsEncryptEmail: null,
 	sshPrivateKey: null,
-	enableDockerCleanup: false,
+	enableDockerCleanup: true,
 	logCleanupCron: null,
 	metricsConfig: {
 		containers: {

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -270,13 +270,16 @@ export const settingsRouter = createTRPCRouter({
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
 			// Execute cleanup in background and return immediately to avoid gateway timeouts
-			const result = void cleanupAll(input?.serverId);
+			void cleanupAll(input?.serverId);
 			await audit(ctx, {
 				action: "delete",
 				resourceType: "settings",
 				resourceName: "clean-all",
 			});
-			return result;
+			return {
+				status: "scheduled",
+				message: "Docker cleanup has been initiated in the background",
+			};
 		}),
 	cleanMonitoring: adminProcedure.mutation(async ({ ctx }) => {
 		if (IS_CLOUD) {

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -6,7 +6,6 @@ import {
 	checkRedisHealth,
 	checkTraefikHealth,
 	cleanupAll,
-	cleanupAllBackground,
 	cleanupBuilders,
 	cleanupContainers,
 	cleanupImages,
@@ -271,7 +270,7 @@ export const settingsRouter = createTRPCRouter({
 		.input(apiServerSchema)
 		.mutation(async ({ input, ctx }) => {
 			// Execute cleanup in background and return immediately to avoid gateway timeouts
-			const result = await cleanupAllBackground(input?.serverId);
+			const result = void cleanupAll(input?.serverId);
 			await audit(ctx, {
 				action: "delete",
 				resourceType: "settings",

--- a/packages/server/src/db/schema/schema.dbml
+++ b/packages/server/src/db/schema/schema.dbml
@@ -864,7 +864,7 @@ table server {
   port integer [not null]
   username text [not null, default: 'root']
   appName text [not null]
-  enableDockerCleanup boolean [not null, default: false]
+  enableDockerCleanup boolean [not null, default: true]
   createdAt text [not null]
   organizationId text [not null]
   serverStatus serverStatus [not null, default: 'active']
@@ -938,7 +938,7 @@ table user_temp {
   host text
   letsEncryptEmail text
   sshPrivateKey text
-  enableDockerCleanup boolean [not null, default: false]
+  enableDockerCleanup boolean [not null, default: true]
   logCleanupCron text [default: '0 0 * * *']
   role text [not null, default: 'user']
   enablePaidFeatures boolean [not null, default: false]

--- a/packages/server/src/db/schema/server.ts
+++ b/packages/server/src/db/schema/server.ts
@@ -40,7 +40,7 @@ export const server = pgTable("server", {
 	appName: text("appName")
 		.notNull()
 		.$defaultFn(() => generateAppName("server")),
-	enableDockerCleanup: boolean("enableDockerCleanup").notNull().default(false),
+	enableDockerCleanup: boolean("enableDockerCleanup").notNull().default(true),
 	createdAt: text("createdAt").notNull(),
 	organizationId: text("organizationId")
 		.notNull()

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -159,7 +159,7 @@ echo "Preparing for execution..."
 while true; do
   docker_processes=$(pgrep -af "(docker|podman) [a-zA-Z]")
 
-  if test -z "\${docker_processes}"; then
+  if [ -z "\${docker_processes}" ]; then
     echo "Docker is idle. Starting execution..."
 
     break

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -159,7 +159,7 @@ echo "Preparing for execution..."
 while true; do
   docker_processes=$(pgrep -af "(docker|podman) [a-zA-Z]")
 
-  if [ -z "\${docker_processes}" ]; then
+  if test -z "\${docker_processes}"; then
     echo "Docker is idle. Starting execution..."
 
     break

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -164,7 +164,7 @@ while true; do
 
     break
   else
-    echo "Docker is busy. Will check again in \${check_interval} seconds..."
+    echo "Docker is busy. It will check again in \${check_interval} seconds..."
 
     sleep "\${check_interval}"
   fi

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -151,34 +151,36 @@ export const getContainerByName = (name: string): Promise<ContainerInfo> => {
  *
  * https://github.com/Dokploy/dokploy/pull/3064
  */
-export const dockerSafeExec = (exec: string) => `
-CHECK_INTERVAL=10
+export const dockerIdleExec = (command: string) => `
+check_interval=10
 
 echo "Preparing for execution..."
 
 while true; do
-    PROCESSES=$(ps aux | grep -E "^.*docker [A-Za-z]" | grep -v grep)
+  docker_processes=$(pgrep -af "(docker|podman) [a-zA-Z]")
 
-    if [ -z "$PROCESSES" ]; then
-        echo "Docker is idle. Starting execution..."
-        break
-    else
-        echo "Docker is busy. Will check again in $CHECK_INTERVAL seconds..."
-        sleep $CHECK_INTERVAL
-    fi
+  if [ -z "\${docker_processes}" ]; then
+    echo "Docker is idle. Starting execution..."
+
+    break
+  else
+    echo "Docker is busy. Will check again in \${check_interval} seconds..."
+
+    sleep "\${check_interval}"
+  fi
 done
 
-${exec}
+${command}
 
 echo "Execution completed."
 `;
 
 const cleanupCommands = {
-	containers: "docker container prune --force",
-	images: "docker image prune --all --force",
-	volumes: "docker volume prune --all --force",
-	builders: "docker builder prune --all --force",
-	system: "docker system prune --all --force",
+	containers: dockerIdleExec("docker container prune --force"),
+	images: dockerIdleExec("docker image prune --all --force"),
+	volumes: dockerIdleExec("docker volume prune --all --force"),
+	builders: dockerIdleExec("docker builder prune --all --force"),
+	system: dockerIdleExec("docker system prune --all --force"),
 };
 
 export const cleanupContainers = async (serverId?: string) => {
@@ -186,9 +188,9 @@ export const cleanupContainers = async (serverId?: string) => {
 		const command = cleanupCommands.containers;
 
 		if (serverId) {
-			await execAsyncRemote(serverId, dockerSafeExec(command));
+			await execAsyncRemote(serverId, command);
 		} else {
-			await execAsync(dockerSafeExec(command));
+			await execAsync(command);
 		}
 	} catch (error) {
 		console.error(error);
@@ -202,8 +204,10 @@ export const cleanupImages = async (serverId?: string) => {
 		const command = cleanupCommands.images;
 
 		if (serverId) {
-			await execAsyncRemote(serverId, dockerSafeExec(command));
-		} else await execAsync(dockerSafeExec(command));
+			await execAsyncRemote(serverId, command);
+		} else {
+			await execAsync(command);
+		}
 	} catch (error) {
 		console.error(error);
 
@@ -216,9 +220,9 @@ export const cleanupVolumes = async (serverId?: string) => {
 		const command = cleanupCommands.volumes;
 
 		if (serverId) {
-			await execAsyncRemote(serverId, dockerSafeExec(command));
+			await execAsyncRemote(serverId, command);
 		} else {
-			await execAsync(dockerSafeExec(command));
+			await execAsync(command);
 		}
 	} catch (error) {
 		console.error(error);
@@ -232,9 +236,9 @@ export const cleanupBuilders = async (serverId?: string) => {
 		const command = cleanupCommands.builders;
 
 		if (serverId) {
-			await execAsyncRemote(serverId, dockerSafeExec(command));
+			await execAsyncRemote(serverId, command);
 		} else {
-			await execAsync(dockerSafeExec(command));
+			await execAsync(command);
 		}
 	} catch (error) {
 		console.error(error);
@@ -248,14 +252,40 @@ export const cleanupSystem = async (serverId?: string) => {
 		const command = cleanupCommands.system;
 
 		if (serverId) {
-			await execAsyncRemote(serverId, dockerSafeExec(command));
+			await execAsyncRemote(serverId, command);
 		} else {
-			await execAsync(dockerSafeExec(command));
+			await execAsync(command);
 		}
 	} catch (error) {
 		console.error(error);
 
 		throw error;
+	}
+};
+
+/**
+ * Volume cleanup should always be performed manually by the user. The reason is that during automatic cleanup, a volume may be deleted due to a stopped container, which is a dangerous situation.
+ *
+ * https://github.com/Dokploy/dokploy/pull/3267
+ */
+const excludedCleanupAllCommands: (keyof typeof cleanupCommands)[] = [
+	"volumes",
+];
+
+export const cleanupAll = async (serverId?: string) => {
+	for (const [key, command] of Object.entries(cleanupCommands) as [
+		keyof typeof cleanupCommands,
+		string,
+	][]) {
+		if (excludedCleanupAllCommands.includes(key)) continue;
+
+		try {
+			if (serverId) {
+				await execAsyncRemote(serverId, command);
+			} else {
+				await execAsync(command);
+			}
+		} catch {}
 	}
 };
 
@@ -299,65 +329,6 @@ export const getDockerDiskUsage = async (): Promise<DockerDiskUsageItem[]> => {
 			sizeBytes: parseSizeToBytes(data.Size),
 		};
 	});
-};
-
-/**
- * Volume cleanup should always be performed manually by the user. The reason is that during automatic cleanup, a volume may be deleted due to a stopped container, which is a dangerous situation.
- *
- * https://github.com/Dokploy/dokploy/pull/3267
- */
-const excludedCleanupAllCommands: (keyof typeof cleanupCommands)[] = [
-	"volumes",
-];
-
-export const cleanupAll = async (serverId?: string) => {
-	for (const [key, command] of Object.entries(cleanupCommands) as [
-		keyof typeof cleanupCommands,
-		string,
-	][]) {
-		if (excludedCleanupAllCommands.includes(key)) continue;
-
-		try {
-			if (serverId) {
-				await execAsyncRemote(serverId, dockerSafeExec(command));
-			} else {
-				await execAsync(dockerSafeExec(command));
-			}
-		} catch {}
-	}
-};
-
-export const cleanupAllBackground = async (serverId?: string) => {
-	Promise.allSettled(
-		(
-			Object.entries(cleanupCommands) as [
-				keyof typeof cleanupCommands,
-				string,
-			][]
-		)
-			.filter(([key]) => !excludedCleanupAllCommands.includes(key))
-			.map(async ([, command]) => {
-				if (serverId) {
-					await execAsyncRemote(serverId, dockerSafeExec(command));
-				} else {
-					await execAsync(dockerSafeExec(command));
-				}
-			}),
-	)
-		.then((results) => {
-			const failed = results.filter((r) => r.status === "rejected");
-			if (failed.length > 0) {
-				console.error(`Docker cleanup: ${failed.length} operations failed`);
-			} else {
-				console.log("Docker cleanup completed successfully");
-			}
-		})
-		.catch((error) => console.error("Error in cleanup:", error));
-
-	return {
-		status: "scheduled",
-		message: "Docker cleanup has been initiated in the background",
-	};
 };
 
 export const startService = async (appName: string) => {


### PR DESCRIPTION
## What is this PR about?

The following changes have been made in this pull request:

- **Shortcut**. Removed `cleanupAllBackground()`, using `void cleanupAll()` instead.
- **Feat.** Added Podman support to the `dockerIdleExec()`.
- **Code beautifing**. Moved the `cleanupAll()` _(which was located below Docker Disk Usage)_ further up.
- **Cleanup Setting**. `enableDockerCleanup` should be set to `true` by default. The parts that were set to `false` have been changed to `true`.

## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

## Screenshots (if applicable)

