### PR TITLE
fix: preserve HOME in compose deploy so --with-registry-auth can read docker config

### DIFF
--- a/apps/dokploy/__test__/compose/build-compose-command.test.ts
+++ b/apps/dokploy/__test__/compose/build-compose-command.test.ts
@@ -1,0 +1,52 @@
+import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
+import { describe, expect, it, vi } from "vitest";
+
+// Isolate the command builder from the compose-file I/O performed by
+// writeDomainsToCompose; we only care about the docker invocation it emits.
+vi.mock("@dokploy/server/utils/docker/domain", () => ({
+	writeDomainsToCompose: vi.fn().mockResolvedValue(""),
+}));
+
+const baseCompose = {
+	appName: "my-app",
+	sourceType: "raw",
+	command: "",
+	composePath: "docker-compose.yml",
+	composeType: "stack",
+	isolatedDeployment: false,
+	randomize: false,
+	suffix: "",
+	serverId: null,
+	env: "",
+	mounts: [],
+	domains: [],
+	environment: { project: { env: "" }, env: "" },
+} as unknown as Parameters<typeof getBuildComposeCommand>[0];
+
+// Regression coverage for #4401: the deploy command runs under `env -i`, which
+// clears the environment except for the vars listed explicitly. HOME must be
+// preserved so docker can resolve ~/.docker/config.json — otherwise
+// `docker stack deploy --with-registry-auth` ships no credentials to the swarm
+// and private-registry images fail to pull.
+describe("getBuildComposeCommand registry auth (#4401)", () => {
+	it("preserves HOME for swarm stack deploys", async () => {
+		const command = await getBuildComposeCommand({
+			...baseCompose,
+			composeType: "stack",
+		});
+
+		expect(command).toContain("stack deploy");
+		expect(command).toContain("--with-registry-auth");
+		expect(command).toContain('env -i PATH="$PATH" HOME="$HOME"');
+	});
+
+	it("preserves HOME for docker compose deploys", async () => {
+		const command = await getBuildComposeCommand({
+			...baseCompose,
+			composeType: "docker-compose",
+		});
+
+		expect(command).toContain("compose -p my-app");
+		expect(command).toContain('env -i PATH="$PATH" HOME="$HOME"');
+	});
+});

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -54,7 +54,7 @@ Compose Type: ${composeType} ✅`;
 		cd "${projectPath}";
 
 		${compose.isolatedDeployment ? `docker network inspect ${compose.appName} >/dev/null 2>&1 || docker network create ${compose.composeType === "stack" ? "--driver overlay" : ""} --attachable ${compose.appName}` : ""}
-		env -i PATH="$PATH" ${exportEnvCommand} docker ${command.split(" ").join(" ")} 2>&1 || { echo "Error: ❌ Docker command failed"; exit 1; }
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${command.split(" ").join(" ")} 2>&1 || { echo "Error: ❌ Docker command failed"; exit 1; }
 		${compose.isolatedDeployment ? `docker network connect ${compose.appName} $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1` : ""}
 
 		echo "Docker Compose Deployed: ✅";


### PR DESCRIPTION
## What

Fixes #4401 — `docker stack deploy --with-registry-auth` (and `docker compose up -d --build`) cannot read the docker registry credentials Dokploy saves, because the deploy command runs under `env -i` which strips `HOME`.

## Root cause

`getBuildComposeCommand` in `packages/server/src/utils/builders/compose.ts` wraps the deploy in:

```sh
env -i PATH="$PATH" ${exportEnvCommand} docker stack deploy ... --prune --with-registry-auth
```

`env -i` clears the whole environment except what's listed explicitly — so `HOME` is gone. The docker CLI resolves credentials from `$DOCKER_CONFIG` (unset here) and falls back to `$HOME/.docker/config.json`. With `HOME` stripped it finds neither, so `--with-registry-auth` forwards no credentials to the swarm and private-registry images fail to pull on the nodes:

```
image registry.example.com/my-org/my-app:latest could not be accessed on a
registry to record its digest. Each node will access ... independently ...
```

…while the deploy still prints `Docker Compose Deployed: ✅`. (Note: `getCreateEnvFileCommand` already writes `DOCKER_CONFIG=/root/.docker`, but only into the compose **`.env` file** for the services — not into the docker CLI's own environment, so it doesn't help the deploy invocation.)

## Fix

Preserve `HOME` in the isolated command while keeping `PATH` isolation intact:

```diff
- env -i PATH="$PATH" ${exportEnvCommand} docker ...
+ env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ...
```

This lets docker resolve `~/.docker/config.json` again. It's a one-token change scoped to the deploy command builder; it doesn't leak host env into the deployed containers (those still get their environment from the compose file / `exportEnvCommand`).

## Testing

- Added `apps/dokploy/__test__/compose/build-compose-command.test.ts`, asserting the generated command preserves `env -i PATH="$PATH" HOME="$HOME"` for both `stack` and `docker-compose` deploys.
- **Verified red → green:** reverting the fix makes both new assertions fail (the emitted command is `env -i PATH="$PATH"  docker stack deploy … --with-registry-auth`, no `HOME`); with the fix they pass.
- `pnpm --filter=dokploy exec vitest run __test__/compose/build-compose-command.test.ts` → **2 passed**.
- `biome check` on the changed files → clean.

> The diagnosis in #4401 (and this fix) was produced with the help of Claude Code; I reviewed it, reproduced the root cause against the code, and verified the change with the test above before submitting.
