### PR TITLE
refactor: improve restore logging for database backups

### DIFF
--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -77,9 +77,7 @@ export const restoreComposeBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Backup path: ${backupPath}`);
-
-		emit(`Executing command: ${restoreCommand}`);
+		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, restoreCommand);

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -77,7 +77,9 @@ export const restoreComposeBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
+		emit(
+			`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`,
+		);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, restoreCommand);

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -21,15 +21,13 @@ export const restoreLibsqlBackup = async (
 
 		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}"`;
 
-		emit("Starting restore...");
-		emit(`Backup path: ${backupPath}`);
-
 		const containerSearch = getServiceContainerCommand(appName);
 		const restoreCommand = `docker exec -i $CONTAINER_ID sh -c "tar xzf - -C /var/lib/sqld"`;
 
 		const command = `CONTAINER_ID=$(${containerSearch}) && ${rcloneCommand} | ${restoreCommand}`;
 
-		emit(`Executing command: ${command}`);
+		emit("Starting restore...");
+		emit(`Restoring libsql from ${backupInput.backupFile}`);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -34,8 +34,7 @@ export const restoreMariadbBackup = async (
 		});
 
 		emit("Starting restore...");
-
-		emit(`Executing command: ${command}`);
+		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -34,7 +34,9 @@ export const restoreMariadbBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
+		emit(
+			`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`,
+		);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -34,8 +34,7 @@ export const restoreMongoBackup = async (
 		});
 
 		emit("Starting restore...");
-
-		emit(`Executing command: ${command}`);
+		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -34,7 +34,9 @@ export const restoreMongoBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
+		emit(
+			`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`,
+		);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -33,7 +33,9 @@ export const restoreMySqlBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
+		emit(
+			`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`,
+		);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -33,8 +33,7 @@ export const restoreMySqlBackup = async (
 		});
 
 		emit("Starting restore...");
-
-		emit(`Executing command: ${command}`);
+		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -22,9 +22,6 @@ export const restorePostgresBackup = async (
 
 		const rcloneCommand = `rclone cat ${rcloneFlags.join(" ")} "${backupPath}" | gunzip`;
 
-		emit("Starting restore...");
-		emit(`Backup path: ${backupPath}`);
-
 		const command = getRestoreCommand({
 			appName,
 			credentials: {
@@ -36,7 +33,8 @@ export const restorePostgresBackup = async (
 			restoreType: "database",
 		});
 
-		emit(`Executing command: ${command}`);
+		emit("Starting restore...");
+		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -34,7 +34,9 @@ export const restorePostgresBackup = async (
 		});
 
 		emit("Starting restore...");
-		emit(`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`);
+		emit(
+			`Restoring database: ${backupInput.databaseName} from ${backupInput.backupFile}`,
+		);
 
 		if (serverId) {
 			await execAsyncRemote(serverId, command);


### PR DESCRIPTION
- Updated restore functions across various database types (Postgres, MySQL, MongoDB, MariaDB, LibSQL, and Compose) to provide clearer logging messages.
- Replaced generic command execution logs with specific messages indicating the database being restored and the source backup file.
- This change enhances the clarity of restore operations and aids in troubleshooting by providing more context in the logs.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)



## Screenshots (if applicable)

