### PR TITLE
fix: strip credentials from gitProvider.getAll API response

### DIFF
--- a/apps/dokploy/components/dashboard/settings/git/show-git-providers.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/show-git-providers.tsx
@@ -134,15 +134,10 @@ export const ShowGitProviders = () => {
 												const canManage = gitProvider.isOwner || isOrgAdmin;
 
 												const haveGithubRequirements =
-													isGithub &&
-													gitProvider.github?.githubPrivateKey &&
-													gitProvider.github?.githubAppId &&
-													gitProvider.github?.githubInstallationId;
+													isGithub && gitProvider.github?.isConfigured;
 
 												const haveGitlabRequirements =
-													isGitlab &&
-													gitProvider.gitlab?.accessToken &&
-													gitProvider.gitlab?.refreshToken;
+													isGitlab && gitProvider.gitlab?.isConfigured;
 
 												return (
 													<div
@@ -230,8 +225,7 @@ export const ShowGitProviders = () => {
 																)}
 
 																{isBitbucket &&
-																gitProvider.bitbucket?.appPassword &&
-																!gitProvider.bitbucket?.apiToken ? (
+																gitProvider.bitbucket?.isDeprecated ? (
 																	<Badge variant="yellow">Deprecated</Badge>
 																) : null}
 
@@ -244,7 +238,7 @@ export const ShowGitProviders = () => {
 																			Action Required
 																		</Badge>
 																		<Link
-																			href={`${gitProvider?.github?.githubAppName}/installations/new?state=gh_setup:${gitProvider?.github.githubId}`}
+																			href={`${gitProvider?.github?.githubAppName}/installations/new?state=gh_setup:${gitProvider?.github?.githubId}`}
 																			className={buttonVariants({
 																				size: "icon",
 																				variant: "ghost",
@@ -280,7 +274,7 @@ export const ShowGitProviders = () => {
 																			href={getGitlabUrl(
 																				gitProvider.gitlab?.applicationId || "",
 																				gitProvider.gitlab?.gitlabId || "",
-																				gitProvider.gitlab?.gitlabUrl,
+																				gitProvider.gitlab?.gitlabUrl || "",
 																			)}
 																			target="_blank"
 																			className={buttonVariants({
@@ -295,29 +289,27 @@ export const ShowGitProviders = () => {
 
 																{canManage && (
 																	<>
-																		{isGithub && haveGithubRequirements && (
+																		{isGithub && haveGithubRequirements && gitProvider.github?.githubId && (
 																			<EditGithubProvider
-																				githubId={gitProvider.github?.githubId}
+																				githubId={gitProvider.github.githubId}
 																			/>
 																		)}
 
-																		{isGitlab && (
+																		{isGitlab && gitProvider.gitlab?.gitlabId && (
 																			<EditGitlabProvider
-																				gitlabId={gitProvider.gitlab?.gitlabId}
+																				gitlabId={gitProvider.gitlab.gitlabId}
 																			/>
 																		)}
 
-																		{isBitbucket && (
+																		{isBitbucket && gitProvider.bitbucket?.bitbucketId && (
 																			<EditBitbucketProvider
-																				bitbucketId={
-																					gitProvider.bitbucket?.bitbucketId
-																				}
+																				bitbucketId={gitProvider.bitbucket.bitbucketId}
 																			/>
 																		)}
 
-																		{isGitea && (
+																		{isGitea && gitProvider.gitea?.giteaId && (
 																			<EditGiteaProvider
-																				giteaId={gitProvider.gitea?.giteaId}
+																				giteaId={gitProvider.gitea.giteaId}
 																			/>
 																		)}
 

--- a/apps/dokploy/components/dashboard/settings/git/show-git-providers.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/show-git-providers.tsx
@@ -289,23 +289,29 @@ export const ShowGitProviders = () => {
 
 																{canManage && (
 																	<>
-																		{isGithub && haveGithubRequirements && gitProvider.github?.githubId && (
-																			<EditGithubProvider
-																				githubId={gitProvider.github.githubId}
-																			/>
-																		)}
+																		{isGithub &&
+																			haveGithubRequirements &&
+																			gitProvider.github?.githubId && (
+																				<EditGithubProvider
+																					githubId={gitProvider.github.githubId}
+																				/>
+																			)}
 
-																		{isGitlab && gitProvider.gitlab?.gitlabId && (
-																			<EditGitlabProvider
-																				gitlabId={gitProvider.gitlab.gitlabId}
-																			/>
-																		)}
+																		{isGitlab &&
+																			gitProvider.gitlab?.gitlabId && (
+																				<EditGitlabProvider
+																					gitlabId={gitProvider.gitlab.gitlabId}
+																				/>
+																			)}
 
-																		{isBitbucket && gitProvider.bitbucket?.bitbucketId && (
-																			<EditBitbucketProvider
-																				bitbucketId={gitProvider.bitbucket.bitbucketId}
-																			/>
-																		)}
+																		{isBitbucket &&
+																			gitProvider.bitbucket?.bitbucketId && (
+																				<EditBitbucketProvider
+																					bitbucketId={
+																						gitProvider.bitbucket.bitbucketId
+																					}
+																				/>
+																			)}
 
 																		{isGitea && gitProvider.gitea?.giteaId && (
 																			<EditGiteaProvider

--- a/apps/dokploy/server/api/routers/git-provider.ts
+++ b/apps/dokploy/server/api/routers/git-provider.ts
@@ -42,6 +42,43 @@ export const gitProviderRouter = createTRPCRouter({
 		return results.map((r) => ({
 			...r,
 			isOwner: r.userId === ctx.session.userId,
+			github: r.github
+				? {
+						githubId: r.github.githubId,
+						githubAppName: r.github.githubAppName,
+						githubAppId: r.github.githubAppId,
+						githubInstallationId: r.github.githubInstallationId,
+						isConfigured: !!(
+							r.github.githubPrivateKey &&
+							r.github.githubAppId &&
+							r.github.githubInstallationId
+						),
+					}
+				: null,
+			gitlab: r.gitlab
+				? {
+						gitlabId: r.gitlab.gitlabId,
+						applicationId: r.gitlab.applicationId,
+						gitlabUrl: r.gitlab.gitlabUrl,
+						isConfigured: !!(r.gitlab.accessToken && r.gitlab.refreshToken),
+					}
+				: null,
+			bitbucket: r.bitbucket
+				? {
+						bitbucketId: r.bitbucket.bitbucketId,
+						bitbucketUsername: r.bitbucket.bitbucketUsername,
+						isConfigured: false,
+						isDeprecated: !!(r.bitbucket.appPassword && !r.bitbucket.apiToken),
+					}
+				: null,
+			gitea: r.gitea
+				? {
+						giteaId: r.gitea.giteaId,
+						giteaUrl: r.gitea.giteaUrl,
+						clientId: r.gitea.clientId,
+						isConfigured: !!(r.gitea.accessToken && r.gitea.refreshToken),
+					}
+				: null,
 		}));
 	}),
 


### PR DESCRIPTION
## Summary

Fixes #4441

The `gitProvider.getAll` endpoint was returning all columns from the database joins, including sensitive credentials (RSA private keys, OAuth tokens, client secrets, webhook secrets) to any authenticated user with list permissions.

- Server-side query still fetches all fields to compute derived boolean flags (`isConfigured`, `isDeprecated`)
- The `.map()` return explicitly allowlists only safe fields — no secrets are serialized in the tRPC response
- UI updated to use `isConfigured` / `isDeprecated` flags instead of checking credential values directly

**Fields now stripped from the response:**
- GitHub: `githubPrivateKey`, `githubClientSecret`, `githubWebhookSecret`
- GitLab: `accessToken`, `refreshToken`, `clientSecret`
- Bitbucket: `appPassword`, `apiToken`
- Gitea: `accessToken`, `refreshToken`, `clientSecret`