### PR TITLE
feat(backups): add rclone destination providers

### DIFF
--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -1,5 +1,30 @@
-import { normalizeS3Path } from "@dokploy/server/utils/backups/utils";
+import type { Destination } from "@dokploy/server/services/destination";
+import {
+	getRcloneDestination,
+	getRcloneDestinationProvider,
+	getRcloneFlags,
+	normalizeRclonePath,
+	normalizeS3Path,
+	shellQuote,
+} from "@dokploy/server/utils/backups/utils";
 import { describe, expect, test } from "vitest";
+
+const createDestination = (
+	overrides: Partial<Destination> = {},
+): Destination => ({
+	destinationId: "destination",
+	name: "Backups",
+	provider: "AWS",
+	accessKey: "access-key",
+	secretAccessKey: "secret-key",
+	bucket: "dokploy-backups",
+	region: "us-east-1",
+	endpoint: "https://s3.example.com",
+	additionalFlags: [],
+	organizationId: "organization",
+	createdAt: new Date("2026-01-01T00:00:00.000Z"),
+	...overrides,
+});
 
 describe("normalizeS3Path", () => {
 	test("should handle empty and whitespace-only prefix", () => {
@@ -57,5 +82,124 @@ describe("normalizeS3Path", () => {
 		expect(normalizeS3Path("instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("/instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("instance-backups")).toBe("instance-backups/");
+	});
+});
+
+describe("rclone destination providers", () => {
+	test("should keep existing S3 providers mapped to the s3 backend", () => {
+		const destination = createDestination({ provider: "Cloudflare" });
+
+		expect(getRcloneDestinationProvider(destination)).toBe("s3");
+		expect(getRcloneDestination(destination, "app/prefix/backup.sql.gz")).toBe(
+			":s3:dokploy-backups/app/prefix/backup.sql.gz",
+		);
+		expect(getRcloneFlags(destination)).toEqual([
+			"--s3-provider='Cloudflare'",
+			"--s3-access-key-id='access-key'",
+			"--s3-secret-access-key='secret-key'",
+			"--s3-region='us-east-1'",
+			"--s3-endpoint='https://s3.example.com'",
+			"--s3-no-check-bucket",
+			"--s3-force-path-style",
+		]);
+	});
+
+	test("should build FTP flags and preserve absolute base paths", () => {
+		const destination = createDestination({
+			provider: "ftp",
+			accessKey: "backup-user",
+			secretAccessKey: "pa'ss word",
+			bucket: "/srv/backups",
+			region: "2121",
+			endpoint: "ftp.example.com",
+		});
+
+		expect(getRcloneDestinationProvider(destination)).toBe("ftp");
+		expect(getRcloneDestination(destination, "app/backup.sql.gz")).toBe(
+			":ftp:/srv/backups/app/backup.sql.gz",
+		);
+		expect(getRcloneFlags(destination)).toEqual([
+			"--ftp-host='ftp.example.com'",
+			"--ftp-user='backup-user'",
+			"--ftp-port='2121'",
+			"--ftp-pass=$(rclone obscure 'pa'\\''ss word')",
+		]);
+	});
+
+	test("should build SFTP flags with additional rclone options", () => {
+		const destination = createDestination({
+			provider: "sftp",
+			accessKey: "dokploy",
+			secretAccessKey: "secret",
+			bucket: "relative/backups",
+			region: "",
+			endpoint: "sftp.example.com",
+			additionalFlags: ["--sftp-known-hosts-file=/root/.ssh/known_hosts"],
+		});
+
+		expect(getRcloneDestination(destination, "app/backup.sql.gz")).toBe(
+			":sftp:relative/backups/app/backup.sql.gz",
+		);
+		expect(getRcloneFlags(destination)).toEqual([
+			"--sftp-host='sftp.example.com'",
+			"--sftp-user='dokploy'",
+			"--sftp-pass=$(rclone obscure 'secret')",
+			"--sftp-known-hosts-file=/root/.ssh/known_hosts",
+		]);
+	});
+
+	test("should build Google Drive flags from token JSON", () => {
+		const token =
+			'{"access_token":"access","token_type":"Bearer","refresh_token":"refresh","expiry":"2026-01-01T00:00:00Z"}';
+		const destination = createDestination({
+			provider: "drive",
+			accessKey: "client-id",
+			secretAccessKey: "client-secret",
+			bucket: "Dokploy Backups",
+			region: "root-folder-id",
+			endpoint: token,
+		});
+
+		expect(getRcloneDestination(destination, "app/backup.sql.gz")).toBe(
+			":drive:Dokploy Backups/app/backup.sql.gz",
+		);
+		expect(getRcloneFlags(destination)).toEqual([
+			"--drive-client-id='client-id'",
+			"--drive-client-secret='client-secret'",
+			`--drive-token=${shellQuote(token)}`,
+			"--drive-root-folder-id='root-folder-id'",
+		]);
+	});
+
+	test("should build OneDrive flags without optional client credentials", () => {
+		const token = '{"access_token":"access","refresh_token":"refresh"}';
+		const destination = createDestination({
+			provider: "onedrive",
+			accessKey: "",
+			secretAccessKey: "",
+			bucket: "",
+			region: "drive-id",
+			endpoint: token,
+		});
+
+		expect(getRcloneDestination(destination, "app/backup.sql.gz")).toBe(
+			":onedrive:app/backup.sql.gz",
+		);
+		expect(getRcloneFlags(destination)).toEqual([
+			`--onedrive-token=${shellQuote(token)}`,
+			"--onedrive-drive-id='drive-id'",
+		]);
+	});
+
+	test("should normalize rclone paths while preserving FTP/SFTP root semantics", () => {
+		expect(
+			normalizeRclonePath("/absolute/path/", { preserveLeadingSlash: true }),
+		).toBe("/absolute/path/");
+		expect(normalizeRclonePath("/absolute/path/")).toBe("absolute/path/");
+	});
+
+	test("should quote shell values safely", () => {
+		expect(shellQuote("path/with spaces")).toBe("'path/with spaces'");
+		expect(shellQuote("value'with'quotes")).toBe("'value'\\''with'\\''quotes'");
 	});
 });

--- a/apps/dokploy/components/dashboard/settings/destination/constants.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/constants.ts
@@ -1,3 +1,38 @@
+export const RCLONE_DESTINATION_PROVIDERS = [
+	{
+		key: "ftp",
+		name: "FTP",
+	},
+	{
+		key: "sftp",
+		name: "SFTP",
+	},
+	{
+		key: "drive",
+		name: "Google Drive",
+	},
+	{
+		key: "onedrive",
+		name: "Microsoft OneDrive",
+	},
+] as const;
+
+const RCLONE_DESTINATION_PROVIDER_KEYS = new Set(
+	RCLONE_DESTINATION_PROVIDERS.map((provider) => provider.key),
+);
+
+export const getDestinationProviderType = (provider: string) => {
+	const normalizedProvider = provider.trim().toLowerCase();
+	if (
+		RCLONE_DESTINATION_PROVIDER_KEYS.has(
+			normalizedProvider as (typeof RCLONE_DESTINATION_PROVIDERS)[number]["key"],
+		)
+	) {
+		return normalizedProvider as (typeof RCLONE_DESTINATION_PROVIDERS)[number]["key"];
+	}
+	return "s3";
+};
+
 export const S3_PROVIDERS: Array<{
 	key: string;
 	name: string;

--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -37,32 +37,159 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
-import { S3_PROVIDERS } from "./constants";
+import {
+	getDestinationProviderType,
+	RCLONE_DESTINATION_PROVIDERS,
+	S3_PROVIDERS,
+} from "./constants";
 
-const addDestination = z.object({
-	name: z.string().min(1, "Name is required"),
-	provider: z.string().min(1, "Provider is required"),
-	accessKeyId: z.string().min(1, "Access Key Id is required"),
-	secretAccessKey: z.string().min(1, "Secret Access Key is required"),
-	bucket: z.string().min(1, "Bucket is required"),
-	region: z.string(),
-	endpoint: z.string().min(1, "Endpoint is required"),
-	serverId: z.string().optional(),
-	additionalFlags: z
-		.array(
-			z.object({
-				value: z
-					.string()
-					.min(1, "Flag cannot be empty")
-					.regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR),
-			}),
-		)
-		.optional(),
-});
+type DestinationFieldName =
+	| "accessKeyId"
+	| "secretAccessKey"
+	| "bucket"
+	| "region"
+	| "endpoint";
+
+const addDestination = z
+	.object({
+		name: z.string().min(1, "Name is required"),
+		provider: z.string().min(1, "Provider is required"),
+		accessKeyId: z.string(),
+		secretAccessKey: z.string(),
+		bucket: z.string(),
+		region: z.string(),
+		endpoint: z.string(),
+		serverId: z.string().optional(),
+		additionalFlags: z
+			.array(
+				z.object({
+					value: z
+						.string()
+						.min(1, "Flag cannot be empty")
+						.regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR),
+				}),
+			)
+			.optional(),
+	})
+	.superRefine((data, ctx) => {
+		const providerType = getDestinationProviderType(data.provider);
+		const addRequiredIssue = (path: DestinationFieldName, message: string) => {
+			ctx.addIssue({ code: "custom", path: [path], message });
+		};
+
+		if (providerType === "s3") {
+			if (!data.accessKeyId.trim()) {
+				addRequiredIssue("accessKeyId", "Access Key Id is required");
+			}
+			if (!data.secretAccessKey.trim()) {
+				addRequiredIssue("secretAccessKey", "Secret Access Key is required");
+			}
+			if (!data.bucket.trim()) {
+				addRequiredIssue("bucket", "Bucket is required");
+			}
+			if (!data.endpoint.trim()) {
+				addRequiredIssue("endpoint", "Endpoint is required");
+			}
+			return;
+		}
+
+		if (providerType === "ftp" || providerType === "sftp") {
+			if (!data.endpoint.trim()) {
+				addRequiredIssue("endpoint", "Host is required");
+			}
+			if (!data.accessKeyId.trim()) {
+				addRequiredIssue("accessKeyId", "Username is required");
+			}
+			if (!data.secretAccessKey.trim()) {
+				addRequiredIssue("secretAccessKey", "Password is required");
+			}
+			if (data.region.trim()) {
+				const port = Number(data.region);
+				if (!Number.isInteger(port) || port < 1 || port > 65535) {
+					addRequiredIssue("region", "Port must be between 1 and 65535");
+				}
+			}
+			return;
+		}
+
+		if (!data.endpoint.trim()) {
+			addRequiredIssue("endpoint", "OAuth token JSON is required");
+			return;
+		}
+
+		try {
+			JSON.parse(data.endpoint);
+		} catch {
+			addRequiredIssue("endpoint", "OAuth token must be valid JSON");
+		}
+	});
 
 type AddDestination = z.infer<typeof addDestination>;
+
+const getFieldLabels = (provider: string) => {
+	const providerType = getDestinationProviderType(provider);
+	if (providerType === "ftp" || providerType === "sftp") {
+		return {
+			namePlaceholder: `${providerType.toUpperCase()} Backups`,
+			accessKeyLabel: "Username",
+			accessKeyPlaceholder: "dokploy",
+			secretLabel: "Password",
+			secretPlaceholder: "password",
+			bucketLabel: "Base Path",
+			bucketPlaceholder: "/backups",
+			regionLabel: "Port",
+			regionPlaceholder: providerType === "ftp" ? "21" : "22",
+			endpointLabel: "Host",
+			endpointPlaceholder: "backup.example.com",
+			additionalFlagPlaceholder:
+				providerType === "ftp"
+					? "--ftp-explicit-tls=true"
+					: "--sftp-known-hosts-file=/root/.ssh/known_hosts",
+		};
+	}
+	if (providerType === "drive" || providerType === "onedrive") {
+		return {
+			namePlaceholder:
+				providerType === "drive" ? "Google Drive Backups" : "OneDrive Backups",
+			accessKeyLabel: "Client ID (Optional)",
+			accessKeyPlaceholder: "client-id",
+			secretLabel: "Client Secret (Optional)",
+			secretPlaceholder: "client-secret",
+			bucketLabel: "Base Folder",
+			bucketPlaceholder: "dokploy-backups",
+			regionLabel:
+				providerType === "drive"
+					? "Root Folder ID (Optional)"
+					: "Drive ID (Optional)",
+			regionPlaceholder:
+				providerType === "drive" ? "root-folder-id" : "drive-id",
+			endpointLabel: "OAuth Token JSON",
+			endpointPlaceholder:
+				'{"access_token":"...","token_type":"Bearer","refresh_token":"...","expiry":"..."}',
+			additionalFlagPlaceholder:
+				providerType === "drive"
+					? "--drive-scope=drive"
+					: "--onedrive-drive-type=business",
+		};
+	}
+	return {
+		namePlaceholder: "S3 Bucket",
+		accessKeyLabel: "Access Key Id",
+		accessKeyPlaceholder: "xcas41dasde",
+		secretLabel: "Secret Access Key",
+		secretPlaceholder: "asd123asdasw",
+		bucketLabel: "Bucket",
+		bucketPlaceholder: "dokploy-bucket",
+		regionLabel: "Region",
+		regionPlaceholder: "us-east-1",
+		endpointLabel: "Endpoint",
+		endpointPlaceholder: "https://us.bucket.aws/s3",
+		additionalFlagPlaceholder: "--s3-sign-accept-encoding=false",
+	};
+};
 
 interface Props {
 	destinationId?: string;
@@ -112,6 +239,9 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		control: form.control,
 		name: "additionalFlags",
 	});
+	const selectedProvider = form.watch("provider");
+	const selectedProviderType = getDestinationProviderType(selectedProvider);
+	const fieldLabels = getFieldLabels(selectedProvider);
 
 	useEffect(() => {
 		if (destination) {
@@ -161,12 +291,35 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 			});
 	};
 
+	const handleProviderChange = (value: string) => {
+		const previousType = getDestinationProviderType(form.getValues("provider"));
+		const nextType = getDestinationProviderType(value);
+		form.setValue("provider", value);
+		if (previousType !== nextType) {
+			form.setValue("accessKeyId", "");
+			form.setValue("secretAccessKey", "");
+			form.setValue("bucket", "");
+			form.setValue("region", "");
+			form.setValue("endpoint", "");
+			form.setValue("additionalFlags", []);
+			form.clearErrors([
+				"accessKeyId",
+				"secretAccessKey",
+				"bucket",
+				"region",
+				"endpoint",
+				"additionalFlags",
+			]);
+		}
+	};
+
 	const handleTestConnection = async (serverId?: string) => {
 		const result = await form.trigger([
 			"provider",
 			"accessKeyId",
 			"secretAccessKey",
 			"bucket",
+			"region",
 			"endpoint",
 			"additionalFlags",
 		]);
@@ -195,8 +348,11 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		const bucket = form.getValues("bucket");
 		const endpoint = form.getValues("endpoint");
 		const region = form.getValues("region");
-
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
+		const providerType = getDestinationProviderType(provider);
+		const connectionString =
+			providerType === "s3"
+				? `:s3,provider=${provider},access_key_id=***,secret_access_key=***,endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`
+				: `:${providerType}:${bucket}`;
 
 		await testConnection({
 			provider,
@@ -269,7 +425,10 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 									<FormItem>
 										<FormLabel>Name</FormLabel>
 										<FormControl>
-											<Input placeholder={"S3 Bucket"} {...field} />
+											<Input
+												placeholder={fieldLabels.namePlaceholder}
+												{...field}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -285,24 +444,38 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 										<FormLabel>Provider</FormLabel>
 										<FormControl>
 											<Select
-												onValueChange={field.onChange}
+												onValueChange={handleProviderChange}
 												defaultValue={field.value}
 												value={field.value}
 											>
 												<FormControl>
 													<SelectTrigger>
-														<SelectValue placeholder="Select a S3 Provider" />
+														<SelectValue placeholder="Select a destination type" />
 													</SelectTrigger>
 												</FormControl>
 												<SelectContent>
-													{S3_PROVIDERS.map((s3Provider) => (
-														<SelectItem
-															key={s3Provider.key}
-															value={s3Provider.key}
-														>
-															{s3Provider.name}
-														</SelectItem>
-													))}
+													<SelectGroup>
+														<SelectLabel>Destination Types</SelectLabel>
+														{RCLONE_DESTINATION_PROVIDERS.map((provider) => (
+															<SelectItem
+																key={provider.key}
+																value={provider.key}
+															>
+																{provider.name}
+															</SelectItem>
+														))}
+													</SelectGroup>
+													<SelectGroup>
+														<SelectLabel>S3 Compatible Providers</SelectLabel>
+														{S3_PROVIDERS.map((s3Provider) => (
+															<SelectItem
+																key={s3Provider.key}
+																value={s3Provider.key}
+															>
+																{s3Provider.name}
+															</SelectItem>
+														))}
+													</SelectGroup>
 												</SelectContent>
 											</Select>
 										</FormControl>
@@ -318,9 +491,12 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => {
 								return (
 									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
+										<FormLabel>{fieldLabels.accessKeyLabel}</FormLabel>
 										<FormControl>
-											<Input placeholder={"xcas41dasde"} {...field} />
+											<Input
+												placeholder={fieldLabels.accessKeyPlaceholder}
+												{...field}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -333,10 +509,13 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
+										<FormLabel>{fieldLabels.secretLabel}</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"asd123asdasw"} {...field} />
+										<Input
+											placeholder={fieldLabels.secretPlaceholder}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -348,10 +527,13 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
+										<FormLabel>{fieldLabels.bucketLabel}</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"dokploy-bucket"} {...field} />
+										<Input
+											placeholder={fieldLabels.bucketPlaceholder}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -363,10 +545,13 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
+										<FormLabel>{fieldLabels.regionLabel}</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"us-east-1"} {...field} />
+										<Input
+											placeholder={fieldLabels.regionPlaceholder}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -377,12 +562,21 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							name="endpoint"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
+									<FormLabel>{fieldLabels.endpointLabel}</FormLabel>
 									<FormControl>
-										<Input
-											placeholder={"https://us.bucket.aws/s3"}
-											{...field}
-										/>
+										{selectedProviderType === "drive" ||
+										selectedProviderType === "onedrive" ? (
+											<Textarea
+												className="min-h-24 font-mono text-xs"
+												placeholder={fieldLabels.endpointPlaceholder}
+												{...field}
+											/>
+										) : (
+											<Input
+												placeholder={fieldLabels.endpointPlaceholder}
+												{...field}
+											/>
+										)}
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -411,7 +605,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 											<div className="flex items-center gap-2">
 												<FormControl>
 													<Input
-														placeholder="--s3-sign-accept-encoding=false"
+														placeholder={fieldLabels.additionalFlagPlaceholder}
 														{...field}
 													/>
 												</FormControl>

--- a/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
@@ -24,11 +24,11 @@ export const ShowDestinations = () => {
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
 							<Database className="size-6 text-muted-foreground self-center" />
-							S3 Destinations
+							Backup Destinations
 						</CardTitle>
 						<CardDescription>
-							Add your providers like AWS S3, Cloudflare R2, Wasabi,
-							DigitalOcean Spaces etc.
+							Add destinations like S3-compatible storage, FTP, SFTP, Google
+							Drive, or OneDrive.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-2 py-8 border-t">

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -357,7 +357,7 @@ const MENU: Menu = {
 		},
 		{
 			isSingle: true,
-			title: "S3 Destinations",
+			title: "Backup Destinations",
 			url: "/dashboard/settings/destinations",
 			icon: Database,
 			isEnabled: ({ permissions }) => !!permissions?.destination.read,

--- a/apps/dokploy/pages/dashboard/settings/destinations.tsx
+++ b/apps/dokploy/pages/dashboard/settings/destinations.tsx
@@ -18,7 +18,9 @@ const Page = () => {
 export default Page;
 
 Page.getLayout = (page: ReactElement) => {
-	return <DashboardLayout metaName="S3 Destinations">{page}</DashboardLayout>;
+	return (
+		<DashboardLayout metaName="Backup Destinations">{page}</DashboardLayout>
+	);
 };
 export async function getServerSideProps(
 	ctx: GetServerSidePropsContext<{ serviceId: string }>,

--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -31,8 +31,10 @@ import { findDestinationById } from "@dokploy/server/services/destination";
 import { checkServicePermissionAndAccess } from "@dokploy/server/services/permission";
 import { runComposeBackup } from "@dokploy/server/utils/backups/compose";
 import {
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "@dokploy/server/utils/backups/utils";
 import {
 	execAsync,
@@ -478,8 +480,7 @@ export const backupRouter = createTRPCRouter({
 						});
 					}
 				}
-				const rcloneFlags = getS3Credentials(destination);
-				const bucketPath = `:s3:${destination.bucket}`;
+				const rcloneFlags = getRcloneFlags(destination);
 
 				const lastSlashIndex = input.search.lastIndexOf("/");
 				const baseDir =
@@ -491,8 +492,8 @@ export const backupRouter = createTRPCRouter({
 						? input.search.slice(lastSlashIndex + 1)
 						: input.search;
 
-				const searchPath = baseDir ? `${bucketPath}/${baseDir}` : bucketPath;
-				const listCommand = `rclone lsjson ${rcloneFlags.join(" ")} "${searchPath}" --no-mimetype --no-modtime 2>/dev/null`;
+				const searchPath = getRcloneDestination(destination, baseDir);
+				const listCommand = `rclone lsjson ${rcloneFlags.join(" ")} ${shellQuote(searchPath)} --no-mimetype --no-modtime 2>/dev/null`;
 
 				let stdout = "";
 

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -3,8 +3,11 @@ import {
 	execAsync,
 	execAsyncRemote,
 	findDestinationById,
+	getRcloneDestination,
+	getRcloneTestFlags,
 	IS_CLOUD,
 	removeDestinationById,
+	shellQuote,
 	updateDestinationById,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
@@ -47,36 +50,16 @@ export const destinationRouter = createTRPCRouter({
 	testConnection: withPermission("destination", "create")
 		.input(apiCreateDestination)
 		.mutation(async ({ input }) => {
-			const {
-				secretAccessKey,
-				bucket,
-				region,
-				endpoint,
-				accessKey,
-				provider,
-				additionalFlags,
-			} = input;
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
-				}
-				if (additionalFlags?.length) {
-					rcloneFlags.push(...additionalFlags);
-				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+				const destination = {
+					...input,
+					destinationId: "",
+					organizationId: "",
+					createdAt: new Date(),
+				};
+				const rcloneFlags = getRcloneTestFlags(destination);
+				const rcloneDestination = getRcloneDestination(destination);
+				const rcloneCommand = `rclone lsf ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)} --max-depth 1`;
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -79,7 +79,7 @@ export const destinationRouter = createTRPCRouter({
 					message:
 						error instanceof Error
 							? error?.message
-							: "Error connecting to bucket",
+							: "Error connecting to destination",
 					cause: error,
 				});
 			}
@@ -157,7 +157,7 @@ export const destinationRouter = createTRPCRouter({
 					message:
 						error instanceof Error
 							? error?.message
-							: "Error connecting to bucket",
+							: "Error connecting to destination",
 					cause: error,
 				});
 			}

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import {
 	ADDITIONAL_FLAG_ERROR,
 	ADDITIONAL_FLAG_REGEX,
+	getRcloneDestinationType,
 } from "../validations/destination";
 import { organization } from "./account";
 import { backups } from "./backups";
@@ -54,6 +55,85 @@ const createSchema = createInsertSchema(destinations, {
 		.default([]),
 });
 
+type DestinationInput = {
+	provider: string | null;
+	accessKey: string;
+	secretAccessKey: string;
+	bucket: string;
+	region: string;
+	endpoint: string;
+};
+
+const addRequiredIssue = (
+	ctx: z.RefinementCtx,
+	path: keyof DestinationInput,
+	message: string,
+) => {
+	ctx.addIssue({
+		code: "custom",
+		path: [path],
+		message,
+	});
+};
+
+const validateDestinationInput = (
+	data: DestinationInput,
+	ctx: z.RefinementCtx,
+) => {
+	if (!data.provider?.trim()) {
+		addRequiredIssue(ctx, "provider", "Provider is required");
+		return;
+	}
+
+	const destinationType = getRcloneDestinationType(data.provider ?? "");
+
+	if (destinationType === "s3") {
+		if (!data.accessKey.trim()) {
+			addRequiredIssue(ctx, "accessKey", "Access key is required");
+		}
+		if (!data.secretAccessKey.trim()) {
+			addRequiredIssue(ctx, "secretAccessKey", "Secret access key is required");
+		}
+		if (!data.bucket.trim()) {
+			addRequiredIssue(ctx, "bucket", "Bucket is required");
+		}
+		if (!data.endpoint.trim()) {
+			addRequiredIssue(ctx, "endpoint", "Endpoint is required");
+		}
+		return;
+	}
+
+	if (destinationType === "ftp" || destinationType === "sftp") {
+		if (!data.endpoint.trim()) {
+			addRequiredIssue(ctx, "endpoint", "Host is required");
+		}
+		if (!data.accessKey.trim()) {
+			addRequiredIssue(ctx, "accessKey", "Username is required");
+		}
+		if (!data.secretAccessKey.trim()) {
+			addRequiredIssue(ctx, "secretAccessKey", "Password is required");
+		}
+		if (data.region.trim()) {
+			const port = Number(data.region);
+			if (!Number.isInteger(port) || port < 1 || port > 65535) {
+				addRequiredIssue(ctx, "region", "Port must be between 1 and 65535");
+			}
+		}
+		return;
+	}
+
+	if (!data.endpoint.trim()) {
+		addRequiredIssue(ctx, "endpoint", "OAuth token JSON is required");
+		return;
+	}
+
+	try {
+		JSON.parse(data.endpoint);
+	} catch {
+		addRequiredIssue(ctx, "endpoint", "OAuth token must be valid JSON");
+	}
+};
+
 export const apiCreateDestination = createSchema
 	.pick({
 		name: true,
@@ -67,8 +147,10 @@ export const apiCreateDestination = createSchema
 	})
 	.required()
 	.extend({
+		provider: z.string().min(1),
 		serverId: z.string().optional(),
-	});
+	})
+	.superRefine(validateDestinationInput);
 
 export const apiFindOneDestination = z.object({
 	destinationId: z.string().min(1),
@@ -94,5 +176,7 @@ export const apiUpdateDestination = createSchema
 	})
 	.required()
 	.extend({
+		provider: z.string().min(1),
 		serverId: z.string().optional(),
-	});
+	})
+	.superRefine(validateDestinationInput);

--- a/packages/server/src/db/validations/destination.ts
+++ b/packages/server/src/db/validations/destination.ts
@@ -1,3 +1,22 @@
 export const ADDITIONAL_FLAG_REGEX = /^--[a-zA-Z0-9-]+(=[a-zA-Z0-9._:/@-]+)?$/;
 export const ADDITIONAL_FLAG_ERROR =
 	"Invalid flag format. Must start with -- (e.g. --s3-sign-accept-encoding=false)";
+
+export const RCLONE_DESTINATION_TYPES = [
+	"ftp",
+	"sftp",
+	"drive",
+	"onedrive",
+] as const;
+
+export type RcloneDestinationType = (typeof RCLONE_DESTINATION_TYPES)[number];
+
+const RCLONE_DESTINATION_TYPE_SET = new Set<string>(RCLONE_DESTINATION_TYPES);
+
+export const getRcloneDestinationType = (provider: string) => {
+	const normalizedProvider = provider.trim().toLowerCase();
+	if (RCLONE_DESTINATION_TYPE_SET.has(normalizedProvider)) {
+		return normalizedProvider as RcloneDestinationType;
+	}
+	return "s3";
+};

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -11,8 +11,10 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "./utils";
 
 export const runComposeBackup = async (
@@ -34,9 +36,12 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -10,7 +10,13 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	normalizeS3Path,
+	scheduleBackup,
+	shellQuote,
+} from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -131,17 +137,21 @@ export const keepLatestNBackups = async (
 	if (!backup.keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(backup.destination);
+		const rcloneFlags = getRcloneFlags(backup.destination);
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${backup.destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = getRcloneDestination(
+			backup.destination,
+			`${appName}/${normalizeS3Path(backup.prefix)}`,
+		);
 
 		// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
-		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;
+		const includePattern = `*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}`;
+		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include ${shellQuote(includePattern)} ${shellQuote(backupFilesPath)}`;
 		// when we pipe the above command with this one, we only get the list of files we want to delete
 		const sortAndPickUnwantedBackups = `sort -r | tail -n +$((${backup.keepLatestCount}+1)) | xargs -I{}`;
 		// this command deletes the files
 		// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
-		const rcloneDelete = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		const rcloneDelete = `rclone delete ${rcloneFlags.join(" ")} ${shellQuote(`${backupFilesPath}{}`)}`;
 
 		const rcloneCommand = `${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
 

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -11,8 +11,10 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "./utils";
 
 export const runLibsqlBackup = async (
@@ -33,10 +35,13 @@ export const runLibsqlBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -11,8 +11,10 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "./utils";
 
 export const runMariadbBackup = async (
@@ -32,9 +34,12 @@ export const runMariadbBackup = async (
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -11,8 +11,10 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "./utils";
 
 export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
@@ -29,9 +31,12 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -11,8 +11,10 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "./utils";
 
 export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
@@ -30,10 +32,13 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -11,8 +11,10 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "./utils";
 
 export const runPostgresBackup = async (
@@ -33,10 +35,13 @@ export const runPostgresBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const rcloneDestination = getRcloneDestination(
+			destination,
+			bucketDestination,
+		);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${shellQuote(rcloneDestination)}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -60,26 +60,126 @@ export const getBackupTimestamp = () =>
 	new Date().toISOString().replace(/[:.]/g, "-");
 
 export const normalizeS3Path = (prefix: string) => {
-	// Trim whitespace and remove leading/trailing slashes
-	const normalizedPrefix = prefix.trim().replace(/^\/+|\/+$/g, "");
-	// Return empty string if prefix is empty, otherwise append trailing slash
-	return normalizedPrefix ? `${normalizedPrefix}/` : "";
+	return normalizeRclonePath(prefix);
 };
 
-export const getS3Credentials = (destination: Destination) => {
+export const RCLONE_DESTINATION_PROVIDERS = [
+	"ftp",
+	"sftp",
+	"drive",
+	"onedrive",
+] as const;
+
+export type RcloneDestinationProvider =
+	| "s3"
+	| (typeof RCLONE_DESTINATION_PROVIDERS)[number];
+
+const RCLONE_PROVIDER_SET = new Set<string>(RCLONE_DESTINATION_PROVIDERS);
+
+export const shellQuote = (value: string) =>
+	`'${value.replace(/'/g, "'\\''")}'`;
+
+export const normalizeRclonePath = (
+	prefix: string,
+	options?: { preserveLeadingSlash?: boolean },
+) => {
+	const trimmed = prefix.trim();
+	const hasLeadingSlash =
+		options?.preserveLeadingSlash === true && trimmed.startsWith("/");
+	const normalizedPrefix = trimmed.replace(/^\/+|\/+$/g, "");
+	if (!normalizedPrefix) {
+		return hasLeadingSlash ? "/" : "";
+	}
+	return `${hasLeadingSlash ? "/" : ""}${normalizedPrefix}/`;
+};
+
+export const getRcloneDestinationProvider = (
+	destination: Pick<Destination, "provider">,
+): RcloneDestinationProvider => {
+	const provider = destination.provider?.trim().toLowerCase();
+	if (provider && RCLONE_PROVIDER_SET.has(provider)) {
+		return provider as RcloneDestinationProvider;
+	}
+	return "s3";
+};
+
+const joinRclonePath = (
+	basePath: string,
+	path = "",
+	options?: { preserveLeadingSlash?: boolean },
+) => {
+	const normalizedBase = normalizeRclonePath(basePath, options);
+	const normalizedPath = path.trim().replace(/^\/+/, "");
+	if (!normalizedPath) {
+		return normalizedBase === "/"
+			? normalizedBase
+			: normalizedBase.slice(0, -1);
+	}
+	return `${normalizedBase}${normalizedPath}`;
+};
+
+export const getRcloneDestination = (destination: Destination, path = "") => {
+	const provider = getRcloneDestinationProvider(destination);
+	const basePath = destination.bucket || "";
+	const remotePath = joinRclonePath(basePath, path, {
+		preserveLeadingSlash: provider === "ftp" || provider === "sftp",
+	});
+
+	return `:${provider}:${remotePath}`;
+};
+
+const getOptionalFlag = (flag: string, value?: string | null) => {
+	const trimmedValue = value?.trim();
+	return trimmedValue ? [`${flag}=${shellQuote(trimmedValue)}`] : [];
+};
+
+const getObscuredPasswordFlag = (flag: string, value: string) =>
+	`${flag}=$(rclone obscure ${shellQuote(value)})`;
+
+export const getRcloneFlags = (destination: Destination) => {
+	const providerType = getRcloneDestinationProvider(destination);
 	const { accessKey, secretAccessKey, region, endpoint, provider } =
 		destination;
-	const rcloneFlags = [
-		`--s3-access-key-id="${accessKey}"`,
-		`--s3-secret-access-key="${secretAccessKey}"`,
-		`--s3-region="${region}"`,
-		`--s3-endpoint="${endpoint}"`,
-		"--s3-no-check-bucket",
-		"--s3-force-path-style",
-	];
+	let rcloneFlags: string[] = [];
 
-	if (provider) {
-		rcloneFlags.unshift(`--s3-provider="${provider}"`);
+	if (providerType === "s3") {
+		rcloneFlags = [
+			...getOptionalFlag("--s3-provider", provider),
+			`--s3-access-key-id=${shellQuote(accessKey)}`,
+			`--s3-secret-access-key=${shellQuote(secretAccessKey)}`,
+			`--s3-region=${shellQuote(region)}`,
+			`--s3-endpoint=${shellQuote(endpoint)}`,
+			"--s3-no-check-bucket",
+			"--s3-force-path-style",
+		];
+	} else if (providerType === "ftp") {
+		rcloneFlags = [
+			`--ftp-host=${shellQuote(endpoint)}`,
+			`--ftp-user=${shellQuote(accessKey)}`,
+			...getOptionalFlag("--ftp-port", region),
+			getObscuredPasswordFlag("--ftp-pass", secretAccessKey),
+		];
+	} else if (providerType === "sftp") {
+		rcloneFlags = [
+			`--sftp-host=${shellQuote(endpoint)}`,
+			`--sftp-user=${shellQuote(accessKey)}`,
+			...getOptionalFlag("--sftp-port", region),
+			getObscuredPasswordFlag("--sftp-pass", secretAccessKey),
+		];
+	} else if (providerType === "drive") {
+		rcloneFlags = [
+			...getOptionalFlag("--drive-client-id", accessKey),
+			...getOptionalFlag("--drive-client-secret", secretAccessKey),
+			`--drive-token=${shellQuote(endpoint)}`,
+			...getOptionalFlag("--drive-root-folder-id", region),
+		];
+	} else if (providerType === "onedrive") {
+		rcloneFlags = [
+			...getOptionalFlag("--onedrive-client-id", accessKey),
+			...getOptionalFlag("--onedrive-client-secret", secretAccessKey),
+			`--onedrive-token=${shellQuote(endpoint)}`,
+			...getOptionalFlag("--onedrive-drive-id", region),
+		];
 	}
 
 	if (destination.additionalFlags?.length) {
@@ -88,6 +188,17 @@ export const getS3Credentials = (destination: Destination) => {
 
 	return rcloneFlags;
 };
+
+export const getRcloneTestFlags = (destination: Destination) => [
+	...getRcloneFlags(destination),
+	"--retries 1",
+	"--low-level-retries 1",
+	"--timeout 10s",
+	"--contimeout 5s",
+];
+
+export const getS3Credentials = (destination: Destination) =>
+	getRcloneFlags(destination);
 
 export const getPostgresBackupCommand = (
 	database: string,
@@ -289,16 +400,16 @@ export const getBackupCommand = (
 	}
 
 	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
+	echo "[$(date)] Starting upload to backup destination..." >> ${logPath};
 
 	# Run the upload command and capture the exit status
 	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
+		echo "[$(date)] ❌ Error: Upload to backup destination failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
 		exit 1;
 	}
 
-	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
+	echo "[$(date)] ✅ Upload to backup destination completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -11,7 +11,13 @@ import {
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { sendDokployBackupNotifications } from "../notifications/dokploy-backup";
 import { execAsync } from "../process/execAsync";
-import { getBackupTimestamp, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupTimestamp,
+	getRcloneDestination,
+	getRcloneFlags,
+	normalizeS3Path,
+	shellQuote,
+} from "./utils";
 
 function formatBytes(bytes?: number) {
 	if (bytes === undefined) return "Unknown size";
@@ -36,12 +42,15 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 	let computedBackupSize: number | undefined;
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
+		const rcloneFlags = getRcloneFlags(destination);
 		const timestamp = getBackupTimestamp();
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const destinationPath = getRcloneDestination(
+			destination,
+			`${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`,
+		);
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -98,10 +107,10 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 				// If stat fails, keep undefined
 			}
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${zipPath}" "${s3Path}"`;
-			writeStream.write("Running command to upload backup to S3\n");
+			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} ${shellQuote(zipPath)} ${shellQuote(destinationPath)}`;
+			writeStream.write("Running command to upload backup to destination\n");
 			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			writeStream.write("Uploaded backup to destination ✅\n");
 			writeStream.end();
 			await sendDokployBackupNotifications({
 				type: "success",

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -23,13 +27,15 @@ export const restoreComposeBackup = async (
 		}
 		const { serverId, appName, composeType } = compose;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		let rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(
+			destination,
+			backupInput.backupFile,
+		);
+		let rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} ${shellQuote(backupPath)} | gunzip`;
 
 		if (backupInput.metadata?.mongo) {
-			rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+			rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} ${shellQuote(backupPath)}`;
 		}
 
 		let credentials: DatabaseCredentials = {};

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -2,7 +2,12 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Libsql } from "@dokploy/server/services/libsql";
 import type { z } from "zod";
-import { getS3Credentials, getServiceContainerCommand } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	getServiceContainerCommand,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 
 export const restoreLibsqlBackup = async (
@@ -14,12 +19,13 @@ export const restoreLibsqlBackup = async (
 	try {
 		const { appName, serverId } = libsql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(
+			destination,
+			backupInput.backupFile,
+		);
 
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} ${shellQuote(backupPath)}`;
 
 		emit("Starting restore...");
 		emit(`Backup path: ${backupPath}`);

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mariadb } from "@dokploy/server/services/mariadb";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +19,13 @@ export const restoreMariadbBackup = async (
 	try {
 		const { appName, serverId, databaseUser, databasePassword } = mariadb;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(
+			destination,
+			backupInput.backupFile,
+		);
 
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} ${shellQuote(backupPath)} | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mongo } from "@dokploy/server/services/mongo";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,10 +19,12 @@ export const restoreMongoBackup = async (
 	try {
 		const { appName, databasePassword, databaseUser, serverId } = mongo;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-		const rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(
+			destination,
+			backupInput.backupFile,
+		);
+		const rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} ${shellQuote(backupPath)}`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { MySql } from "@dokploy/server/services/mysql";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,11 +19,13 @@ export const restoreMySqlBackup = async (
 	try {
 		const { appName, databaseRootPassword, serverId } = mysql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(
+			destination,
+			backupInput.backupFile,
+		);
 
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} ${shellQuote(backupPath)} | gunzip`;
 
 		const command = getRestoreCommand({
 			appName,

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Postgres } from "@dokploy/server/services/postgres";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,12 +19,13 @@ export const restorePostgresBackup = async (
 	try {
 		const { appName, databaseUser, serverId } = postgres;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(
+			destination,
+			backupInput.backupFile,
+		);
 
-		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
-
-		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
+		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} ${shellQuote(backupPath)} | gunzip`;
 
 		emit("Starting restore...");
 		emit(`Backup path: ${backupPath}`);

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
-import { getS3Credentials } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	shellQuote,
+} from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
 export const restoreWebServerBackup = async (
@@ -15,9 +19,8 @@ export const restoreWebServerBackup = async (
 		return;
 	}
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
-		const backupPath = `${bucketPath}/${backupFile}`;
+		const rcloneFlags = getRcloneFlags(destination);
+		const backupPath = getRcloneDestination(destination, backupFile);
 		const { BASE_PATH } = paths();
 
 		// Create a temporary directory outside of BASE_PATH
@@ -32,10 +35,10 @@ export const restoreWebServerBackup = async (
 			emit("Creating temporary directory...");
 			await execAsync(`mkdir -p ${tempDir}`);
 
-			// Download backup from S3
-			emit("Downloading backup from S3...");
+			// Download backup from configured backup destination
+			emit("Downloading backup from destination...");
 			await execAsync(
-				`rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${tempDir}/${backupFile}"`,
+				`rclone copyto ${rcloneFlags.join(" ")} ${shellQuote(backupPath)} ${shellQuote(`${tempDir}/${backupFile}`)}`,
 			);
 
 			// List files before extraction

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -4,8 +4,10 @@ import { findComposeById } from "@dokploy/server/services/compose";
 import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
 import {
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	normalizeS3Path,
+	shellQuote,
 } from "../backups/utils";
 
 export const getVolumeServiceAppName = (
@@ -38,11 +40,14 @@ export const backupVolume = async (
 	const s3AppName = getVolumeServiceAppName(volumeBackup);
 	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar`;
 	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
-	const rcloneFlags = getS3Credentials(volumeBackup.destination);
-	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+	const rcloneFlags = getRcloneFlags(volumeBackup.destination);
+	const rcloneDestination = getRcloneDestination(
+		destination,
+		bucketDestination,
+	);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeBackup.appName);
 
-	const rcloneCommand = `rclone copyto ${rcloneFlags.join(" ")} "${volumeBackupPath}/${backupFileName}" "${rcloneDestination}"`;
+	const rcloneCommand = `rclone copyto ${rcloneFlags.join(" ")} ${shellQuote(`${volumeBackupPath}/${backupFileName}`)} ${shellQuote(rcloneDestination)}`;
 
 	const backupCommand = `
 	set -e
@@ -60,9 +65,9 @@ export const backupVolume = async (
   `;
 
 	const uploadCommand = `
-  echo "Starting upload to S3..."
+  echo "Starting upload to backup destination..."
   ${rcloneCommand}
-  echo "Upload to S3 done ✅"
+  echo "Upload to backup destination done ✅"
   echo "Cleaning up local backup file..."
   rm "${volumeBackupPath}/${backupFileName}"
   echo "Local backup file cleaned up ✅"

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -3,8 +3,10 @@ import {
 	findApplicationById,
 	findComposeById,
 	findDestinationById,
-	getS3Credentials,
+	getRcloneDestination,
+	getRcloneFlags,
 	paths,
+	shellQuote,
 } from "../..";
 
 export const restoreVolume = async (
@@ -18,12 +20,11 @@ export const restoreVolume = async (
 	const destination = await findDestinationById(destinationId);
 	const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeName);
-	const rcloneFlags = getS3Credentials(destination);
-	const bucketPath = `:s3:${destination.bucket}`;
-	const backupPath = `${bucketPath}/${backupFileName}`;
+	const rcloneFlags = getRcloneFlags(destination);
+	const backupPath = getRcloneDestination(destination, backupFileName);
 
-	// Command to download backup file from S3
-	const downloadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${volumeBackupPath}/${backupFileName}"`;
+	// Command to download backup file from the configured backup destination
+	const downloadCommand = `rclone copyto ${rcloneFlags.join(" ")} ${shellQuote(backupPath)} ${shellQuote(`${volumeBackupPath}/${backupFileName}`)}`;
 
 	// Base restore command that creates the volume and restores data
 	const baseRestoreCommand = `
@@ -31,7 +32,7 @@ export const restoreVolume = async (
 	echo "Volume name: ${volumeName}"
 	echo "Backup file name: ${backupFileName}"
 	echo "Volume backup path: ${volumeBackupPath}"
-	echo "Downloading backup from S3..."
+	echo "Downloading backup from backup destination..."
 	mkdir -p ${volumeBackupPath}
 	${downloadCommand}
 	echo "Download completed ✅"

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -10,7 +10,12 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { getS3Credentials, normalizeS3Path } from "../backups/utils";
+import {
+	getRcloneDestination,
+	getRcloneFlags,
+	normalizeS3Path,
+	shellQuote,
+} from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
 
@@ -61,6 +66,9 @@ const getOrganizationId = (
 	return "";
 };
 
+const escapeRcloneGlob = (value: string) =>
+	value.replace(/([\\[\]{}?*])/g, "\\$1");
+
 export const scheduleVolumeBackup = async (volumeBackupId: string) => {
 	const volumeBackup = await findVolumeBackupById(volumeBackupId);
 	scheduleJob(volumeBackupId, volumeBackup.cronExpression, async () => {
@@ -82,12 +90,16 @@ const cleanupOldVolumeBackups = async (
 	if (!keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
+		const rcloneFlags = getRcloneFlags(destination);
 		const s3AppName = getVolumeServiceAppName(volumeBackup);
-		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
-		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
+		const backupFilesPath = getRcloneDestination(
+			destination,
+			`${s3AppName}/${normalizeS3Path(prefix || "")}`,
+		);
+		const includePattern = `${escapeRcloneGlob(volumeName)}-*.tar`;
+		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include ${shellQuote(includePattern)} ${shellQuote(backupFilesPath)}`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
-		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${shellQuote(`${backupFilesPath}{}`)}`;
 		const fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
 
 		if (serverId) {


### PR DESCRIPTION
/claim #416

Fixes #416.

Demo: attached `ui-destination-demo.mp4` shows the Add Destination provider selector and the FTP, SFTP, Google Drive, and OneDrive field sets.

## Summary
- Adds rclone-backed backup destination support for FTP, SFTP, Google Drive, and OneDrive while keeping existing S3-compatible destinations on the same schema.
- Centralizes provider-aware rclone flag and remote path generation, including shell quoting for destination values.
- Wires the provider-aware helpers through database, compose, web server, and volume backup upload, retention, file listing, and restore paths.
- Updates the destination settings UI from S3-only wording to provider-aware fields and validation.
- Adds focused coverage for provider mapping, remote path construction, backend flags, and shell quoting.

## Validation
- `corepack pnpm exec biome check $(git diff --name-only origin/canary..HEAD)`
- `corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/utils/backups.test.ts --run`
- `corepack pnpm --filter=server run typecheck`
- `corepack pnpm --filter=dokploy run typecheck`
- `corepack pnpm --filter=dokploy run build-server`
- `corepack pnpm --filter=dokploy run build-next`
- Local rclone command-generation smoke for S3, FTP, SFTP, Google Drive, and OneDrive upload/list command strings.
- Chrome-captured UI demo/screenshots for the Add Destination provider selector and provider-specific fields.