### PR TITLE
fix(custom-role): return NOT_FOUND when updating missing role

### DIFF
--- a/apps/dokploy/server/api/routers/proprietary/custom-role.ts
+++ b/apps/dokploy/server/api/routers/proprietary/custom-role.ts
@@ -150,6 +150,20 @@ export const customRoleRouter = createTRPCRouter({
 				});
 			}
 
+			const currentRole = await db.query.organizationRole.findFirst({
+				where: and(
+					eq(organizationRole.organizationId, ctx.session.activeOrganizationId),
+					eq(organizationRole.role, input.roleName),
+				),
+			});
+
+			if (!currentRole) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: `Role "${input.roleName}" not found`,
+				});
+			}
+
 			const effectiveRoleName = input.newRoleName ?? input.roleName;
 
 			if (input.newRoleName && input.newRoleName !== input.roleName) {


### PR DESCRIPTION
## Summary
- add an existence check in `customRole.update` for `input.roleName` scoped to the active organization
- return `NOT_FOUND` before any member role migration or permission/audit side effects when the source role does not exist

## Why
Issue #1413 has many parallel slices; this is a narrow correctness hardening path for custom-role updates.

## Testing
- attempted: `pnpm --filter=dokploy run test`
- blocked locally because dependencies are not installed in this workspace (`node_modules` missing, `vitest: command not found`)

Closes #1413