### PR TITLE
fix: gate stale invitation removal

### DIFF
--- a/apps/dokploy/__test__/organization/invitations.test.ts
+++ b/apps/dokploy/__test__/organization/invitations.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { canRemoveInvitation } from "@/lib/invitations";
+
+const now = new Date("2026-05-20T12:00:00.000Z");
+
+describe("canRemoveInvitation", () => {
+	it("allows expired pending invitations to be removed", () => {
+		expect(
+			canRemoveInvitation(
+				{
+					status: "pending",
+					expiresAt: new Date("2026-05-20T11:59:59.000Z"),
+				},
+				now,
+			),
+		).toBe(true);
+	});
+
+	it("allows canceled invitations to be removed before expiry", () => {
+		expect(
+			canRemoveInvitation(
+				{
+					status: "canceled",
+					expiresAt: new Date("2026-05-20T12:30:00.000Z"),
+				},
+				now,
+			),
+		).toBe(true);
+	});
+
+	it("keeps active pending invitations on the cancel flow", () => {
+		expect(
+			canRemoveInvitation(
+				{
+					status: "pending",
+					expiresAt: new Date("2026-05-20T12:30:00.000Z"),
+				},
+				now,
+			),
+		).toBe(false);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
@@ -2,6 +2,7 @@ import copy from "copy-to-clipboard";
 import { format, isPast } from "date-fns";
 import { Loader2, Mail, MoreHorizontal, Users } from "lucide-react";
 import { toast } from "sonner";
+import { DialogAction } from "@/components/shared/dialog-action";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,6 +29,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
+import { canRemoveInvitation } from "@/lib/invitations";
 import { api } from "@/utils/api";
 import { AddInvitation } from "./add-invitation";
 
@@ -87,6 +89,7 @@ export const ShowInvitations = () => {
 													const isExpired = isPast(
 														new Date(invitation.expiresAt),
 													);
+													const canRemove = canRemoveInvitation(invitation);
 													return (
 														<TableRow key={invitation.id}>
 															<TableCell className="w-[100px]">
@@ -175,7 +178,7 @@ export const ShowInvitations = () => {
 																								);
 																							} else {
 																								toast.success(
-																									"Invitation deleted",
+																									"Invitation canceled",
 																								);
 																								refetch();
 																							}
@@ -186,19 +189,37 @@ export const ShowInvitations = () => {
 																				)}
 																			</>
 																		)}
-																		<DropdownMenuItem
-																			className="w-full cursor-pointer"
-																			onSelect={async () => {
-																				await removeInvitation({
-																					invitationId: invitation.id,
-																				}).then(() => {
-																					refetch();
-																					toast.success("Invitation removed");
-																				});
-																			}}
-																		>
-																			Remove Invitation
-																		</DropdownMenuItem>
+																		{canRemove && (
+																			<DialogAction
+																				title="Remove Invitation"
+																				description={`Remove the invitation for ${invitation.email}? This cannot be undone.`}
+																				type="destructive"
+																				onClick={async () => {
+																					await removeInvitation({
+																						invitationId: invitation.id,
+																					})
+																						.then(() => {
+																							refetch();
+																							toast.success(
+																								"Invitation removed",
+																							);
+																						})
+																						.catch((err) => {
+																							toast.error(
+																								err?.message ||
+																									"Error removing invitation",
+																							);
+																						});
+																				}}
+																			>
+																				<DropdownMenuItem
+																					className="w-full cursor-pointer text-red-500 hover:!text-red-600"
+																					onSelect={(e) => e.preventDefault()}
+																				>
+																					Remove Invitation
+																				</DropdownMenuItem>
+																			</DialogAction>
+																		)}
 																	</DropdownMenuContent>
 																</DropdownMenu>
 															</TableCell>

--- a/apps/dokploy/lib/invitations.ts
+++ b/apps/dokploy/lib/invitations.ts
@@ -1,0 +1,14 @@
+type InvitationRemovalState = {
+	status: string;
+	expiresAt: Date | string;
+};
+
+export const canRemoveInvitation = (
+	invitation: InvitationRemovalState,
+	now = new Date(),
+) => {
+	return (
+		invitation.status !== "pending" ||
+		new Date(invitation.expiresAt).getTime() <= now.getTime()
+	);
+};

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, exists } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { canRemoveInvitation } from "@/lib/invitations";
 import { audit } from "@/server/api/utils/audit";
 import {
 	invitation,
@@ -390,6 +391,13 @@ export const organizationRouter = createTRPCRouter({
 				});
 			}
 
+			if (!canRemoveInvitation(invitationResult)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Cancel active invitations before removing them",
+				});
+			}
+
 			const result = await db
 				.delete(invitation)
 				.where(eq(invitation.id, input.invitationId));
@@ -398,7 +406,10 @@ export const organizationRouter = createTRPCRouter({
 				resourceType: "organization",
 				resourceId: input.invitationId,
 				resourceName: invitationResult.email,
-				metadata: { type: "removeInvitation" },
+				metadata: {
+					type: "removeInvitation",
+					status: invitationResult.status,
+				},
 			});
 			return result;
 		}),


### PR DESCRIPTION
/claim #1413

## What is this PR about?

This PR adds a focused stale-invitation cleanup slice for #1413. It restricts hard removal to expired or non-pending invitations, keeps active pending invitations on the cancel flow, enforces that guard server-side, adds a destructive confirmation/error handling in the Invitations table, and covers the shared removal predicate.

## Checklist

- [x] I created a dedicated branch based on the `canary` branch.
- [x] I have read the suggestions in the CONTRIBUTING.md file.
- [x] I have tested this PR in my local instance.

## Issues related

Related to #1413

## Validation
- `corepack pnpm exec biome check apps/dokploy/lib/invitations.ts apps/dokploy/server/api/routers/organization.ts apps/dokploy/components/dashboard/settings/users/show-invitations.tsx apps/dokploy/__test__/organization/invitations.test.ts`
- `corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/organization/invitations.test.ts --run`
- `corepack pnpm --filter=dokploy run typecheck`
- `git diff --check`

Local instance smoke test:
- created a fresh local Dokploy account
- created a pending invitation and verified its action menu only showed `Copy Invitation` and `Cancel Invitation`
- canceled that invitation and verified its action menu showed `Remove Invitation`
- confirmed the destructive dialog and verified the invitation was removed from the table

## Screenshots / demo

Demo video: [dokploy_1413_invitation_cleanup_demo_hq.mp4](https://github.com/nussann/dokploy/releases/download/pr-4430-demo/dokploy_1413_invitation_cleanup_demo_hq.mp4)

Release asset page: [PR #4430 demo video](https://github.com/nussann/dokploy/releases/tag/pr-4430-demo)

The 12-second demo shows the local Invitations table flow: empty state, pending invitation, pending actions without hard removal, canceled invitation with removal available, destructive confirmation, and the empty state after removal.

## Note
I noticed @manuelsampedro1 outlined a similar invitation-cleanup slice in the issue before this PR was opened. I do not want to race or displace active work; if they already have a PR in progress, I am happy to step back, close this, or collaborate.