### PR TITLE
fix: guard permission assignment targets

### DIFF
--- a/apps/dokploy/__test__/users/member-permissions.test.ts
+++ b/apps/dokploy/__test__/users/member-permissions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { assertPermissionAssignmentTargetAllowed } from "@/lib/member-permissions";
+
+const assertPermissionTarget = (
+	actorUserId = "user-1",
+	targetUserId = "user-2",
+	targetRole = "member",
+) =>
+	assertPermissionAssignmentTargetAllowed({
+		actorUserId,
+		targetUserId,
+		targetRole,
+	});
+
+describe("assertPermissionAssignmentTargetAllowed", () => {
+	it("allows permission assignment to regular and custom-role members", () => {
+		expect(() => assertPermissionTarget()).not.toThrow();
+		expect(() =>
+			assertPermissionTarget("owner-1", "user-2", "staging-deployer"),
+		).not.toThrow();
+	});
+
+	it("rejects self permission assignment", () => {
+		expect(() => assertPermissionTarget("user-1", "user-1")).toThrow(
+			"You cannot assign permissions to yourself",
+		);
+	});
+
+	it("rejects manual permission assignment to static privileged roles", () => {
+		expect(() => assertPermissionTarget("owner-1", "user-2", "owner")).toThrow(
+			"Owner and admin permissions cannot be assigned manually",
+		);
+		expect(() => assertPermissionTarget("owner-1", "user-2", "admin")).toThrow(
+			"Owner and admin permissions cannot be assigned manually",
+		);
+	});
+});

--- a/apps/dokploy/lib/member-permissions.ts
+++ b/apps/dokploy/lib/member-permissions.ts
@@ -1,0 +1,27 @@
+import { TRPCError } from "@trpc/server";
+
+const staticRoles = new Set(["owner", "admin"]);
+
+export const assertPermissionAssignmentTargetAllowed = ({
+	actorUserId,
+	targetUserId,
+	targetRole,
+}: {
+	actorUserId: string;
+	targetUserId: string;
+	targetRole: string;
+}) => {
+	if (targetUserId === actorUserId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You cannot assign permissions to yourself",
+		});
+	}
+
+	if (staticRoles.has(targetRole)) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Owner and admin permissions cannot be assigned manually",
+		});
+	}
+};

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -35,6 +35,7 @@ import { TRPCError } from "@trpc/server";
 import * as bcrypt from "bcrypt";
 import { and, asc, eq, gt, ne } from "drizzle-orm";
 import { z } from "zod";
+import { assertPermissionAssignmentTargetAllowed } from "@/lib/member-permissions";
 import { audit } from "@/server/api/utils/audit";
 import {
 	adminProcedure,
@@ -347,9 +348,8 @@ export const userRouter = createTRPCRouter({
 		.input(apiAssignPermissions)
 		.mutation(async ({ input, ctx }) => {
 			try {
-				const organization = await findOrganizationById(
-					ctx.session?.activeOrganizationId || "",
-				);
+				const activeOrganizationId = ctx.session?.activeOrganizationId || "";
+				const organization = await findOrganizationById(activeOrganizationId);
 
 				if (organization?.ownerId !== ctx.user.ownerId) {
 					throw new TRPCError({
@@ -360,9 +360,27 @@ export const userRouter = createTRPCRouter({
 
 				const { id, accessedGitProviders, accessedServers, ...rest } = input;
 
-				const licensed = await hasValidLicense(
-					ctx.session?.activeOrganizationId || "",
-				);
+				const targetMember = await db.query.member.findFirst({
+					where: and(
+						eq(member.userId, id),
+						eq(member.organizationId, activeOrganizationId),
+					),
+				});
+
+				if (!targetMember) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "Member not found in this organization",
+					});
+				}
+
+				assertPermissionAssignmentTargetAllowed({
+					actorUserId: ctx.user.id,
+					targetUserId: targetMember.userId,
+					targetRole: targetMember.role,
+				});
+
+				const licensed = await hasValidLicense(activeOrganizationId);
 
 				await db
 					.update(member)
@@ -377,17 +395,14 @@ export const userRouter = createTRPCRouter({
 					})
 					.where(
 						and(
-							eq(member.userId, input.id),
-							eq(
-								member.organizationId,
-								ctx.session?.activeOrganizationId || "",
-							),
+							eq(member.userId, id),
+							eq(member.organizationId, activeOrganizationId),
 						),
 					);
 				await audit(ctx, {
 					action: "update",
 					resourceType: "user",
-					resourceId: input.id,
+					resourceId: id,
 					metadata: { permissions: rest },
 				});
 			} catch (error) {


### PR DESCRIPTION
## Summary
- validate the target member before assigning manual permissions
- reject missing organization members before update/audit side effects
- block self-targeted permission changes and manual permission assignment for static owner/admin roles
- add focused unit coverage for the permission target guard

## Why
`user.assignPermissions` is protected by `member.update`, but the mutation updated by `input.id` without first resolving the target member in the active organization. That let callers submit self-targeted permission changes, try static privileged roles that the UI does not expose for manual permission edits, and audit a successful update even when no member row matched the target user.

## Validation
- `corepack pnpm exec biome check apps/dokploy/lib/member-permissions.ts apps/dokploy/server/api/routers/user.ts apps/dokploy/__test__/users/member-permissions.test.ts --write`
- `corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/users/member-permissions.test.ts`
- `corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false`
- `git diff --check`

No screenshot/video included because this is a server-side authorization guard with focused unit coverage.

Refs #1413