### PR TITLE
fix(deploy): notify on container crash loop after deployment

### DIFF
--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -30,7 +30,7 @@ import { createTraefikConfig } from "@dokploy/server/utils/traefik/application";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import type { z } from "zod";
-import { encodeBase64 } from "../utils/docker/utils";
+import { encodeBase64, waitForSwarmServiceStable } from "../utils/docker/utils";
 import { getDokployUrl } from "./admin";
 import {
 	createDeployment,
@@ -222,6 +222,16 @@ export const deployApplication = async ({
 		}
 
 		await mechanizeDockerContainer(application);
+
+		const stability = await waitForSwarmServiceStable(application.appName, {
+			serverId,
+		});
+		if (!stability.stable) {
+			throw new Error(
+				`Container did not stay running after deployment: ${stability.reason}`,
+			);
+		}
+
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 		await updateApplicationStatus(applicationId, "done");
 
@@ -313,6 +323,16 @@ export const rebuildApplication = async ({
 			await execAsync(commandWithLog);
 		}
 		await mechanizeDockerContainer(application);
+
+		const stability = await waitForSwarmServiceStable(application.appName, {
+			serverId,
+		});
+		if (!stability.stable) {
+			throw new Error(
+				`Container did not stay running after rebuild: ${stability.reason}`,
+			);
+		}
+
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 		await updateApplicationStatus(applicationId, "done");
 

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -854,6 +854,89 @@ const getSwarmServiceContainerId = async (
 	}
 };
 
+export type SwarmStabilityResult =
+	| { stable: true }
+	| { stable: false; reason: string };
+
+export const waitForSwarmServiceStable = async (
+	appName: string,
+	{
+		serverId,
+		windowMs = 60_000,
+		pollMs = 5_000,
+	}: { serverId?: string | null; windowMs?: number; pollMs?: number } = {},
+): Promise<SwarmStabilityResult> => {
+	const remoteDocker = await getRemoteDocker(serverId);
+	const deadline = Date.now() + windowMs;
+	let everRunning = false;
+	let lastReason = "Service did not reach running state";
+
+	while (Date.now() < deadline) {
+		try {
+			const tasks = await remoteDocker.listTasks({
+				filters: JSON.stringify({ service: [appName] }),
+			});
+
+			const sorted = [...tasks].sort((a, b) => {
+				const at = new Date(a.UpdatedAt ?? 0).getTime();
+				const bt = new Date(b.UpdatedAt ?? 0).getTime();
+				return bt - at;
+			});
+			const latest = sorted[0];
+			const state = latest?.Status?.State;
+			const message = latest?.Status?.Err || latest?.Status?.Message || "";
+
+			if (state === "failed" || state === "rejected") {
+				return {
+					stable: false,
+					reason: message
+						? `Task ${state}: ${message}`
+						: `Task entered ${state} state`,
+				};
+			}
+
+			const runningCount = sorted.filter(
+				(t) => t.Status?.State === "running",
+			).length;
+			const startingCount = sorted.filter((t) =>
+				[
+					"new",
+					"pending",
+					"assigned",
+					"accepted",
+					"preparing",
+					"starting",
+				].includes(t.Status?.State ?? ""),
+			).length;
+
+			if (runningCount > 0) {
+				everRunning = true;
+			} else if (everRunning && startingCount > 0) {
+				return {
+					stable: false,
+					reason: message
+						? `Container restarted after running: ${message}`
+						: "Container restarted after reaching running state",
+				};
+			}
+
+			lastReason = message
+				? `Latest task state: ${state ?? "unknown"} (${message})`
+				: `Latest task state: ${state ?? "unknown"}`;
+		} catch (error) {
+			lastReason =
+				error instanceof Error ? error.message : "Failed to inspect service";
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, pollMs));
+	}
+
+	if (everRunning) {
+		return { stable: true };
+	}
+	return { stable: false, reason: lastReason };
+};
+
 export const checkPostgresHealth = async (): Promise<ServiceHealthStatus> => {
 	const serviceCheck = await checkSwarmServiceRunning("dokploy-postgres");
 	if (serviceCheck.status === "unhealthy") {


### PR DESCRIPTION
## What is this PR about?

Fixes #4339 — when a container crash-loops right after a successful build, Dokploy was reporting the deploy as successful and skipping the failure notification.

The deploy flow now waits up to 60s for the Swarm task to reach (and stay in) `running`. If it enters `failed`/`rejected` or restarts after running, the deployment is marked `error` and the existing failure notification fires across all configured channels (Slack, Email, Discord, etc.).

New helper `waitForSwarmServiceStable` in [packages/server/src/utils/docker/utils.ts](packages/server/src/utils/docker/utils.ts), wired into `deployApplication` and `rebuildApplication`. Verified against a live local Docker Swarm: healthy `nginx` → `stable: true`; `CMD exit 1` → `stable: false` with the Swarm error surfaced in the notification.


## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4339

## Screenshots (if applicable)

N/A — backend-only change. Verified via a live Docker Swarm test against the helper:

```
=== Test 1: stable nginx service ===
Result: { stable: true }                           ← PASS

=== Test 2: crash-looping service (exit 1) ===
Result: { stable: false, reason: 'Task failed: task: non-zero exit (1)' }   ← PASS
```

**Scope:** covers `deployApplication` and `rebuildApplication`. Compose and preview deployments aren't included — Compose isn't Swarm so it needs a separate check; happy to follow up.

