### PR TITLE
fix: validate custom role names server-side

### DIFF
--- a/apps/dokploy/__test__/permissions/custom-role-validation.test.ts
+++ b/apps/dokploy/__test__/permissions/custom-role-validation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { customRoleNameSchema } from "@/server/api/routers/proprietary/custom-role-validation";
+
+describe("custom role name validation", () => {
+	it("normalizes surrounding whitespace before storing a role name", () => {
+		const parsed = customRoleNameSchema.parse(" deployer ");
+
+		expect(parsed).toBe("deployer");
+	});
+
+	it("rejects empty role names after trimming whitespace", () => {
+		const result = customRoleNameSchema.safeParse("   ");
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects names with unsupported characters", () => {
+		const result = customRoleNameSchema.safeParse("deploy/read");
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects reserved built-in role names after trimming", () => {
+		const result = customRoleNameSchema.safeParse(" admin ");
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx
+++ b/apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx
@@ -537,6 +537,7 @@ const ROLE_PRESETS: {
 const createRoleSchema = z.object({
 	roleName: z
 		.string()
+		.trim()
 		.min(1, "Role name is required")
 		.max(50, "Role name must be 50 characters or less")
 		.regex(

--- a/apps/dokploy/server/api/routers/proprietary/custom-role-validation.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role-validation.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+const RESERVED_ROLE_NAMES = new Set(["owner", "admin", "member"]);
+
+export const isReservedRoleName = (name: string) =>
+	RESERVED_ROLE_NAMES.has(name);
+
+export const customRoleNameSchema = z
+	.string()
+	.trim()
+	.min(1, "Role name is required")
+	.max(50, "Role name must be 50 characters or less")
+	.regex(
+		/^[a-zA-Z0-9_-]+$/,
+		"Only letters, numbers, hyphens, and underscores allowed",
+	)
+	.refine(
+		(name) => !isReservedRoleName(name),
+		"Cannot use reserved role names (owner, admin, member)",
+	);

--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -10,6 +10,10 @@ import {
 	protectedProcedure,
 } from "../../trpc";
 import { audit } from "../../utils/audit";
+import {
+	customRoleNameSchema,
+	isReservedRoleName,
+} from "./custom-role-validation";
 
 const permissionsSchema = z.record(z.string(), z.array(z.string()));
 
@@ -72,14 +76,7 @@ export const customRoleRouter = createTRPCRouter({
 	create: enterpriseProcedure
 		.input(
 			z.object({
-				roleName: z
-					.string()
-					.min(1)
-					.max(50)
-					.refine(
-						(name) => !["owner", "admin", "member"].includes(name),
-						"Cannot use reserved role names (owner, admin, member)",
-					),
+				roleName: customRoleNameSchema,
 				permissions: permissionsSchema,
 			}),
 		)
@@ -130,20 +127,12 @@ export const customRoleRouter = createTRPCRouter({
 		.input(
 			z.object({
 				roleName: z.string().min(1),
-				newRoleName: z
-					.string()
-					.min(1)
-					.max(50)
-					.refine(
-						(name) => !["owner", "admin", "member"].includes(name),
-						"Cannot use reserved role names (owner, admin, member)",
-					)
-					.optional(),
+				newRoleName: customRoleNameSchema.optional(),
 				permissions: permissionsSchema,
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (["owner", "admin", "member"].includes(input.roleName)) {
+			if (isReservedRoleName(input.roleName)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Cannot modify built-in roles",
@@ -214,7 +203,7 @@ export const customRoleRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (["owner", "admin", "member"].includes(input.roleName)) {
+			if (isReservedRoleName(input.roleName)) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
 					message: "Cannot delete built-in roles",


### PR DESCRIPTION
/claim #1413

## Summary

This PR takes a narrow custom-role validation hardening slice from #1413.

- move custom role name validation into a shared server-side schema
- trim custom role names before create/rename duplicate and reserved-name checks
- reject blank names, unsupported characters, and built-in role names after trimming
- keep the custom-role form trim behavior aligned with the server
- add focused unit coverage for normalized and rejected role names

## Demo

This is a server-side validation fix, so the focused test demonstrates the behavior directly:

```text
✓ __test__/permissions/custom-role-validation.test.ts (4 tests) 3ms

Test Files  1 passed (1)
Tests       4 passed (4)
```

The covered cases are:

- `" deployer "` is normalized to `"deployer"`
- whitespace-only names are rejected
- unsupported characters such as `deploy/read` are rejected
- reserved names such as `" admin "` are rejected after trimming

## Validation

- `corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/permissions/custom-role-validation.test.ts`
- `corepack pnpm exec biome check apps/dokploy/server/api/routers/proprietary/custom-role.ts apps/dokploy/server/api/routers/proprietary/custom-role-validation.ts apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx apps/dokploy/__test__/permissions/custom-role-validation.test.ts`
- `corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false`
- `git diff --check`
