### PR TITLE
fix: use swarm advertise address in docker swarm join command

### DIFF
--- a/apps/dokploy/server/api/routers/cluster.ts
+++ b/apps/dokploy/server/api/routers/cluster.ts
@@ -96,9 +96,11 @@ export const clusterRouter = createTRPCRouter({
 			const docker = await getRemoteDocker(input.serverId);
 			const result = await docker.swarmInspect();
 			const docker_version = await docker.version();
+			const info = await docker.info();
 
-			let ip = await getLocalServerIp();
-			if (input.serverId) {
+			const swarmNodeAddr = info?.Swarm?.NodeAddr;
+			let ip = swarmNodeAddr || (await getLocalServerIp());
+			if (!swarmNodeAddr && input.serverId) {
 				const server = await findServerById(input.serverId);
 				ip = server?.ipAddress;
 			}
@@ -128,9 +130,11 @@ export const clusterRouter = createTRPCRouter({
 			const docker = await getRemoteDocker(input.serverId);
 			const result = await docker.swarmInspect();
 			const docker_version = await docker.version();
+			const info = await docker.info();
 
-			let ip = await getLocalServerIp();
-			if (input.serverId) {
+			const swarmNodeAddr = info?.Swarm?.NodeAddr;
+			let ip = swarmNodeAddr || (await getLocalServerIp());
+			if (!swarmNodeAddr && input.serverId) {
 				const server = await findServerById(input.serverId);
 				ip = server?.ipAddress;
 			}


### PR DESCRIPTION
## Summary

- Fixes #4517 — the `docker swarm join` command generated in the "Add Node" UI was using the wrong IP address https://github.com/Dokploy/dokploy/issues/4504
- Now reads `info.Swarm.NodeAddr` from `docker.info()`, which is the actual IP Docker Swarm is advertising
- Falls back to `getLocalServerIp()` / `server.ipAddress` if `NodeAddr` is not available