### PR TITLE
fix: wrap long server names and keep actions menu visible on settings/servers

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
@@ -131,10 +131,10 @@ export const ShowServers = () => {
 																className="relative hover:shadow-lg transition-shadow flex flex-col bg-transparent"
 															>
 																<CardHeader className="pb-3">
-																	<div className="flex items-start justify-between">
-																		<div className="flex items-center gap-2">
-																			<ServerIcon className="size-5 text-muted-foreground" />
-																			<CardTitle className="text-lg">
+																	<div className="flex items-start justify-between gap-2">
+																		<div className="flex min-w-0 items-center gap-2">
+																			<ServerIcon className="size-5 shrink-0 text-muted-foreground" />
+																			<CardTitle className="text-lg break-words min-w-0">
 																				{server.name}
 																			</CardTitle>
 																		</div>
@@ -145,7 +145,7 @@ export const ShowServers = () => {
 																					<DropdownMenuTrigger asChild>
 																						<Button
 																							variant="ghost"
-																							className="h-8 w-8 p-0"
+																							className="h-8 w-8 shrink-0 p-0"
 																						>
 																							<span className="sr-only">
 																								More options


### PR DESCRIPTION
## What is this PR about?

On `/dashboard/settings/servers`, a long server name in the card title (`h3`) did not wrap. It overflowed its container, overlapped the surrounding content, and squeezed the three-dots actions menu until it disappeared.

This fixes the card header layout so the name wraps onto multiple lines and the actions menu stays visible and clickable regardless of the name length. The change is CSS-only (Tailwind classes) in `show-servers.tsx`:

- `min-w-0` on the title container and `break-words min-w-0` on the `CardTitle`, so the title can shrink and wrap instead of overflowing (flex items default to `min-width: auto`, which was preventing the shrink).
- `shrink-0` on the `ServerIcon` and the actions trigger button, so neither gets crushed.
- `gap-2` on the header row to keep space between the title and the actions button.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

> Note: this is a CSS-only change (Tailwind utility classes) with no logic change. I have not yet run it in a full local instance, so a quick visual confirmation with a long server name would be appreciated.

## Issues related (if applicable)

closes #4433

## Screenshots (if applicable)
