### PR TITLE
Add view-only organization user role

### DIFF
--- a/apps/dokploy/__test__/permissions/check-permission.test.ts
+++ b/apps/dokploy/__test__/permissions/check-permission.test.ts
@@ -120,6 +120,48 @@ describe("static roles validate free-tier resources", () => {
 			checkPermission(ctx, { service: ["create"] }),
 		).rejects.toThrow();
 	});
+
+	it("user passes service.read", async () => {
+		memberToReturn = mockMemberData("user");
+		await expect(
+			checkPermission(ctx, { service: ["read"] }),
+		).resolves.toBeUndefined();
+	});
+
+	it("user fails project.create", async () => {
+		memberToReturn = mockMemberData("user");
+		await expect(
+			checkPermission(ctx, { project: ["create"] }),
+		).rejects.toThrow();
+	});
+
+	it("user fails deployment.create", async () => {
+		memberToReturn = mockMemberData("user");
+		await expect(
+			checkPermission(ctx, { deployment: ["create"] }),
+		).rejects.toThrow();
+	});
+
+	it("user passes deployment.read", async () => {
+		memberToReturn = mockMemberData("user");
+		await expect(
+			checkPermission(ctx, { deployment: ["read"] }),
+		).resolves.toBeUndefined();
+	});
+
+	it("user passes domain.read", async () => {
+		memberToReturn = mockMemberData("user");
+		await expect(
+			checkPermission(ctx, { domain: ["read"] }),
+		).resolves.toBeUndefined();
+	});
+
+	it("user fails domain.create", async () => {
+		memberToReturn = mockMemberData("user");
+		await expect(
+			checkPermission(ctx, { domain: ["create"] }),
+		).rejects.toThrow();
+	});
 });
 
 describe("legacy boolean overrides for member", () => {

--- a/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
+++ b/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
@@ -145,6 +145,43 @@ describe("free-tier resources for member", () => {
 	});
 });
 
+describe("view-only user role", () => {
+	it("gets assigned-resource read permissions", async () => {
+		memberToReturn = mockMemberData("user");
+		const perms = await resolvePermissions(ctx);
+
+		expect(perms.service.read).toBe(true);
+		expect(perms.environment.read).toBe(true);
+		expect(perms.deployment.read).toBe(true);
+		expect(perms.domain.read).toBe(true);
+		expect(perms.logs.read).toBe(true);
+		expect(perms.monitoring.read).toBe(true);
+	});
+
+	it("cannot create projects, deployments, or domains", async () => {
+		memberToReturn = mockMemberData("user");
+		const perms = await resolvePermissions(ctx);
+
+		expect(perms.project.create).toBe(false);
+		expect(perms.service.create).toBe(false);
+		expect(perms.deployment.create).toBe(false);
+		expect(perms.deployment.cancel).toBe(false);
+		expect(perms.domain.create).toBe(false);
+		expect(perms.domain.delete).toBe(false);
+	});
+
+	it("does not inherit member legacy boolean overrides", async () => {
+		memberToReturn = mockMemberData("user", {
+			canCreateProjects: true,
+			canAccessToDocker: true,
+		});
+		const perms = await resolvePermissions(ctx);
+
+		expect(perms.project.create).toBe(false);
+		expect(perms.docker.read).toBe(false);
+	});
+});
+
 describe("free-tier resources for owner", () => {
 	it("owner gets all free-tier permissions as true", async () => {
 		memberToReturn = mockMemberData("owner");

--- a/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
@@ -278,6 +278,7 @@ export const AddInvitation = () => {
 											</FormControl>
 											<SelectContent>
 												<SelectItem value="member">Member</SelectItem>
+												<SelectItem value="user">User</SelectItem>
 												<SelectItem value="admin">Admin</SelectItem>
 												{customRoles?.map((role) => (
 													<SelectItem key={role.role} value={role.role}>

--- a/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
@@ -194,7 +194,8 @@ interface Props {
 }
 
 export const AddUserPermissions = ({ userId, role }: Props) => {
-	const isCustomRole = !!role && !["owner", "admin", "member"].includes(role);
+	const isCustomRole =
+		!!role && !["owner", "admin", "member", "user"].includes(role);
 	const [isOpen, setIsOpen] = useState(false);
 	const { data: projects } = api.project.allForPermissions.useQuery(undefined, {
 		enabled: isOpen,

--- a/apps/dokploy/components/dashboard/settings/users/change-role.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/change-role.tsx
@@ -129,6 +129,7 @@ export const ChangeRole = ({ memberId, currentRole, userEmail }: Props) => {
 										<SelectContent>
 											<SelectItem value="admin">Admin</SelectItem>
 											<SelectItem value="member">Member</SelectItem>
+											<SelectItem value="user">User</SelectItem>
 											{customRoles?.map((customRole) => (
 												<SelectItem
 													key={customRole.role}
@@ -144,6 +145,9 @@ export const ChangeRole = ({ memberId, currentRole, userEmail }: Props) => {
 										<br />
 										<strong>Member:</strong> Limited permissions, can be
 										customized.
+										<br />
+										<strong>User:</strong> View-only access to assigned
+										services.
 										{customRoles && customRoles.length > 0 && (
 											<>
 												<br />

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -43,7 +43,7 @@ export const ShowUsers = () => {
 	const utils = api.useUtils();
 	const { data: session } = api.user.session.useQuery();
 
-	const FREE_ROLES = ["owner", "admin", "member"];
+	const FREE_ROLES = ["owner", "admin", "member", "user"];
 	const membersWithCustomRoles = data?.filter(
 		(member) => !FREE_ROLES.includes(member.role),
 	);

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -304,7 +304,7 @@ export const organizationRouter = createTRPCRouter({
 			}
 
 			// If assigning a custom role, verify it exists
-			if (!["owner", "admin", "member"].includes(input.role)) {
+			if (!["owner", "admin", "member", "user"].includes(input.role)) {
 				const customRole = await db.query.organizationRole.findFirst({
 					where: and(
 						eq(organizationRole.organizationId, orgId),
@@ -454,7 +454,11 @@ export const organizationRouter = createTRPCRouter({
 			}
 
 			// If assigning a custom role (not admin/member), verify it exists
-			if (input.role !== "admin" && input.role !== "member") {
+			if (
+				input.role !== "admin" &&
+				input.role !== "member" &&
+				input.role !== "user"
+			) {
 				const customRole = await db.query.organizationRole.findFirst({
 					where: and(
 						eq(

--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -77,8 +77,8 @@ export const customRoleRouter = createTRPCRouter({
 					.min(1)
 					.max(50)
 					.refine(
-						(name) => !["owner", "admin", "member"].includes(name),
-						"Cannot use reserved role names (owner, admin, member)",
+						(name) => !["owner", "admin", "member", "user"].includes(name),
+						"Cannot use reserved role names (owner, admin, member, user)",
 					),
 				permissions: permissionsSchema,
 			}),
@@ -135,15 +135,15 @@ export const customRoleRouter = createTRPCRouter({
 					.min(1)
 					.max(50)
 					.refine(
-						(name) => !["owner", "admin", "member"].includes(name),
-						"Cannot use reserved role names (owner, admin, member)",
+						(name) => !["owner", "admin", "member", "user"].includes(name),
+						"Cannot use reserved role names (owner, admin, member, user)",
 					)
 					.optional(),
 				permissions: permissionsSchema,
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (["owner", "admin", "member"].includes(input.roleName)) {
+			if (["owner", "admin", "member", "user"].includes(input.roleName)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Cannot modify built-in roles",
@@ -214,7 +214,7 @@ export const customRoleRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (["owner", "admin", "member"].includes(input.roleName)) {
+			if (["owner", "admin", "member", "user"].includes(input.roleName)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Cannot delete built-in roles",

--- a/packages/server/src/lib/access-control.ts
+++ b/packages/server/src/lib/access-control.ts
@@ -53,7 +53,8 @@ export const statements = {
 /**
  * Enterprise-only resources. For static roles (owner/admin/member),
  * permission checks on these resources are bypassed — they only apply
- * when using custom roles with an enterprise license.
+ * when using custom roles with an enterprise license. The view-only user role is
+ * intentionally excluded from that bypass in the permission resolver.
  */
 export const enterpriseOnlyResources = new Set<string>([
 	"volume",
@@ -191,5 +192,44 @@ export const memberRole = ac.newRole({
 	destination: [],
 	notification: [],
 	tag: ["read"],
+	auditLog: [],
+});
+
+/**
+ * User role — view-only access to assigned services.
+ * Users can inspect assigned resources, domains, deployments, logs, and metrics,
+ * but cannot create projects, deploy/cancel, or manage organization-level assets.
+ */
+export const userRole = ac.newRole({
+	organization: [],
+	member: [],
+	invitation: [],
+	team: [],
+	ac: ["read"],
+	project: [],
+	service: ["read"],
+	environment: ["read"],
+	docker: [],
+	sshKeys: [],
+	gitProviders: [],
+	traefikFiles: [],
+	api: [],
+	volume: ["read"],
+	deployment: ["read"],
+	envVars: ["read"],
+	projectEnvVars: ["read"],
+	environmentEnvVars: ["read"],
+	server: [],
+	registry: [],
+	certificate: [],
+	backup: ["read"],
+	volumeBackup: ["read"],
+	schedule: ["read"],
+	domain: ["read"],
+	destination: [],
+	notification: [],
+	tag: ["read"],
+	logs: ["read"],
+	monitoring: ["read"],
 	auditLog: [],
 });

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -26,7 +26,13 @@ import {
 	sendVerificationEmail,
 } from "../verification/send-verification-email";
 import { getPublicIpWithFallback } from "../wss/utils";
-import { ac, adminRole, memberRole, ownerRole } from "./access-control";
+import {
+	ac,
+	adminRole,
+	memberRole,
+	ownerRole,
+	userRole,
+} from "./access-control";
 import { betterAuthSecret } from "./auth-secret";
 
 const { handler, api } = betterAuth({
@@ -406,6 +412,7 @@ const { handler, api } = betterAuth({
 				owner: ownerRole,
 				admin: adminRole,
 				member: memberRole,
+				user: userRole,
 			},
 			dynamicAccessControl: {
 				enabled: true,

--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -10,6 +10,7 @@ import {
 	memberRole,
 	ownerRole,
 	statements,
+	userRole,
 } from "../lib/access-control";
 
 type Statements = typeof statements;
@@ -34,6 +35,7 @@ const staticRoles: Record<string, ReturnType<typeof ac.newRole>> = {
 	owner: ownerRole,
 	admin: adminRole,
 	member: memberRole,
+	user: userRole,
 };
 
 const resolveRole = async (
@@ -80,9 +82,8 @@ export const checkPermission = async (
 	const { id: userId } = ctx.user;
 	const { activeOrganizationId: organizationId } = ctx.session;
 	const memberRecord = await findMemberByUserId(userId, organizationId);
-	const isStaticRole = memberRecord.role in staticRoles;
 
-	if (isStaticRole) {
+	if (["owner", "admin", "member"].includes(memberRecord.role)) {
 		const allEnterprise = Object.keys(permissions).every((r) =>
 			enterpriseOnlyResources.has(r),
 		);


### PR DESCRIPTION
/claim #1413

## Summary
- add a built-in `user` organization role with view-only access to assigned services and related runtime resources
- register the role with Better Auth and server permission resolution without giving it the existing owner/admin/member enterprise-resource bypass
- expose `User` in invitation/change-role UI and treat it as a reserved built-in role for custom-role validation
- add permission coverage proving `user` can read assigned services, environments, deployments, domains, logs, and monitoring, but cannot create projects/services/deployments/domains or inherit member legacy boolean overrides

## Demo / validation
This is a focused permission/role slice, so the behavior is demonstrated by the targeted permission tests:

```text
corepack pnpm --filter=dokploy exec vitest run __test__/permissions/check-permission.test.ts __test__/permissions/resolve-permissions.test.ts --config __test__/vitest.config.ts
✓ __test__/permissions/check-permission.test.ts (17 tests)
✓ __test__/permissions/resolve-permissions.test.ts (13 tests)
Test Files 2 passed (2)
Tests 30 passed (30)
```

Additional checks run:

```text
corepack pnpm exec biome check packages/server/src/lib/access-control.ts packages/server/src/services/permission.ts packages/server/src/lib/auth.ts apps/dokploy/server/api/routers/organization.ts apps/dokploy/server/api/routers/proprietary/custom-role.ts apps/dokploy/components/dashboard/settings/users/add-invitation.tsx apps/dokploy/components/dashboard/settings/users/change-role.tsx apps/dokploy/components/dashboard/settings/users/show-users.tsx apps/dokploy/components/dashboard/settings/users/add-permissions.tsx apps/dokploy/__test__/permissions/check-permission.test.ts apps/dokploy/__test__/permissions/resolve-permissions.test.ts
corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false
git diff --check
```

Note: local validation ran on Node v22.22.2, so pnpm printed the repo engine warning for Node ^24.4.0, but the focused tests, typecheck, Biome check, and diff check all passed.
