### PR TITLE
fix: enable comment toggle shortcut in env variable editor (#4402)

### DIFF
--- a/apps/dokploy/components/shared/code-editor.tsx
+++ b/apps/dokploy/components/shared/code-editor.tsx
@@ -167,7 +167,13 @@ export const CodeEditor = ({
 								? css()
 								: language === "shell"
 									? StreamLanguage.define(shell)
-									: StreamLanguage.define(properties),
+									: StreamLanguage.define({
+											...properties,
+											// The legacy properties mode lacks comment metadata, so
+											// CodeMirror's toggle-comment shortcut (Mod-/) has no comment
+											// token to use. Declare `#` as the line comment for env editors.
+											languageData: { commentTokens: { line: "#" } },
+										}),
 					props.lineWrapping ? EditorView.lineWrapping : [],
 					language === "yaml"
 						? autocompletion({


### PR DESCRIPTION
## Summary

The comment toggle shortcut (`Mod-/`) did not work in the environment variable editor. The editor uses the legacy `properties` mode via `StreamLanguage.define(properties)`, which does not expose comment-token metadata, so CodeMirror's `toggleComment` command had no comment token to insert. YAML worked because `@codemirror/lang-yaml` provides that metadata.

## Fix

Attach `languageData: { commentTokens: { line: "#" } }` to the properties `StreamLanguage` definition so `Mod-/` toggles `#` line comments in env editors. No new dependencies — uses the existing `@codemirror/language` `StreamParser.languageData` field.

Closes #4402