### PR TITLE
feat: add organization ownership transfer

### DIFF
--- a/apps/dokploy/__test__/users/organization-ownership.test.ts
+++ b/apps/dokploy/__test__/users/organization-ownership.test.ts
@@ -1,0 +1,54 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+import { assertCanTransferOwnership } from "@/lib/organization-ownership";
+
+const baseInput = {
+	activeOrganizationId: "org-1",
+	organizationOwnerId: "owner-user",
+	currentUserId: "owner-user",
+	currentOwnerMemberId: "owner-member",
+	targetUserId: "target-user",
+	targetOrganizationId: "org-1",
+};
+
+describe("assertCanTransferOwnership", () => {
+	it("allows the organization owner to transfer to another member", () => {
+		expect(() => assertCanTransferOwnership(baseInput)).not.toThrow();
+	});
+
+	it("requires an active organization", () => {
+		expect(() =>
+			assertCanTransferOwnership({
+				...baseInput,
+				activeOrganizationId: null,
+			}),
+		).toThrow(TRPCError);
+	});
+
+	it("rejects non-owner users", () => {
+		expect(() =>
+			assertCanTransferOwnership({
+				...baseInput,
+				currentUserId: "admin-user",
+			}),
+		).toThrow("Only the organization owner can transfer ownership");
+	});
+
+	it("rejects members from other organizations", () => {
+		expect(() =>
+			assertCanTransferOwnership({
+				...baseInput,
+				targetOrganizationId: "org-2",
+			}),
+		).toThrow("You are not allowed to transfer ownership to this member");
+	});
+
+	it("rejects self transfers", () => {
+		expect(() =>
+			assertCanTransferOwnership({
+				...baseInput,
+				targetUserId: "owner-user",
+			}),
+		).toThrow("You cannot transfer ownership to yourself");
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -31,6 +31,7 @@ import { authClient } from "@/lib/auth-client";
 import { api } from "@/utils/api";
 import { AddUserPermissions } from "./add-permissions";
 import { ChangeRole } from "./change-role";
+import { TransferOwnership } from "./transfer-ownership";
 
 export const ShowUsers = () => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
@@ -145,12 +146,17 @@ export const ShowUsers = () => {
 
 													const canDelete = canRemove && !isCloud;
 													const canUnlink = canRemove && !!isCloud;
+													const canTransferOwnership =
+														currentUserRole === "owner" &&
+														member.role !== "owner" &&
+														member.user.id !== session?.user?.id;
 
 													const hasAnyAction =
 														canEditPermissions ||
 														canChangeRole ||
 														canDelete ||
-														canUnlink;
+														canUnlink ||
+														canTransferOwnership;
 
 													return (
 														<TableRow key={member.id}>
@@ -215,6 +221,13 @@ export const ShowUsers = () => {
 																				<AddUserPermissions
 																					userId={member.user.id}
 																					role={member.role}
+																				/>
+																			)}
+
+																			{canTransferOwnership && (
+																				<TransferOwnership
+																					memberId={member.id}
+																					userEmail={member.user.email}
 																				/>
 																			)}
 

--- a/apps/dokploy/components/dashboard/settings/users/transfer-ownership.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/transfer-ownership.tsx
@@ -1,0 +1,47 @@
+import { toast } from "sonner";
+import { DialogAction } from "@/components/shared/dialog-action";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { api } from "@/utils/api";
+
+interface Props {
+	memberId: string;
+	userEmail: string;
+}
+
+export const TransferOwnership = ({ memberId, userEmail }: Props) => {
+	const utils = api.useUtils();
+	const { mutateAsync, isPending } =
+		api.organization.transferOwnership.useMutation();
+
+	return (
+		<DialogAction
+			title="Transfer Ownership"
+			description={
+				<>
+					Transfer organization ownership to <strong>{userEmail}</strong>? You
+					will become an admin.
+				</>
+			}
+			disabled={isPending}
+			type="destructive"
+			onClick={async () => {
+				await mutateAsync({ memberId })
+					.then(async () => {
+						toast.success("Ownership transferred successfully");
+						await utils.user.all.invalidate();
+						await utils.organization.active.invalidate();
+					})
+					.catch((error) => {
+						toast.error(error?.message || "Error transferring ownership");
+					});
+			}}
+		>
+			<DropdownMenuItem
+				className="w-full cursor-pointer text-red-500 hover:!text-red-600"
+				onSelect={(e) => e.preventDefault()}
+			>
+				Transfer Ownership
+			</DropdownMenuItem>
+		</DialogAction>
+	);
+};

--- a/apps/dokploy/lib/organization-ownership.ts
+++ b/apps/dokploy/lib/organization-ownership.ts
@@ -1,0 +1,54 @@
+import { TRPCError } from "@trpc/server";
+
+interface TransferOwnershipInput {
+	activeOrganizationId?: string | null;
+	organizationOwnerId: string;
+	currentUserId: string;
+	currentOwnerMemberId?: string | null;
+	targetUserId: string;
+	targetOrganizationId: string;
+}
+
+export const assertCanTransferOwnership = ({
+	activeOrganizationId,
+	organizationOwnerId,
+	currentUserId,
+	currentOwnerMemberId,
+	targetUserId,
+	targetOrganizationId,
+}: TransferOwnershipInput) => {
+	if (!activeOrganizationId) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "No active organization selected",
+		});
+	}
+
+	if (organizationOwnerId !== currentUserId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Only the organization owner can transfer ownership",
+		});
+	}
+
+	if (!currentOwnerMemberId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Current owner membership not found",
+		});
+	}
+
+	if (targetOrganizationId !== activeOrganizationId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You are not allowed to transfer ownership to this member",
+		});
+	}
+
+	if (targetUserId === currentUserId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "You cannot transfer ownership to yourself",
+		});
+	}
+};

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { and, desc, eq, exists } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { assertCanTransferOwnership } from "@/lib/organization-ownership";
 import { audit } from "@/server/api/utils/audit";
 import {
 	invitation,
@@ -401,6 +402,94 @@ export const organizationRouter = createTRPCRouter({
 				metadata: { type: "removeInvitation" },
 			});
 			return result;
+		}),
+	transferOwnership: protectedProcedure
+		.input(z.object({ memberId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const orgId = ctx.session.activeOrganizationId;
+
+			if (!orgId) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "No active organization selected",
+				});
+			}
+
+			const org = await db.query.organization.findFirst({
+				where: eq(organization.id, orgId),
+			});
+
+			if (!org) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Organization not found",
+				});
+			}
+
+			const [currentOwnerMember, target] = await Promise.all([
+				db.query.member.findFirst({
+					where: and(
+						eq(member.organizationId, org.id),
+						eq(member.userId, ctx.user.id),
+					),
+				}),
+				db.query.member.findFirst({
+					where: eq(member.id, input.memberId),
+					with: { user: true },
+				}),
+			]);
+
+			if (!target) {
+				throw new TRPCError({ code: "NOT_FOUND", message: "Member not found" });
+			}
+
+			const currentOwnerMemberId = currentOwnerMember?.id;
+			if (!currentOwnerMemberId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Current owner membership not found",
+				});
+			}
+
+			assertCanTransferOwnership({
+				activeOrganizationId: orgId,
+				organizationOwnerId: org.ownerId,
+				currentUserId: ctx.user.id,
+				currentOwnerMemberId,
+				targetUserId: target.userId,
+				targetOrganizationId: target.organizationId,
+			});
+
+			await db.transaction(async (tx) => {
+				await tx
+					.update(organization)
+					.set({ ownerId: target.userId })
+					.where(eq(organization.id, org.id));
+
+				await tx
+					.update(member)
+					.set({ role: "owner" })
+					.where(eq(member.id, target.id));
+
+				await tx
+					.update(member)
+					.set({ role: "admin" })
+					.where(eq(member.id, currentOwnerMemberId));
+			});
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "organization",
+				resourceId: org.id,
+				resourceName: org.name,
+				metadata: {
+					type: "transferOwnership",
+					before: org.ownerId,
+					after: target.userId,
+				},
+			});
+
+			return true;
 		}),
 	updateMemberRole: withPermission("member", "update")
 		.input(


### PR DESCRIPTION
## Summary

Adds organization ownership transfer from the Users settings page.

Owners can now transfer ownership to another member of the active organization. The transfer updates the organization owner, promotes the target member to `owner`, and demotes the previous owner to `admin` in a transaction.

Closes part of #1413.

/claim #1413

## Tests

- `pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/users/organization-ownership.test.ts --run`
- `pnpm exec biome check apps/dokploy/lib/organization-ownership.ts apps/dokploy/server/api/routers/organization.ts apps/dokploy/components/dashboard/settings/users/show-users.tsx apps/dokploy/components/dashboard/settings/users/transfer-ownership.tsx apps/dokploy/__test__/users/organization-ownership.test.ts --no-errors-on-unmatched --files-ignore-unknown=true`
- `pnpm --filter=dokploy run typecheck`

I also attempted the full app test suite locally, but unrelated Windows/native setup failures prevented a clean run (`bcrypt_lib.node` missing after `--ignore-scripts`, and real deploy tests invoking POSIX commands such as `mkdir -p` / `rm -rf ... || true` under Windows).