### PR TITLE
Add editable organization descriptions

### DIFF
--- a/apps/dokploy/components/dashboard/organization/handle-organization.tsx
+++ b/apps/dokploy/components/dashboard/organization/handle-organization.tsx
@@ -31,7 +31,21 @@ const organizationSchema = z.object({
 		message: "Organization name is required",
 	}),
 	logo: z.string().optional(),
+	description: z.string().max(280).optional(),
 });
+
+const getOrganizationDescription = (metadata?: string | null) => {
+	if (!metadata) {
+		return "";
+	}
+
+	try {
+		const parsed = JSON.parse(metadata);
+		return typeof parsed?.description === "string" ? parsed.description : "";
+	} catch {
+		return "";
+	}
+};
 
 type OrganizationFormValues = z.infer<typeof organizationSchema>;
 
@@ -60,6 +74,7 @@ export function AddOrganization({ organizationId }: Props) {
 		defaultValues: {
 			name: "",
 			logo: "",
+			description: "",
 		},
 	});
 
@@ -68,6 +83,7 @@ export function AddOrganization({ organizationId }: Props) {
 			form.reset({
 				name: organization.name,
 				logo: organization.logo || "",
+				description: getOrganizationDescription(organization.metadata),
 			});
 		}
 	}, [organization, form]);
@@ -76,6 +92,7 @@ export function AddOrganization({ organizationId }: Props) {
 		await mutateAsync({
 			name: values.name,
 			logo: values.logo,
+			description: values.description,
 			organizationId: organizationId ?? "",
 		})
 			.then(() => {
@@ -129,7 +146,7 @@ export function AddOrganization({ organizationId }: Props) {
 					</DialogTitle>
 					<DialogDescription>
 						{organizationId
-							? "Update the organization name and logo"
+							? "Update the organization name, logo, and description"
 							: "Create a new organization to manage your projects."}
 					</DialogDescription>
 				</DialogHeader>
@@ -164,6 +181,24 @@ export function AddOrganization({ organizationId }: Props) {
 									<FormControl>
 										<Input
 											placeholder="https://example.com/logo.png"
+											{...field}
+											value={field.value || ""}
+											className="col-span-3"
+										/>
+									</FormControl>
+									<FormMessage className="col-span-3 col-start-2" />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="description"
+							render={({ field }) => (
+								<FormItem className="gap-4">
+									<FormLabel className="text-right">Description</FormLabel>
+									<FormControl>
+										<Input
+											placeholder="What this organization is for"
 											{...field}
 											value={field.value || ""}
 											className="col-span-3"

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -13,15 +13,52 @@ import {
 	user,
 } from "@/server/db/schema";
 import { createTRPCRouter, protectedProcedure, withPermission } from "../trpc";
+
+const parseOrganizationMetadata = (metadata: string | null) => {
+	if (!metadata) {
+		return {} as Record<string, unknown>;
+	}
+
+	try {
+		const parsed = JSON.parse(metadata);
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: ({} as Record<string, unknown>);
+	} catch {
+		return {} as Record<string, unknown>;
+	}
+};
+
+const stringifyOrganizationMetadata = (
+	metadata: Record<string, unknown>,
+	description?: string,
+) => {
+	const nextMetadata = { ...metadata };
+	const normalizedDescription = description?.trim();
+
+	if (normalizedDescription) {
+		nextMetadata.description = normalizedDescription;
+	} else {
+		delete nextMetadata.description;
+	}
+
+	return Object.keys(nextMetadata).length > 0
+		? JSON.stringify(nextMetadata)
+		: null;
+};
+
 export const organizationRouter = createTRPCRouter({
 	create: protectedProcedure
 		.input(
 			z.object({
 				name: z.string(),
 				logo: z.string().optional(),
+				description: z.string().max(280).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			const normalizedDescription = input.description?.trim();
+
 			if (ctx.user.role !== "owner" && ctx.user.role !== "admin" && !IS_CLOUD) {
 				throw new TRPCError({
 					code: "FORBIDDEN",
@@ -31,7 +68,9 @@ export const organizationRouter = createTRPCRouter({
 			const result = await db
 				.insert(organization)
 				.values({
-					...input,
+					name: input.name,
+					logo: input.logo,
+					metadata: stringifyOrganizationMetadata({}, input.description),
 					slug: nanoid(),
 					createdAt: new Date(),
 					ownerId: ctx.user.id,
@@ -62,6 +101,9 @@ export const organizationRouter = createTRPCRouter({
 				resourceType: "organization",
 				resourceId: result.id,
 				resourceName: result.name,
+				metadata: normalizedDescription
+					? { description: normalizedDescription }
+					: undefined,
 			});
 			return result;
 		}),
@@ -119,6 +161,7 @@ export const organizationRouter = createTRPCRouter({
 				organizationId: z.string(),
 				name: z.string(),
 				logo: z.string().optional(),
+				description: z.string().max(280).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -166,6 +209,10 @@ export const organizationRouter = createTRPCRouter({
 				.set({
 					name: input.name,
 					logo: input.logo,
+					metadata: stringifyOrganizationMetadata(
+						parseOrganizationMetadata(org.metadata),
+						input.description,
+					),
 				})
 				.where(eq(organization.id, input.organizationId))
 				.returning();
@@ -174,6 +221,7 @@ export const organizationRouter = createTRPCRouter({
 				resourceType: "organization",
 				resourceId: input.organizationId,
 				resourceName: input.name,
+				metadata: { description: input.description?.trim() || null },
 			});
 			return result[0];
 		}),


### PR DESCRIPTION
## Summary
- Add an optional organization description field to the create/update organization dialog
- Store the description inside the existing organization metadata JSON, preserving any other metadata keys
- Trim blank descriptions and remove the metadata description key when the field is empty

## Validation
- `corepack pnpm exec biome check apps/dokploy/server/api/routers/organization.ts apps/dokploy/components/dashboard/organization/handle-organization.tsx`
- `corepack pnpm --filter dokploy run typecheck`

Notes:
- Full recursive `corepack pnpm -r run typecheck` currently fails on pre-existing unrelated workspace errors in apps/api/apps/schedules under packages/server (module import/implicit any/template processor errors), while the Dokploy app typecheck passes.
- This is a focused slice toward #1413: editable organization descriptions via existing metadata, without a schema migration.

Related to #1413