### PR TITLE
FIX: replicaSets default to false after updating mongo due to default

### DIFF
--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -195,6 +195,7 @@ export const apiUpdateMongo = createSchema
 	.extend({
 		mongoId: z.string().min(1),
 		dockerImage: z.string().optional(),
+		replicaSets: z.boolean().optional(),
 	})
 	.omit({ serverId: true });
 


### PR DESCRIPTION
## What is this PR about?

Fixes a bug where the replicaSets field on a MongoDB service would silently reset to false whenever any partial update was saved (e.g. editing ulimits, resource limits, or other advanced settings).

The root cause was that apiUpdateMongo is built from createSchema.partial(), but the base createSchema defines replicaSets: z.boolean().default(false). Zod applies that default even in a partial context when the field is absent from the payload — so any update that doesn't explicitly include replicaSets would write false to the database, overwriting the user's original setting.

## Fix 
Override replicaSets in apiUpdateMongo to z.boolean().optional(), removing the default so absent fields stay absent.