### PR TITLE
Add organization ownership transfer

### DIFF
--- a/apps/dokploy/components/dashboard/settings/users/change-role.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/change-role.tsx
@@ -153,7 +153,8 @@ export const ChangeRole = ({ memberId, currentRole, userEmail }: Props) => {
 										)}
 										<br />
 										<em className="text-muted-foreground text-xs">
-											Note: Owner role is nontransferable.
+											Note: Owner role can only be changed with Transfer
+											Ownership.
 										</em>
 									</FormDescription>
 									<FormMessage />

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -36,6 +36,8 @@ export const ShowUsers = () => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data, isPending, refetch } = api.user.all.useQuery();
 	const { mutateAsync } = api.user.remove.useMutation();
+	const { mutateAsync: transferOwnership } =
+		api.organization.transferOwnership.useMutation();
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const { data: hasValidLicense } =
 		api.licenseKey.haveValidLicenseKey.useQuery();
@@ -130,6 +132,11 @@ export const ShowUsers = () => {
 															(currentUserRole === "admin" &&
 																member.role !== "admin"));
 
+													const canTransferOwnership =
+														currentUserRole === "owner" &&
+														member.role !== "owner" &&
+														member.user.id !== session?.user?.id;
+
 													const canDeleteMember =
 														permissions?.member.delete ?? false;
 
@@ -149,6 +156,7 @@ export const ShowUsers = () => {
 													const hasAnyAction =
 														canEditPermissions ||
 														canChangeRole ||
+														canTransferOwnership ||
 														canDelete ||
 														canUnlink;
 
@@ -209,6 +217,41 @@ export const ShowUsers = () => {
 																					currentRole={member.role}
 																					userEmail={member.user.email}
 																				/>
+																			)}
+
+																			{canTransferOwnership && (
+																				<DialogAction
+																					title="Transfer Ownership"
+																					description={`Transfer ownership of this organization to ${member.user.email}. Your role will become Admin.`}
+																					type="default"
+																					onClick={async () => {
+																						await transferOwnership({
+																							memberId: member.id,
+																						})
+																							.then(async () => {
+																								toast.success(
+																									"Ownership transferred successfully",
+																								);
+																								await Promise.all([
+																									refetch(),
+																									utils.organization.all.invalidate(),
+																								]);
+																							})
+																							.catch((err) => {
+																								toast.error(
+																									err?.message ||
+																										"Error transferring ownership",
+																								);
+																							});
+																					}}
+																				>
+																					<DropdownMenuItem
+																						className="w-full cursor-pointer"
+																						onSelect={(e) => e.preventDefault()}
+																					>
+																						Transfer Ownership
+																					</DropdownMenuItem>
+																				</DialogAction>
 																			)}
 
 																			{canEditPermissions && (

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -488,6 +488,88 @@ export const organizationRouter = createTRPCRouter({
 			});
 			return true;
 		}),
+	transferOwnership: protectedProcedure
+		.input(
+			z.object({
+				memberId: z.string(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const orgId = ctx.session.activeOrganizationId;
+
+			const org = await db.query.organization.findFirst({
+				where: eq(organization.id, orgId),
+			});
+
+			if (!org) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Organization not found",
+				});
+			}
+
+			if (org.ownerId !== ctx.user.id) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Only the current organization owner can transfer ownership",
+				});
+			}
+
+			const target = await db.query.member.findFirst({
+				where: eq(member.id, input.memberId),
+				with: { user: true },
+			});
+
+			if (!target || target.organizationId !== orgId) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Member not found in this organization",
+				});
+			}
+
+			if (target.userId === ctx.user.id) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "You already own this organization",
+				});
+			}
+
+			await db.transaction(async (tx) => {
+				await tx
+					.update(organization)
+					.set({ ownerId: target.userId })
+					.where(eq(organization.id, orgId));
+
+				await tx
+					.update(member)
+					.set({ role: "admin" })
+					.where(
+						and(
+							eq(member.organizationId, orgId),
+							eq(member.userId, ctx.user.id),
+						),
+					);
+
+				await tx
+					.update(member)
+					.set({ role: "owner" })
+					.where(eq(member.id, target.id));
+			});
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "organization",
+				resourceId: orgId,
+				resourceName: org.name,
+				metadata: {
+					type: "transferOwnership",
+					fromUserId: ctx.user.id,
+					toUserId: target.userId,
+				},
+			});
+
+			return true;
+		}),
 	setDefault: protectedProcedure
 		.input(
 			z.object({


### PR DESCRIPTION
## Summary

Focused contribution toward #1413: add organization ownership transfer from the Users settings table.

This PR implements the explicit "Add the ability to transfer ownership" item without trying to over-scope the broader teams/permissions roadmap in that issue.

## Changes

- Add `organization.transferOwnership` mutation
  - only the current organization owner can transfer ownership
  - target must be a member of the active organization
  - updates `organization.ownerId`, promotes the target member to `owner`, and demotes the previous owner to `admin` in one transaction
  - writes an audit event with previous/new owner IDs
- Add a guarded "Transfer Ownership" action in the Users table for owners
- Update the role-change helper text so owner changes point users to the transfer action

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec biome check apps/dokploy/server/api/routers/organization.ts apps/dokploy/components/dashboard/settings/users/show-users.tsx apps/dokploy/components/dashboard/settings/users/change-role.tsx`
- `corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false`
- `git diff --check`

Notes: local shell is Node v22.16.0 while the repo requests Node ^24.4.0, so pnpm prints engine warnings. A normal install script run is also blocked on this machine by the unaccepted local Xcode license while building native dependencies, so I used `--ignore-scripts` for static validation.

/claim #1413
