### PR TITLE
fix(wss): add colon to directory validation regex to fix deployment logs loading

### DIFF
--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dokploy",
-	"version": "v0.29.3",
+	"version": "v0.29.4",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/packages/server/src/wss/utils.ts
+++ b/packages/server/src/wss/utils.ts
@@ -40,7 +40,7 @@ export const readValidDirectory = (
 	directory: string,
 	serverId?: string | null,
 ) => {
-	if (!/^[\w/. -]{1,500}$/.test(directory)) {
+	if (!/^[\w/. :-]{1,500}$/.test(directory)) {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

- Fixes #4379 — deployments stuck loading after v0.29.3
- The `readValidDirectory` validation regex `^[\w/. -]{1,500}$` introduced in a4e2317 was missing `:` (colon), which is present in all deployment log filenames (format: `appName-yyyy-MM-dd:HH:mm:ss.log`)
- This caused the WebSocket to immediately close with "Invalid log path", leaving the UI in an infinite loading state
- Fix: add `:` to the character class → `^[\w/. :-]{1,500}$`