### PR TITLE
feat: sort services in breadcrumb dropdown by user preference

### DIFF
--- a/apps/dokploy/components/shared/advance-breadcrumb.tsx
+++ b/apps/dokploy/components/shared/advance-breadcrumb.tsx
@@ -45,10 +45,12 @@ type ServiceItem = {
 	id: string;
 	name: string;
 	type: ServiceType;
+	createdAt: string;
 };
 
 type NamedService = {
 	name: string;
+	createdAt: string;
 };
 
 type EnvironmentServiceCollections = {
@@ -127,7 +129,7 @@ const countEnvironmentServices = (environment: ServiceCollections): number =>
 		0,
 	);
 
-const mapServices = <T extends { name: string }>(
+const mapServices = <T extends { name: string; createdAt: string }>(
 	items: readonly T[],
 	getId: (item: T) => string,
 	type: ServiceType,
@@ -136,7 +138,46 @@ const mapServices = <T extends { name: string }>(
 		id: getId(item),
 		name: item.name,
 		type,
+		createdAt: item.createdAt,
 	}));
+
+const SERVICES_SORT_KEY = "servicesSort";
+const DEFAULT_SORT = "lastDeploy-desc";
+
+const parseSortBy = (sortBy: string): { field: string; direction: string } => {
+	const idx = sortBy.lastIndexOf("-");
+	if (idx === -1) return { field: sortBy, direction: "desc" };
+	return { field: sortBy.slice(0, idx), direction: sortBy.slice(idx + 1) };
+};
+
+const sortServices = (services: ServiceItem[], sortBy: string): ServiceItem[] => {
+	const { field, direction } = parseSortBy(sortBy);
+
+	if (field === "createdAt" || field === "lastDeploy") {
+		const timestamps = new Map(
+			services.map((s) => [s.id, new Date(s.createdAt).getTime()]),
+		);
+		return [...services].sort((a, b) => {
+			const diff = (timestamps.get(a.id) ?? 0) - (timestamps.get(b.id) ?? 0);
+			return direction === "asc" ? diff : -diff;
+		});
+	}
+
+	return [...services].sort((a, b) => {
+		let comparison = 0;
+		switch (field) {
+			case "name":
+				comparison = a.name.localeCompare(b.name);
+				break;
+			case "type":
+				comparison = a.type.localeCompare(b.type);
+				break;
+			default:
+				comparison = 0;
+		}
+		return direction === "asc" ? comparison : -comparison;
+	});
+};
 
 const extractServicesFromEnvironment = (
 	environment: EnvironmentDetails | null | undefined,
@@ -203,6 +244,22 @@ export const AdvanceBreadcrumb = () => {
 	const [expandedProjectId, setExpandedProjectId] = useState<string | null>(
 		null,
 	);
+	const [servicesSort, setServicesSort] = useState(() => {
+		if (typeof window !== "undefined") {
+			return localStorage.getItem(SERVICES_SORT_KEY) || DEFAULT_SORT;
+		}
+		return DEFAULT_SORT;
+	});
+
+	useEffect(() => {
+		const onStorage = (e: StorageEvent) => {
+			if (e.key === SERVICES_SORT_KEY) {
+				setServicesSort(e.newValue || DEFAULT_SORT);
+			}
+		};
+		window.addEventListener("storage", onStorage);
+		return () => window.removeEventListener("storage", onStorage);
+	}, []);
 
 	// Fetch all projects
 	const { data: allProjects } = api.project.all.useQuery();
@@ -296,11 +353,12 @@ export const AdvanceBreadcrumb = () => {
 		[allProjects, projectSearch],
 	);
 
-	const filteredServices = useMemo(
-		() =>
-			services.filter((service) => includesSearch(service.name, serviceSearch)),
-		[serviceSearch, services],
-	);
+	const filteredServices = useMemo(() => {
+		const filtered = services.filter((service) =>
+			includesSearch(service.name, serviceSearch),
+		);
+		return sortServices(filtered, servicesSort);
+	}, [serviceSearch, services, servicesSort]);
 
 	const filteredEnvironments = useMemo(
 		() =>


### PR DESCRIPTION
## Summary
- The breadcrumb service selector dropdown now sorts services using the same `servicesSort` preference (from `localStorage`) that the environment page already uses
- Adds `createdAt` to the breadcrumb's `ServiceItem` type so date-based sorting works
- Listens for `storage` events to stay in sync when the user changes sort on the environment page
- Pre-computes timestamps for date sorts to avoid repeated `new Date()` allocations in the comparator
- Uses `lastIndexOf("-")` to safely parse sort values like `lastDeploy-desc`

## Context
Currently the environment page lets users pick a sort order (name, type, createdAt, lastDeploy × asc/desc) and persists it in `localStorage` under `servicesSort`. But the breadcrumb's service dropdown ignores this preference and always shows services in the default extraction order. This PR makes both views consistent.

> **Note:** `lastDeploy` sort falls back to `createdAt` in the breadcrumb since `lastDeployDate` is not available from the `environment.one` query used here.

## Screenshots

**1 — Pick the sort order on the environment page**

The sort dropdown writes the chosen order to `servicesSort`.

![Sort order selector on the environment page](https://raw.githubusercontent.com/vadamk/dokploy/pr-4388-assets/pr-assets/pr-1-sort-order.png)

**2 — The breadcrumb service switcher now follows the same order**

The same preference is applied here, not just on the environment page.

![Breadcrumb service switcher respecting the sort order](https://raw.githubusercontent.com/vadamk/dokploy/pr-4388-assets/pr-assets/pr-2-switcher.png)

## Test plan
- [ ] Open a project environment page, change the service sort (e.g. name ascending)
- [ ] Navigate to a service — verify the breadcrumb dropdown lists services in the same order
- [ ] Change sort on the environment page in another tab — verify the breadcrumb updates (cross-tab sync via `storage` event)
- [ ] Verify default sort (`lastDeploy-desc`) works when no preference is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
