### PR TITLE
feat(organization): add built-in viewer role

### DIFF
--- a/apps/dokploy/__test__/permissions/check-permission.test.ts
+++ b/apps/dokploy/__test__/permissions/check-permission.test.ts
@@ -90,6 +90,13 @@ describe("static roles bypass enterprise resources", () => {
 			}),
 		).resolves.toBeUndefined();
 	});
+
+	it("viewer does not bypass enterprise write permissions", async () => {
+		memberToReturn = mockMemberData("viewer");
+		await expect(
+			checkPermission(ctx, { deployment: ["create"] }),
+		).rejects.toThrow();
+	});
 });
 
 describe("static roles validate free-tier resources", () => {
@@ -120,6 +127,27 @@ describe("static roles validate free-tier resources", () => {
 			checkPermission(ctx, { service: ["create"] }),
 		).rejects.toThrow();
 	});
+
+	it("viewer passes service.read", async () => {
+		memberToReturn = mockMemberData("viewer");
+		await expect(
+			checkPermission(ctx, { service: ["read"] }),
+		).resolves.toBeUndefined();
+	});
+
+	it("viewer fails project.create", async () => {
+		memberToReturn = mockMemberData("viewer");
+		await expect(
+			checkPermission(ctx, { project: ["create"] }),
+		).rejects.toThrow();
+	});
+
+	it("viewer passes deployment.read", async () => {
+		memberToReturn = mockMemberData("viewer");
+		await expect(
+			checkPermission(ctx, { deployment: ["read"] }),
+		).resolves.toBeUndefined();
+	});
 });
 
 describe("legacy boolean overrides for member", () => {
@@ -140,5 +168,12 @@ describe("legacy boolean overrides for member", () => {
 	it("member fails docker.read with canAccessToDocker=false", async () => {
 		memberToReturn = mockMemberData("member");
 		await expect(checkPermission(ctx, { docker: ["read"] })).rejects.toThrow();
+	});
+
+	it("viewer ignores member legacy overrides", async () => {
+		memberToReturn = mockMemberData("viewer", { canCreateProjects: true });
+		await expect(
+			checkPermission(ctx, { project: ["create"] }),
+		).rejects.toThrow();
 	});
 });

--- a/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
+++ b/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
@@ -111,6 +111,18 @@ describe("enterprise resources for static roles", () => {
 		expect(perms.notification.read).toBe(false);
 		expect(perms.auditLog.read).toBe(false);
 	});
+
+	it("viewer gets read-only service-scoped enterprise permissions", async () => {
+		memberToReturn = mockMemberData("viewer");
+		const perms = await resolvePermissions(ctx);
+
+		expect(perms.deployment.read).toBe(true);
+		expect(perms.deployment.create).toBe(false);
+		expect(perms.domain.read).toBe(true);
+		expect(perms.logs.read).toBe(true);
+		expect(perms.monitoring.read).toBe(true);
+		expect(perms.server.read).toBe(false);
+	});
 });
 
 describe("free-tier resources for member", () => {
@@ -142,6 +154,21 @@ describe("free-tier resources for member", () => {
 		memberToReturn = mockMemberData("member", { canAccessToDocker: true });
 		const perms = await resolvePermissions(ctx);
 		expect(perms.docker.read).toBe(true);
+	});
+
+	it("viewer gets read-only runtime access without project creation", async () => {
+		memberToReturn = mockMemberData("viewer");
+		const perms = await resolvePermissions(ctx);
+		expect(perms.service.read).toBe(true);
+		expect(perms.environment.read).toBe(true);
+		expect(perms.project.create).toBe(false);
+		expect(perms.member.read).toBe(false);
+	});
+
+	it("viewer ignores legacy member overrides", async () => {
+		memberToReturn = mockMemberData("viewer", { canCreateProjects: true });
+		const perms = await resolvePermissions(ctx);
+		expect(perms.project.create).toBe(false);
 	});
 });
 

--- a/apps/dokploy/__test__/permissions/service-access.test.ts
+++ b/apps/dokploy/__test__/permissions/service-access.test.ts
@@ -106,6 +106,24 @@ describe("checkServicePermissionAndAccess", () => {
 			}),
 		).rejects.toThrow("You don't have access to this service");
 	});
+
+	it("viewer with access to service passes read-only deployment checks", async () => {
+		memberToReturn = mockMemberData("viewer", ["service-123"]);
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["read"],
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("viewer cannot create deployments even with service access", async () => {
+		memberToReturn = mockMemberData("viewer", ["service-123"]);
+		await expect(
+			checkServicePermissionAndAccess(ctx, "service-123", {
+				deployment: ["create"],
+			}),
+		).rejects.toThrow();
+	});
 });
 
 describe("checkServiceAccess", () => {
@@ -127,6 +145,13 @@ describe("checkServiceAccess", () => {
 		memberToReturn = mockMemberData("owner", [], []);
 		await expect(
 			checkServiceAccess(ctx, "project-1", "create"),
+		).resolves.toBeUndefined();
+	});
+
+	it("viewer with service access passes read check", async () => {
+		memberToReturn = mockMemberData("viewer", ["app-1"]);
+		await expect(
+			checkServiceAccess(ctx, "app-1", "read"),
 		).resolves.toBeUndefined();
 	});
 });

--- a/apps/dokploy/__test__/vitest.config.ts
+++ b/apps/dokploy/__test__/vitest.config.ts
@@ -23,12 +23,4 @@ export default defineConfig({
 			projects: [path.resolve(__dirname, "../tsconfig.json")],
 		}),
 	],
-	resolve: {
-		alias: {
-			"@dokploy/server": path.resolve(
-				__dirname,
-				"../../../packages/server/src",
-			),
-		},
-	},
 });

--- a/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-invitation.tsx
@@ -112,7 +112,7 @@ export const AddInvitation = () => {
 		defaultValues: {
 			mode: "invitation",
 			email: "",
-			role: "member",
+			role: "viewer",
 			notificationId: "",
 			password: "",
 			confirmPassword: "",
@@ -277,6 +277,7 @@ export const AddInvitation = () => {
 												</SelectTrigger>
 											</FormControl>
 											<SelectContent>
+												<SelectItem value="viewer">Viewer</SelectItem>
 												<SelectItem value="member">Member</SelectItem>
 												<SelectItem value="admin">Admin</SelectItem>
 												{customRoles?.map((role) => (
@@ -287,7 +288,7 @@ export const AddInvitation = () => {
 											</SelectContent>
 										</Select>
 										<FormDescription>
-											Select the role for the new user
+											Viewer has read-only access to assigned runtime resources.
 										</FormDescription>
 										<FormMessage />
 									</FormItem>

--- a/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
@@ -194,7 +194,9 @@ interface Props {
 }
 
 export const AddUserPermissions = ({ userId, role }: Props) => {
-	const isCustomRole = !!role && !["owner", "admin", "member"].includes(role);
+	const isViewerRole = role === "viewer";
+	const isCustomRole =
+		!!role && !["owner", "admin", "member", "viewer"].includes(role);
 	const [isOpen, setIsOpen] = useState(false);
 	const { data: projects } = api.project.allForPermissions.useQuery(undefined, {
 		enabled: isOpen,
@@ -322,14 +324,14 @@ export const AddUserPermissions = ({ userId, role }: Props) => {
 						onSubmit={form.handleSubmit(onSubmit)}
 						className="grid  grid-cols-1 md:grid-cols-2  w-full gap-4"
 					>
-						{isCustomRole && (
+						{(isCustomRole || isViewerRole) && (
 							<div className="md:col-span-2 rounded-lg border p-3 bg-muted/50 text-sm text-muted-foreground">
-								This user has a custom role assigned. Capabilities are defined
-								by the role. You can still manage which projects, environments,
-								and services they can access below.
+								{isViewerRole
+									? "This user has the built-in viewer role. You can manage which projects, environments, and services they can access below."
+									: "This user has a custom role assigned. Capabilities are defined by the role. You can still manage which projects, environments, and services they can access below."}
 							</div>
 						)}
-						{!isCustomRole && (
+						{!isCustomRole && !isViewerRole && (
 							<>
 								<FormField
 									control={form.control}

--- a/apps/dokploy/components/dashboard/settings/users/change-role.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/change-role.tsx
@@ -128,6 +128,7 @@ export const ChangeRole = ({ memberId, currentRole, userEmail }: Props) => {
 										</FormControl>
 										<SelectContent>
 											<SelectItem value="admin">Admin</SelectItem>
+											<SelectItem value="viewer">Viewer</SelectItem>
 											<SelectItem value="member">Member</SelectItem>
 											{customRoles?.map((customRole) => (
 												<SelectItem
@@ -141,6 +142,9 @@ export const ChangeRole = ({ memberId, currentRole, userEmail }: Props) => {
 									</Select>
 									<FormDescription>
 										<strong>Admin:</strong> Can manage users and settings.
+										<br />
+										<strong>Viewer:</strong> Read-only access to assigned
+										runtime resources.
 										<br />
 										<strong>Member:</strong> Limited permissions, can be
 										customized.

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -43,7 +43,7 @@ export const ShowUsers = () => {
 	const utils = api.useUtils();
 	const { data: session } = api.user.session.useQuery();
 
-	const FREE_ROLES = ["owner", "admin", "member"];
+	const FREE_ROLES = ["owner", "admin", "member", "viewer"];
 	const membersWithCustomRoles = data?.filter(
 		(member) => !FREE_ROLES.includes(member.role),
 	);

--- a/apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx
+++ b/apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx
@@ -432,8 +432,8 @@ const ROLE_PRESETS: {
 	permissions: Record<string, string[]>;
 }[] = [
 	{
-		name: "viewer",
-		label: "Viewer",
+		name: "auditor",
+		label: "Auditor",
 		description: "Read-only access across all resources",
 		permissions: {
 			service: ["read"],
@@ -704,7 +704,7 @@ function HandleCustomRole({
 									<FormLabel>Role Name</FormLabel>
 									<FormControl>
 										<Input
-											placeholder="e.g. developer, viewer, deployer"
+											placeholder="e.g. developer, auditor, deployer"
 											{...field}
 										/>
 									</FormControl>

--- a/apps/dokploy/pages/dashboard/settings/ai.tsx
+++ b/apps/dokploy/pages/dashboard/settings/ai.tsx
@@ -42,7 +42,7 @@ export async function getServerSideProps(
 
 	await helpers.user.get.prefetch();
 
-	if (!user || user.role === "member") {
+	if (!user || user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/certificates.tsx
+++ b/apps/dokploy/pages/dashboard/settings/certificates.tsx
@@ -25,7 +25,7 @@ export async function getServerSideProps(
 ) {
 	const { req, res } = ctx;
 	const { user, session } = await validateRequest(req);
-	if (!user || user.role === "member") {
+	if (!user || user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/cluster.tsx
+++ b/apps/dokploy/pages/dashboard/settings/cluster.tsx
@@ -33,7 +33,7 @@ export async function getServerSideProps(
 		};
 	}
 	const { user, session } = await validateRequest(ctx.req);
-	if (!user || user.role === "member") {
+	if (!user || user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/destinations.tsx
+++ b/apps/dokploy/pages/dashboard/settings/destinations.tsx
@@ -25,7 +25,7 @@ export async function getServerSideProps(
 ) {
 	const { req, res } = ctx;
 	const { user, session } = await validateRequest(req);
-	if (!user || user.role === "member") {
+	if (!user || user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/notifications.tsx
+++ b/apps/dokploy/pages/dashboard/settings/notifications.tsx
@@ -25,7 +25,7 @@ export async function getServerSideProps(
 ) {
 	const { req, res } = ctx;
 	const { user, session } = await validateRequest(req);
-	if (!user || user.role === "member") {
+	if (!user || user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/registry.tsx
+++ b/apps/dokploy/pages/dashboard/settings/registry.tsx
@@ -25,7 +25,7 @@ export async function getServerSideProps(
 ) {
 	const { req, res } = ctx;
 	const { user, session } = await validateRequest(req);
-	if (!user || user.role === "member") {
+	if (!user || user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/server.tsx
+++ b/apps/dokploy/pages/dashboard/settings/server.tsx
@@ -58,7 +58,7 @@ export async function getServerSideProps(
 			},
 		};
 	}
-	if (user.role === "member") {
+	if (user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/servers.tsx
+++ b/apps/dokploy/pages/dashboard/settings/servers.tsx
@@ -33,7 +33,7 @@ export async function getServerSideProps(
 			},
 		};
 	}
-	if (user.role === "member") {
+	if (user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/pages/dashboard/settings/sso.tsx
+++ b/apps/dokploy/pages/dashboard/settings/sso.tsx
@@ -51,7 +51,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 			},
 		};
 	}
-	if (user.role === "member") {
+	if (user.role === "member" || user.role === "viewer") {
 		return {
 			redirect: {
 				permanent: false,

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -304,7 +304,7 @@ export const organizationRouter = createTRPCRouter({
 			}
 
 			// If assigning a custom role, verify it exists
-			if (!["owner", "admin", "member"].includes(input.role)) {
+			if (!["owner", "admin", "member", "viewer"].includes(input.role)) {
 				const customRole = await db.query.organizationRole.findFirst({
 					where: and(
 						eq(organizationRole.organizationId, orgId),
@@ -453,8 +453,12 @@ export const organizationRouter = createTRPCRouter({
 				});
 			}
 
-			// If assigning a custom role (not admin/member), verify it exists
-			if (input.role !== "admin" && input.role !== "member") {
+			// If assigning a custom role, verify it exists
+			if (
+				input.role !== "admin" &&
+				input.role !== "member" &&
+				input.role !== "viewer"
+			) {
 				const customRole = await db.query.organizationRole.findFirst({
 					where: and(
 						eq(
@@ -468,7 +472,7 @@ export const organizationRouter = createTRPCRouter({
 				if (!customRole) {
 					throw new TRPCError({
 						code: "NOT_FOUND",
-						message: `Custom role "${input.role}" not found`,
+						message: `Role "${input.role}" not found`,
 					});
 				}
 			}

--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -77,8 +77,8 @@ export const customRoleRouter = createTRPCRouter({
 					.min(1)
 					.max(50)
 					.refine(
-						(name) => !["owner", "admin", "member"].includes(name),
-						"Cannot use reserved role names (owner, admin, member)",
+						(name) => !["owner", "admin", "member", "viewer"].includes(name),
+						"Cannot use reserved role names (owner, admin, member, viewer)",
 					),
 				permissions: permissionsSchema,
 			}),
@@ -135,15 +135,15 @@ export const customRoleRouter = createTRPCRouter({
 					.min(1)
 					.max(50)
 					.refine(
-						(name) => !["owner", "admin", "member"].includes(name),
-						"Cannot use reserved role names (owner, admin, member)",
+						(name) => !["owner", "admin", "member", "viewer"].includes(name),
+						"Cannot use reserved role names (owner, admin, member, viewer)",
 					)
 					.optional(),
 				permissions: permissionsSchema,
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (["owner", "admin", "member"].includes(input.roleName)) {
+			if (["owner", "admin", "member", "viewer"].includes(input.roleName)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Cannot modify built-in roles",
@@ -214,7 +214,7 @@ export const customRoleRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (["owner", "admin", "member"].includes(input.roleName)) {
+			if (["owner", "admin", "member", "viewer"].includes(input.roleName)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Cannot delete built-in roles",

--- a/apps/dokploy/server/api/routers/proprietary/sso.ts
+++ b/apps/dokploy/server/api/routers/proprietary/sso.ts
@@ -1,4 +1,3 @@
-import { normalizeTrustedOrigin } from "@dokploy/server";
 import { IS_CLOUD } from "@dokploy/server/constants";
 import { db } from "@dokploy/server/db";
 import { member, ssoProvider, user } from "@dokploy/server/db/schema";
@@ -8,6 +7,7 @@ import {
 	requestToHeaders,
 } from "@dokploy/server/index";
 import { auth } from "@dokploy/server/lib/auth";
+import { normalizeTrustedOrigin } from "@dokploy/server/services/proprietary/sso";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";

--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -1,4 +1,4 @@
-import { IS_CLOUD, removeScheduleJob, scheduleJob } from "@dokploy/server";
+import { IS_CLOUD } from "@dokploy/server/constants";
 import { db } from "@dokploy/server/db";
 import { deployments } from "@dokploy/server/db/schema/deployment";
 import {
@@ -6,7 +6,6 @@ import {
 	schedules,
 	updateScheduleSchema,
 } from "@dokploy/server/db/schema/schedule";
-import { runCommand } from "@dokploy/server/index";
 import {
 	checkPermission,
 	checkServicePermissionAndAccess,
@@ -19,6 +18,11 @@ import {
 	updateSchedule,
 } from "@dokploy/server/services/schedule";
 import { findServerById } from "@dokploy/server/services/server";
+import {
+	removeScheduleJob,
+	runCommand,
+	scheduleJob,
+} from "@dokploy/server/utils/schedules/utils";
 import { TRPCError } from "@trpc/server";
 import { asc, desc, eq } from "drizzle-orm";
 import { z } from "zod";

--- a/apps/dokploy/server/api/trpc.ts
+++ b/apps/dokploy/server/api/trpc.ts
@@ -34,7 +34,7 @@ type ActionOf<R extends Resource> = (typeof statements)[R][number];
 interface CreateContextOptions {
 	user:
 		| (User & {
-				role: "member" | "admin" | "owner";
+				role: "member" | "admin" | "owner" | "viewer";
 				ownerId: string;
 				enableEnterpriseFeatures: boolean;
 				isValidEnterpriseLicense: boolean;
@@ -94,7 +94,7 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 			? {
 					...user,
 					email: user.email,
-					role: user.role as "owner" | "member" | "admin",
+					role: user.role as "owner" | "member" | "admin" | "viewer",
 					id: user.id,
 					ownerId: user.ownerId,
 				}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,9 +9,49 @@
       "import": "./src/db/index.ts",
       "require": "./dist/db/index.cjs.js"
     },
+    "./db/schema": {
+      "import": "./src/db/schema/index.ts",
+      "require": "./dist/db/schema/index.js"
+    },
+    "./db/*": {
+      "import": "./src/db/*.ts",
+      "require": "./dist/db/*.js"
+    },
     "./setup/*": {
       "import": "./src/setup/*.ts",
       "require": "./dist/setup/index.cjs.js"
+    },
+    "./services/*": {
+      "import": "./src/services/*.ts",
+      "require": "./dist/services/*.js"
+    },
+    "./lib/*": {
+      "import": "./src/lib/*.ts",
+      "require": "./dist/lib/*.js"
+    },
+    "./utils/*": {
+      "import": "./src/utils/*.ts",
+      "require": "./dist/utils/*.js"
+    },
+    "./monitoring/*": {
+      "import": "./src/monitoring/*.ts",
+      "require": "./dist/monitoring/*.js"
+    },
+    "./emails/*": {
+      "import": "./src/emails/*.ts",
+      "require": "./dist/emails/*.js"
+    },
+    "./templates": {
+      "import": "./src/templates/index.ts",
+      "require": "./dist/templates/index.js"
+    },
+    "./types/*": {
+      "import": "./src/types/*.ts",
+      "require": "./dist/types/*.js"
+    },
+    "./wss/*": {
+      "import": "./src/wss/*.ts",
+      "require": "./dist/wss/*.js"
     },
     "./constants": {
       "import": "./src/constants/index.ts",

--- a/packages/server/scripts/switchToDist.js
+++ b/packages/server/scripts/switchToDist.js
@@ -19,6 +19,54 @@ pkg.exports = {
 		import: "./dist/db/index.js",
 		require: "./dist/db/index.cjs.js",
 	},
+	"./db/schema": {
+		import: "./dist/db/schema/index.js",
+		require: "./dist/db/schema/index.js",
+	},
+	"./db/*": {
+		import: "./dist/db/*.js",
+		require: "./dist/db/*.js",
+	},
+	"./setup/*": {
+		import: "./dist/setup/*.js",
+		require: "./dist/setup/*.js",
+	},
+	"./services/*": {
+		import: "./dist/services/*.js",
+		require: "./dist/services/*.js",
+	},
+	"./lib/*": {
+		import: "./dist/lib/*.js",
+		require: "./dist/lib/*.js",
+	},
+	"./utils/*": {
+		import: "./dist/utils/*.js",
+		require: "./dist/utils/*.js",
+	},
+	"./monitoring/*": {
+		import: "./dist/monitoring/*.js",
+		require: "./dist/monitoring/*.js",
+	},
+	"./emails/*": {
+		import: "./dist/emails/*.js",
+		require: "./dist/emails/*.js",
+	},
+	"./templates": {
+		import: "./dist/templates/index.js",
+		require: "./dist/templates/index.js",
+	},
+	"./types/*": {
+		import: "./dist/types/*.js",
+		require: "./dist/types/*.js",
+	},
+	"./wss/*": {
+		import: "./dist/wss/*.js",
+		require: "./dist/wss/*.js",
+	},
+	"./constants": {
+		import: "./dist/constants/index.js",
+		require: "./dist/constants/index.js",
+	},
 	"./*": {
 		import: "./dist/*",
 		require: "./dist/*.cjs",

--- a/packages/server/scripts/switchToSrc.js
+++ b/packages/server/scripts/switchToSrc.js
@@ -19,9 +19,49 @@ pkg.exports = {
 		import: "./src/db/index.ts",
 		require: "./dist/db/index.cjs.js",
 	},
+	"./db/schema": {
+		import: "./src/db/schema/index.ts",
+		require: "./dist/db/schema/index.js",
+	},
+	"./db/*": {
+		import: "./src/db/*.ts",
+		require: "./dist/db/*.js",
+	},
 	"./setup/*": {
 		import: "./src/setup/*.ts",
 		require: "./dist/setup/index.cjs.js",
+	},
+	"./services/*": {
+		import: "./src/services/*.ts",
+		require: "./dist/services/*.js",
+	},
+	"./lib/*": {
+		import: "./src/lib/*.ts",
+		require: "./dist/lib/*.js",
+	},
+	"./utils/*": {
+		import: "./src/utils/*.ts",
+		require: "./dist/utils/*.js",
+	},
+	"./monitoring/*": {
+		import: "./src/monitoring/*.ts",
+		require: "./dist/monitoring/*.js",
+	},
+	"./emails/*": {
+		import: "./src/emails/*.ts",
+		require: "./dist/emails/*.js",
+	},
+	"./templates": {
+		import: "./src/templates/index.ts",
+		require: "./dist/templates/index.js",
+	},
+	"./types/*": {
+		import: "./src/types/*.ts",
+		require: "./dist/types/*.js",
+	},
+	"./wss/*": {
+		import: "./src/wss/*.ts",
+		require: "./dist/wss/*.js",
 	},
 	"./constants": {
 		import: "./src/constants/index.ts",

--- a/packages/server/src/db/schema/account.ts
+++ b/packages/server/src/db/schema/account.ts
@@ -127,7 +127,7 @@ export const member = pgTable("member", {
 		.references(() => user.id, { onDelete: "cascade" }),
 	role: text("role")
 		.notNull()
-		.$type<"owner" | "member" | "admin" | (string & {})>(),
+		.$type<"owner" | "member" | "admin" | "viewer" | (string & {})>(),
 	createdAt: timestamp("created_at").notNull(),
 	teamId: text("team_id"),
 	isDefault: boolean("is_default").notNull().default(false),
@@ -190,7 +190,9 @@ export const invitation = pgTable("invitation", {
 		.notNull()
 		.references(() => organization.id, { onDelete: "cascade" }),
 	email: text("email").notNull(),
-	role: text("role").$type<"owner" | "member" | "admin" | (string & {})>(),
+	role: text("role").$type<
+		"owner" | "member" | "admin" | "viewer" | (string & {})
+	>(),
 	status: text("status").notNull(),
 	expiresAt: timestamp("expires_at").notNull(),
 	inviterId: text("inviter_id")

--- a/packages/server/src/lib/access-control.ts
+++ b/packages/server/src/lib/access-control.ts
@@ -51,9 +51,8 @@ export const statements = {
 } as const;
 
 /**
- * Enterprise-only resources. For static roles (owner/admin/member),
- * permission checks on these resources are bypassed — they only apply
- * when using custom roles with an enterprise license.
+ * Enterprise-only resources. Built-in roles can reference these resources
+ * without requiring an enterprise license.
  */
 export const enterpriseOnlyResources = new Set<string>([
 	"volume",
@@ -185,6 +184,44 @@ export const memberRole = ac.newRole({
 	logs: ["read"],
 	monitoring: ["read"],
 	// Org-level enterprise resources — member cannot manage these
+	server: [],
+	registry: [],
+	certificate: [],
+	destination: [],
+	notification: [],
+	tag: ["read"],
+	auditLog: [],
+});
+
+/**
+ * Viewer role — read-only access to assigned runtime resources.
+ * Unlike member, viewer never inherits the legacy boolean write toggles.
+ */
+export const viewerRole = ac.newRole({
+	organization: [],
+	member: [],
+	invitation: [],
+	team: [],
+	ac: [],
+	project: [],
+	service: ["read"],
+	environment: ["read"],
+	docker: [],
+	sshKeys: [],
+	gitProviders: [],
+	traefikFiles: [],
+	api: [],
+	volume: ["read"],
+	deployment: ["read"],
+	envVars: ["read"],
+	projectEnvVars: ["read"],
+	environmentEnvVars: ["read"],
+	backup: ["read"],
+	volumeBackup: ["read"],
+	schedule: ["read"],
+	domain: ["read"],
+	logs: ["read"],
+	monitoring: ["read"],
 	server: [],
 	registry: [],
 	certificate: [],

--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -10,6 +10,7 @@ import {
 	memberRole,
 	ownerRole,
 	statements,
+	viewerRole,
 } from "../lib/access-control";
 
 type Statements = typeof statements;
@@ -34,7 +35,10 @@ const staticRoles: Record<string, ReturnType<typeof ac.newRole>> = {
 	owner: ownerRole,
 	admin: adminRole,
 	member: memberRole,
+	viewer: viewerRole,
 };
+
+const enterpriseBypassRoles = new Set(["owner", "admin", "member"]);
 
 const resolveRole = async (
 	roleName: string,
@@ -82,7 +86,7 @@ export const checkPermission = async (
 	const memberRecord = await findMemberByUserId(userId, organizationId);
 	const isStaticRole = memberRecord.role in staticRoles;
 
-	if (isStaticRole) {
+	if (isStaticRole && enterpriseBypassRoles.has(memberRecord.role)) {
 		const allEnterprise = Object.keys(permissions).every((r) =>
 			enterpriseOnlyResources.has(r),
 		);


### PR DESCRIPTION
/claim #1413

## What is this PR about?

This PR implements a focused built-in `viewer` role slice from #1413. It adds a read-only role for assigned runtime resources, wires that role through the invite and change-role flows, reserves the `viewer` name from enterprise custom roles, renames the old enterprise viewer preset to `auditor` to avoid collisions, and blocks viewers from opening admin-only settings routes directly. The existing enterprise bypass behavior remains limited to owner/admin/member so the new viewer role stays truly read-only.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. I validated this slice with `pnpm --filter=dokploy run typecheck` and `pnpm --filter=dokploy run build-server`. `pnpm --filter=dokploy run build-next` compiled successfully but later failed during page-data collection because this workspace does not have the expected `dokploy-postgres` / `dokploy-redis` services available (`ENOTFOUND`), so I could not complete end-to-end runtime verification here. I also added focused permission tests for the new viewer behavior, but the current Vitest setup in this checkout fails before running them because deep imports like `@dokploy/server/services/permission` are not exported to the test resolver.

## Issues related (if applicable)

Related to #1413

## Screenshots (if applicable)

N/A for this permission/backend slice. If maintainers want it, I can follow up with a short demo video once I can run the full local stack.