### PR TITLE
fix: refresh server IP after web server restore

### DIFF
--- a/apps/dokploy/__test__/restore/web-server.test.ts
+++ b/apps/dokploy/__test__/restore/web-server.test.ts
@@ -1,0 +1,91 @@
+import { restoreWebServerBackup } from "@dokploy/server/utils/restore/web-server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execAsyncMock = vi.fn();
+const updateWebServerSettingsMock = vi.fn();
+const getPublicIpWithFallbackMock = vi.fn();
+
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsync: (...args: unknown[]) => execAsyncMock(...args),
+}));
+
+vi.mock("@dokploy/server/services/web-server-settings", () => ({
+	updateWebServerSettings: (...args: unknown[]) =>
+		updateWebServerSettingsMock(...args),
+}));
+
+vi.mock("@dokploy/server/wss/utils", () => ({
+	getPublicIpWithFallback: (...args: unknown[]) =>
+		getPublicIpWithFallbackMock(...args),
+}));
+
+vi.mock("@dokploy/server/utils/backups/utils", () => ({
+	getS3Credentials: () => ["--s3-flag"],
+}));
+
+const destination = {
+	bucket: "my-bucket",
+} as any;
+
+describe("restoreWebServerBackup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+
+		// Default execAsync behaviour: the two `ls ... || true` probes must report
+		// that the database files exist, every other command resolves with no output.
+		execAsyncMock.mockImplementation((command: string) => {
+			if (command.includes("database.sql.gz")) {
+				return Promise.resolve({ stdout: "database.sql.gz", stderr: "" });
+			}
+			if (command.includes("ls") && command.includes("database.sql")) {
+				return Promise.resolve({ stdout: "database.sql", stderr: "" });
+			}
+			if (command.includes("docker ps")) {
+				return Promise.resolve({ stdout: "container-id", stderr: "" });
+			}
+			return Promise.resolve({ stdout: "", stderr: "" });
+		});
+	});
+
+	it("re-detects and persists the current public IP after a restore", async () => {
+		getPublicIpWithFallbackMock.mockResolvedValue("203.0.113.10");
+		const emit = vi.fn();
+
+		await restoreWebServerBackup(destination, "backup.zip", emit);
+
+		expect(getPublicIpWithFallbackMock).toHaveBeenCalledTimes(1);
+		expect(updateWebServerSettingsMock).toHaveBeenCalledWith({
+			serverIp: "203.0.113.10",
+		});
+		expect(emit).toHaveBeenCalledWith("Server IP updated to: 203.0.113.10");
+		expect(emit).toHaveBeenCalledWith("Restore completed successfully!");
+	});
+
+	it("does not overwrite the server IP when detection fails", async () => {
+		getPublicIpWithFallbackMock.mockResolvedValue(null);
+		const emit = vi.fn();
+
+		await restoreWebServerBackup(destination, "backup.zip", emit);
+
+		expect(getPublicIpWithFallbackMock).toHaveBeenCalledTimes(1);
+		expect(updateWebServerSettingsMock).not.toHaveBeenCalled();
+		expect(emit).toHaveBeenCalledWith(
+			"Warning: could not detect the public IP, the server IP was left unchanged. Update it manually in Web Server settings if needed.",
+		);
+		expect(emit).toHaveBeenCalledWith("Restore completed successfully!");
+	});
+
+	it("refreshes the IP only after the database restore has run", async () => {
+		getPublicIpWithFallbackMock.mockResolvedValue("203.0.113.10");
+		const emit = vi.fn();
+
+		await restoreWebServerBackup(destination, "backup.zip", emit);
+
+		// pg_restore must have been invoked before we touch the server IP.
+		const restoreCalled = execAsyncMock.mock.calls.some(([command]) =>
+			String(command).includes("pg_restore"),
+		);
+		expect(restoreCalled).toBe(true);
+		expect(updateWebServerSettingsMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
+import { updateWebServerSettings } from "@dokploy/server/services/web-server-settings";
+import { getPublicIpWithFallback } from "@dokploy/server/wss/utils";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
@@ -132,6 +134,20 @@ export const restoreWebServerBackup = async (
 			await execAsync(
 				`docker exec ${postgresContainerId} rm /tmp/database.sql`,
 			);
+
+			// The restored database contains the server IP from the machine the
+			// backup was taken on. Re-detect the current host's public IP so the
+			// dashboard reflects this server instead of the old one.
+			emit("Refreshing server IP...");
+			const serverIp = await getPublicIpWithFallback();
+			if (serverIp) {
+				await updateWebServerSettings({ serverIp });
+				emit(`Server IP updated to: ${serverIp}`);
+			} else {
+				emit(
+					"Warning: could not detect the public IP, the server IP was left unchanged. Update it manually in Web Server settings if needed.",
+				);
+			}
 
 			emit("Restore completed successfully!");
 		} finally {


### PR DESCRIPTION
## What

When restoring a Dokploy **web server** backup, the PostgreSQL database is restored as-is. That database row (`webServerSettings`) contains the `serverIp` of the machine the backup was originally taken on, so after restoring a backup onto a **different host** the dashboard keeps displaying the *old* "Server IP" indefinitely.

This PR re-detects the current host's public IP once the database restore finishes and persists it, so the restored instance reflects the machine it is actually running on.

## How

In `restoreWebServerBackup` (`packages/server/src/utils/restore/web-server.ts`), right after the database `pg_restore` completes:

- Call `getPublicIpWithFallback()` (the same helper used during initial setup in `lib/auth.ts`).
- If an IP is detected, persist it via `updateWebServerSettings({ serverIp })`.
- If detection fails, leave the existing value untouched and emit a warning so the user knows to set it manually in Web Server settings.

This mirrors exactly how `serverIp` is populated when the first admin is created, so there's no new detection logic — just reuse of the existing path at the right moment.

## Why this scope

Kept intentionally narrow to the reported "Server IP stays stale after restore" bug. Other instance-specific values that are also restored from the backup (metrics callback URLs, SSH keys, registry URLs, bind-mount/cert paths, ACME data) can be stale after restoring onto a new host too, but those are separate concerns and are out of scope here.

## Testing

- Added `apps/dokploy/__test__/restore/web-server.test.ts` (vitest) covering:
  - IP is re-detected and persisted after a successful restore.
  - The stored IP is **not** overwritten when detection returns `null`.
  - The IP refresh happens **after** `pg_restore` has run.
- `pnpm --filter=@dokploy/server typecheck` passes.
- `biome check` clean on the changed files.
- Full related suite (`__test__/restore`, `__test__/wss/utils`, `__test__/utils/backups`) passes — 28/28.

```
 ✓ __test__/restore/web-server.test.ts (3 tests)
 ✓ __test__/utils/backups.test.ts (9 tests)
 ✓ __test__/wss/utils.test.ts (16 tests)
 Test Files  3 passed (3)
      Tests  28 passed (28)
```