### PR TITLE
fix: prevent webhook deploy crash on commits without modified files

### DIFF
--- a/apps/dokploy/__test__/deploy/should-deploy.test.ts
+++ b/apps/dokploy/__test__/deploy/should-deploy.test.ts
@@ -1,0 +1,41 @@
+import { shouldDeploy } from "@dokploy/server";
+import { describe, expect, it } from "vitest";
+
+describe("shouldDeploy", () => {
+	it("should deploy when no watch paths are configured", () => {
+		expect(shouldDeploy(null, ["src/index.ts"])).toBe(true);
+		expect(shouldDeploy([], ["src/index.ts"])).toBe(true);
+	});
+
+	it("should deploy when watch paths match modified files", () => {
+		expect(shouldDeploy(["src/**"], ["src/index.ts"])).toBe(true);
+		expect(shouldDeploy(["apps/web/**"], ["apps/web/page.tsx"])).toBe(true);
+	});
+
+	it("should not deploy when watch paths do not match", () => {
+		expect(shouldDeploy(["src/**"], ["docs/readme.md"])).toBe(false);
+	});
+
+	it("should not throw when modified files contain non-string values", () => {
+		expect(() =>
+			shouldDeploy(["src/**"], ["src/index.ts", undefined, null] as any),
+		).not.toThrow();
+		expect(
+			shouldDeploy(["src/**"], ["src/index.ts", undefined, null] as any),
+		).toBe(true);
+	});
+
+	it("should not throw when modified files are undefined or null", () => {
+		expect(() => shouldDeploy(["src/**"], undefined)).not.toThrow();
+		expect(() => shouldDeploy(["src/**"], null)).not.toThrow();
+		expect(shouldDeploy(["src/**"], undefined)).toBe(false);
+		expect(shouldDeploy(["src/**"], null)).toBe(false);
+	});
+
+	it("should not throw when every modified file is non-string", () => {
+		expect(() =>
+			shouldDeploy(["src/**"], [undefined, undefined] as any),
+		).not.toThrow();
+		expect(shouldDeploy(["src/**"], [undefined, undefined] as any)).toBe(false);
+	});
+});

--- a/packages/server/src/utils/watch-paths/should-deploy.ts
+++ b/packages/server/src/utils/watch-paths/should-deploy.ts
@@ -2,8 +2,11 @@ import micromatch from "micromatch";
 
 export const shouldDeploy = (
 	watchPaths: string[] | null,
-	modifiedFiles: string[],
+	modifiedFiles: (string | null | undefined)[] | null | undefined,
 ): boolean => {
 	if (!watchPaths || watchPaths?.length === 0) return true;
-	return micromatch.some(modifiedFiles, watchPaths);
+	const files = (modifiedFiles ?? []).filter(
+		(file): file is string => typeof file === "string",
+	);
+	return micromatch.some(files, watchPaths);
 };


### PR DESCRIPTION
## Summary

Fixes #4452 (duplicate of #4081).

Webhook-based deployments crash with `TypeError: Expected input to be a string` whenever **Watch Paths** are configured on an application/compose service.

The deploy webhook endpoints normalize commit data with:

```ts
const normalizedCommits = req.body?.commits?.flatMap(
  (commit: any) => commit.modified,
);
```

When a commit has no `modified` array (or `commits` is absent), this yields `undefined`/`null` entries — or `undefined` entirely — which get passed into `micromatch.some()` inside `shouldDeploy()`. `micromatch` rejects any non-string input and throws, failing the deployment.

This makes `shouldDeploy()` defensive: it filters out non-string entries (and tolerates a `null`/`undefined` list) before matching, so it can never throw regardless of webhook payload shape. The early-return path for empty/absent watch paths is unchanged, which is why removing Watch Paths was the known workaround.

Covers all webhook deploy endpoints (`compose/[refreshToken].ts`, `[refreshToken].ts`, `github.ts`) since they all call `shouldDeploy`.