### PR TITLE
fix(gitlab): use default expires_in for older GitLab versions

### DIFF
--- a/apps/dokploy/pages/api/providers/gitlab/callback.ts
+++ b/apps/dokploy/pages/api/providers/gitlab/callback.ts
@@ -53,7 +53,7 @@ export default async function handler(
 		return res.status(400).json({ error: "Missing or invalid code" });
 	}
 
-	const expiresAt = Math.floor(Date.now() / 1000) + result.expires_in;
+	const expiresAt = Math.floor(Date.now() / 1000) + (result.expires_in || 7200);
 	await updateGitlab(gitlab.gitlabId, {
 		accessToken: result.access_token,
 		refreshToken: result.refresh_token,


### PR DESCRIPTION
Some older GitLab versions return empty expires_in parameter during OAuth callback, causing database update errors. Now defaults to 7200 seconds (2 hours) when expires_in is not provided.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

