### PR TITLE
fix: guard invitation cleanup

### DIFF
--- a/apps/dokploy/__test__/organization/invitations.test.ts
+++ b/apps/dokploy/__test__/organization/invitations.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isInvitationRemovable } from "@/lib/invitations";
+
+describe("isInvitationRemovable", () => {
+	const now = new Date("2026-05-20T12:00:00.000Z");
+
+	it("blocks active pending invitations", () => {
+		expect(
+			isInvitationRemovable("pending", "2026-05-20T12:01:00.000Z", now),
+		).toBe(false);
+	});
+
+	it("allows expired pending invitations", () => {
+		expect(
+			isInvitationRemovable("pending", "2026-05-20T11:59:00.000Z", now),
+		).toBe(true);
+	});
+
+	it("allows canceled invitations before expiry", () => {
+		expect(
+			isInvitationRemovable("canceled", "2026-05-20T12:01:00.000Z", now),
+		).toBe(true);
+	});
+
+	it("allows accepted invitations before expiry", () => {
+		expect(
+			isInvitationRemovable("accepted", "2026-05-20T12:01:00.000Z", now),
+		).toBe(true);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
@@ -28,6 +28,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
+import { isInvitationRemovable } from "@/lib/invitations";
 import { api } from "@/utils/api";
 import { AddInvitation } from "./add-invitation";
 
@@ -86,6 +87,10 @@ export const ShowInvitations = () => {
 												{data?.map((invitation) => {
 													const isExpired = isPast(
 														new Date(invitation.expiresAt),
+													);
+													const canRemoveInvitation = isInvitationRemovable(
+														invitation.status,
+														invitation.expiresAt,
 													);
 													return (
 														<TableRow key={invitation.id}>
@@ -186,19 +191,28 @@ export const ShowInvitations = () => {
 																				)}
 																			</>
 																		)}
-																		<DropdownMenuItem
-																			className="w-full cursor-pointer"
-																			onSelect={async () => {
-																				await removeInvitation({
-																					invitationId: invitation.id,
-																				}).then(() => {
-																					refetch();
-																					toast.success("Invitation removed");
-																				});
-																			}}
-																		>
-																			Remove Invitation
-																		</DropdownMenuItem>
+																		{canRemoveInvitation && (
+																			<DropdownMenuItem
+																				className="w-full cursor-pointer"
+																				onSelect={async () => {
+																					try {
+																						await removeInvitation({
+																							invitationId: invitation.id,
+																						});
+																						refetch();
+																						toast.success("Invitation removed");
+																					} catch (error) {
+																						toast.error(
+																							error instanceof Error
+																								? error.message
+																								: "Failed to remove invitation",
+																						);
+																					}
+																				}}
+																			>
+																				Remove Invitation
+																			</DropdownMenuItem>
+																		)}
 																	</DropdownMenuContent>
 																</DropdownMenu>
 															</TableCell>

--- a/apps/dokploy/lib/invitations.ts
+++ b/apps/dokploy/lib/invitations.ts
@@ -1,0 +1,12 @@
+type InvitationStatus =
+	| "pending"
+	| "accepted"
+	| "canceled"
+	| "rejected"
+	| string;
+
+export const isInvitationRemovable = (
+	status: InvitationStatus,
+	expiresAt: Date | string,
+	now = new Date(),
+) => status !== "pending" || new Date(expiresAt).getTime() <= now.getTime();

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, exists } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { isInvitationRemovable } from "@/lib/invitations";
 import { audit } from "@/server/api/utils/audit";
 import {
 	invitation,
@@ -387,6 +388,18 @@ export const organizationRouter = createTRPCRouter({
 				throw new TRPCError({
 					code: "FORBIDDEN",
 					message: "You are not allowed to remove this invitation",
+				});
+			}
+
+			if (
+				!isInvitationRemovable(
+					invitationResult.status,
+					invitationResult.expiresAt,
+				)
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Only expired or inactive invitations can be removed",
 				});
 			}
 


### PR DESCRIPTION
## Summary

This is a focused slice of #1413 for invitation cleanup.

- Adds one shared invitation cleanup helper.
- Keeps active pending invitations on the cancel flow.
- Allows hard removal only after an invitation is expired or inactive.
- Enforces that rule in the API and mirrors it in the settings UI.
- Adds focused state coverage for pending, expired, canceled, and accepted invitations.

/claim #1413

## Validation

Passed locally:
- focused Vitest invitation test
- Biome check on touched files
- Dokploy TypeScript check

Local note: pnpm prints the repository Node engine warning because this machine is on Node v23.11.0 and the repo asks for Node ^24.4.0.