### PR TITLE
fix: store serverId on deployment record to enable remote log cleanup

### DIFF
--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -151,6 +151,7 @@ export const createDeployment = async (
 			.insert(deployments)
 			.values({
 				applicationId: deployment.applicationId,
+				serverId: application.serverId,
 				title: deployment.title || "Deployment",
 				status: "running",
 				logPath: logFilePath,
@@ -173,6 +174,7 @@ export const createDeployment = async (
 			.insert(deployments)
 			.values({
 				applicationId: deployment.applicationId,
+				serverId: application.serverId,
 				title: deployment.title || "Deployment",
 				status: "error",
 				logPath: "",
@@ -238,6 +240,7 @@ export const createDeploymentPreview = async (
 				logPath: logFilePath,
 				description: deployment.description || "",
 				previewDeploymentId: deployment.previewDeploymentId,
+				serverId: previewDeployment?.application?.serverId,
 				startedAt: new Date().toISOString(),
 			})
 			.returning();
@@ -253,6 +256,7 @@ export const createDeploymentPreview = async (
 			.insert(deployments)
 			.values({
 				previewDeploymentId: deployment.previewDeploymentId,
+				serverId: previewDeployment?.application?.serverId,
 				title: deployment.title || "Deployment",
 				status: "error",
 				logPath: "",
@@ -311,6 +315,7 @@ echo "Initializing deployment\n" >> ${logFilePath};
 			.insert(deployments)
 			.values({
 				composeId: deployment.composeId,
+				serverId: compose.serverId,
 				title: deployment.title || "Deployment",
 				description: deployment.description || "",
 				status: "running",
@@ -330,6 +335,7 @@ echo "Initializing deployment\n" >> ${logFilePath};
 			.insert(deployments)
 			.values({
 				composeId: deployment.composeId,
+				serverId: compose.serverId,
 				title: deployment.title || "Deployment",
 				status: "error",
 				logPath: "",
@@ -395,6 +401,7 @@ echo "Initializing backup\n" >> ${logFilePath};
 			.insert(deployments)
 			.values({
 				backupId: deployment.backupId,
+				serverId: serverId,
 				title: deployment.title || "Backup",
 				description: deployment.description || "",
 				status: "running",
@@ -414,6 +421,7 @@ echo "Initializing backup\n" >> ${logFilePath};
 			.insert(deployments)
 			.values({
 				backupId: deployment.backupId,
+				serverId: serverId,
 				title: deployment.title || "Backup",
 				status: "error",
 				logPath: "",
@@ -469,6 +477,7 @@ export const createDeploymentSchedule = async (
 			.insert(deployments)
 			.values({
 				scheduleId: deployment.scheduleId,
+				serverId: serverId,
 				title: deployment.title || "Deployment",
 				status: "running",
 				logPath: logFilePath,
@@ -489,6 +498,7 @@ export const createDeploymentSchedule = async (
 			.insert(deployments)
 			.values({
 				scheduleId: deployment.scheduleId,
+				serverId: serverId,
 				title: deployment.title || "Deployment",
 				status: "error",
 				logPath: "",
@@ -554,6 +564,7 @@ export const createDeploymentVolumeBackup = async (
 			.insert(deployments)
 			.values({
 				volumeBackupId: deployment.volumeBackupId,
+				serverId: serverId,
 				title: deployment.title || "Deployment",
 				status: "running",
 				logPath: logFilePath,
@@ -574,6 +585,7 @@ export const createDeploymentVolumeBackup = async (
 			.insert(deployments)
 			.values({
 				volumeBackupId: deployment.volumeBackupId,
+				serverId: serverId,
 				title: deployment.title || "Deployment",
 				status: "error",
 				logPath: "",


### PR DESCRIPTION
## Problem

`removeDeployment` was not deleting log files for remote server deployments because `serverId` was never stored on the deployment record — it only lived on the parent application/compose. So `deployment.serverId` was always null, causing `execAsync` (local) to run instead of `execAsyncRemote`.

## Changes

Store `serverId` from the parent service onto the deployment record at creation time across all deployment types:

- createDeployment
- createDeploymentCompose
- createDeploymentPreview
- createDeploymentBackup
- createDeploymentSchedule
- createDeploymentVolumeBackup

`removeDeployment` now can delete the log file in remote server since `deployment.serverId` is properly populated.

## Testing

Confirmed log file is removed when delete deployment on:

- [x] Application
- [x] Compose
- [ ] Preview
- [x] Backup
- [x] Schedule
- [x] Volume Backup

https://github.com/user-attachments/assets/af80b364-82ea-44ee-a9a1-ae161adb5e17


https://github.com/user-attachments/assets/c476320f-6578-4532-8c31-e68ee5dab647

