### PR TITLE
fix: clear old deployment records and logs keeping only active deployment

### DIFF
--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -754,7 +754,7 @@ export const applicationRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const application = await findApplicationById(input.applicationId);
-			await clearOldDeployments(application.applicationId, "application", application.serverId);
+			await clearOldDeployments(application.applicationId, "application");
 			await audit(ctx, {
 				action: "delete",
 				resourceType: "application",

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -754,7 +754,7 @@ export const applicationRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const application = await findApplicationById(input.applicationId);
-			await clearOldDeployments(application.appName, application.serverId);
+			await clearOldDeployments(application.applicationId, "application", application.serverId);
 			await audit(ctx, {
 				action: "delete",
 				resourceType: "application",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -298,7 +298,7 @@ export const composeRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const compose = await findComposeById(input.composeId);
-			await clearOldDeployments(compose.composeId, "compose", compose.serverId);
+			await clearOldDeployments(compose.composeId, "compose");
 			await audit(ctx, {
 				action: "update",
 				resourceType: "compose",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -298,7 +298,7 @@ export const composeRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const compose = await findComposeById(input.composeId);
-			await clearOldDeployments(compose.appName, compose.serverId);
+			await clearOldDeployments(compose.composeId, "compose", compose.serverId);
 			await audit(ctx, {
 				action: "update",
 				resourceType: "compose",

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1036,8 +1036,7 @@ export const findAllDeploymentsByServerId = async (serverId: string) => {
 
 export const clearOldDeployments = async (
 	id: string,
-	type: "application" | "compose",
-	serverId: string | null,
+	type: "application" | "compose"
 ) => {
 	const deploymentsList = await db.query.deployments.findMany({
 		where: eq(deployments[`${type}Id`], id),
@@ -1055,19 +1054,10 @@ export const clearOldDeployments = async (
 		(d) => d.deploymentId !== currentDeployment.deploymentId,
 	);
 
-	const remoteLogCommands: string[] = [];
-
 	for (const oldDeployment of deploymentsToDelete) {
 		try {
 			if (oldDeployment.rollbackId) {
 				await removeRollbackById(oldDeployment.rollbackId);
-			}
-
-			const logPath = path.join(oldDeployment.logPath);
-			const hasLogPath = logPath && logPath !== ".";
-
-			if (serverId) {
-				if (hasLogPath) remoteLogCommands.push(`rm -f "${logPath}"`);
 			}
 
 			await removeDeployment(oldDeployment.deploymentId);
@@ -1077,9 +1067,5 @@ export const clearOldDeployments = async (
 				err,
 			);
 		}
-	}
-
-	if (serverId && remoteLogCommands.length > 0) {
-		await execAsyncRemote(serverId, remoteLogCommands.join(";"));
 	}
 };

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1035,17 +1035,37 @@ export const findAllDeploymentsByServerId = async (serverId: string) => {
 };
 
 export const clearOldDeployments = async (
-	appName: string,
+	id: string,
+	type: "application" | "compose",
 	serverId: string | null,
 ) => {
-	const { LOGS_PATH } = paths(!!serverId);
-	const folder = path.join(LOGS_PATH, appName);
-	const command = `
-		rm -rf ${folder};
-	`;
-	if (serverId) {
-		await execAsyncRemote(serverId, command);
-	} else {
-		await execAsync(command);
+	const deploymentsList = await db.query.deployments.findMany({
+		where: eq(deployments[`${type}Id`], id),
+		orderBy: desc(deployments.createdAt),
+	});
+
+	const currentDeployment =
+		deploymentsList.find((d) => d.status === "done") ?? deploymentsList[0];
+
+	if (!currentDeployment || deploymentsList.length <= 1) {
+		return;
+	}
+
+	const deploymentsToDelete = deploymentsList.filter(
+		(d) => d.deploymentId !== currentDeployment.deploymentId,
+	);
+
+	for (const oldDeployment of deploymentsToDelete) {
+		try {
+			if (oldDeployment.rollbackId) {
+				await removeRollbackById(oldDeployment.rollbackId);
+			}
+			await removeDeployment(oldDeployment.deploymentId);
+		} catch (err) {
+			console.error(
+				`Failed to remove deployment ${oldDeployment.deploymentId} during cleanup:`,
+				err,
+			);
+		}
 	}
 };

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1055,11 +1055,21 @@ export const clearOldDeployments = async (
 		(d) => d.deploymentId !== currentDeployment.deploymentId,
 	);
 
+	const remoteLogCommands: string[] = [];
+
 	for (const oldDeployment of deploymentsToDelete) {
 		try {
 			if (oldDeployment.rollbackId) {
 				await removeRollbackById(oldDeployment.rollbackId);
 			}
+
+			const logPath = path.join(oldDeployment.logPath);
+			const hasLogPath = logPath && logPath !== ".";
+
+			if (serverId) {
+				if (hasLogPath) remoteLogCommands.push(`rm -f "${logPath}"`);
+			}
+
 			await removeDeployment(oldDeployment.deploymentId);
 		} catch (err) {
 			console.error(
@@ -1067,5 +1077,9 @@ export const clearOldDeployments = async (
 				err,
 			);
 		}
+	}
+
+	if (serverId && remoteLogCommands.length > 0) {
+		await execAsyncRemote(serverId, remoteLogCommands.join(";"));
 	}
 };


### PR DESCRIPTION
## Problem

`clearOldDeployments` was only deleting log files via `rm -rf`. The modal says "This will delete all old deployment records and logs, keeping only the active deployment", but records were never actually deleted.

## Changes

- Now fetches deployment records by applicationId or composeId
- Keeps the most recent successful (done) deployment, falling back to the latest if none is found
- Deletes rollbacks, log files, and DB records for all others via removeDeployment
- Remote log files are explicitly deleted via a batched `rm -f` command before `removeDeployment` is called, since `removeDeployment` cannot handle remote log cleanup for application/compose deployments (serverId is not stored on the deployment record itself)

## Verification

- [x] Triggered clear old deployments on an application: confirmed only the active deployment record and log remain
- [x] Triggered clear old deployments on a compose: same result
- [x]  Verified remote server deployments are cleaned up correctly

Before

https://github.com/user-attachments/assets/715625a0-be5f-4690-928a-a2f967067c75


After

https://github.com/user-attachments/assets/b3df737a-e5d9-4de3-b497-9cc880507fa5

## Note

currently `removeDeployment` does not correctly delete log files for remote server deployments because `serverId` is never stored on the deployment record for application/compose deployments.

Fixed: https://github.com/Dokploy/dokploy/pull/4565