### PR TITLE
feat(security): display a masked webhook url by default with optional toggle

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/refresh-token.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/refresh-token.tsx
@@ -12,6 +12,7 @@ import {
 	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { api } from "@/utils/api";
+import { Button } from "@/components/ui/button";
 
 interface Props {
 	id: string;
@@ -25,8 +26,10 @@ export const RefreshToken = ({ id, type }: Props) => {
 	const utils = api.useUtils();
 	return (
 		<AlertDialog>
-			<AlertDialogTrigger>
-				<RefreshCcw className="h-4 w-4 cursor-pointer text-muted-foreground" />
+			<AlertDialogTrigger asChild>
+				<Button variant="ghost" size="icon">
+					<RefreshCcw className="h-4 w-4 cursor-pointer text-muted-foreground" />
+				</Button>
 			</AlertDialogTrigger>
 			<AlertDialogContent>
 				<AlertDialogHeader>

--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -4,6 +4,9 @@ import {
 	ChevronUp,
 	Clock,
 	Copy,
+	EyeClosedIcon,
+	EyeIcon,
+	EyeOffIcon,
 	Loader2,
 	RefreshCcw,
 	RocketIcon,
@@ -98,11 +101,17 @@ export const ShowDeployments = ({
 	const [expandedDescriptions, setExpandedDescriptions] = useState<Set<string>>(
 		new Set(),
 	);
+	const [showWebhookUrl, setShowWebhookUrl] = useState(false);
 
 	const webhookUrl = useMemo(
 		() =>
 			`${url}/api/deploy${type === "compose" ? "/compose" : ""}/${refreshToken}`,
 		[url, refreshToken, type],
+	);
+
+	const webhookUrlMasked = useMemo(
+		() => "•".repeat(webhookUrl.length),
+		[webhookUrl],
 	);
 
 	const MAX_DESCRIPTION_LENGTH = 200;
@@ -231,7 +240,7 @@ export const ShowDeployments = ({
 						</span>
 						<div className="flex flex-row items-center gap-2 flex-wrap">
 							<span>Webhook URL: </span>
-							<div className="flex flex-row items-center gap-2">
+							<div className="flex flex-row items-center gap-1">
 								<Badge
 									role="button"
 									tabIndex={0}
@@ -250,9 +259,24 @@ export const ShowDeployments = ({
 										toast.success("Copied to clipboard.");
 									}}
 								>
-									{webhookUrl}
+									<span className="font-mono">
+										{showWebhookUrl ? webhookUrl : webhookUrlMasked}
+									</span>
 									<Copy className="h-4 w-4 ml-2" />
 								</Badge>
+								<Button
+									variant="ghost"
+									size="icon"
+									onClick={() => {
+										setShowWebhookUrl((v) => !v);
+									}}
+								>
+									{showWebhookUrl ? (
+										<EyeIcon className="h-4 w-4 cursor-pointer text-muted-foreground" />
+									) : (
+										<EyeOffIcon className="h-4 w-4 cursor-pointer text-muted-foreground" />
+									)}
+								</Button>
 								{(type === "application" || type === "compose") && (
 									<RefreshToken id={id} type={type} />
 								)}


### PR DESCRIPTION
## What is this PR about?

The Webhook URL for triggering deployment contains a sensitive refresh token.

This should not be shown by default, as it could **accidentally be leaked during an online meeting or video recording**.

This pull request adds a client-side toggle button (default off) to control the visibility of the Webhook URL. See video further below.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Screenshots (if applicable)

Toggle off:

<img width="1268" height="570" alt="toggle-off-image" src="https://github.com/user-attachments/assets/74dcc494-c440-4741-ba1d-8105000355d5" />

Toggle on:

<img width="1267" height="561" alt="toggle-on-image" src="https://github.com/user-attachments/assets/eadf7572-3866-4a8f-91c5-a0e1f2c73375" />

Video demo:

[demo-webhook-visibility-toggle.webm](https://github.com/user-attachments/assets/9c2d16a0-63b4-4e14-8357-381f05a936f1)
