### PR TITLE
fix: enforce docker:read on container start/stop/kill/restart mutations

### DIFF
--- a/apps/dokploy/server/api/routers/docker.ts
+++ b/apps/dokploy/server/api/routers/docker.ts
@@ -38,7 +38,7 @@ export const dockerRouter = createTRPCRouter({
 			return await getContainers(input.serverId);
 		}),
 
-	restartContainer: withPermission("service", "read")
+	restartContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -64,7 +64,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	startContainer: withPermission("service", "read")
+	startContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -90,7 +90,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	stopContainer: withPermission("service", "read")
+	stopContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z
@@ -116,7 +116,7 @@ export const dockerRouter = createTRPCRouter({
 			});
 		}),
 
-	killContainer: withPermission("service", "read")
+	killContainer: withPermission("docker", "read")
 		.input(
 			z.object({
 				containerId: z


### PR DESCRIPTION
## Summary

Four Docker mutation endpoints (`startContainer`, `stopContainer`, `killContainer`, `restartContainer`) were gated by `withPermission("service", "read")`, which the default member role grants. This allowed any authenticated org member to mutate container state regardless of `canAccessToDocker` or `accessedServices` scope.

- Switch all four mutations to `withPermission("docker", "read")`, matching `removeContainer`, `getConfig`, and `getContainers` which were already correctly gated.

Fixes #4486, closes #4332.