### PR TITLE
fix: prevent middleware help icon from submitting form and creating domain (#4400)

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -806,10 +806,13 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 												<FormLabel>Middlewares</FormLabel>
 												<TooltipProvider>
 													<Tooltip>
-														<TooltipTrigger>
-															<div className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold">
+														<TooltipTrigger asChild>
+															<button
+																type="button"
+																className="size-4 rounded-full bg-muted flex items-center justify-center text-[10px] font-bold"
+															>
 																?
-															</div>
+															</button>
 														</TooltipTrigger>
 														<TooltipContent className="max-w-[300px]">
 															<p>


### PR DESCRIPTION
## Summary

The `?` help icon next to the **Middlewares** label in the domain form was a plain `<div>` wrapped in `<TooltipTrigger>` without `asChild`. Since `TooltipTrigger` renders as a `<button>` by default and the surrounding form has no explicit button types, clicking the icon submitted the form and wrongly created a domain.

## Fix

Render the trigger as a `<button type="button">` with `asChild`, matching the pattern already used by the other tooltips in this same component.

Closes #4400