### PR TITLE
fix(monitoring): disable animation and use linear interpolation in charts

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-block-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-block-chart.tsx
@@ -83,14 +83,16 @@ export const DockerBlockChart = ({ accumulativeData }: Props) => {
 					}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="readMb"
 					stroke="var(--color-readMb)"
 					fill="url(#fillBlockRead)"
 					strokeWidth={2}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="writeMb"
 					stroke="var(--color-writeMb)"
 					fill="url(#fillBlockWrite)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-cpu-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-cpu-chart.tsx
@@ -68,7 +68,8 @@ export const DockerCpuChart = ({ accumulativeData }: Props) => {
 					}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="usage"
 					stroke="var(--color-usage)"
 					fill="url(#fillCpu)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-chart.tsx
@@ -70,7 +70,8 @@ export const DockerDiskChart = ({ accumulativeData, diskTotal }: Props) => {
 					}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="usedGb"
 					stroke="var(--color-usedGb)"
 					fill="url(#fillDiskUsed)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx
@@ -74,7 +74,8 @@ export const DockerMemoryChart = ({
 					}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="usage"
 					stroke="var(--color-usage)"
 					fill="url(#fillMemory)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-network-chart.tsx
@@ -79,14 +79,16 @@ export const DockerNetworkChart = ({ accumulativeData }: Props) => {
 					}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="inMB"
 					stroke="var(--color-inMB)"
 					fill="url(#fillNetIn)"
 					strokeWidth={2}
 				/>
 				<Area
-					type="monotone"
+					type="linear"
+					isAnimationActive={false}
 					dataKey="outMB"
 					stroke="var(--color-outMB)"
 					fill="url(#fillNetOut)"

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-block-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-block-chart.tsx
@@ -153,7 +153,8 @@ export const ContainerBlockChart = ({ data }: Props) => {
 						<Area
 							name="Write"
 							dataKey="write"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillWrite)"
 							stroke="hsl(142, 71%, 45%)"
 							strokeWidth={2}
@@ -162,7 +163,8 @@ export const ContainerBlockChart = ({ data }: Props) => {
 						<Area
 							name="Read"
 							dataKey="read"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillRead)"
 							stroke="hsl(217, 91%, 60%)"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-cpu-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-cpu-chart.tsx
@@ -110,7 +110,8 @@ export const ContainerCPUChart = ({ data }: Props) => {
 						<Area
 							name="CPU"
 							dataKey="cpu"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillCPU)"
 							stroke="hsl(var(--chart-1))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-memory-chart.tsx
@@ -131,7 +131,8 @@ export const ContainerMemoryChart = ({ data }: Props) => {
 						<Area
 							name="Memory"
 							dataKey="memory"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillMemory)"
 							stroke="hsl(var(--chart-2))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-network-chart.tsx
@@ -160,7 +160,8 @@ export const ContainerNetworkChart = ({ data }: Props) => {
 						<Area
 							name="Input"
 							dataKey="input"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillInput)"
 							stroke="hsl(var(--chart-3))"
 							strokeWidth={2}
@@ -168,7 +169,8 @@ export const ContainerNetworkChart = ({ data }: Props) => {
 						<Area
 							name="Output"
 							dataKey="output"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillOutput)"
 							stroke="hsl(var(--chart-4))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/cpu-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/cpu-chart.tsx
@@ -97,7 +97,8 @@ export function CPUChart({ data }: CPUChartProps) {
 						<Area
 							name="CPU"
 							dataKey="cpu"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillCPU)"
 							stroke="hsl(var(--chart-1))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/memory-chart.tsx
@@ -114,7 +114,8 @@ export function MemoryChart({ data }: MemoryChartProps) {
 						<Area
 							yAxisId="left"
 							dataKey="memUsed"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillMemory)"
 							stroke="hsl(var(--chart-2))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/network-chart.tsx
@@ -119,7 +119,8 @@ export function NetworkChart({ data }: NetworkChartProps) {
 						<Area
 							name="Network In"
 							dataKey="networkIn"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillNetworkIn)"
 							stroke="hsl(var(--chart-3))"
 							strokeWidth={2}
@@ -127,7 +128,8 @@ export function NetworkChart({ data }: NetworkChartProps) {
 						<Area
 							name="Network Out"
 							dataKey="networkOut"
-							type="monotone"
+							type="linear"
+							isAnimationActive={false}
 							fill="url(#fillNetworkOut)"
 							stroke="hsl(var(--chart-4))"
 							strokeWidth={2}


### PR DESCRIPTION
## What is this PR about?

Recharts' default animation interpolates between old and new Y-values at each X position instead of scrolling the curve left as data arrives. Combined with monotone smoothing, this makes the chart morph in place during updates, causing peaks to appear larger than they actually are. Switching to linear interpolation and disabling animation on all monitoring Area charts eliminates the visual artifact and ensures the displayed values always match the actual data.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

Fixes #4414