### PR TITLE
fix: allow square brackets in zip path validation for Next.js dynamic routes

### DIFF
--- a/apps/dokploy/__test__/wss/readValidDirectory.test.ts
+++ b/apps/dokploy/__test__/wss/readValidDirectory.test.ts
@@ -78,4 +78,10 @@ describe("readValidDirectory (path traversal)", () => {
 	it("returns false for empty string (resolves to cwd)", () => {
 		expect(readValidDirectory("")).toBe(false);
 	});
+
+	it("returns true for Next.js dynamic route paths with square brackets", () => {
+		expect(readValidDirectory(`${BASE}/applications/myapp/code/app/api/[id]/route.ts`)).toBe(true);
+		expect(readValidDirectory(`${BASE}/applications/myapp/code/pages/[slug].tsx`)).toBe(true);
+		expect(readValidDirectory(`${BASE}/applications/myapp/code/app/[...catch]/page.tsx`)).toBe(true);
+	});
 });

--- a/apps/dokploy/__test__/wss/readValidDirectory.test.ts
+++ b/apps/dokploy/__test__/wss/readValidDirectory.test.ts
@@ -80,8 +80,18 @@ describe("readValidDirectory (path traversal)", () => {
 	});
 
 	it("returns true for Next.js dynamic route paths with square brackets", () => {
-		expect(readValidDirectory(`${BASE}/applications/myapp/code/app/api/[id]/route.ts`)).toBe(true);
-		expect(readValidDirectory(`${BASE}/applications/myapp/code/pages/[slug].tsx`)).toBe(true);
-		expect(readValidDirectory(`${BASE}/applications/myapp/code/app/[...catch]/page.tsx`)).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/app/api/[id]/route.ts`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(`${BASE}/applications/myapp/code/pages/[slug].tsx`),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/app/[...catch]/page.tsx`,
+			),
+		).toBe(true);
 	});
 });

--- a/packages/server/src/wss/utils.ts
+++ b/packages/server/src/wss/utils.ts
@@ -40,7 +40,7 @@ export const readValidDirectory = (
 	directory: string,
 	serverId?: string | null,
 ) => {
-	if (!/^[\w/. :-]{1,500}$/.test(directory)) {
+	if (!/^[\w/. :[\]-]{1,500}$/.test(directory)) {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

- ZIP uploads containing Next.js dynamic route files (e.g. `app/api/[id]/route.ts`, `pages/[slug].tsx`, `app/[...catch]/page.tsx`) were rejected by `readValidDirectory` because the path validation regex did not allow square bracket characters `[` and `]`
- Added `[]` to the allowed character set in the regex
- Added test cases covering Next.js dynamic route path patterns

Fixes the issue reported by American Credit Acceptance where dropping ZIP files for Next.js applications was failing after the zip hardening deployed in 0.29.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)