### PR TITLE
feat: add container resource breakdown to monitoring

### DIFF
--- a/apps/dokploy/__test__/monitoring/container-resource-usage.test.ts
+++ b/apps/dokploy/__test__/monitoring/container-resource-usage.test.ts
@@ -1,0 +1,130 @@
+import { parseDockerTopProcesses } from "@dokploy/server/services/docker";
+import { describe, expect, test } from "vitest";
+import {
+	type ContainerResourceStat,
+	getContainerResourceValues,
+	parseDockerSize,
+	sortContainerStats,
+} from "@/components/dashboard/monitoring/container-resource-usage/utils";
+
+const stats: ContainerResourceStat[] = [
+	{
+		BlockIO: "1.2MB / 300kB",
+		CPUPerc: "8.50%",
+		Container: "api",
+		ID: "a1",
+		MemPerc: "20.00%",
+		MemUsage: "512MiB / 2GiB",
+		Name: "api",
+		NetIO: "2MB / 1MB",
+		Size: "1.2MB (virtual 120MB)",
+	},
+	{
+		BlockIO: "20MB / 12MB",
+		CPUPerc: "1.20%",
+		Container: "worker",
+		ID: "b2",
+		MemPerc: "40.00%",
+		MemUsage: "1.5GiB / 4GiB",
+		Name: "worker",
+		NetIO: "4MB / 8MB",
+		Size: "512kB (virtual 80MB)",
+	},
+	{
+		BlockIO: "500kB / 200kB",
+		CPUPerc: "65.30%",
+		Container: "db",
+		ID: "c3",
+		MemPerc: "10.00%",
+		MemUsage: "256MiB / 8GiB",
+		Name: "db",
+		NetIO: "1MB / 900kB",
+		Size: "2.5GB (virtual 4GB)",
+	},
+];
+
+describe("container resource usage utils", () => {
+	test("parses Docker size units into bytes for sorting", () => {
+		expect(parseDockerSize("1KiB")).toBe(1024);
+		expect(parseDockerSize("1MiB")).toBe(1024 ** 2);
+		expect(parseDockerSize("1.5GiB")).toBe(1.5 * 1024 ** 3);
+		expect(parseDockerSize("20MB")).toBe(20 * 1000 ** 2);
+		expect(parseDockerSize("300kB")).toBe(300 * 1000);
+		expect(parseDockerSize("0B")).toBe(0);
+		expect(parseDockerSize("--")).toBe(0);
+	});
+
+	test("extracts comparable numeric values from docker stats output", () => {
+		const workerStat = stats[1];
+		expect(workerStat).toBeDefined();
+
+		const values = getContainerResourceValues(workerStat!);
+
+		expect(values.cpuPercent).toBe(1.2);
+		expect(values.memoryUsedBytes).toBe(1.5 * 1024 ** 3);
+		expect(values.memoryLimitBytes).toBe(4 * 1024 ** 3);
+		expect(values.blockTotalBytes).toBe(32 * 1000 ** 2);
+		expect(values.networkTotalBytes).toBe(12 * 1000 ** 2);
+		expect(values.diskSizeBytes).toBe(512 * 1000);
+		expect(values.virtualSizeBytes).toBe(80 * 1000 ** 2);
+	});
+
+	test("sorts containers by the selected resource pressure", () => {
+		expect(sortContainerStats(stats, "cpu").map((stat) => stat.Name)).toEqual([
+			"db",
+			"api",
+			"worker",
+		]);
+
+		expect(
+			sortContainerStats(stats, "memory").map((stat) => stat.Name),
+		).toEqual(["worker", "api", "db"]);
+
+		expect(sortContainerStats(stats, "block").map((stat) => stat.Name)).toEqual(
+			["worker", "api", "db"],
+		);
+
+		expect(sortContainerStats(stats, "size").map((stat) => stat.Name)).toEqual([
+			"db",
+			"api",
+			"worker",
+		]);
+	});
+});
+
+describe("parseDockerTopProcesses", () => {
+	test("parses docker top output and sorts processes by CPU then memory", () => {
+		const output = [
+			"PID %CPU %MEM RSS COMMAND",
+			"101 0.4 1.2 20480 nginx: worker process",
+			"102 18.5 0.7 10240 node /app/server.js --port 3000",
+			"103 18.5 3.1 40960 postgres: checkpointer",
+		].join("\n");
+
+		const processes = parseDockerTopProcesses(output);
+
+		expect(processes).toEqual([
+			{
+				command: "postgres: checkpointer",
+				cpuPercent: 18.5,
+				memoryPercent: 3.1,
+				pid: "103",
+				rssBytes: 40960 * 1024,
+			},
+			{
+				command: "node /app/server.js --port 3000",
+				cpuPercent: 18.5,
+				memoryPercent: 0.7,
+				pid: "102",
+				rssBytes: 10240 * 1024,
+			},
+			{
+				command: "nginx: worker process",
+				cpuPercent: 0.4,
+				memoryPercent: 1.2,
+				pid: "101",
+				rssBytes: 20480 * 1024,
+			},
+		]);
+	});
+});

--- a/apps/dokploy/components/dashboard/monitoring/container-resource-usage/container-resource-usage.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/container-resource-usage/container-resource-usage.tsx
@@ -1,0 +1,466 @@
+import {
+	Activity,
+	ArrowDownUp,
+	ChevronDown,
+	ChevronRight,
+	HardDrive,
+	Loader2,
+	MemoryStick,
+	Network,
+	RefreshCw,
+} from "lucide-react";
+import { Fragment, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { api, type RouterOutputs } from "@/utils/api";
+import {
+	type ContainerResourceSort,
+	type ContainerResourceStat,
+	formatDockerStatSize,
+	getContainerResourceValues,
+	sortContainerStats,
+} from "./utils";
+
+const SORT_LABELS: Record<ContainerResourceSort, string> = {
+	block: "Disk I/O",
+	cpu: "CPU",
+	memory: "Memory",
+	network: "Network",
+	size: "Disk Size",
+};
+
+const getPressureBadge = (value: number) => {
+	if (value >= 90) return "destructive";
+	if (value >= 70) return "orange";
+	if (value >= 40) return "yellow";
+	return "secondary";
+};
+
+const getTopContainer = (
+	stats: ContainerResourceStat[],
+	sortBy: ContainerResourceSort,
+) => {
+	const [topContainer] = sortContainerStats(stats, sortBy);
+	return topContainer;
+};
+
+type ContainerProcess =
+	RouterOutputs["server"]["getContainerProcesses"][number];
+
+const ContainerProcesses = ({ containerId }: { containerId: string }) => {
+	const { data, error, isLoading } = api.server.getContainerProcesses.useQuery(
+		{ containerId },
+		{
+			enabled: Boolean(containerId),
+			refetchInterval: 5000,
+			refetchOnWindowFocus: false,
+		},
+	);
+
+	const processes = (data ?? []) as ContainerProcess[];
+
+	return (
+		<div className="p-3">
+			<div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+				<div>
+					<p className="text-sm font-medium">Processes</p>
+					<p className="text-xs text-muted-foreground">
+						Top 20 by CPU; refreshes every 5 seconds.
+					</p>
+				</div>
+			</div>
+
+			{isLoading ? (
+				<div className="flex min-h-24 items-center justify-center gap-2 text-sm text-muted-foreground">
+					<Loader2 className="size-4 animate-spin" />
+					Loading processes...
+				</div>
+			) : error ? (
+				<div className="rounded-md border border-destructive/40 p-3">
+					<p className="text-sm font-medium text-destructive">
+						Error loading processes
+					</p>
+					<p className="mt-1 text-sm text-muted-foreground">
+						{error instanceof Error
+							? error.message
+							: "Unable to read container processes."}
+					</p>
+				</div>
+			) : processes.length === 0 ? (
+				<p className="rounded-md border p-3 text-sm text-muted-foreground">
+					No processes reported by Docker top.
+				</p>
+			) : (
+				<div className="overflow-x-auto rounded-md border">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>PID</TableHead>
+								<TableHead className="text-right">CPU</TableHead>
+								<TableHead className="text-right">Memory</TableHead>
+								<TableHead className="text-right">RSS</TableHead>
+								<TableHead>Command</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{processes.map((process) => (
+								<TableRow key={`${process.pid}-${process.command}`}>
+									<TableCell className="font-mono text-xs">
+										{process.pid}
+									</TableCell>
+									<TableCell className="text-right">
+										<Badge variant={getPressureBadge(process.cpuPercent)}>
+											{process.cpuPercent.toFixed(1)}%
+										</Badge>
+									</TableCell>
+									<TableCell className="text-right">
+										<Badge variant={getPressureBadge(process.memoryPercent)}>
+											{process.memoryPercent.toFixed(1)}%
+										</Badge>
+									</TableCell>
+									<TableCell className="text-right">
+										{formatDockerStatSize(process.rssBytes)}
+									</TableCell>
+									<TableCell>
+										<span className="block max-w-[520px] truncate font-mono text-xs">
+											{process.command}
+										</span>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export const ContainerResourceUsage = () => {
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [expandedContainerId, setExpandedContainerId] = useState<string | null>(
+		null,
+	);
+	const [sortBy, setSortBy] = useState<ContainerResourceSort>("cpu");
+
+	const { data, error, isLoading, isRefetching, refetch } =
+		api.server.getContainerResourceStats.useQuery(undefined, {
+			enabled: isExpanded,
+			refetchInterval: isExpanded ? 5000 : undefined,
+			refetchOnWindowFocus: false,
+		});
+
+	const stats = (data ?? []) as ContainerResourceStat[];
+	const sortedStats = useMemo(
+		() => sortContainerStats(stats, sortBy).slice(0, 12),
+		[sortBy, stats],
+	);
+
+	const topCpuContainer = getTopContainer(stats, "cpu");
+	const topMemoryContainer = getTopContainer(stats, "memory");
+	const topSizeContainer = getTopContainer(stats, "size");
+	const topBlockContainer = getTopContainer(stats, "block");
+	const topNetworkContainer = getTopContainer(stats, "network");
+
+	const topCpuValues = topCpuContainer
+		? getContainerResourceValues(topCpuContainer)
+		: undefined;
+	const topMemoryValues = topMemoryContainer
+		? getContainerResourceValues(topMemoryContainer)
+		: undefined;
+	const topSizeValues = topSizeContainer
+		? getContainerResourceValues(topSizeContainer)
+		: undefined;
+	const topBlockValues = topBlockContainer
+		? getContainerResourceValues(topBlockContainer)
+		: undefined;
+	const topNetworkValues = topNetworkContainer
+		? getContainerResourceValues(topNetworkContainer)
+		: undefined;
+
+	return (
+		<Card className="bg-background">
+			<CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
+				<div className="space-y-1">
+					<CardTitle className="text-sm font-medium flex items-center gap-2">
+						<Activity className="size-4 text-muted-foreground" />
+						Resource Usage
+					</CardTitle>
+					<p className="text-sm text-muted-foreground">
+						Find which running containers are using CPU, memory, disk I/O, and
+						network right now.
+					</p>
+				</div>
+				<div className="flex items-center gap-2">
+					{isExpanded && (
+						<Button
+							variant="ghost"
+							size="icon"
+							className="size-8"
+							onClick={() => refetch()}
+							disabled={isRefetching}
+						>
+							<RefreshCw
+								className={`size-4 ${isRefetching ? "animate-spin" : ""}`}
+							/>
+						</Button>
+					)}
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setIsExpanded((value) => !value)}
+					>
+						<ArrowDownUp className="size-4 mr-2" />
+						{isExpanded ? "Hide breakdown" : "View breakdown"}
+					</Button>
+				</div>
+			</CardHeader>
+
+			{isExpanded && (
+				<CardContent className="flex flex-col gap-4">
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<Tabs
+							value={sortBy}
+							onValueChange={(value) =>
+								setSortBy(value as ContainerResourceSort)
+							}
+						>
+							<TabsList>
+								<TabsTrigger value="cpu">CPU</TabsTrigger>
+								<TabsTrigger value="memory">Memory</TabsTrigger>
+								<TabsTrigger value="size">Disk Size</TabsTrigger>
+								<TabsTrigger value="block">Disk I/O</TabsTrigger>
+								<TabsTrigger value="network">Network</TabsTrigger>
+							</TabsList>
+						</Tabs>
+						<p className="text-xs text-muted-foreground">
+							Sorted by {SORT_LABELS[sortBy]}; refreshes every 5 seconds.
+						</p>
+					</div>
+
+					{topCpuContainer &&
+						topCpuValues &&
+						topMemoryContainer &&
+						topMemoryValues &&
+						topSizeContainer &&
+						topSizeValues &&
+						topBlockContainer &&
+						topBlockValues &&
+						topNetworkContainer &&
+						topNetworkValues && (
+							<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+								<div className="rounded-md border p-3">
+									<div className="flex items-center gap-2 text-xs text-muted-foreground">
+										<Activity className="size-3.5" />
+										Top CPU
+									</div>
+									<p className="mt-1 text-sm font-medium">
+										{topCpuContainer.Name}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{topCpuValues.cpuPercent.toFixed(1)}%
+									</p>
+								</div>
+								<div className="rounded-md border p-3">
+									<div className="flex items-center gap-2 text-xs text-muted-foreground">
+										<MemoryStick className="size-3.5" />
+										Memory Used
+									</div>
+									<p className="mt-1 text-sm font-medium">
+										{formatDockerStatSize(topMemoryValues.memoryUsedBytes)}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{topMemoryContainer.Name} - {topMemoryContainer.MemUsage}
+									</p>
+								</div>
+								<div className="rounded-md border p-3">
+									<div className="flex items-center gap-2 text-xs text-muted-foreground">
+										<HardDrive className="size-3.5" />
+										Disk Size
+									</div>
+									<p className="mt-1 text-sm font-medium">
+										{formatDockerStatSize(topSizeValues.diskSizeBytes)}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{topSizeContainer.Name} - {topSizeContainer.Size || "--"}
+									</p>
+								</div>
+								<div className="rounded-md border p-3">
+									<div className="flex items-center gap-2 text-xs text-muted-foreground">
+										<HardDrive className="size-3.5" />
+										Disk I/O
+									</div>
+									<p className="mt-1 text-sm font-medium">
+										{formatDockerStatSize(topBlockValues.blockTotalBytes)}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{topBlockContainer.Name} - {topBlockContainer.BlockIO}
+									</p>
+								</div>
+								<div className="rounded-md border p-3">
+									<div className="flex items-center gap-2 text-xs text-muted-foreground">
+										<Network className="size-3.5" />
+										Network I/O
+									</div>
+									<p className="mt-1 text-sm font-medium">
+										{formatDockerStatSize(topNetworkValues.networkTotalBytes)}
+									</p>
+									<p className="text-xs text-muted-foreground">
+										{topNetworkContainer.Name} - {topNetworkContainer.NetIO}
+									</p>
+								</div>
+							</div>
+						)}
+
+					{isLoading ? (
+						<div className="flex min-h-40 items-center justify-center gap-2 text-sm text-muted-foreground">
+							<Loader2 className="size-4 animate-spin" />
+							Loading container usage...
+						</div>
+					) : error ? (
+						<div className="rounded-md border border-destructive/40 p-4">
+							<p className="text-sm font-medium text-destructive">
+								Error loading container usage
+							</p>
+							<p className="mt-1 text-sm text-muted-foreground">
+								{error instanceof Error
+									? error.message
+									: "Unable to read Docker stats."}
+							</p>
+						</div>
+					) : sortedStats.length === 0 ? (
+						<p className="rounded-md border p-4 text-sm text-muted-foreground">
+							No running containers reported by Docker stats.
+						</p>
+					) : (
+						<div className="overflow-x-auto">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead className="w-10" />
+										<TableHead>Container</TableHead>
+										<TableHead className="text-right">CPU</TableHead>
+										<TableHead className="text-right">Memory</TableHead>
+										<TableHead className="text-right">Disk Size</TableHead>
+										<TableHead className="text-right">Disk I/O</TableHead>
+										<TableHead className="text-right">Network I/O</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{sortedStats.map((stat) => {
+										const values = getContainerResourceValues(stat);
+										const isContainerExpanded = expandedContainerId === stat.ID;
+
+										return (
+											<Fragment key={`${stat.ID}-${stat.Name}`}>
+												<TableRow>
+													<TableCell>
+														<Button
+															variant="ghost"
+															size="icon"
+															className="size-7"
+															aria-label={
+																isContainerExpanded
+																	? `Hide processes for ${stat.Name}`
+																	: `Show processes for ${stat.Name}`
+															}
+															onClick={() =>
+																setExpandedContainerId((value) =>
+																	value === stat.ID ? null : stat.ID,
+																)
+															}
+														>
+															{isContainerExpanded ? (
+																<ChevronDown className="size-4" />
+															) : (
+																<ChevronRight className="size-4" />
+															)}
+														</Button>
+													</TableCell>
+													<TableCell>
+														<div className="flex flex-col gap-1">
+															<span className="font-medium">{stat.Name}</span>
+															<span className="max-w-[260px] truncate text-xs text-muted-foreground">
+																{stat.ID}
+															</span>
+														</div>
+													</TableCell>
+													<TableCell className="text-right">
+														<Badge
+															variant={getPressureBadge(values.cpuPercent)}
+														>
+															{values.cpuPercent.toFixed(1)}%
+														</Badge>
+													</TableCell>
+													<TableCell className="text-right">
+														<div className="flex flex-col items-end gap-1">
+															<Badge
+																variant={getPressureBadge(values.memoryPercent)}
+															>
+																{values.memoryPercent.toFixed(1)}%
+															</Badge>
+															<span className="text-xs text-muted-foreground">
+																{stat.MemUsage}
+															</span>
+														</div>
+													</TableCell>
+													<TableCell className="text-right">
+														<div className="flex flex-col items-end">
+															<span className="text-sm font-medium">
+																{formatDockerStatSize(values.diskSizeBytes)}
+															</span>
+															<span className="text-xs text-muted-foreground">
+																{stat.Size || "--"}
+															</span>
+														</div>
+													</TableCell>
+													<TableCell className="text-right">
+														<div className="flex flex-col items-end">
+															<span className="text-sm font-medium">
+																{formatDockerStatSize(values.blockTotalBytes)}
+															</span>
+															<span className="text-xs text-muted-foreground">
+																{stat.BlockIO}
+															</span>
+														</div>
+													</TableCell>
+													<TableCell className="text-right">
+														<div className="flex flex-col items-end">
+															<span className="text-sm font-medium">
+																{formatDockerStatSize(values.networkTotalBytes)}
+															</span>
+															<span className="text-xs text-muted-foreground">
+																{stat.NetIO}
+															</span>
+														</div>
+													</TableCell>
+												</TableRow>
+												{isContainerExpanded && (
+													<TableRow>
+														<TableCell colSpan={7} className="bg-muted/20 p-0">
+															<ContainerProcesses containerId={stat.ID} />
+														</TableCell>
+													</TableRow>
+												)}
+											</Fragment>
+										);
+									})}
+								</TableBody>
+							</Table>
+						</div>
+					)}
+				</CardContent>
+			)}
+		</Card>
+	);
+};

--- a/apps/dokploy/components/dashboard/monitoring/container-resource-usage/utils.ts
+++ b/apps/dokploy/components/dashboard/monitoring/container-resource-usage/utils.ts
@@ -1,0 +1,150 @@
+export interface ContainerResourceStat {
+	BlockIO: string;
+	CPUPerc: string;
+	Container: string;
+	ID: string;
+	MemPerc: string;
+	MemUsage: string;
+	Name: string;
+	NetIO: string;
+	Size?: string;
+}
+
+export type ContainerResourceSort =
+	| "cpu"
+	| "memory"
+	| "size"
+	| "block"
+	| "network";
+
+export interface ContainerResourceValues {
+	blockReadBytes: number;
+	blockTotalBytes: number;
+	blockWriteBytes: number;
+	cpuPercent: number;
+	diskSizeBytes: number;
+	memoryLimitBytes: number;
+	memoryPercent: number;
+	memoryUsedBytes: number;
+	networkInputBytes: number;
+	networkOutputBytes: number;
+	networkTotalBytes: number;
+	virtualSizeBytes: number;
+}
+
+const SIZE_UNITS: Record<string, number> = {
+	b: 1,
+	kb: 1000,
+	mb: 1000 ** 2,
+	gb: 1000 ** 3,
+	tb: 1000 ** 4,
+	kib: 1024,
+	mib: 1024 ** 2,
+	gib: 1024 ** 3,
+	tib: 1024 ** 4,
+};
+
+export const parseDockerPercent = (raw: string): number => {
+	const value = Number.parseFloat(raw.replace("%", ""));
+	return Number.isFinite(value) ? value : 0;
+};
+
+export const parseDockerSize = (raw: string): number => {
+	const match = raw.trim().match(/^([\d.]+)\s*([a-zA-Z]+)$/);
+	if (!match?.[1] || !match[2]) {
+		return 0;
+	}
+
+	const value = Number.parseFloat(match[1]);
+	const multiplier = SIZE_UNITS[match[2].toLowerCase()];
+	if (!Number.isFinite(value) || !multiplier) {
+		return 0;
+	}
+
+	return value * multiplier;
+};
+
+export const parseDockerPair = (
+	raw: string,
+): { leftBytes: number; rightBytes: number; totalBytes: number } => {
+	const [left = "", right = ""] = raw.split("/").map((part) => part.trim());
+	const leftBytes = parseDockerSize(left);
+	const rightBytes = parseDockerSize(right);
+
+	return {
+		leftBytes,
+		rightBytes,
+		totalBytes: leftBytes + rightBytes,
+	};
+};
+
+export const parseDockerContainerSize = (
+	raw: string | undefined,
+): { diskSizeBytes: number; virtualSizeBytes: number } => {
+	if (!raw) {
+		return {
+			diskSizeBytes: 0,
+			virtualSizeBytes: 0,
+		};
+	}
+
+	const [diskSize = ""] = raw.split("(");
+	const virtualMatch = raw.match(/\(virtual\s+([^)]+)\)/i);
+
+	return {
+		diskSizeBytes: parseDockerSize(diskSize.trim()),
+		virtualSizeBytes: parseDockerSize(virtualMatch?.[1]?.trim() ?? ""),
+	};
+};
+
+export const getContainerResourceValues = (
+	stat: ContainerResourceStat,
+): ContainerResourceValues => {
+	const memory = parseDockerPair(stat.MemUsage);
+	const block = parseDockerPair(stat.BlockIO);
+	const network = parseDockerPair(stat.NetIO);
+	const size = parseDockerContainerSize(stat.Size);
+
+	return {
+		blockReadBytes: block.leftBytes,
+		blockTotalBytes: block.totalBytes,
+		blockWriteBytes: block.rightBytes,
+		cpuPercent: parseDockerPercent(stat.CPUPerc),
+		diskSizeBytes: size.diskSizeBytes,
+		memoryLimitBytes: memory.rightBytes,
+		memoryPercent: parseDockerPercent(stat.MemPerc),
+		memoryUsedBytes: memory.leftBytes,
+		networkInputBytes: network.leftBytes,
+		networkOutputBytes: network.rightBytes,
+		networkTotalBytes: network.totalBytes,
+		virtualSizeBytes: size.virtualSizeBytes,
+	};
+};
+
+export const sortContainerStats = (
+	stats: ContainerResourceStat[],
+	sortBy: ContainerResourceSort,
+) => {
+	return [...stats].sort((a, b) => {
+		const aValues = getContainerResourceValues(a);
+		const bValues = getContainerResourceValues(b);
+
+		const sortValues: Record<ContainerResourceSort, [number, number]> = {
+			block: [aValues.blockTotalBytes, bValues.blockTotalBytes],
+			cpu: [aValues.cpuPercent, bValues.cpuPercent],
+			memory: [aValues.memoryUsedBytes, bValues.memoryUsedBytes],
+			network: [aValues.networkTotalBytes, bValues.networkTotalBytes],
+			size: [aValues.diskSizeBytes, bValues.diskSizeBytes],
+		};
+		const [aValue, bValue] = sortValues[sortBy];
+
+		return bValue - aValue;
+	});
+};
+
+export const formatDockerStatSize = (bytes: number): string => {
+	if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+	if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+	if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+	return `${bytes.toFixed(0)} B`;
+};

--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { api } from "@/utils/api";
+import { ContainerResourceUsage } from "../../container-resource-usage/container-resource-usage";
 import { DockerBlockChart } from "./docker-block-chart";
 import { DockerCpuChart } from "./docker-cpu-chart";
 import { DockerDiskChart } from "./docker-disk-chart";
@@ -211,6 +212,8 @@ export const ContainerFreeMonitoring = ({
 					</p>
 				</div>
 			</header>
+
+			{appName === "dokploy" && <ContainerResourceUsage />}
 
 			<div className="grid gap-6 lg:grid-cols-2">
 				<Card className="bg-background">

--- a/apps/dokploy/server/api/routers/server.ts
+++ b/apps/dokploy/server/api/routers/server.ts
@@ -6,6 +6,8 @@ import {
 	findServersByUserId,
 	findUserById,
 	getAccessibleServerIds,
+	getAllContainerStats,
+	getContainerProcesses,
 	getPublicIpWithFallback,
 	haveActiveServices,
 	IS_CLOUD,
@@ -552,5 +554,33 @@ export const serverRouter = createTRPCRouter({
 			} catch (error) {
 				throw error;
 			}
+		}),
+	getContainerResourceStats: withPermission("monitoring", "read").query(
+		async () => {
+			if (IS_CLOUD) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "Functionality not available in cloud version",
+				});
+			}
+
+			return await getAllContainerStats();
+		},
+	),
+	getContainerProcesses: withPermission("monitoring", "read")
+		.input(
+			z.object({
+				containerId: z.string().regex(/^[a-zA-Z0-9.\-_]+$/),
+			}),
+		)
+		.query(async ({ input }) => {
+			if (IS_CLOUD) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "Functionality not available in cloud version",
+				});
+			}
+
+			return await getContainerProcesses(input.containerId);
 		}),
 });

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -627,30 +627,118 @@ export const getApplicationInfo = async (
 
 export const getAllContainerStats = async (serverId?: string) => {
 	try {
-		let stdout = "";
-		const command =
+		const statsCommand =
 			'docker stats --no-stream --format \'{"BlockIO":"{{.BlockIO}}","CPUPerc":"{{.CPUPerc}}","Container":"{{.Container}}","ID":"{{.ID}}","MemPerc":"{{.MemPerc}}","MemUsage":"{{.MemUsage}}","Name":"{{.Name}}","NetIO":"{{.NetIO}}"}\'';
+		const sizeCommand =
+			'docker ps --size --format \'{"ID":"{{.ID}}","Name":"{{.Names}}","Size":"{{.Size}}"}\'';
 
+		let statsStdout = "";
+		let sizeStdout = "";
 		if (serverId) {
-			const result = await execAsyncRemote(serverId, command);
-			stdout = result.stdout;
+			const statsResult = await execAsyncRemote(serverId, statsCommand);
+			const sizeResult = await execAsyncRemote(serverId, sizeCommand);
+			statsStdout = statsResult.stdout;
+			sizeStdout = sizeResult.stdout;
 		} else {
-			const result = await execAsync(command);
-			stdout = result.stdout;
+			const statsResult = await execAsync(statsCommand);
+			const sizeResult = await execAsync(sizeCommand);
+			statsStdout = statsResult.stdout;
+			sizeStdout = sizeResult.stdout;
 		}
 
-		if (!stdout.trim()) {
+		if (!statsStdout.trim()) {
 			return [];
 		}
 
-		const stats = stdout
+		const sizeByContainerId = new Map<string, string>();
+		if (sizeStdout.trim()) {
+			const sizes = sizeStdout
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+
+			for (const size of sizes) {
+				sizeByContainerId.set(size.ID, size.Size);
+			}
+		}
+
+		const stats = statsStdout
 			.trim()
 			.split("\n")
-			.map((line) => JSON.parse(line));
+			.map((line) => {
+				const stat = JSON.parse(line);
+				return {
+					...stat,
+					Size: sizeByContainerId.get(stat.ID) ?? "",
+				};
+			});
 
 		return stats;
 	} catch (error) {
 		console.error("getAllContainerStats error:", error);
+		return [];
+	}
+};
+
+export interface DockerContainerProcess {
+	command: string;
+	cpuPercent: number;
+	memoryPercent: number;
+	pid: string;
+	rssBytes: number;
+}
+
+export const parseDockerTopProcesses = (
+	output: string,
+): DockerContainerProcess[] => {
+	const [, ...lines] = output.trim().split("\n");
+
+	return lines
+		.map((line) => {
+			const match = line.trim().match(/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/);
+			if (!match?.[1] || !match[2] || !match[3] || !match[4] || !match[5]) {
+				return null;
+			}
+
+			const cpuPercent = Number.parseFloat(match[2]);
+			const memoryPercent = Number.parseFloat(match[3]);
+			const rssKb = Number.parseFloat(match[4]);
+
+			return {
+				command: match[5],
+				cpuPercent: Number.isFinite(cpuPercent) ? cpuPercent : 0,
+				memoryPercent: Number.isFinite(memoryPercent) ? memoryPercent : 0,
+				pid: match[1],
+				rssBytes: Number.isFinite(rssKb) ? rssKb * 1024 : 0,
+			};
+		})
+		.filter((process): process is DockerContainerProcess => process !== null)
+		.sort((a, b) => {
+			if (b.cpuPercent !== a.cpuPercent) {
+				return b.cpuPercent - a.cpuPercent;
+			}
+			return b.memoryPercent - a.memoryPercent;
+		});
+};
+
+export const getContainerProcesses = async (
+	containerId: string,
+	serverId?: string,
+) => {
+	const containerIdRegex = /^[a-zA-Z0-9.\-_]+$/;
+	if (!containerIdRegex.test(containerId)) {
+		throw new Error("Invalid container ID");
+	}
+
+	try {
+		const command = `docker top ${containerId} -eo pid,pcpu,pmem,rss,args`;
+		const result = serverId
+			? await execAsyncRemote(serverId, command)
+			: await execAsync(command);
+
+		return parseDockerTopProcesses(result.stdout).slice(0, 20);
+	} catch (error) {
+		console.error("getContainerProcesses error:", error);
 		return [];
 	}
 };


### PR DESCRIPTION
## What is this PR about?

This PR adds a self-hosted Resource Usage breakdown to the Monitoring page. It shows the current CPU, memory, disk size, disk I/O, and network I/O usage per running Docker container, and lets users expand a container row to inspect its top processes by CPU/memory usage.

The feature is only exposed for the Dokploy container monitoring view and reuses the existing `monitoring:read` permission. Docker container IDs are validated before running `docker top`, and the Cloud version keeps the same restricted behavior as the existing monitoring endpoints.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Testing

- [x] `corepack pnpm --dir apps/dokploy exec vitest --config __test__/vitest.config.ts __test__/monitoring/container-resource-usage.test.ts --run`
- [x] `corepack pnpm exec biome check apps/dokploy/__test__/monitoring/container-resource-usage.test.ts apps/dokploy/components/dashboard/monitoring/container-resource-usage/container-resource-usage.tsx apps/dokploy/components/dashboard/monitoring/container-resource-usage/utils.ts apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx apps/dokploy/server/api/routers/server.ts packages/server/src/services/docker.ts`
- [x] `corepack pnpm --filter=dokploy run typecheck`
- [x] `corepack pnpm --filter=server run typecheck`
- [x] `corepack pnpm --filter=dokploy run build-server`
- [x] `corepack pnpm --filter=dokploy run build-next`
- [x] `corepack pnpm --filter=server run build`
- [x] Tested locally at `http://localhost:3000/dashboard/monitoring` with the Resource Usage table expanded and container process drill-down verified.

## Issues related (if applicable)

Closes #4653

## Screenshots (if applicable)

![Resource Usage breakdown](https://raw.githubusercontent.com/agentHits/dokploy/pr-assets-monitoring-resource-usage/monitoring-resource-usage.png)

