### PR TITLE
feat(templates): support isolated = false opt-out in template.toml

### DIFF
--- a/apps/dokploy/__test__/templates/config.template.test.ts
+++ b/apps/dokploy/__test__/templates/config.template.test.ts
@@ -494,4 +494,49 @@ describe("processTemplate", () => {
 			expect(result.mounts).toHaveLength(1);
 		});
 	});
+
+	describe("isolated deployment config", () => {
+		it("should default to isolated=true when not specified", () => {
+			const template: CompleteTemplate = {
+				metadata: {} as any,
+				variables: {},
+				config: {
+					domains: [],
+					env: {},
+				},
+			};
+
+			expect(template.config.isolated).toBeUndefined();
+			// undefined !== false => isolatedDeployment = true
+			expect(template.config.isolated !== false).toBe(true);
+		});
+
+		it("should be isolated when isolated=true is explicitly set", () => {
+			const template: CompleteTemplate = {
+				metadata: {} as any,
+				variables: {},
+				config: {
+					isolated: true,
+					domains: [],
+					env: {},
+				},
+			};
+
+			expect(template.config.isolated !== false).toBe(true);
+		});
+
+		it("should disable isolated deployment when isolated=false", () => {
+			const template: CompleteTemplate = {
+				metadata: {} as any,
+				variables: {},
+				config: {
+					isolated: false,
+					domains: [],
+					env: {},
+				},
+			};
+
+			expect(template.config.isolated !== false).toBe(false);
+		});
+	});
 });

--- a/apps/dokploy/__test__/templates/helpers.template.test.ts
+++ b/apps/dokploy/__test__/templates/helpers.template.test.ts
@@ -30,9 +30,7 @@ describe("helpers functions", () => {
 			const domain = processValue("${domain}", {}, mockSchema);
 			expect(domain.startsWith(`${mockSchema.projectName}-`)).toBeTruthy();
 			expect(
-				domain.endsWith(
-					`${mockSchema.serverIp.replaceAll(".", "-")}.sslip.io`,
-				),
+				domain.endsWith(`${mockSchema.serverIp.replaceAll(".", "-")}.sslip.io`),
 			).toBeTruthy();
 		});
 	});

--- a/apps/dokploy/__test__/templates/helpers.template.test.ts
+++ b/apps/dokploy/__test__/templates/helpers.template.test.ts
@@ -31,7 +31,7 @@ describe("helpers functions", () => {
 			expect(domain.startsWith(`${mockSchema.projectName}-`)).toBeTruthy();
 			expect(
 				domain.endsWith(
-					`${mockSchema.serverIp.replaceAll(".", "-")}.traefik.me`,
+					`${mockSchema.serverIp.replaceAll(".", "-")}.sslip.io`,
 				),
 			).toBeTruthy();
 		});

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -640,7 +640,7 @@ export const composeRouter = createTRPCRouter({
 				name: input.id,
 				sourceType: "raw",
 				appName: appName,
-				isolatedDeployment: true,
+				isolatedDeployment: template.config.config?.isolated !== false,
 			});
 
 			await addNewService(ctx, compose.composeId);

--- a/packages/server/src/templates/github.ts
+++ b/packages/server/src/templates/github.ts
@@ -21,6 +21,7 @@ export interface CompleteTemplate {
 		[key: string]: string;
 	};
 	config: {
+		isolated?: boolean;
 		domains: Array<{
 			serviceName: string;
 			port: number;

--- a/packages/server/src/templates/processors.ts
+++ b/packages/server/src/templates/processors.ts
@@ -45,6 +45,7 @@ export interface CompleteTemplate {
 	};
 	variables: Record<string, string>;
 	config: {
+		isolated?: boolean;
 		domains: DomainConfig[];
 		env:
 			| Record<string, string | boolean | number>


### PR DESCRIPTION
## Summary

- Adds `isolated?: boolean` field to `[config]` in the `CompleteTemplate` interface
- When a template sets `isolated = false` in its `template.toml`, Dokploy skips isolated deployment (no network injection)
- Default behavior is unchanged — `isolated` is `true` by default for all existing templates

This fixes deployments of templates like cloudflared that use `network_mode: host`, which is mutually exclusive with Docker networks. Without this, Dokploy's network injection causes:
```
service cloudflared declares mutually exclusive network_mode and networks: invalid compose project
```

Closes #4366

**Related:** Dokploy/templates#856 (adds `isolated = false` to the cloudflared template)