### PR TITLE
Add inactive invitation cleanup action

### DIFF
--- a/apps/dokploy/__test__/settings/invitation-status.test.ts
+++ b/apps/dokploy/__test__/settings/invitation-status.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isInactiveInvitation } from "@/components/dashboard/settings/users/invitation-status";
+
+const now = new Date("2026-05-19T12:00:00.000Z");
+
+describe("isInactiveInvitation", () => {
+	it("treats canceled invitations as inactive before expiry", () => {
+		expect(
+			isInactiveInvitation(
+				{
+					status: "canceled",
+					expiresAt: "2026-05-20T12:00:00.000Z",
+				},
+				now,
+			),
+		).toBe(true);
+	});
+
+	it("treats expired pending invitations as inactive", () => {
+		expect(
+			isInactiveInvitation(
+				{
+					status: "pending",
+					expiresAt: "2026-05-18T12:00:00.000Z",
+				},
+				now,
+			),
+		).toBe(true);
+	});
+
+	it("keeps active pending invitations out of bulk cleanup", () => {
+		expect(
+			isInactiveInvitation(
+				{
+					status: "pending",
+					expiresAt: "2026-05-20T12:00:00.000Z",
+				},
+				now,
+			),
+		).toBe(false);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/users/invitation-status.ts
+++ b/apps/dokploy/components/dashboard/settings/users/invitation-status.ts
@@ -1,0 +1,11 @@
+type InvitationStatusInput = {
+	status: string;
+	expiresAt: Date | string;
+};
+
+export const isInactiveInvitation = (
+	invitation: InvitationStatusInput,
+	now = new Date(),
+) =>
+	invitation.status === "canceled" ||
+	new Date(invitation.expiresAt).getTime() < now.getTime();

--- a/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
@@ -1,7 +1,8 @@
 import copy from "copy-to-clipboard";
 import { format, isPast } from "date-fns";
-import { Loader2, Mail, MoreHorizontal, Users } from "lucide-react";
+import { Loader2, Mail, MoreHorizontal, Trash2, Users } from "lucide-react";
 import { toast } from "sonner";
+import { DialogAction } from "@/components/shared/dialog-action";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,6 +38,18 @@ export const ShowInvitations = () => {
 
 	const { mutateAsync: removeInvitation } =
 		api.organization.removeInvitation.useMutation();
+	const {
+		mutateAsync: removeInactiveInvitations,
+		isPending: isRemovingInactive,
+	} = api.organization.removeInactiveInvitations.useMutation();
+
+	const inactiveInvitations =
+		data?.filter(
+			(invitation) =>
+				invitation.status === "canceled" ||
+				isPast(new Date(invitation.expiresAt)),
+		) ?? [];
+	const inactiveInvitationCount = inactiveInvitations.length;
 
 	return (
 		<div className="w-full">
@@ -209,6 +222,37 @@ export const ShowInvitations = () => {
 										</Table>
 
 										<div className="flex flex-row gap-2 flex-wrap w-full justify-end mr-4">
+											{inactiveInvitationCount > 0 && (
+												<DialogAction
+													title="Remove inactive invitations"
+													description={`Remove ${inactiveInvitationCount} expired or canceled invitation${inactiveInvitationCount === 1 ? "" : "s"} from this organization? This action cannot be undone.`}
+													type="destructive"
+													disabled={isRemovingInactive}
+													onClick={async () => {
+														await removeInactiveInvitations()
+															.then(async ({ count }) => {
+																await refetch();
+																toast.success(
+																	`${count} inactive invitation${count === 1 ? "" : "s"} removed`,
+																);
+															})
+															.catch((error) => {
+																toast.error(
+																	error?.message ||
+																		"Error removing inactive invitations",
+																);
+															});
+													}}
+												>
+													<Button
+														variant="outline"
+														isLoading={isRemovingInactive}
+													>
+														<Trash2 className="size-4" />
+														Remove inactive
+													</Button>
+												</DialogAction>
+											)}
 											<AddInvitation />
 										</div>
 									</div>

--- a/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
@@ -31,6 +31,7 @@ import {
 import { authClient } from "@/lib/auth-client";
 import { api } from "@/utils/api";
 import { AddInvitation } from "./add-invitation";
+import { isInactiveInvitation } from "./invitation-status";
 
 export const ShowInvitations = () => {
 	const { data, isPending, refetch } =
@@ -44,11 +45,7 @@ export const ShowInvitations = () => {
 	} = api.organization.removeInactiveInvitations.useMutation();
 
 	const inactiveInvitations =
-		data?.filter(
-			(invitation) =>
-				invitation.status === "canceled" ||
-				isPast(new Date(invitation.expiresAt)),
-		) ?? [];
+		data?.filter((invitation) => isInactiveInvitation(invitation)) ?? [];
 	const inactiveInvitationCount = inactiveInvitations.length;
 
 	return (

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -1,7 +1,7 @@
 import { db } from "@dokploy/server/db";
 import { IS_CLOUD, sendInvitationEmail } from "@dokploy/server/index";
 import { TRPCError } from "@trpc/server";
-import { and, desc, eq, exists } from "drizzle-orm";
+import { and, desc, eq, exists, lt, or } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
@@ -402,6 +402,42 @@ export const organizationRouter = createTRPCRouter({
 			});
 			return result;
 		}),
+	removeInactiveInvitations: withPermission("member", "create").mutation(
+		async ({ ctx }) => {
+			const orgId = ctx.session.activeOrganizationId;
+			const removed = await db
+				.delete(invitation)
+				.where(
+					and(
+						eq(invitation.organizationId, orgId),
+						or(
+							eq(invitation.status, "canceled"),
+							lt(invitation.expiresAt, new Date()),
+						),
+					),
+				)
+				.returning({
+					id: invitation.id,
+					email: invitation.email,
+				});
+
+			if (removed.length > 0) {
+				await audit(ctx, {
+					action: "delete",
+					resourceType: "organization",
+					resourceId: orgId,
+					resourceName: "inactive invitations",
+					metadata: {
+						type: "removeInactiveInvitations",
+						count: removed.length,
+						invitationIds: removed.map((invite) => invite.id),
+					},
+				});
+			}
+
+			return { count: removed.length };
+		},
+	),
 	updateMemberRole: withPermission("member", "update")
 		.input(
 			z.object({


### PR DESCRIPTION
## Summary

Focused contribution toward #1413: add a bulk cleanup path for organization invitations that are no longer actionable.

This covers the unchecked invitation-management slice by allowing admins/owners with member-create permission to remove expired or canceled invitations from the active organization in one confirmed action.

## Changes

- Add `organization.removeInactiveInvitations`
  - scoped to `ctx.session.activeOrganizationId`
  - removes invitations whose status is `canceled` or whose `expiresAt` is in the past
  - records an audit event with the removed invitation count and ids
- Add a destructive-confirmation action to the Invitations table
  - shown only when inactive invitations exist
  - refetches the table and reports the number removed
- Add focused coverage for inactive invitation detection
  - canceled invitations are cleanup-eligible
  - expired pending invitations are cleanup-eligible
  - active pending invitations are not cleanup-eligible

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec biome check apps/dokploy/server/api/routers/organization.ts apps/dokploy/components/dashboard/settings/users/show-invitations.tsx`
- `corepack pnpm exec biome check apps/dokploy/components/dashboard/settings/users/show-invitations.tsx apps/dokploy/components/dashboard/settings/users/invitation-status.ts apps/dokploy/__test__/settings/invitation-status.test.ts`
- `corepack pnpm --filter=dokploy exec vitest run --config __test__/vitest.config.ts __test__/settings/invitation-status.test.ts`
- `corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false`
- `git diff --check`

Note: I could not record a live demo video in this environment because there is no configured Dokploy instance/database session available. I added focused test coverage for the new invitation-status behavior and kept the runtime change limited to the existing invitations settings surface plus the tRPC mutation.

/claim #1413
