### PR TITLE
fix: validate custom role permissions before rename

### DIFF
--- a/apps/dokploy/__test__/server/custom-role-utils.test.ts
+++ b/apps/dokploy/__test__/server/custom-role-utils.test.ts
@@ -1,0 +1,31 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import { validatePermissions } from "@/server/api/routers/proprietary/custom-role-utils";
+
+describe("validatePermissions", () => {
+	it("accepts valid custom role permissions", () => {
+		expect(() =>
+			validatePermissions({
+				project: ["create"],
+				service: ["read", "delete"],
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects internally managed better-auth resources", () => {
+		expect(() =>
+			validatePermissions({
+				organization: ["update"],
+			}),
+		).toThrow(TRPCError);
+	});
+
+	it("rejects invalid actions before role update side effects can run", () => {
+		expect(() =>
+			validatePermissions({
+				project: ["read"],
+			}),
+		).toThrow('Invalid action "read" for resource "project"');
+	});
+});

--- a/apps/dokploy/server/api/routers/proprietary/custom-role-utils.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role-utils.ts
@@ -1,0 +1,32 @@
+import { statements } from "@dokploy/server/lib/access-control";
+import { TRPCError } from "@trpc/server";
+
+const INTERNAL_RESOURCES = ["organization", "invitation", "team", "ac"];
+
+export function validatePermissions(permissions: Record<string, string[]>) {
+	for (const [resource, actions] of Object.entries(permissions)) {
+		if (INTERNAL_RESOURCES.includes(resource)) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Resource "${resource}" is managed internally and cannot be assigned to custom roles`,
+			});
+		}
+
+		if (!(resource in statements)) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message: `Unknown resource: ${resource}`,
+			});
+		}
+
+		const validActions = statements[resource as keyof typeof statements];
+		for (const action of actions) {
+			if (!validActions.includes(action as never)) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `Invalid action "${action}" for resource "${resource}". Valid actions: ${validActions.join(", ")}`,
+				});
+			}
+		}
+	}
+}

--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -10,6 +10,7 @@ import {
 	protectedProcedure,
 } from "../../trpc";
 import { audit } from "../../utils/audit";
+import { validatePermissions } from "./custom-role-utils";
 
 const permissionsSchema = z.record(z.string(), z.array(z.string()));
 
@@ -150,6 +151,8 @@ export const customRoleRouter = createTRPCRouter({
 				});
 			}
 
+			validatePermissions(input.permissions);
+
 			const effectiveRoleName = input.newRoleName ?? input.roleName;
 
 			if (input.newRoleName && input.newRoleName !== input.roleName) {
@@ -179,8 +182,6 @@ export const customRoleRouter = createTRPCRouter({
 						),
 					);
 			}
-
-			validatePermissions(input.permissions);
 
 			const [updated] = await db
 				.update(organizationRole)
@@ -289,33 +290,3 @@ export const customRoleRouter = createTRPCRouter({
 		return statements;
 	}),
 });
-
-const INTERNAL_RESOURCES = ["organization", "invitation", "team", "ac"];
-
-function validatePermissions(permissions: Record<string, string[]>) {
-	for (const [resource, actions] of Object.entries(permissions)) {
-		if (INTERNAL_RESOURCES.includes(resource)) {
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: `Resource "${resource}" is managed internally and cannot be assigned to custom roles`,
-			});
-		}
-
-		if (!(resource in statements)) {
-			throw new TRPCError({
-				code: "BAD_REQUEST",
-				message: `Unknown resource: ${resource}`,
-			});
-		}
-
-		const validActions = statements[resource as keyof typeof statements];
-		for (const action of actions) {
-			if (!validActions.includes(action as never)) {
-				throw new TRPCError({
-					code: "BAD_REQUEST",
-					message: `Invalid action "${action}" for resource "${resource}". Valid actions: ${validActions.join(", ")}`,
-				});
-			}
-		}
-	}
-}


### PR DESCRIPTION
## Summary
- extract custom role permission validation into a small tested helper
- validate permissions before custom role rename member updates run
- prevent invalid permission payloads from partially rewriting member roles before the mutation throws

/claim #1413

## Validation
- corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/server/custom-role-utils.test.ts --run
- corepack pnpm exec biome check apps/dokploy/server/api/routers/proprietary/custom-role.ts apps/dokploy/server/api/routers/proprietary/custom-role-utils.ts apps/dokploy/__test__/server/custom-role-utils.test.ts
- corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false