### PR TITLE
fix: member SSH keys create/delete access

### DIFF
--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -164,6 +164,8 @@ const getLegacyOverrides = (
 		},
 		sshKeys: {
 			read: !!memberRecord.canAccessToSSHKeys,
+			create: !!memberRecord.canAccessToSSHKeys,
+			delete: !!memberRecord.canAccessToSSHKeys,
 		},
 		gitProviders: {
 			read: !!memberRecord.canAccessToGitProviders,


### PR DESCRIPTION
When `canAccessToSSHKeys` was enabled for a member, only `read` permission was granted, preventing them from creating or deleting SSH keys.

## Changes
- Grant `create` and `delete` SSH key permissions alongside `read` when `canAccessToSSHKeys` toggle is enabled for members.