### PR TITLE
Add generic rclone remote support for backup destinations

### DIFF
--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -1,4 +1,10 @@
-import { normalizeS3Path } from "@dokploy/server/utils/backups/utils";
+import {
+	GENERIC_RCLONE_PROVIDER,
+	getRcloneCredentials,
+	getRcloneDestination,
+	getRcloneTestFlags,
+	normalizeS3Path,
+} from "@dokploy/server/utils/backups/utils";
 import { describe, expect, test } from "vitest";
 
 describe("normalizeS3Path", () => {
@@ -57,5 +63,59 @@ describe("normalizeS3Path", () => {
 		expect(normalizeS3Path("instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("/instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("instance-backups")).toBe("instance-backups/");
+	});
+});
+
+describe("rclone destination helpers", () => {
+	const s3Destination = {
+		provider: "AWS",
+		accessKey: "access",
+		secretAccessKey: "secret",
+		bucket: "dokploy-backups",
+		region: "us-east-1",
+		endpoint: "https://s3.example.com",
+		additionalFlags: ["--s3-no-head"],
+	} as const;
+
+	const genericDestination = {
+		provider: GENERIC_RCLONE_PROVIDER,
+		accessKey: "",
+		secretAccessKey: "",
+		bucket: "gdrive:backups",
+		region: "",
+		endpoint: "",
+		additionalFlags: ["--drive-root-folder-id=abc123"],
+	} as const;
+
+	test("should keep s3 destinations on the s3 remote path", () => {
+		expect(getRcloneDestination(s3Destination as never)).toBe(
+			":s3:dokploy-backups",
+		);
+		expect(getRcloneCredentials(s3Destination as never)).toEqual([
+			'--s3-provider="AWS"',
+			'--s3-access-key-id="access"',
+			'--s3-secret-access-key="secret"',
+			'--s3-region="us-east-1"',
+			'--s3-endpoint="https://s3.example.com"',
+			"--s3-no-check-bucket",
+			"--s3-force-path-style",
+			"--s3-no-head",
+		]);
+	});
+
+	test("should allow generic rclone remotes", () => {
+		expect(getRcloneDestination(genericDestination as never)).toBe(
+			"gdrive:backups",
+		);
+		expect(getRcloneCredentials(genericDestination as never)).toEqual([
+			"--drive-root-folder-id=abc123",
+		]);
+		expect(getRcloneTestFlags(genericDestination as never)).toEqual([
+			"--drive-root-folder-id=abc123",
+			"--retries 1",
+			"--low-level-retries 1",
+			"--timeout 10s",
+			"--contimeout 5s",
+		]);
 	});
 });

--- a/apps/dokploy/components/dashboard/settings/destination/constants.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/constants.ts
@@ -95,6 +95,10 @@ export const S3_PROVIDERS: Array<{
 		name: "Rclone S3 Server",
 	},
 	{
+		key: "GenericRclone",
+		name: "Generic rclone remote",
+	},
+	{
 		key: "Scaleway",
 		name: "Scaleway Object Storage",
 	},

--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -1,6 +1,7 @@
 import {
 	ADDITIONAL_FLAG_ERROR,
 	ADDITIONAL_FLAG_REGEX,
+	GENERIC_RCLONE_PROVIDER,
 } from "@dokploy/server/db/validations/destination";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { PenBoxIcon, PlusIcon, Trash2 } from "lucide-react";
@@ -44,11 +45,11 @@ import { S3_PROVIDERS } from "./constants";
 const addDestination = z.object({
 	name: z.string().min(1, "Name is required"),
 	provider: z.string().min(1, "Provider is required"),
-	accessKeyId: z.string().min(1, "Access Key Id is required"),
-	secretAccessKey: z.string().min(1, "Secret Access Key is required"),
+	accessKeyId: z.string(),
+	secretAccessKey: z.string(),
 	bucket: z.string().min(1, "Bucket is required"),
 	region: z.string(),
-	endpoint: z.string().min(1, "Endpoint is required"),
+	endpoint: z.string(),
 	serverId: z.string().optional(),
 	additionalFlags: z
 		.array(
@@ -60,6 +61,32 @@ const addDestination = z.object({
 			}),
 		)
 		.optional(),
+}).superRefine((data, ctx) => {
+	const isGenericRclone = data.provider === GENERIC_RCLONE_PROVIDER;
+
+	if (!isGenericRclone && !data.accessKeyId.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["accessKeyId"],
+			message: "Access Key Id is required",
+		});
+	}
+
+	if (!isGenericRclone && !data.secretAccessKey.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["secretAccessKey"],
+			message: "Secret Access Key is required",
+		});
+	}
+
+	if (!isGenericRclone && !data.endpoint.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["endpoint"],
+			message: "Endpoint is required",
+		});
+	}
 });
 
 type AddDestination = z.infer<typeof addDestination>;
@@ -107,6 +134,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		},
 		resolver: zodResolver(addDestination),
 	});
+	const selectedProvider = form.watch("provider");
 
 	const { fields, append, remove } = useFieldArray({
 		control: form.control,
@@ -196,7 +224,10 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		const endpoint = form.getValues("endpoint");
 		const region = form.getValues("region");
 
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
+		const connectionString =
+			provider === GENERIC_RCLONE_PROVIDER
+				? bucket
+				: `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
 
 		await testConnection({
 			provider,
@@ -291,7 +322,7 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 											>
 												<FormControl>
 													<SelectTrigger>
-														<SelectValue placeholder="Select a S3 Provider" />
+														<SelectValue placeholder="Select a provider" />
 													</SelectTrigger>
 												</FormControl>
 												<SelectContent>
@@ -307,6 +338,13 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 											</Select>
 										</FormControl>
 										<FormMessage />
+										{selectedProvider === GENERIC_RCLONE_PROVIDER && (
+											<p className="text-xs text-muted-foreground">
+												Use a preconfigured rclone remote such as{" "}
+												<code>gdrive:backups</code> or <code>ftp:archives</code>.
+												Leave S3 credentials blank for this mode.
+											</p>
+										)}
 									</FormItem>
 								);
 							}}
@@ -318,7 +356,12 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => {
 								return (
 									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
+										<FormLabel>
+											Access Key Id
+											{selectedProvider === GENERIC_RCLONE_PROVIDER
+												? " (optional)"
+												: ""}
+										</FormLabel>
 										<FormControl>
 											<Input placeholder={"xcas41dasde"} {...field} />
 										</FormControl>
@@ -333,7 +376,12 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
+										<FormLabel>
+											Secret Access Key
+											{selectedProvider === GENERIC_RCLONE_PROVIDER
+												? " (optional)"
+												: ""}
+										</FormLabel>
 									</div>
 									<FormControl>
 										<Input placeholder={"asd123asdasw"} {...field} />
@@ -348,10 +396,21 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
+										<FormLabel>
+											{selectedProvider === GENERIC_RCLONE_PROVIDER
+												? "Remote path"
+												: "Bucket"}
+										</FormLabel>
 									</div>
 									<FormControl>
-										<Input placeholder={"dokploy-bucket"} {...field} />
+										<Input
+											placeholder={
+												selectedProvider === GENERIC_RCLONE_PROVIDER
+													? "gdrive:backups"
+													: "dokploy-bucket"
+											}
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -377,7 +436,12 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							name="endpoint"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
+									<FormLabel>
+										Endpoint
+										{selectedProvider === GENERIC_RCLONE_PROVIDER
+											? " (optional)"
+											: ""}
+									</FormLabel>
 									<FormControl>
 										<Input
 											placeholder={"https://us.bucket.aws/s3"}

--- a/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
@@ -24,11 +24,11 @@ export const ShowDestinations = () => {
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
 							<Database className="size-6 text-muted-foreground self-center" />
-							S3 Destinations
+							Backup Destinations
 						</CardTitle>
 						<CardDescription>
 							Add your providers like AWS S3, Cloudflare R2, Wasabi,
-							DigitalOcean Spaces etc.
+							DigitalOcean Spaces, or a generic rclone remote.
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-2 py-8 border-t">
@@ -44,7 +44,7 @@ export const ShowDestinations = () => {
 										<FolderUp className="size-8 self-center text-muted-foreground" />
 										<span className="text-base text-muted-foreground">
 											To create a backup it is required to set at least 1
-											provider.
+											provider or remote.
 										</span>
 										{permissions?.destination.create && <HandleDestinations />}
 									</div>

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -8,6 +8,10 @@ import {
 	updateDestinationById,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import {
+	getRcloneDestination,
+	getRcloneTestFlags,
+} from "@dokploy/server/utils/backups/utils";
 import { TRPCError } from "@trpc/server";
 import { desc, eq } from "drizzle-orm";
 import { createTRPCRouter, withPermission } from "@/server/api/trpc";
@@ -47,35 +51,9 @@ export const destinationRouter = createTRPCRouter({
 	testConnection: withPermission("destination", "create")
 		.input(apiCreateDestination)
 		.mutation(async ({ input }) => {
-			const {
-				secretAccessKey,
-				bucket,
-				region,
-				endpoint,
-				accessKey,
-				provider,
-				additionalFlags,
-			} = input;
 			try {
-				const rcloneFlags = [
-					`--s3-access-key-id="${accessKey}"`,
-					`--s3-secret-access-key="${secretAccessKey}"`,
-					`--s3-region="${region}"`,
-					`--s3-endpoint="${endpoint}"`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
-					"--retries 1",
-					"--low-level-retries 1",
-					"--timeout 10s",
-					"--contimeout 5s",
-				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider="${provider}"`);
-				}
-				if (additionalFlags?.length) {
-					rcloneFlags.push(...additionalFlags);
-				}
-				const rcloneDestination = `:s3:${bucket}`;
+				const rcloneFlags = getRcloneTestFlags(input);
+				const rcloneDestination = getRcloneDestination(input);
 				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 				if (IS_CLOUD && !input.serverId) {

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import {
 	ADDITIONAL_FLAG_ERROR,
 	ADDITIONAL_FLAG_REGEX,
+	GENERIC_RCLONE_PROVIDER,
 } from "../validations/destination";
 import { organization } from "./account";
 import { backups } from "./backups";
@@ -52,6 +53,48 @@ const createSchema = createInsertSchema(destinations, {
 	additionalFlags: z
 		.array(z.string().regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR))
 		.default([]),
+}).superRefine((data, ctx) => {
+	const isGenericRclone = data.provider === GENERIC_RCLONE_PROVIDER;
+
+	if (!data.provider?.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["provider"],
+			message: "Provider is required",
+		});
+	}
+
+	if (!data.bucket?.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["bucket"],
+			message: "Bucket is required",
+		});
+	}
+
+	if (!isGenericRclone && !data.accessKey?.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["accessKey"],
+			message: "Access Key Id is required",
+		});
+	}
+
+	if (!isGenericRclone && !data.secretAccessKey?.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["secretAccessKey"],
+			message: "Secret Access Key is required",
+		});
+	}
+
+	if (!isGenericRclone && !data.endpoint?.trim()) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["endpoint"],
+			message: "Endpoint is required",
+		});
+	}
 });
 
 export const apiCreateDestination = createSchema

--- a/packages/server/src/db/validations/destination.ts
+++ b/packages/server/src/db/validations/destination.ts
@@ -1,3 +1,4 @@
 export const ADDITIONAL_FLAG_REGEX = /^--[a-zA-Z0-9-]+(=[a-zA-Z0-9._:/@-]+)?$/;
 export const ADDITIONAL_FLAG_ERROR =
 	"Invalid flag format. Must start with -- (e.g. --s3-sign-accept-encoding=false)";
+export const GENERIC_RCLONE_PROVIDER = "GenericRclone";

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -11,7 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "./utils";
 
@@ -34,8 +35,8 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -10,7 +10,12 @@ import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import {
+	getRcloneCredentials,
+	getRcloneDestination,
+	normalizeS3Path,
+	scheduleBackup,
+} from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -131,9 +136,9 @@ export const keepLatestNBackups = async (
 	if (!backup.keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(backup.destination);
+		const rcloneFlags = getRcloneCredentials(backup.destination);
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${backup.destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = `${getRcloneDestination(backup.destination)}/${appName}/${normalizeS3Path(backup.prefix)}`;
 
 		// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
 		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -11,7 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "./utils";
 
@@ -33,8 +34,8 @@ export const runLibsqlBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -11,7 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "./utils";
 
@@ -32,8 +33,8 @@ export const runMariadbBackup = async (
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -11,7 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "./utils";
 
@@ -29,8 +30,8 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -11,7 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "./utils";
 
@@ -30,8 +31,8 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -11,7 +11,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "./utils";
 
@@ -33,8 +34,8 @@ export const runPostgresBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -1,6 +1,7 @@
 import { logger } from "@dokploy/server/lib/logger";
 import type { BackupSchedule } from "@dokploy/server/services/backup";
 import type { Destination } from "@dokploy/server/services/destination";
+import { GENERIC_RCLONE_PROVIDER } from "@dokploy/server/db/validations/destination";
 import { scheduledJobs, scheduleJob } from "node-schedule";
 import { keepLatestNBackups } from ".";
 import { runComposeBackup } from "./compose";
@@ -66,10 +67,24 @@ export const normalizeS3Path = (prefix: string) => {
 	return normalizedPrefix ? `${normalizedPrefix}/` : "";
 };
 
-export const getS3Credentials = (destination: Destination) => {
+export const isGenericRcloneDestination = (destination: Destination) =>
+	destination.provider === GENERIC_RCLONE_PROVIDER;
+
+export const getRcloneDestination = (destination: Destination) =>
+	isGenericRcloneDestination(destination)
+		? destination.bucket
+		: `:s3:${destination.bucket}`;
+
+export const getRcloneCredentials = (destination: Destination) => {
 	const { accessKey, secretAccessKey, region, endpoint, provider } =
 		destination;
+
+	if (isGenericRcloneDestination(destination)) {
+		return destination.additionalFlags?.length ? [...destination.additionalFlags] : [];
+	}
+
 	const rcloneFlags = [
+		`--s3-provider="${provider}"`,
 		`--s3-access-key-id="${accessKey}"`,
 		`--s3-secret-access-key="${secretAccessKey}"`,
 		`--s3-region="${region}"`,
@@ -78,16 +93,22 @@ export const getS3Credentials = (destination: Destination) => {
 		"--s3-force-path-style",
 	];
 
-	if (provider) {
-		rcloneFlags.unshift(`--s3-provider="${provider}"`);
-	}
-
 	if (destination.additionalFlags?.length) {
 		rcloneFlags.push(...destination.additionalFlags);
 	}
 
 	return rcloneFlags;
 };
+
+export const getRcloneTestFlags = (destination: Destination) => [
+	...getRcloneCredentials(destination),
+	"--retries 1",
+	"--low-level-retries 1",
+	"--timeout 10s",
+	"--contimeout 5s",
+];
+
+export const getS3Credentials = getRcloneCredentials;
 
 export const getPostgresBackupCommand = (
 	database: string,
@@ -289,16 +310,16 @@ export const getBackupCommand = (
 	}
 
 	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
+	echo "[$(date)] Starting upload to destination..." >> ${logPath};
 
 	# Run the upload command and capture the exit status
 	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
+		echo "[$(date)] ❌ Error: Upload to destination failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
 		exit 1;
 	}
 
-	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
+	echo "[$(date)] ✅ Upload to destination completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -11,7 +11,12 @@ import {
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { sendDokployBackupNotifications } from "../notifications/dokploy-backup";
 import { execAsync } from "../process/execAsync";
-import { getBackupTimestamp, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupTimestamp,
+	getRcloneCredentials,
+	getRcloneDestination,
+	normalizeS3Path,
+} from "./utils";
 
 function formatBytes(bytes?: number) {
 	if (bytes === undefined) return "Unknown size";
@@ -36,12 +41,12 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 	let computedBackupSize: number | undefined;
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
+		const rcloneFlags = getRcloneCredentials(destination);
 		const timestamp = getBackupTimestamp();
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const s3Path = `${getRcloneDestination(destination)}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -99,9 +104,9 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 			}
 
 			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${zipPath}" "${s3Path}"`;
-			writeStream.write("Running command to upload backup to S3\n");
+			writeStream.write("Running command to upload backup to destination\n");
 			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			writeStream.write("Uploaded backup to destination ✅\n");
 			writeStream.end();
 			await sendDokployBackupNotifications({
 				type: "success",

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCredentials, getRcloneDestination } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -23,8 +23,8 @@ export const restoreComposeBackup = async (
 		}
 		const { serverId, appName, composeType } = compose;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
 		let rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
 

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -2,7 +2,11 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Libsql } from "@dokploy/server/services/libsql";
 import type { z } from "zod";
-import { getS3Credentials, getServiceContainerCommand } from "../backups/utils";
+import {
+	getRcloneCredentials,
+	getRcloneDestination,
+	getServiceContainerCommand,
+} from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 
 export const restoreLibsqlBackup = async (
@@ -14,8 +18,8 @@ export const restoreLibsqlBackup = async (
 	try {
 		const { appName, serverId } = libsql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 
 		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
 

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mariadb } from "@dokploy/server/services/mariadb";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCredentials, getRcloneDestination } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,8 +15,8 @@ export const restoreMariadbBackup = async (
 	try {
 		const { appName, serverId, databaseUser, databasePassword } = mariadb;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
 
 		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Mongo } from "@dokploy/server/services/mongo";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCredentials, getRcloneDestination } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,8 +15,8 @@ export const restoreMongoBackup = async (
 	try {
 		const { appName, databasePassword, databaseUser, serverId } = mongo;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
 		const rcloneCommand = `rclone copy ${rcloneFlags.join(" ")} "${backupPath}"`;
 

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { MySql } from "@dokploy/server/services/mysql";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCredentials, getRcloneDestination } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,8 +15,8 @@ export const restoreMySqlBackup = async (
 	try {
 		const { appName, databaseRootPassword, serverId } = mysql;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
 
 		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -2,7 +2,7 @@ import type { apiRestoreBackup } from "@dokploy/server/db/schema";
 import type { Destination } from "@dokploy/server/services/destination";
 import type { Postgres } from "@dokploy/server/services/postgres";
 import type { z } from "zod";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCredentials, getRcloneDestination } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
 
@@ -15,8 +15,8 @@ export const restorePostgresBackup = async (
 	try {
 		const { appName, databaseUser, serverId } = postgres;
 
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 
 		const backupPath = `${bucketPath}/${backupInput.backupFile}`;
 

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
-import { getS3Credentials } from "../backups/utils";
+import { getRcloneCredentials, getRcloneDestination } from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
 export const restoreWebServerBackup = async (
@@ -15,8 +15,8 @@ export const restoreWebServerBackup = async (
 		return;
 	}
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const bucketPath = `:s3:${destination.bucket}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const bucketPath = getRcloneDestination(destination);
 		const backupPath = `${bucketPath}/${backupFile}`;
 		const { BASE_PATH } = paths();
 
@@ -33,7 +33,7 @@ export const restoreWebServerBackup = async (
 			await execAsync(`mkdir -p ${tempDir}`);
 
 			// Download backup from S3
-			emit("Downloading backup from S3...");
+			emit("Downloading backup from destination...");
 			await execAsync(
 				`rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${tempDir}/${backupFile}"`,
 			);

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -4,7 +4,8 @@ import { findComposeById } from "@dokploy/server/services/compose";
 import type { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
 import {
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestination,
 	normalizeS3Path,
 } from "../backups/utils";
 
@@ -38,8 +39,8 @@ export const backupVolume = async (
 	const s3AppName = getVolumeServiceAppName(volumeBackup);
 	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar`;
 	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
-	const rcloneFlags = getS3Credentials(volumeBackup.destination);
-	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+	const rcloneFlags = getRcloneCredentials(volumeBackup.destination);
+	const rcloneDestination = `${getRcloneDestination(destination)}/${bucketDestination}`;
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeBackup.appName);
 
 	const rcloneCommand = `rclone copyto ${rcloneFlags.join(" ")} "${volumeBackupPath}/${backupFileName}" "${rcloneDestination}"`;
@@ -60,9 +61,9 @@ export const backupVolume = async (
   `;
 
 	const uploadCommand = `
-  echo "Starting upload to S3..."
+  echo "Starting upload to destination..."
   ${rcloneCommand}
-  echo "Upload to S3 done ✅"
+  echo "Upload to destination done ✅"
   echo "Cleaning up local backup file..."
   rm "${volumeBackupPath}/${backupFileName}"
   echo "Local backup file cleaned up ✅"

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -3,9 +3,12 @@ import {
 	findApplicationById,
 	findComposeById,
 	findDestinationById,
-	getS3Credentials,
 	paths,
 } from "../..";
+import {
+	getRcloneCredentials,
+	getRcloneDestination,
+} from "../backups/utils";
 
 export const restoreVolume = async (
 	id: string,
@@ -18,11 +21,11 @@ export const restoreVolume = async (
 	const destination = await findDestinationById(destinationId);
 	const { VOLUME_BACKUPS_PATH } = paths(!!serverId);
 	const volumeBackupPath = path.join(VOLUME_BACKUPS_PATH, volumeName);
-	const rcloneFlags = getS3Credentials(destination);
-	const bucketPath = `:s3:${destination.bucket}`;
+	const rcloneFlags = getRcloneCredentials(destination);
+	const bucketPath = getRcloneDestination(destination);
 	const backupPath = `${bucketPath}/${backupFileName}`;
 
-	// Command to download backup file from S3
+	// Command to download backup file from the configured destination
 	const downloadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${backupPath}" "${volumeBackupPath}/${backupFileName}"`;
 
 	// Base restore command that creates the volume and restores data
@@ -31,7 +34,7 @@ export const restoreVolume = async (
 	echo "Volume name: ${volumeName}"
 	echo "Backup file name: ${backupFileName}"
 	echo "Volume backup path: ${volumeBackupPath}"
-	echo "Downloading backup from S3..."
+	echo "Downloading backup from destination..."
 	mkdir -p ${volumeBackupPath}
 	${downloadCommand}
 	echo "Download completed ✅"

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -10,7 +10,11 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 import { scheduledJobs, scheduleJob } from "node-schedule";
-import { getS3Credentials, normalizeS3Path } from "../backups/utils";
+import {
+	getRcloneCredentials,
+	getRcloneDestination,
+	normalizeS3Path,
+} from "../backups/utils";
 import { sendVolumeBackupNotifications } from "../notifications/volume-backup";
 import { backupVolume, getVolumeServiceAppName } from "./backup";
 
@@ -82,9 +86,9 @@ const cleanupOldVolumeBackups = async (
 	if (!keepLatestCount) return;
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
+		const rcloneFlags = getRcloneCredentials(destination);
 		const s3AppName = getVolumeServiceAppName(volumeBackup);
-		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
+		const backupFilesPath = `${getRcloneDestination(destination)}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
 		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
 		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;


### PR DESCRIPTION
Add generic rclone remote support for backup destinations

This patch adds a generic rclone destination mode so Dokploy can back up to preconfigured remotes such as Google Drive, FTP, SFTP, or OneDrive without breaking the current S3-compatible flow.

Highlights:
- new `GenericRclone` provider option
- conditional validation for S3 vs generic rclone destinations
- shared helper for destination path / rclone flags
- backup, cleanup, and restore paths updated to use the helper
- focused tests for S3 and generic remotes

This is aimed at issue #416.

