### PR TITLE
fix: comment toggle shortcut not working in environment variable editors

### DIFF
--- a/apps/dokploy/components/shared/code-editor.tsx
+++ b/apps/dokploy/components/shared/code-editor.tsx
@@ -167,7 +167,12 @@ export const CodeEditor = ({
 								? css()
 								: language === "shell"
 									? StreamLanguage.define(shell)
-									: StreamLanguage.define(properties),
+									: StreamLanguage.define({
+											...properties,
+											languageData: {
+												commentTokens: { line: "#" },
+											},
+										}),
 					props.lineWrapping ? EditorView.lineWrapping : [],
 					language === "yaml"
 						? autocompletion({


### PR DESCRIPTION
## What is this PR about?

Fix `Cmd+/` or `Ctrl+/` comment toggle shortcut not working in environment variable editors (properties language mode).

CodeMirror's `toggleComment` command requires `commentTokens` metadata (via `languageData`) to know which syntax to use for commenting. The `properties` language mode from `@codemirror/legacy-modes` does not export this metadata, unlike `yaml`, `shell`, and `json` modes which all include it. This caused `Ctrl+/` to silently fail in all editors using `language="properties"` including environment variable editors, volume content, and more.

The fix adds `languageData: { commentTokens: { line: "#" } }` to the properties stream parser definition in the shared `CodeEditor` component, enabling `#` line comments via `Ctrl+/` across all properties-mode editors in the app.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4402 

## Screenshots (if applicable)

