### PR TITLE
fix: use create permission for basic auth delete

### DIFF
--- a/apps/dokploy/server/api/routers/security.ts
+++ b/apps/dokploy/server/api/routers/security.ts
@@ -45,7 +45,7 @@ export const securityRouter = createTRPCRouter({
 		.mutation(async ({ input, ctx }) => {
 			const security = await findSecurityById(input.securityId);
 			await checkServicePermissionAndAccess(ctx, security.applicationId, {
-				service: ["delete"],
+				service: ["create"],
 			});
 			const result = await deleteSecurityById(input.securityId);
 			await audit(ctx, {


### PR DESCRIPTION
## Summary

- Users with `service:create` permission were unable to delete basic auth entries they created, because the delete endpoint incorrectly required `service:delete` permission.
- Changed `security.delete` to require `service:create` permission, consistent with `security.create` and `security.update`.