### PR TITLE
fix: guard custom role listings

### DIFF
--- a/apps/dokploy/__test__/permissions/custom-role-list-read-gate.test.ts
+++ b/apps/dokploy/__test__/permissions/custom-role-list-read-gate.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMemberData = (role: string) => ({
+	id: "member-1",
+	role,
+	userId: "user-1",
+	organizationId: "org-1",
+	accessedProjects: [] as string[],
+	accessedServices: [] as string[],
+	accessedEnvironments: [] as string[],
+	canCreateProjects: false,
+	canDeleteProjects: false,
+	canCreateServices: false,
+	canDeleteServices: false,
+	canCreateEnvironments: false,
+	canDeleteEnvironments: false,
+	canAccessToTraefikFiles: false,
+	canAccessToDocker: false,
+	canAccessToAPI: false,
+	canAccessToSSHKeys: false,
+	canAccessToGitProviders: false,
+	user: { id: "user-1", email: "test@test.com" },
+});
+
+const organizationRoles = [
+	{
+		id: "role-1",
+		organizationId: "org-1",
+		role: "limited",
+		permission: JSON.stringify({ service: ["read"] }),
+		createdAt: new Date("2026-01-01T00:00:00Z"),
+	},
+];
+
+const groupBy = vi.fn(() => Promise.resolve([{ role: "limited", count: 1 }]));
+const where = vi.fn(() => ({ groupBy }));
+const from = vi.fn(() => ({ where }));
+const select = vi.fn(() => ({ from }));
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			member: {
+				findFirst: vi.fn(() => Promise.resolve(mockMemberData("limited"))),
+			},
+			organizationRole: {
+				findMany: vi.fn(() => Promise.resolve(organizationRoles)),
+			},
+		},
+		select,
+	},
+}));
+
+vi.mock("@dokploy/server/services/proprietary/license-key", () => ({
+	hasValidLicense: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("@dokploy/server/index", () => ({
+	hasValidLicense: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("@dokploy/server/lib/auth", () => ({
+	validateRequest: vi.fn(() =>
+		Promise.resolve({
+			session: null,
+			user: null,
+		}),
+	),
+}));
+
+const { customRoleRouter } = await import(
+	"../../server/api/routers/proprietary/custom-role"
+);
+
+const ctx = {
+	user: { id: "user-1" },
+	session: { activeOrganizationId: "org-1" },
+	req: {},
+	res: {},
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("customRole.all permission gate", () => {
+	it("rejects users without member.read before listing custom roles", async () => {
+		const caller = customRoleRouter.createCaller(ctx as never);
+
+		await expect(caller.all()).rejects.toThrow("member");
+		expect(select).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -8,13 +8,14 @@ import {
 	createTRPCRouter,
 	enterpriseProcedure,
 	protectedProcedure,
+	withPermission,
 } from "../../trpc";
 import { audit } from "../../utils/audit";
 
 const permissionsSchema = z.record(z.string(), z.array(z.string()));
 
 export const customRoleRouter = createTRPCRouter({
-	all: protectedProcedure.query(async ({ ctx }) => {
+	all: withPermission("member", "read").query(async ({ ctx }) => {
 		const [roles, memberCounts] = await Promise.all([
 			db.query.organizationRole.findMany({
 				where: eq(


### PR DESCRIPTION
/claim #1413

## Summary
- Gate `customRole.all` with the existing `member.read` permission check.
- Add focused router coverage proving a custom role without `member.read` cannot list custom roles and the listing handler is not reached.
- Keep this separate from #4463, which covers `customRole.membersByRole`.

## Demo
Backend/API-only change. The focused regression test demonstrates the denied access path:
`customRole.all permission gate > rejects users without member.read before listing custom roles`

## Validation
- `corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/permissions/custom-role-list-read-gate.test.ts`
- `corepack pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/permissions`
- `corepack pnpm exec biome check apps/dokploy/server/api/routers/proprietary/custom-role.ts apps/dokploy/__test__/permissions/custom-role-list-read-gate.test.ts`
- `corepack pnpm --filter=dokploy exec tsc --noEmit --pretty false`

Note: local commands completed with exit 0. The environment emitted Node engine warnings because it runs Node v20.20.2 while this repo recommends Node ^24.4.0.