### PR TITLE
feat: add monitoring stats for remote servers

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -1,3 +1,7 @@
+import {
+	getMonitoringAppName,
+	LOCAL_SERVER_ID,
+} from "@dokploy/server/monitoring/constants";
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
@@ -43,6 +47,12 @@ const defaultData = {
 interface Props {
 	appName: string;
 	appType?: "application" | "stack" | "docker-compose";
+	/**
+	 * When set (and not `LOCAL_SERVER_ID`), the WebSocket appends
+	 * `serverId=<id>` so the backend collects stats from that remote server.
+	 * Only meaningful when `appName === "dokploy"` (host-level monitoring).
+	 */
+	serverId?: string;
 }
 export interface DockerStats {
 	cpu: {
@@ -117,9 +127,16 @@ export const convertMemoryToBytes = (
 export const ContainerFreeMonitoring = ({
 	appName,
 	appType = "application",
+	serverId,
 }: Props) => {
+	// For host-level monitoring (`appName === "dokploy"`), redirect to the
+	// remote bucket `dokploy-<serverId>` when a remote server is selected;
+	// helper returns the local "dokploy" bucket for `LOCAL_SERVER_ID`/missing.
+	// For container-level monitoring, `appName` stays as-is.
+	const effectiveAppName =
+		appName === "dokploy" ? getMonitoringAppName(serverId) : appName;
 	const { data } = api.application.readAppMonitoring.useQuery(
-		{ appName },
+		{ appName: effectiveAppName },
 		{
 			refetchOnWindowFocus: false,
 		},
@@ -143,7 +160,7 @@ export const ContainerFreeMonitoring = ({
 			network: [],
 			disk: [],
 		});
-	}, [appName]);
+	}, [appName, serverId]);
 
 	useEffect(() => {
 		if (!data) return;
@@ -166,7 +183,11 @@ export const ContainerFreeMonitoring = ({
 
 	useEffect(() => {
 		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-		const wsUrl = `${protocol}//${window.location.host}/listen-docker-stats-monitoring?appName=${appName}&appType=${appType}`;
+		const params = new URLSearchParams({ appName, appType });
+		if (serverId && serverId !== LOCAL_SERVER_ID) {
+			params.set("serverId", serverId);
+		}
+		const wsUrl = `${protocol}//${window.location.host}/listen-docker-stats-monitoring?${params.toString()}`;
 		const ws = new WebSocket(wsUrl);
 
 		ws.onmessage = (e) => {
@@ -198,7 +219,7 @@ export const ContainerFreeMonitoring = ({
 		};
 
 		return () => ws.close();
-	}, [appName]);
+	}, [appName, appType, serverId]);
 
 	return (
 		<div className="rounded-xl bg-background flex flex-col gap-4">

--- a/apps/dokploy/pages/dashboard/monitoring.tsx
+++ b/apps/dokploy/pages/dashboard/monitoring.tsx
@@ -195,7 +195,9 @@ const Dashboard = () => {
 							/>
 						</div>
 					)} */}
-					{toggleMonitoring ? paidMonitoringContent : (
+					{toggleMonitoring ? (
+						paidMonitoringContent
+					) : (
 						<Card className="h-full bg-sidebar  p-2.5 rounded-xl">
 							<div className="rounded-xl bg-background shadow-md p-6">
 								<ContainerFreeMonitoring

--- a/apps/dokploy/pages/dashboard/monitoring.tsx
+++ b/apps/dokploy/pages/dashboard/monitoring.tsx
@@ -1,13 +1,24 @@
 import { IS_CLOUD } from "@dokploy/server/constants";
 import { validateRequest } from "@dokploy/server/lib/auth";
+import { LOCAL_SERVER_ID } from "@dokploy/server/monitoring/constants";
 import { hasPermission } from "@dokploy/server/services/permission";
 import { Loader2 } from "lucide-react";
 import type { GetServerSidePropsContext } from "next";
+import Link from "next/link";
 import type { ReactElement } from "react";
+import { useState } from "react";
 import { ContainerFreeMonitoring } from "@/components/dashboard/monitoring/free/container/show-free-container-monitoring";
 import { ShowPaidMonitoring } from "@/components/dashboard/monitoring/paid/servers/show-paid-monitoring";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { api } from "@/utils/api";
 
@@ -22,6 +33,106 @@ const Dashboard = () => {
 	);
 
 	const { data: monitoring, isPending } = api.user.getMetricsToken.useQuery();
+	const [selectedServerId, setSelectedServerId] =
+		useState<string>(LOCAL_SERVER_ID);
+	const { data: servers } = api.server.getServersForMonitoring.useQuery();
+	const isRemoteSelected = selectedServerId !== LOCAL_SERVER_ID;
+	const selectedServer = isRemoteSelected
+		? servers?.find((s) => s.serverId === selectedServerId)
+		: undefined;
+	// Fetch the metrics token only when a remote server is selected. The
+	// dropdown list does not include the token; it is gated by `monitoring:read`
+	// here so users with read-only monitoring access can still scope to a
+	// specific server without seeing other tokens.
+	const {
+		data: remoteMonitoringConfig,
+		isPending: remoteMonitoringConfigPending,
+	} = api.server.getMonitoringConfig.useQuery(
+		{ serverId: selectedServerId },
+		{ enabled: isRemoteSelected },
+	);
+
+	// In dev, ShowPaidMonitoring talks to a local stub at `BASE_URL` with
+	// `DEFAULT_TOKEN` regardless of which server is selected. In prod we point
+	// it at the real ip:port/metrics endpoint and pass the configured token.
+	const resolveMetricsEndpoint = (
+		ip: string | undefined | null,
+		port: number | undefined | null,
+		token: string | undefined | null,
+	): { url: string; token: string | undefined } => {
+		const isProd = process.env.NODE_ENV === "production";
+		return {
+			url: isProd ? `http://${ip}:${port}/metrics` : BASE_URL,
+			token: isProd ? (token ?? undefined) : DEFAULT_TOKEN,
+		};
+	};
+
+	let paidMonitoringContent: ReactElement;
+	if (selectedServer) {
+		const remotePort = remoteMonitoringConfig?.port;
+		const remoteToken = remoteMonitoringConfig?.token;
+		// Hold the loader while the remote config is in flight so the user
+		// doesn't see a "Monitoring is not configured" flash before the query
+		// resolves.
+		if (remoteMonitoringConfigPending) {
+			paidMonitoringContent = (
+				<Card className="bg-sidebar  p-2.5 rounded-xl  mx-auto  items-center">
+					<div className="rounded-xl bg-background flex shadow-md px-4 min-h-[50vh] justify-center items-center text-muted-foreground">
+						Loading...
+						<Loader2 className="h-4 w-4 animate-spin" />
+					</div>
+				</Card>
+			);
+		} else if (!remotePort || !remoteToken) {
+			paidMonitoringContent = (
+				<Card className="bg-sidebar p-2.5 rounded-xl mx-auto">
+					<div className="rounded-xl bg-background shadow-md p-6 text-sm text-muted-foreground space-y-2">
+						<p>Monitoring is not configured for this server.</p>
+						<p>
+							Go to{" "}
+							<Link className="underline" href="/dashboard/settings/servers">
+								Settings → Servers
+							</Link>{" "}
+							→ {selectedServer.name} → Setup Monitoring.
+						</p>
+					</div>
+				</Card>
+			);
+		} else {
+			const endpoint = resolveMetricsEndpoint(
+				remoteMonitoringConfig?.ipAddress,
+				remotePort,
+				remoteToken,
+			);
+			paidMonitoringContent = (
+				<Card
+					key={`paid-${selectedServerId}`}
+					className="bg-sidebar  p-2.5 rounded-xl  mx-auto"
+				>
+					<div className="rounded-xl bg-background shadow-md">
+						<ShowPaidMonitoring
+							BASE_URL={endpoint.url}
+							token={endpoint.token}
+						/>
+					</div>
+				</Card>
+			);
+		}
+	} else {
+		const endpoint = resolveMetricsEndpoint(
+			monitoring?.serverIp,
+			monitoring?.metricsConfig?.server?.port,
+			monitoring?.metricsConfig?.server?.token,
+		);
+		paidMonitoringContent = (
+			<Card className="bg-sidebar  p-2.5 rounded-xl  mx-auto">
+				<div className="rounded-xl bg-background shadow-md">
+					<ShowPaidMonitoring BASE_URL={endpoint.url} token={endpoint.token} />
+				</div>
+			</Card>
+		);
+	}
+
 	return (
 		<div className="space-y-4 pb-10">
 			{/* <AlertBlock>
@@ -36,6 +147,36 @@ const Dashboard = () => {
 				</a>{" "}
 				to get more features.
 			</AlertBlock> */}
+			<div className="flex items-center gap-2">
+				<Label htmlFor="monitoring-server-select">Server</Label>
+				<Select value={selectedServerId} onValueChange={setSelectedServerId}>
+					<SelectTrigger id="monitoring-server-select" className="w-[260px]">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value={LOCAL_SERVER_ID}>
+							<span className="flex items-center gap-2 justify-between w-full">
+								<span>Dokploy (Main)</span>
+								{monitoring?.serverIp ? (
+									<span className="text-muted-foreground text-xs">
+										{monitoring.serverIp}
+									</span>
+								) : null}
+							</span>
+						</SelectItem>
+						{servers?.map((server) => (
+							<SelectItem key={server.serverId} value={server.serverId}>
+								<span className="flex items-center gap-2 justify-between w-full">
+									<span>{server.name}</span>
+									<span className="text-muted-foreground text-xs">
+										{server.ipAddress}
+									</span>
+								</span>
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
 			{isPending ? (
 				<Card className="bg-sidebar  p-2.5 rounded-xl  mx-auto  items-center">
 					<div className="rounded-xl bg-background flex shadow-md px-4 min-h-[50vh] justify-center items-center text-muted-foreground">
@@ -54,27 +195,14 @@ const Dashboard = () => {
 							/>
 						</div>
 					)} */}
-					{toggleMonitoring ? (
-						<Card className="bg-sidebar  p-2.5 rounded-xl  mx-auto">
-							<div className="rounded-xl bg-background shadow-md">
-								<ShowPaidMonitoring
-									BASE_URL={
-										process.env.NODE_ENV === "production"
-											? `http://${monitoring?.serverIp}:${monitoring?.metricsConfig?.server?.port}/metrics`
-											: BASE_URL
-									}
-									token={
-										process.env.NODE_ENV === "production"
-											? monitoring?.metricsConfig?.server?.token
-											: DEFAULT_TOKEN
-									}
-								/>
-							</div>
-						</Card>
-					) : (
+					{toggleMonitoring ? paidMonitoringContent : (
 						<Card className="h-full bg-sidebar  p-2.5 rounded-xl">
 							<div className="rounded-xl bg-background shadow-md p-6">
-								<ContainerFreeMonitoring appName="dokploy" />
+								<ContainerFreeMonitoring
+									key={selectedServerId}
+									appName="dokploy"
+									serverId={selectedServerId}
+								/>
 							</div>
 						</Card>
 					)}

--- a/apps/dokploy/server/api/routers/server.ts
+++ b/apps/dokploy/server/api/routers/server.ts
@@ -90,6 +90,49 @@ export const serverRouter = createTRPCRouter({
 
 			return server;
 		}),
+	getMonitoringConfig: withPermission("monitoring", "read")
+		.input(apiFindOneServer)
+		.query(async ({ input, ctx }) => {
+			// Collapse both "server doesn't exist" and "server belongs to another
+			// org" into the same error so callers cannot enumerate serverIds across
+			// organizations.
+			const notFound = new TRPCError({
+				code: "NOT_FOUND",
+				message: "Server not found",
+			});
+			let targetServer: Awaited<ReturnType<typeof findServerById>>;
+			try {
+				targetServer = await findServerById(input.serverId);
+			} catch {
+				throw notFound;
+			}
+			if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+				throw notFound;
+			}
+			return {
+				ipAddress: targetServer.ipAddress,
+				port: targetServer.metricsConfig?.server?.port,
+				token: targetServer.metricsConfig?.server?.token,
+			};
+		}),
+	getServersForMonitoring: withPermission("monitoring", "read").query(
+		async ({ ctx }) => {
+			// Minimal org-scoped server list for the monitoring page dropdown.
+			// Gated on `monitoring:read` so users with that permission but without
+			// `server:read` still see their org's servers (without sensitive fields
+			// like the metrics token).
+			const result = await db
+				.select({
+					serverId: server.serverId,
+					name: server.name,
+					ipAddress: server.ipAddress,
+				})
+				.from(server)
+				.where(eq(server.organizationId, ctx.session.activeOrganizationId))
+				.orderBy(desc(server.createdAt));
+			return result;
+		},
+	),
 	getDefaultCommand: withPermission("server", "read")
 		.input(apiFindOneServer)
 		.query(async ({ input }) => {

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -2,13 +2,24 @@ import type http from "node:http";
 import {
 	docker,
 	execAsync,
+	findServerById,
 	getHostSystemStats,
 	getLastAdvancedStatsFile,
+	getMonitoringAppName,
+	getRemoteSystemStats,
 	IS_CLOUD,
+	LOCAL_SERVER_ID,
 	recordAdvancedStats,
+	recordRemoteDiskStats,
 	validateRequest,
 } from "@dokploy/server";
+import { hasPermission } from "@dokploy/server/services/permission";
 import { WebSocketServer } from "ws";
+
+// serverIds are nanoid-generated (alphanumeric + `_` and `-`). Reject anything
+// else at the WS boundary so user input cannot reach filesystem paths or SSH
+// lookups in unexpected forms.
+const SERVER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 export const setupDockerStatsMonitoringSocketServer = (
 	server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>,
@@ -44,6 +55,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 			| "application"
 			| "stack"
 			| "docker-compose";
+		const serverIdParam = url.searchParams.get("serverId");
 		const { user, session } = await validateRequest(req);
 
 		if (!appName) {
@@ -55,20 +67,82 @@ export const setupDockerStatsMonitoringSocketServer = (
 			ws.close();
 			return;
 		}
-		const intervalId = setInterval(async () => {
+
+		// Resolve the optional remote serverId. We do this up-front so authz and
+		// path-traversal checks run before any SSH or filesystem work.
+		let resolvedServerId: string | null = null;
+		if (serverIdParam && serverIdParam !== LOCAL_SERVER_ID) {
+			if (!SERVER_ID_PATTERN.test(serverIdParam)) {
+				ws.close(4400, "Invalid serverId");
+				return;
+			}
+
+			const activeOrganizationId = (
+				session as typeof session & { activeOrganizationId?: string }
+			).activeOrganizationId;
+			if (!activeOrganizationId) {
+				ws.close(4403, "forbidden");
+				return;
+			}
+
 			try {
-				// Special case: when monitoring "dokploy", get host system stats instead of container stats
+				const remoteServer = await findServerById(serverIdParam);
+				if (remoteServer.organizationId !== activeOrganizationId) {
+					ws.close(4403, "forbidden");
+					return;
+				}
+				const canRead = await hasPermission(
+					{
+						user: { id: user.id },
+						session: { activeOrganizationId },
+					},
+					{ monitoring: ["read"] },
+				);
+				if (!canRead) {
+					ws.close(4403, "forbidden");
+					return;
+				}
+				// Use the canonical DB-resolved serverId, not the raw query param.
+				resolvedServerId = remoteServer.serverId;
+			} catch {
+				ws.close(4403, "forbidden");
+				return;
+			}
+		}
+
+		// `inFlight` guards against overlapping ticks. The tick body awaits SSH
+		// (`getRemoteSystemStats`) which can take longer than the 1300ms interval,
+		// and `updateStatsFile` does non-atomic read-modify-write on shared JSON
+		// files; overlapping invocations would race on those writes (lost samples,
+		// possible JSON corruption). If a tick is still running we skip this one.
+		let inFlight = false;
+		let intervalId: ReturnType<typeof setInterval> | null = null;
+		intervalId = setInterval(async () => {
+			if (inFlight) return;
+			inFlight = true;
+			try {
+				// Special case: when monitoring "dokploy" (the host system rather than a
+				// container). If serverId is provided and not "local", fetch the host stats
+				// from that remote server over SSH; otherwise read local host stats.
 				if (appName === "dokploy") {
-					const stat = await getHostSystemStats();
-
-					await recordAdvancedStats(stat, appName);
-					const data = await getLastAdvancedStatsFile(appName);
-
-					ws.send(
-						JSON.stringify({
-							data,
-						}),
-					);
+					if (resolvedServerId) {
+						const recordedAppName = getMonitoringAppName(resolvedServerId);
+						const { container, disk } =
+							await getRemoteSystemStats(resolvedServerId);
+						await recordAdvancedStats(container, recordedAppName);
+						await recordRemoteDiskStats(
+							recordedAppName,
+							disk.diskTotal,
+							disk.diskUsed,
+						);
+						const data = await getLastAdvancedStatsFile(recordedAppName);
+						ws.send(JSON.stringify({ data }));
+					} else {
+						const stat = await getHostSystemStats();
+						await recordAdvancedStats(stat, "dokploy");
+						const data = await getLastAdvancedStatsFile("dokploy");
+						ws.send(JSON.stringify({ data }));
+					}
 					return;
 				}
 
@@ -112,13 +186,25 @@ export const setupDockerStatsMonitoringSocketServer = (
 					}),
 				);
 			} catch (error) {
+				// Clear the interval BEFORE closing the socket so no further tick can
+				// fire (and trigger a `ws.send` on an already-closed socket, or kick off
+				// another SSH connection after we've decided to give up).
+				if (intervalId !== null) {
+					clearInterval(intervalId);
+					intervalId = null;
+				}
 				// @ts-ignore
 				ws.close(4000, `Error: ${error.message}`);
+			} finally {
+				inFlight = false;
 			}
 		}, 1300);
 
 		ws.on("close", () => {
-			clearInterval(intervalId);
+			if (intervalId !== null) {
+				clearInterval(intervalId);
+				intervalId = null;
+			}
 		});
 	});
 };

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -518,8 +518,17 @@ export const apiSaveEnvironmentVariables = createSchema
 	})
 	.required();
 
+// `appName` is concatenated into MONITORING_PATH on disk by
+// `getApplicationStats` -> `getAdvancedStats` -> `readStatsFile`. Restrict to
+// the literal `dokploy` host bucket or `dokploy-<serverId>` (nanoid-shaped)
+// so a crafted value cannot traverse out of MONITORING_PATH. Container app
+// names fed through this same endpoint are auto-generated and only contain
+// these characters as well.
 export const apiFindMonitoringStats = z.object({
-	appName: z.string().min(1),
+	appName: z
+		.string()
+		.min(1)
+		.regex(/^[A-Za-z0-9_.-]+$/, { message: "Invalid appName" }),
 });
 
 export const apiUpdateApplication = createSchema

--- a/packages/server/src/monitoring/constants.ts
+++ b/packages/server/src/monitoring/constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Sentinel server id used by the monitoring UI/WS to mean "the local Dokploy
+ * host" rather than a remote server. Any other value is treated as a nanoid
+ * pointing at a row in the `server` table.
+ */
+export const LOCAL_SERVER_ID = "local";
+
+/**
+ * Resolve the on-disk monitoring bucket name for host-level stats:
+ * - `"dokploy"` for the local host
+ * - `"dokploy-<serverId>"` for a remote server
+ *
+ * The shape returned here is validated by
+ * `DOKPLOY_HOST_STATS_PATTERN` in `services/application.ts` and by
+ * `apiFindMonitoringStats` before it is concatenated into MONITORING_PATH.
+ *
+ * Kept in a dependency-free module so client bundles can import these
+ * without pulling in `node:fs`, `ssh2`, or other server-only modules
+ * transitively reachable from `monitoring/utils.ts`.
+ */
+export const getMonitoringAppName = (serverId?: string | null): string =>
+	serverId && serverId !== LOCAL_SERVER_ID ? `dokploy-${serverId}` : "dokploy";

--- a/packages/server/src/monitoring/utils.ts
+++ b/packages/server/src/monitoring/utils.ts
@@ -1,6 +1,9 @@
 import { promises } from "node:fs";
 import { OSUtils } from "node-os-utils";
 import { paths } from "../constants";
+import { execAsyncRemote } from "../utils/process/execAsync";
+
+export { LOCAL_SERVER_ID, getMonitoringAppName } from "./constants";
 
 export interface Container {
 	BlockIO: string;
@@ -152,6 +155,157 @@ export const getHostSystemStats = async (): Promise<Container> => {
 		ID: "host-system",
 		Name: "dokploy",
 	};
+};
+
+// LC_ALL=C forces a POSIX locale so numeric output uses `.` as the decimal
+// separator. Without it, locales like de_DE.UTF-8 emit `0,5` which breaks
+// every `awk` arithmetic and our downstream `Number.parseFloat`.
+//
+// CPU: `top -bn1` reports the CPU snapshot accumulated since boot (effectively
+// stale/~0 for steady-state systems). We use `top -bn2 -d 0.5` and parse the
+// SECOND `%Cpu` line, which is the delta over the 0.5s interval.
+//
+// Network interface filter is a deny-list (lo, docker*, veth*, br-*) so we
+// pick up real NICs of any name (eth*, ens*, enp*, wlan*, bond*, wg*,
+// tailscale*, etc.) without enumerating them.
+const REMOTE_STATS_SCRIPT = `
+export LC_ALL=C
+CPU=$(top -bn2 -d 0.5 2>/dev/null | grep 'Cpu(s)' | tail -1 | awk '{print $2+$4}' 2>/dev/null || echo 0)
+MEM_TOTAL=$(free -b 2>/dev/null | awk '/^Mem:/ {print $2}' 2>/dev/null || echo 0)
+MEM_USED=$(free -b 2>/dev/null | awk '/^Mem:/ {print $3}' 2>/dev/null || echo 0)
+DISK_TOTAL=$(df -B1 / 2>/dev/null | awk 'NR==2 {print $2}' 2>/dev/null || echo 0)
+DISK_USED=$(df -B1 / 2>/dev/null | awk 'NR==2 {print $3}' 2>/dev/null || echo 0)
+NET_RX=$(cat /proc/net/dev 2>/dev/null | awk 'NR>2 {iface=$1; sub(/:$/,"",iface); if (iface !~ /^(lo|docker|veth|br-)/) rx+=$2} END {print rx+0}')
+NET_TX=$(cat /proc/net/dev 2>/dev/null | awk 'NR>2 {iface=$1; sub(/:$/,"",iface); if (iface !~ /^(lo|docker|veth|br-)/) tx+=$10} END {print tx+0}')
+BLOCK_READ=$(cat /proc/diskstats 2>/dev/null | awk '$3 ~ /^(sd|nvme|vd)/ {r+=$6} END {print (r+0)*512}')
+BLOCK_WRITE=$(cat /proc/diskstats 2>/dev/null | awk '$3 ~ /^(sd|nvme|vd)/ {w+=$10} END {print (w+0)*512}')
+echo "{\\"cpu\\":\\"$CPU\\",\\"memTotal\\":\\"$MEM_TOTAL\\",\\"memUsed\\":\\"$MEM_USED\\",\\"diskTotal\\":\\"$DISK_TOTAL\\",\\"diskUsed\\":\\"$DISK_USED\\",\\"netRx\\":\\"$NET_RX\\",\\"netTx\\":\\"$NET_TX\\",\\"blockRead\\":\\"$BLOCK_READ\\",\\"blockWrite\\":\\"$BLOCK_WRITE\\"}"
+`;
+
+interface RawRemoteStats {
+	cpu: number;
+	memTotal: number;
+	memUsed: number;
+	diskTotal: number;
+	diskUsed: number;
+	netRx: number;
+	netTx: number;
+	blockRead: number;
+	blockWrite: number;
+}
+
+const parseNum = (val: unknown): number => {
+	if (typeof val !== "string" && typeof val !== "number") return 0;
+	const n = Number.parseFloat(String(val).trim());
+	return Number.isFinite(n) ? n : 0;
+};
+
+const formatBytesPair = (a: number, b: number): string => {
+	const fmt = (n: number): string => {
+		if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(2)}GiB`;
+		if (n >= 1024 ** 2) return `${(n / 1024 ** 2).toFixed(2)}MiB`;
+		if (n >= 1024) return `${(n / 1024).toFixed(2)}KiB`;
+		return `${n}B`;
+	};
+	return `${fmt(a)} / ${fmt(b)}`;
+};
+
+const parseRemoteStats = (stdout: string): RawRemoteStats => {
+	try {
+		const json = JSON.parse(stdout.trim()) as Record<string, unknown>;
+		return {
+			cpu: parseNum(json.cpu),
+			memTotal: parseNum(json.memTotal),
+			memUsed: parseNum(json.memUsed),
+			diskTotal: parseNum(json.diskTotal),
+			diskUsed: parseNum(json.diskUsed),
+			netRx: parseNum(json.netRx),
+			netTx: parseNum(json.netTx),
+			blockRead: parseNum(json.blockRead),
+			blockWrite: parseNum(json.blockWrite),
+		};
+	} catch {
+		return {
+			cpu: 0,
+			memTotal: 0,
+			memUsed: 0,
+			diskTotal: 0,
+			diskUsed: 0,
+			netRx: 0,
+			netTx: 0,
+			blockRead: 0,
+			blockWrite: 0,
+		};
+	}
+};
+
+/**
+ * Fetch host system stats from a remote server over SSH and return them
+ * in the same shape as `getHostSystemStats` so downstream `recordAdvancedStats`
+ * works unchanged.
+ *
+ * Disk stats are intentionally returned alongside (via the `disk` property)
+ * because `recordAdvancedStats` only writes disk for the local "dokploy" appName.
+ * Callers should pass the disk numbers to `recordRemoteDiskStats` themselves.
+ */
+export const getRemoteSystemStats = async (
+	serverId: string,
+): Promise<{
+	container: Container;
+	disk: { diskTotal: number; diskUsed: number };
+}> => {
+	const { stdout } = await execAsyncRemote(serverId, REMOTE_STATS_SCRIPT);
+	const raw = parseRemoteStats(stdout);
+
+	const memUsedGiB = raw.memUsed / 1024 ** 3;
+	const memTotalGiB = raw.memTotal / 1024 ** 3;
+	const memUsedPercent =
+		raw.memTotal > 0 ? (raw.memUsed / raw.memTotal) * 100 : 0;
+
+	const container: Container = {
+		CPUPerc: `${raw.cpu.toFixed(2)}%`,
+		MemPerc: `${memUsedPercent.toFixed(2)}%`,
+		MemUsage: `${memUsedGiB.toFixed(2)}GiB / ${memTotalGiB.toFixed(2)}GiB`,
+		BlockIO: formatBytesPair(raw.blockRead, raw.blockWrite),
+		NetIO: `${(raw.netRx / 1024 ** 2).toFixed(2)}MB / ${(raw.netTx / 1024 ** 2).toFixed(2)}MB`,
+		Container: serverId,
+		ID: "remote-host",
+		Name: serverId,
+	};
+
+	return {
+		container,
+		disk: { diskTotal: raw.diskTotal, diskUsed: raw.diskUsed },
+	};
+};
+
+/**
+ * Write disk stats for a remote server. `recordAdvancedStats` only writes
+ * the disk stat file when `appName === "dokploy"` (using local node-os-utils),
+ * so for remote servers we write it explicitly here.
+ */
+export const recordRemoteDiskStats = async (
+	appName: string,
+	diskTotalBytes: number,
+	diskUsedBytes: number,
+): Promise<void> => {
+	const { MONITORING_PATH } = paths();
+	await promises.mkdir(`${MONITORING_PATH}/${appName}`, { recursive: true });
+
+	const diskTotal = +(diskTotalBytes / 1024 ** 3).toFixed(2);
+	const diskUsage = +(diskUsedBytes / 1024 ** 3).toFixed(2);
+	const diskFree = +((diskTotalBytes - diskUsedBytes) / 1024 ** 3).toFixed(2);
+	const diskUsedPercentage =
+		diskTotalBytes > 0
+			? +((diskUsedBytes / diskTotalBytes) * 100).toFixed(2)
+			: 0;
+
+	await updateStatsFile(appName, "disk", {
+		diskTotal,
+		diskUsage,
+		diskFree,
+		diskUsedPercentage,
+	});
 };
 
 export const getAdvancedStats = async (appName: string) => {

--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -600,8 +600,19 @@ export const rebuildPreviewApplication = async ({
 	return true;
 };
 
+// Matches the literal `dokploy` bucket plus `dokploy-<serverId>` where the
+// suffix is the same character set as a nanoid (alphanumeric + `_`/`-`).
+// Used as a defense-in-depth guard before treating `appName` as a host-stats
+// directory under MONITORING_PATH.
+// The {21} length constraint matches the default nanoid() output exactly, so
+// names like `dokploy-traefik` cannot be mis-routed through host-stats lookup.
+const DOKPLOY_HOST_STATS_PATTERN = /^dokploy(-[A-Za-z0-9_-]{21})?$/;
+
 export const getApplicationStats = async (appName: string) => {
-	if (appName === "dokploy") {
+	// "dokploy" = main server host stats; "dokploy-<serverId>" = remote
+	// server host stats. Both read from MONITORING_PATH/<appName>/*.json
+	// directly without going through a Docker container lookup.
+	if (DOKPLOY_HOST_STATS_PATTERN.test(appName)) {
 		return await getAdvancedStats(appName);
 	}
 	const filter = {


### PR DESCRIPTION
## What is this PR about?

Adds a server selector to `/dashboard/monitoring` so the page can show CPU, memory, disk, network, and block IO for remote servers in addition to the main Dokploy host. Previously the page only surfaced stats for the local Dokploy host, and there was no way to view monitoring for any of the remote servers attached to the org.

The free tier collects host stats over SSH on each poll using a single shell script (`top`, `free`, `df`, `/proc/net/dev`, `/proc/diskstats`) and persists them under `MONITORING_PATH/dokploy-<serverId>/*.json`. The paid tier reuses the existing `ShowPaidMonitoring` Prometheus view scoped to the selected server's metrics endpoint.

Selecting the local "Dokploy (Main)" entry preserves the current behavior byte-for-byte, so existing users see no change unless they pick a remote server from the new dropdown.

A few extras worth flagging for review:

- The `/listen-docker-stats-monitoring` WebSocket now does an org-match check and a `monitoring:read` permission check before any SSH or filesystem work when a `serverId` query param is present. The local-host path is unchanged.
- `serverId` is validated against a strict regex at the WebSocket boundary, and the canonical DB value (not the raw URL param) is used to build any path under `MONITORING_PATH`, so the new `dokploy-<id>` directories cannot escape via traversal.
- A new permission-gated `server.getMonitoringConfig` tRPC query returns only the metrics port and token for one server, so the bulk `server.all` response (gated on `server:read`) no longer needs to expose tokens to the wider audience.
- A separate `server.getServersForMonitoring` query feeds the dropdown so users with `monitoring:read` but not `server:read` still see their servers.
- The remote `readAppMonitoring` path is hardened with a regex on `appName` at the zod schema and a defense-in-depth pattern (`/^dokploy(-[A-Za-z0-9_-]{21})?$/`) inside `getApplicationStats` so the new `dokploy-<id>` bucket cannot be tricked into reading arbitrary files.

Developed against the current `canary` tip (`290a03c`). Production is on v0.29.4 which is ahead of canary; if features that land in canary later touch the same monitoring files, conflicts are something maintainers may want to flag during review.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

Local testing covered: main-server regression (existing behavior preserved), dropdown switch between main and remote, free-tier stats for a remote server, SSH-failure path (handler closes cleanly without leaking), per-server stats isolation under `MONITORING_PATH/dokploy-<id>/`, permission gating, and the paid-tier flow with and without `metricsConfig` set on the remote server.

## Issues related (if applicable)

Closes #4420
Closes #2685

## Screenshots (if applicable)
<img width="1976" height="1009" alt="image" src="https://github.com/user-attachments/assets/7105172e-bb82-43cf-b85f-adebdd050d2d" />
<img width="1280" height="652" alt="image" src="https://github.com/user-attachments/assets/816f7bfa-919e-4844-b837-94a57fdbbbde" />
