### PR TITLE
fix: gate custom role statements

### DIFF
--- a/apps/dokploy/__test__/permissions/custom-role-statements.test.ts
+++ b/apps/dokploy/__test__/permissions/custom-role-statements.test.ts
@@ -1,0 +1,77 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { checkPermissionMock } = vi.hoisted(() => ({
+	checkPermissionMock: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			member: { findMany: vi.fn() },
+			organizationRole: { findMany: vi.fn(), findFirst: vi.fn() },
+		},
+		select: vi.fn(),
+	},
+}));
+
+vi.mock("@dokploy/server/index", () => ({
+	hasValidLicense: vi.fn(() => Promise.resolve(true)),
+}));
+
+vi.mock("@dokploy/server/services/permission", () => ({
+	checkPermission: checkPermissionMock,
+}));
+
+vi.mock("@/server/api/utils/audit", () => ({
+	audit: vi.fn(),
+}));
+
+const { customRoleRouter } = await import(
+	"@/server/api/routers/proprietary/custom-role"
+);
+
+const createCaller = () =>
+	customRoleRouter.createCaller({
+		session: {
+			activeOrganizationId: "org-1",
+		},
+		user: {
+			id: "user-1",
+		},
+		req: {},
+		res: {},
+	} as never);
+
+describe("customRole.getStatements", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		checkPermissionMock.mockResolvedValue(undefined);
+	});
+
+	it("requires member update permission before returning statements", async () => {
+		const statements = await createCaller().getStatements();
+
+		expect(checkPermissionMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				session: expect.objectContaining({ activeOrganizationId: "org-1" }),
+				user: expect.objectContaining({ id: "user-1" }),
+			}),
+			{ member: ["update"] },
+		);
+		expect(statements.member).toContain("update");
+	});
+
+	it("does not return statements when permission check fails", async () => {
+		checkPermissionMock.mockRejectedValueOnce(
+			new TRPCError({
+				code: "UNAUTHORIZED",
+				message: "Permission denied",
+			}),
+		);
+
+		await expect(createCaller().getStatements()).rejects.toThrow(
+			"Permission denied",
+		);
+	});
+});

--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -8,6 +8,7 @@ import {
 	createTRPCRouter,
 	enterpriseProcedure,
 	protectedProcedure,
+	withPermission,
 } from "../../trpc";
 import { audit } from "../../utils/audit";
 
@@ -285,7 +286,7 @@ export const customRoleRouter = createTRPCRouter({
 			return members;
 		}),
 
-	getStatements: protectedProcedure.query(() => {
+	getStatements: withPermission("member", "update").query(() => {
 		return statements;
 	}),
 });


### PR DESCRIPTION
## Summary
- gate `customRole.getStatements` behind the existing `member.update` permission instead of plain authentication
- keep the permission statement response shape unchanged for authorized callers
- add focused router coverage that verifies the permission check runs and failures do not return the catalog

/claim #1413

## Demo
Short demo video: https://github.com/JacKane21/dokploy/releases/tag/dokploy-4466-demo

## Validation
- `pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/permissions/custom-role-statements.test.ts`
- `pnpm exec biome check apps/dokploy/server/api/routers/proprietary/custom-role.ts apps/dokploy/__test__/permissions/custom-role-statements.test.ts`
- `pnpm --filter=dokploy exec tsc --noEmit --pretty false`
- `git diff --check`

Note: `corepack` is not on PATH in this local shell, so I used the installed `pnpm` 10.22.0 directly. The commands emitted the repo engine warning because local Node is v25.9.0 while the repo wants ^24.4.0, but the checks above completed successfully.