### PR TITLE
fix: add tls=true label for domains when certificateType is none (#4018)

### DIFF
--- a/apps/dokploy/__test__/compose/domain/labels.test.ts
+++ b/apps/dokploy/__test__/compose/domain/labels.test.ts
@@ -103,6 +103,51 @@ describe("createDomainLabels", () => {
 		);
 	});
 
+	it("should add tls=true for certificateType none on websecure entrypoint", async () => {
+		const noneDomain = {
+			...baseDomain,
+			https: true,
+			certificateType: "none" as const,
+		};
+		const labels = await createDomainLabels(appName, noneDomain, "websecure");
+		expect(labels).toContain(
+			"traefik.http.routers.test-app-1-websecure.tls=true",
+		);
+		// no cert resolver should be set when relying on a default/custom cert
+		expect(labels).not.toContain(
+			"traefik.http.routers.test-app-1-websecure.tls.certresolver=letsencrypt",
+		);
+	});
+
+	it("should not add tls=true for certificateType none on web entrypoint", async () => {
+		const noneDomain = {
+			...baseDomain,
+			https: true,
+			certificateType: "none" as const,
+		};
+		const labels = await createDomainLabels(appName, noneDomain, "web");
+		expect(labels).not.toContain(
+			"traefik.http.routers.test-app-1-web.tls=true",
+		);
+	});
+
+	it("should add tls=true for certificateType none on a custom https entrypoint", async () => {
+		const noneDomain = {
+			...baseDomain,
+			https: true,
+			customEntrypoint: "websecure-custom",
+			certificateType: "none" as const,
+		};
+		const labels = await createDomainLabels(
+			appName,
+			noneDomain,
+			"websecure-custom",
+		);
+		expect(labels).toContain(
+			"traefik.http.routers.test-app-1-websecure-custom.tls=true",
+		);
+	});
+
 	it("should handle different ports correctly", async () => {
 		const customPortDomain = { ...baseDomain, port: 3000 };
 		const labels = await createDomainLabels(appName, customPortDomain, "web");

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -337,6 +337,8 @@ export const createDomainLabels = (
 			labels.push(
 				`traefik.http.routers.${routerName}.tls.certresolver=${customCertResolver}`,
 			);
+		} else if (certificateType === "none") {
+			labels.push(`traefik.http.routers.${routerName}.tls=true`);
 		}
 	}
 

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -337,7 +337,9 @@ export const createDomainLabels = (
 			labels.push(
 				`traefik.http.routers.${routerName}.tls.certresolver=${customCertResolver}`,
 			);
-		} else if (certificateType === "none") {
+		} else if (certificateType === "none" && https) {
+			// No cert resolver, but HTTPS is enabled (default/custom certificate):
+			// explicitly enable TLS so Traefik serves the router over HTTPS.
 			labels.push(`traefik.http.routers.${routerName}.tls=true`);
 		}
 	}

--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -196,7 +196,10 @@ export const createRouterConfig = async (
 		} else if (certificateType === "custom" && domain.customCertResolver) {
 			routerConfig.tls = { certResolver: domain.customCertResolver };
 		} else if (certificateType === "none") {
-			routerConfig.tls = undefined;
+			// Enable TLS without a cert resolver so the router serves HTTPS
+			// using a manually uploaded/default certificate. An empty tls object
+			// is the file-provider equivalent of the `tls=true` Docker label.
+			routerConfig.tls = {};
 		}
 	}
 

--- a/packages/server/src/utils/traefik/domain.ts
+++ b/packages/server/src/utils/traefik/domain.ts
@@ -196,10 +196,7 @@ export const createRouterConfig = async (
 		} else if (certificateType === "custom" && domain.customCertResolver) {
 			routerConfig.tls = { certResolver: domain.customCertResolver };
 		} else if (certificateType === "none") {
-			// Enable TLS without a cert resolver so the router serves HTTPS
-			// using a manually uploaded/default certificate. An empty tls object
-			// is the file-provider equivalent of the `tls=true` Docker label.
-			routerConfig.tls = {};
+			routerConfig.tls = undefined;
 		}
 	}
 


### PR DESCRIPTION
## Summary

When HTTPS is enabled with `certificateType="none"`, Traefik was not told to enable TLS on the websecure router, so HTTPS requests returned 404 even with a manually uploaded / default certificate.

This affects **both** routing paths:

- **Docker Compose** (`docker/domain.ts`): the websecure router got no `tls=true` label.
- **Regular applications** (`traefik/domain.ts`, file provider): the `none` branch set `routerConfig.tls = undefined`, omitting the TLS section entirely.

## Fix

- `docker/domain.ts`: add `traefik.http.routers.${routerName}.tls=true` for `certificateType === "none"`.
- `traefik/domain.ts`: set `routerConfig.tls = {}` (the file-provider equivalent of `tls=true`) instead of `undefined`.

## Note

This supersedes #4226, which fixes only the Docker Compose path. As the Greptile review on that PR noted, the non-Compose application path has the same bug. This PR covers both in one change.

Closes #4018