### PR TITLE
refactor: refactor addTestCommand to handle initial values

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/cluster/swarm-forms/health-check-form.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/cluster/swarm-forms/health-check-form.tsx
@@ -127,7 +127,8 @@ export const HealthCheckForm = ({ id, type }: HealthCheckFormProps) => {
 	};
 
 	const addTestCommand = () => {
-		form.setValue("Test", [...testCommands, ""]);
+		const newItems = testCommands.length === 0 ? ["", ""] : [""];
+		form.setValue("Test", [...testCommands, ...newItems]);
 	};
 
 	const updateTestCommand = (index: number, value: string) => {


### PR DESCRIPTION
## What is this PR about?

In issue #4385 , I had to spend some time to figure out how the form UI manages and adds the test commands. This was ambiguous in the example and isnt properly explained in the docs. This simple refactor adds two strings on the first add instead of one so that the placeholders of the first two describe how the test commands form works.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4385 

## Screenshots (if applicable)

<img width="1712" height="428" alt="image" src="https://github.com/user-attachments/assets/2ac86005-98b7-4589-bff1-446cd7a93ad8" />

