### PR TITLE
fix: lowercase username in registery creation and build/update

### DIFF
--- a/packages/server/src/db/schema/registry.ts
+++ b/packages/server/src/db/schema/registry.ts
@@ -44,6 +44,13 @@ export const registryRelations = relations(registry, ({ many }) => ({
 	}),
 }));
 
+// Image references require a lowercase namespace (e.g. Docker Hub username).
+const registryUsernameSchema = z
+	.string()
+	.trim()
+	.min(1)
+	.transform((s) => s.toLowerCase());
+
 // Registry URLs must be hostname[:port] only — no shell metacharacters
 // Empty string is allowed (means default/Docker Hub registry)
 const registryUrlSchema = z
@@ -57,7 +64,7 @@ const registryUrlSchema = z
 
 const createSchema = createInsertSchema(registry, {
 	registryName: z.string().min(1),
-	username: z.string().min(1),
+	username: registryUsernameSchema,
 	password: z.string().min(1),
 	registryUrl: registryUrlSchema,
 	organizationId: z.string().min(1),
@@ -70,7 +77,7 @@ export const apiCreateRegistry = createSchema
 	.pick({})
 	.extend({
 		registryName: z.string().min(1),
-		username: z.string().min(1),
+		username: registryUsernameSchema,
 		password: z.string().min(1),
 		registryUrl: registryUrlSchema,
 		registryType: z.enum(["cloud"]),
@@ -83,7 +90,7 @@ export const apiCreateRegistry = createSchema
 
 export const apiTestRegistry = createSchema.pick({}).extend({
 	registryName: z.string().optional(),
-	username: z.string().min(1),
+	username: registryUsernameSchema,
 	password: z.string().min(1),
 	registryUrl: registryUrlSchema,
 	registryType: z.enum(["cloud"]),

--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -101,8 +101,8 @@ export const getRegistryTag = (registry: Registry, imageName: string) => {
 	// Extract the repository name (last part after '/')
 	const repositoryName = extractRepositoryName(imageName);
 
-	// Build the final tag using registry's username/prefix
-	const targetPrefix = imagePrefix || username;
+	// Build the final tag using registry's username/prefix (must be lowercase for valid image refs)
+	const targetPrefix = (imagePrefix || username).toLowerCase();
 	const finalRegistry = registryUrl || "";
 
 	return finalRegistry


### PR DESCRIPTION
## What is this PR about?

Please describe in a short paragraph what this PR is about.

I recently ran an into an issue with uploading to GHCR with a capital letter in my username e.g. `Baker`. The test was success with the capital but in production it failed to upload, and caused the deployment to fail which is not ideal. 

```
Error parsing reference: "ghcr.io/Baker/dnsbuddy-frontend-pamcuy:v6" is not a valid repository/tag: invalid reference format: repository name (Baker/dnsbuddy-frontend-pamcuy) must be lowercase
❌ Error tagging image
Error occurred ❌, check the logs for details.
```

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A I decided to fix it instead of creating a bug. 

## Screenshots (if applicable)

