### PR TITLE
fix: use stop-first update order for database services

### DIFF
--- a/packages/server/src/utils/databases/libsql.ts
+++ b/packages/server/src/utils/databases/libsql.ts
@@ -140,7 +140,11 @@ export const buildLibsql = async (libsql: LibsqlNested) => {
 					: []),
 			],
 		},
-		UpdateConfig,
+		UpdateConfig: libsql.updateConfigSwarm ?? {
+			Parallelism: 1,
+			Order: "stop-first" as const,
+			FailureAction: "rollback" as const,
+		},
 	};
 	try {
 		const service = docker.getService(appName);

--- a/packages/server/src/utils/databases/mariadb.ts
+++ b/packages/server/src/utils/databases/mariadb.ts
@@ -111,7 +111,11 @@ export const buildMariadb = async (mariadb: MariadbNested) => {
 							]
 						: [],
 				},
-		UpdateConfig,
+		UpdateConfig: mariadb.updateConfigSwarm ?? {
+			Parallelism: 1,
+			Order: "stop-first" as const,
+			FailureAction: "rollback" as const,
+		},
 	};
 	try {
 		const service = docker.getService(appName);

--- a/packages/server/src/utils/databases/mongo.ts
+++ b/packages/server/src/utils/databases/mongo.ts
@@ -167,7 +167,11 @@ ${command ?? "wait $MONGOD_PID"}`;
 							]
 						: [],
 				},
-		UpdateConfig,
+		UpdateConfig: mongo.updateConfigSwarm ?? {
+			Parallelism: 1,
+			Order: "stop-first" as const,
+			FailureAction: "rollback" as const,
+		},
 	};
 
 	try {

--- a/packages/server/src/utils/databases/mysql.ts
+++ b/packages/server/src/utils/databases/mysql.ts
@@ -117,7 +117,11 @@ export const buildMysql = async (mysql: MysqlNested) => {
 							]
 						: [],
 				},
-		UpdateConfig,
+		UpdateConfig: mysql.updateConfigSwarm ?? {
+			Parallelism: 1,
+			Order: "stop-first" as const,
+			FailureAction: "rollback" as const,
+		},
 	};
 	try {
 		const service = docker.getService(appName);

--- a/packages/server/src/utils/databases/postgres.ts
+++ b/packages/server/src/utils/databases/postgres.ts
@@ -109,7 +109,11 @@ export const buildPostgres = async (postgres: PostgresNested) => {
 							]
 						: [],
 				},
-		UpdateConfig,
+		UpdateConfig: postgres.updateConfigSwarm ?? {
+			Parallelism: 1,
+			Order: "stop-first" as const,
+			FailureAction: "rollback" as const,
+		},
 	};
 	try {
 		const service = docker.getService(appName);

--- a/packages/server/src/utils/databases/redis.ts
+++ b/packages/server/src/utils/databases/redis.ts
@@ -115,7 +115,11 @@ export const buildRedis = async (redis: RedisNested) => {
 							]
 						: [],
 				},
-		UpdateConfig,
+		UpdateConfig: redis.updateConfigSwarm ?? {
+			Parallelism: 1,
+			Order: "stop-first" as const,
+			FailureAction: "rollback" as const,
+		},
 	};
 
 	try {


### PR DESCRIPTION
## Summary

- All database services (mongo, postgres, mysql, mariadb, redis, libsql) were using `start-first` as the Docker Swarm update order by default
- This caused the new container to start **before** the old one stopped, resulting in two containers competing for the same data volume lock
- MongoDB exits with code 100 (`DBPathInUse`) when this happens, Docker detects the failure and silently **rolls back** — reverting any env var or config changes the user made
- Fixed by using `stop-first` as the default update order for all database services, which stops the old container first before starting the new one
- The user-configured `updateConfigSwarm` is still respected if set

Closes #4550