### PR TITLE
fix: add type="button" to TooltipTrigger in form components

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
@@ -224,7 +224,7 @@ export const ShowResources = ({ id, type }: Props) => {
 												<FormLabel>Memory Limit</FormLabel>
 												<TooltipProvider>
 													<Tooltip delayDuration={0}>
-														<TooltipTrigger>
+														<TooltipTrigger type="button">
 															<InfoIcon className="h-4 w-4 text-muted-foreground" />
 														</TooltipTrigger>
 														<TooltipContent>
@@ -263,7 +263,7 @@ export const ShowResources = ({ id, type }: Props) => {
 											<FormLabel>Memory Reservation</FormLabel>
 											<TooltipProvider>
 												<Tooltip delayDuration={0}>
-													<TooltipTrigger>
+													<TooltipTrigger type="button">
 														<InfoIcon className="h-4 w-4 text-muted-foreground" />
 													</TooltipTrigger>
 													<TooltipContent>
@@ -303,7 +303,7 @@ export const ShowResources = ({ id, type }: Props) => {
 												<FormLabel>CPU Limit</FormLabel>
 												<TooltipProvider>
 													<Tooltip delayDuration={0}>
-														<TooltipTrigger>
+														<TooltipTrigger type="button">
 															<InfoIcon className="h-4 w-4 text-muted-foreground" />
 														</TooltipTrigger>
 														<TooltipContent>
@@ -343,7 +343,7 @@ export const ShowResources = ({ id, type }: Props) => {
 												<FormLabel>CPU Reservation</FormLabel>
 												<TooltipProvider>
 													<Tooltip delayDuration={0}>
-														<TooltipTrigger>
+														<TooltipTrigger type="button">
 															<InfoIcon className="h-4 w-4 text-muted-foreground" />
 														</TooltipTrigger>
 														<TooltipContent>
@@ -379,7 +379,7 @@ export const ShowResources = ({ id, type }: Props) => {
 									<FormLabel className="text-base">Ulimits</FormLabel>
 									<TooltipProvider>
 										<Tooltip delayDuration={0}>
-											<TooltipTrigger>
+											<TooltipTrigger type="button">
 												<InfoIcon className="h-4 w-4 text-muted-foreground" />
 											</TooltipTrigger>
 											<TooltipContent className="max-w-xs">

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -806,7 +806,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 												<FormLabel>Middlewares</FormLabel>
 												<TooltipProvider>
 													<Tooltip>
-														<TooltipTrigger>
+														<TooltipTrigger type="button">
 															<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
 																?
 															</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
@@ -418,7 +418,7 @@ export const SaveBitbucketProviderCompose = ({ composeId }: Props) => {
 										<FormLabel>Watch Paths</FormLabel>
 										<TooltipProvider>
 											<Tooltip>
-												<TooltipTrigger>
+												<TooltipTrigger type="button">
 													<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
 														?
 													</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -445,7 +445,7 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 											<FormLabel>Watch Paths</FormLabel>
 											<TooltipProvider>
 												<Tooltip>
-													<TooltipTrigger>
+													<TooltipTrigger type="button">
 														<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
 															?
 														</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
@@ -436,7 +436,7 @@ export const SaveGitlabProviderCompose = ({ composeId }: Props) => {
 										<FormLabel>Watch Paths</FormLabel>
 										<TooltipProvider>
 											<Tooltip>
-												<TooltipTrigger>
+												<TooltipTrigger type="button">
 													<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
 														?
 													</div>


### PR DESCRIPTION
Fixes #4400.

`TooltipTrigger` from Radix UI renders as a `<button>` by default. When used inside a `<form>` without an explicit `type="button"`, clicking the tooltip icon triggers form submission (since button default type is "submit").

This fixes the bug where clicking the `?` icon next to the Middlewares field in the domain creation form unexpectedly creates a new domain.

Applied `type="button"` to all `TooltipTrigger` elements that are inside form components:
- `handle-domain.tsx` — the original reported case (Middlewares tooltip)
- `show-resources.tsx` — resource limit tooltips in application advanced settings
- `save-gitlab-provider-compose.tsx`, `save-github-provider-compose.tsx`, `save-bitbucket-provider-compose.tsx` — provider form tooltips