### PR TITLE
feat: add docker disk usage details

### DIFF
--- a/apps/dokploy/__test__/monitoring/docker-disk-usage.test.ts
+++ b/apps/dokploy/__test__/monitoring/docker-disk-usage.test.ts
@@ -1,0 +1,98 @@
+import {
+	parseDockerDiskUsageSummary,
+	parseDockerDiskUsageVerbose,
+} from "@dokploy/server/utils/docker/utils";
+import { describe, expect, test } from "vitest";
+
+const summaryOutput = [
+	'{"Active":"3","Reclaimable":"92.61MB (0%)","Size":"15.84GB","TotalCount":"4","Type":"Images"}',
+	'{"Active":"3","Reclaimable":"0B (0%)","Size":"53.25kB","TotalCount":"3","Type":"Containers"}',
+	'{"Active":"2","Reclaimable":"0B (0%)","Size":"68.57MB","TotalCount":"2","Type":"Local Volumes"}',
+	'{"Active":"0","Reclaimable":"15.2GB","Size":"15.2GB","TotalCount":"326","Type":"Build Cache"}',
+].join("\n");
+
+const verboseOutput = [
+	"Images space usage:",
+	"",
+	"REPOSITORY   TAG       IMAGE ID       CREATED        SIZE      SHARED SIZE   UNIQUE SIZE   CONTAINERS",
+	"nginx        alpine    8b1e78743a03   2 weeks ago    92.6MB    0B            92.61MB       0",
+	"postgres     16        4b7183ac05f8   2 weeks ago    663MB     0B            662.9MB       1",
+	"",
+	"Containers space usage:",
+	"",
+	"CONTAINER ID   IMAGE            COMMAND                  LOCAL VOLUMES   SIZE      CREATED             STATUS             NAMES",
+	'057f8980d33f   postgres:16      "docker-entrypoint.s…"   1               20.5kB    About an hour ago   Up About an hour   dokploy-postgres.1.test',
+	'fc4976a35ce3   redis:7          "docker-entrypoint.s…"   1               4.1kB     About an hour ago   Up About an hour   dokploy-redis.1.test',
+	"",
+	"Local Volumes space usage:",
+	"",
+	"VOLUME NAME        LINKS     SIZE",
+	"dokploy-redis      1         226B",
+	"dokploy-postgres   1         68.57MB",
+	"",
+	"Build cache usage: 15.2GB",
+	"",
+	"CACHE ID       CACHE TYPE     SIZE      CREATED       LAST USED     USAGE     SHARED",
+	"8vq5d5k500k0   regular        13.4MB    5 days ago    5 days ago    1         false",
+	"gso67gl55f9c   regular        123MB     5 days ago    5 days ago    1         false",
+].join("\n");
+
+describe("parseDockerDiskUsageSummary", () => {
+	test("parses Docker system df summary output", () => {
+		expect(parseDockerDiskUsageSummary(summaryOutput)).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					active: 3,
+					reclaimable: "92.61MB (0%)",
+					size: "15.84GB",
+					sizeBytes: 15.84 * 1024 ** 3,
+					totalCount: 4,
+					type: "Images",
+				}),
+				expect.objectContaining({
+					active: 3,
+					size: "53.25kB",
+					sizeBytes: 53.25 * 1024,
+					totalCount: 3,
+					type: "Containers",
+				}),
+			]),
+		);
+	});
+});
+
+describe("parseDockerDiskUsageVerbose", () => {
+	test("parses verbose Docker disk usage sections and sorts details by size", () => {
+		const details = parseDockerDiskUsageVerbose(verboseOutput);
+
+		expect(details.images[0]).toEqual(
+			expect.objectContaining({
+				id: "4b7183ac05f8",
+				name: "postgres:16",
+				size: "663MB",
+				sizeBytes: 663 * 1024 ** 2,
+			}),
+		);
+		expect(details.containers[0]).toEqual(
+			expect.objectContaining({
+				id: "057f8980d33f",
+				name: "dokploy-postgres.1.test",
+				size: "20.5kB",
+			}),
+		);
+		expect(details.volumes[0]).toEqual(
+			expect.objectContaining({
+				id: "dokploy-postgres",
+				name: "dokploy-postgres",
+				size: "68.57MB",
+			}),
+		);
+		expect(details.buildCache[0]).toEqual(
+			expect.objectContaining({
+				id: "gso67gl55f9c",
+				name: "regular",
+				size: "123MB",
+			}),
+		);
+	});
+});

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx
@@ -1,5 +1,5 @@
-import { Loader2, RefreshCw } from "lucide-react";
-import { useMemo } from "react";
+import { ChevronDown, ChevronRight, Loader2, RefreshCw } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Cell, Label, Pie, PieChart } from "recharts";
 import { Button } from "@/components/ui/button";
 import {
@@ -52,6 +52,7 @@ const getChartLabel = (name: string) =>
 	chartConfig[name as keyof typeof chartConfig]?.label ?? name;
 
 export const DockerDiskUsageChart = () => {
+	const [showDetails, setShowDetails] = useState(true);
 	const { data, isLoading, refetch, isRefetching } =
 		api.settings.getDockerDiskUsage.useQuery(undefined, {
 			refetchOnWindowFocus: false,
@@ -102,17 +103,31 @@ export const DockerDiskUsageChart = () => {
 				<span className="text-sm text-muted-foreground">
 					Total: {formatSize(totalBytes)}
 				</span>
-				<Button
-					variant="ghost"
-					size="icon"
-					className="h-7 w-7"
-					onClick={() => refetch()}
-					disabled={isRefetching}
-				>
-					<RefreshCw
-						className={`size-3.5 ${isRefetching ? "animate-spin" : ""}`}
-					/>
-				</Button>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-7 w-7"
+						onClick={() => refetch()}
+						disabled={isRefetching}
+					>
+						<RefreshCw
+							className={`size-3.5 ${isRefetching ? "animate-spin" : ""}`}
+						/>
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setShowDetails((value) => !value)}
+					>
+						{showDetails ? (
+							<ChevronDown className="mr-2 size-4" />
+						) : (
+							<ChevronRight className="mr-2 size-4" />
+						)}
+						{showDetails ? "Hide details" : "Show details"}
+					</Button>
+				</div>
 			</div>
 			<ChartContainer
 				config={chartConfig}
@@ -181,81 +196,83 @@ export const DockerDiskUsageChart = () => {
 					<ChartLegend content={<ChartLegendContent nameKey="name" />} />
 				</PieChart>
 			</ChartContainer>
-			<div className="grid gap-3 xl:grid-cols-2">
-				{chartData.map((item) => {
-					const label = getChartLabel(item.name);
-					const details = item.details;
+			{showDetails && (
+				<div className="grid gap-3 xl:grid-cols-2">
+					{chartData.map((item) => {
+						const label = getChartLabel(item.name);
+						const details = item.details;
 
-					return (
-						<div key={item.name} className="rounded-md border p-3">
-							<div className="flex items-start justify-between gap-3">
-								<div className="min-w-0">
-									<div className="flex items-center gap-2">
-										<span
-											className="size-2.5 rounded-sm"
-											style={{ backgroundColor: item.fill }}
-										/>
-										<p className="text-sm font-medium">{label}</p>
+						return (
+							<div key={item.name} className="rounded-md border p-3">
+								<div className="flex items-start justify-between gap-3">
+									<div className="min-w-0">
+										<div className="flex items-center gap-2">
+											<span
+												className="size-2.5 rounded-sm"
+												style={{ backgroundColor: item.fill }}
+											/>
+											<p className="text-sm font-medium">{label}</p>
+										</div>
+										<p className="mt-1 text-xs text-muted-foreground">
+											{item.active} active / {item.totalCount} total
+										</p>
 									</div>
-									<p className="mt-1 text-xs text-muted-foreground">
-										{item.active} active / {item.totalCount} total
-									</p>
+									<div className="shrink-0 text-right">
+										<p className="text-sm font-medium">{item.size}</p>
+										<p className="text-xs text-muted-foreground">
+											{item.reclaimable} reclaimable
+										</p>
+									</div>
 								</div>
-								<div className="shrink-0 text-right">
-									<p className="text-sm font-medium">{item.size}</p>
-									<p className="text-xs text-muted-foreground">
-										{item.reclaimable} reclaimable
-									</p>
-								</div>
-							</div>
 
-							{details.length > 0 ? (
-								<div className="mt-3 divide-y">
-									{details.map((detail) => (
-										<div
-											key={`${item.name}-${detail.id}`}
-											className="py-2 first:pt-0 last:pb-0"
-										>
-											<div className="flex items-start justify-between gap-3">
-												<div className="min-w-0">
-													<p className="truncate text-sm font-medium">
-														{detail.name}
-													</p>
-													<p className="truncate font-mono text-xs text-muted-foreground">
-														{detail.id}
+								{details.length > 0 ? (
+									<div className="mt-3 divide-y">
+										{details.map((detail) => (
+											<div
+												key={`${item.name}-${detail.id}`}
+												className="py-2 first:pt-0 last:pb-0"
+											>
+												<div className="flex items-start justify-between gap-3">
+													<div className="min-w-0">
+														<p className="truncate text-sm font-medium">
+															{detail.name}
+														</p>
+														<p className="truncate font-mono text-xs text-muted-foreground">
+															{detail.id}
+														</p>
+													</div>
+													<p className="shrink-0 text-sm font-medium">
+														{detail.size}
 													</p>
 												</div>
-												<p className="shrink-0 text-sm font-medium">
-													{detail.size}
-												</p>
+												<div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+													{detail.meta.slice(0, 4).map((meta) => (
+														<span
+															key={`${item.name}-${detail.id}-${meta.label}`}
+															className="min-w-0 truncate"
+														>
+															{meta.label}: {meta.value}
+														</span>
+													))}
+												</div>
 											</div>
-											<div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-												{detail.meta.slice(0, 4).map((meta) => (
-													<span
-														key={`${item.name}-${detail.id}-${meta.label}`}
-														className="min-w-0 truncate"
-													>
-														{meta.label}: {meta.value}
-													</span>
-												))}
-											</div>
-										</div>
-									))}
-									{item.totalCount > details.length && (
-										<p className="pt-2 text-xs text-muted-foreground">
-											Showing largest {details.length} of {item.totalCount}.
-										</p>
-									)}
-								</div>
-							) : (
-								<p className="mt-3 text-xs text-muted-foreground">
-									No detailed usage entries reported by Docker.
-								</p>
-							)}
-						</div>
-					);
-				})}
-			</div>
+										))}
+										{item.totalCount > details.length && (
+											<p className="pt-2 text-xs text-muted-foreground">
+												Showing largest {details.length} of {item.totalCount}.
+											</p>
+										)}
+									</div>
+								) : (
+									<p className="mt-3 text-xs text-muted-foreground">
+										No detailed usage entries reported by Docker.
+									</p>
+								)}
+							</div>
+						);
+					})}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx
@@ -48,6 +48,9 @@ const formatSize = (bytes: number): string => {
 	return `${bytes} B`;
 };
 
+const getChartLabel = (name: string) =>
+	chartConfig[name as keyof typeof chartConfig]?.label ?? name;
+
 export const DockerDiskUsageChart = () => {
 	const { data, isLoading, refetch, isRefetching } =
 		api.settings.getDockerDiskUsage.useQuery(undefined, {
@@ -67,6 +70,7 @@ export const DockerDiskUsageChart = () => {
 						active: item.active,
 						totalCount: item.totalCount,
 						reclaimable: item.reclaimable,
+						details: item.details ?? [],
 						fill: `var(--color-${key})`,
 					};
 				}) ?? [];
@@ -177,6 +181,81 @@ export const DockerDiskUsageChart = () => {
 					<ChartLegend content={<ChartLegendContent nameKey="name" />} />
 				</PieChart>
 			</ChartContainer>
+			<div className="grid gap-3 xl:grid-cols-2">
+				{chartData.map((item) => {
+					const label = getChartLabel(item.name);
+					const details = item.details;
+
+					return (
+						<div key={item.name} className="rounded-md border p-3">
+							<div className="flex items-start justify-between gap-3">
+								<div className="min-w-0">
+									<div className="flex items-center gap-2">
+										<span
+											className="size-2.5 rounded-sm"
+											style={{ backgroundColor: item.fill }}
+										/>
+										<p className="text-sm font-medium">{label}</p>
+									</div>
+									<p className="mt-1 text-xs text-muted-foreground">
+										{item.active} active / {item.totalCount} total
+									</p>
+								</div>
+								<div className="shrink-0 text-right">
+									<p className="text-sm font-medium">{item.size}</p>
+									<p className="text-xs text-muted-foreground">
+										{item.reclaimable} reclaimable
+									</p>
+								</div>
+							</div>
+
+							{details.length > 0 ? (
+								<div className="mt-3 divide-y">
+									{details.map((detail) => (
+										<div
+											key={`${item.name}-${detail.id}`}
+											className="py-2 first:pt-0 last:pb-0"
+										>
+											<div className="flex items-start justify-between gap-3">
+												<div className="min-w-0">
+													<p className="truncate text-sm font-medium">
+														{detail.name}
+													</p>
+													<p className="truncate font-mono text-xs text-muted-foreground">
+														{detail.id}
+													</p>
+												</div>
+												<p className="shrink-0 text-sm font-medium">
+													{detail.size}
+												</p>
+											</div>
+											<div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+												{detail.meta.slice(0, 4).map((meta) => (
+													<span
+														key={`${item.name}-${detail.id}-${meta.label}`}
+														className="min-w-0 truncate"
+													>
+														{meta.label}: {meta.value}
+													</span>
+												))}
+											</div>
+										</div>
+									))}
+									{item.totalCount > details.length && (
+										<p className="pt-2 text-xs text-muted-foreground">
+											Showing largest {details.length} of {item.totalCount}.
+										</p>
+									)}
+								</div>
+							) : (
+								<p className="mt-3 text-xs text-muted-foreground">
+									No detailed usage entries reported by Docker.
+								</p>
+							)}
+						</div>
+					);
+				})}
+			</div>
 		</div>
 	);
 };

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -266,6 +266,26 @@ export interface DockerDiskUsageItem {
 	size: string;
 	reclaimable: string;
 	sizeBytes: number;
+	details?: DockerDiskUsageDetailItem[];
+}
+
+export interface DockerDiskUsageDetailItem {
+	id: string;
+	name: string;
+	size: string;
+	sizeBytes: number;
+	subtitle?: string;
+	meta: {
+		label: string;
+		value: string;
+	}[];
+}
+
+export interface DockerDiskUsageVerboseDetails {
+	images: DockerDiskUsageDetailItem[];
+	containers: DockerDiskUsageDetailItem[];
+	volumes: DockerDiskUsageDetailItem[];
+	buildCache: DockerDiskUsageDetailItem[];
 }
 
 const parseSizeToBytes = (size: string): number => {
@@ -283,10 +303,28 @@ const parseSizeToBytes = (size: string): number => {
 	return value * (multipliers[unit] || 0);
 };
 
-export const getDockerDiskUsage = async (): Promise<DockerDiskUsageItem[]> => {
-	const command = "docker system df --format '{{json .}}'";
-	const { stdout } = await execAsync(command);
+const dockerDiskUsageTypeToDetailsKey: Record<
+	string,
+	keyof DockerDiskUsageVerboseDetails
+> = {
+	"Build Cache": "buildCache",
+	Containers: "containers",
+	Images: "images",
+	"Local Volumes": "volumes",
+};
 
+const splitDockerTableRow = (line: string) =>
+	line
+		.trim()
+		.split(/\s{2,}/)
+		.map((item) => item.trim());
+
+const sortDiskUsageDetails = (items: DockerDiskUsageDetailItem[]) =>
+	items.sort((a, b) => b.sizeBytes - a.sizeBytes);
+
+export const parseDockerDiskUsageSummary = (
+	stdout: string,
+): DockerDiskUsageItem[] => {
 	const lines = stdout.trim().split("\n").filter(Boolean);
 	return lines.map((line) => {
 		const data = JSON.parse(line);
@@ -297,6 +335,170 @@ export const getDockerDiskUsage = async (): Promise<DockerDiskUsageItem[]> => {
 			size: data.Size,
 			reclaimable: data.Reclaimable,
 			sizeBytes: parseSizeToBytes(data.Size),
+		};
+	});
+};
+
+export const parseDockerDiskUsageVerbose = (
+	stdout: string,
+): DockerDiskUsageVerboseDetails => {
+	const rows: Record<keyof DockerDiskUsageVerboseDetails, string[]> = {
+		buildCache: [],
+		containers: [],
+		images: [],
+		volumes: [],
+	};
+	let currentSection: keyof DockerDiskUsageVerboseDetails | null = null;
+	let hasHeader = false;
+
+	for (const line of stdout.split("\n")) {
+		const trimmedLine = line.trim();
+		if (!trimmedLine) {
+			continue;
+		}
+
+		if (trimmedLine === "Images space usage:") {
+			currentSection = "images";
+			hasHeader = false;
+			continue;
+		}
+		if (trimmedLine === "Containers space usage:") {
+			currentSection = "containers";
+			hasHeader = false;
+			continue;
+		}
+		if (trimmedLine === "Local Volumes space usage:") {
+			currentSection = "volumes";
+			hasHeader = false;
+			continue;
+		}
+		if (trimmedLine.startsWith("Build cache usage:")) {
+			currentSection = "buildCache";
+			hasHeader = false;
+			continue;
+		}
+
+		if (!currentSection) {
+			continue;
+		}
+
+		if (!hasHeader) {
+			hasHeader = true;
+			continue;
+		}
+
+		rows[currentSection].push(trimmedLine);
+	}
+
+	return {
+		buildCache: sortDiskUsageDetails(
+			rows.buildCache.flatMap((row) => {
+				const [id, cacheType, size, created, lastUsed, usage, shared] =
+					splitDockerTableRow(row);
+				if (!id || !cacheType || !size) {
+					return [];
+				}
+
+				return {
+					id,
+					meta: [
+						{ label: "Created", value: created ?? "--" },
+						{ label: "Last used", value: lastUsed ?? "--" },
+						{ label: "Usage", value: usage ?? "--" },
+						{ label: "Shared", value: shared ?? "--" },
+					],
+					name: cacheType,
+					size,
+					sizeBytes: parseSizeToBytes(size),
+				};
+			}),
+		),
+		containers: sortDiskUsageDetails(
+			rows.containers.flatMap((row) => {
+				const [id, image, command, localVolumes, size, created, status, name] =
+					splitDockerTableRow(row);
+				if (!id || !image || !size || !name) {
+					return [];
+				}
+
+				return {
+					id,
+					meta: [
+						{ label: "Image", value: image },
+						{ label: "Command", value: command ?? "--" },
+						{ label: "Volumes", value: localVolumes ?? "0" },
+						{ label: "Created", value: created ?? "--" },
+						{ label: "Status", value: status ?? "--" },
+					],
+					name,
+					size,
+					sizeBytes: parseSizeToBytes(size),
+				};
+			}),
+		),
+		images: sortDiskUsageDetails(
+			rows.images.flatMap((row) => {
+				const [
+					repository,
+					tag,
+					id,
+					created,
+					size,
+					sharedSize,
+					uniqueSize,
+					containers,
+				] = splitDockerTableRow(row);
+				if (!repository || !tag || !id || !size) {
+					return [];
+				}
+
+				return {
+					id,
+					meta: [
+						{ label: "Created", value: created ?? "--" },
+						{ label: "Shared", value: sharedSize ?? "--" },
+						{ label: "Unique", value: uniqueSize ?? "--" },
+						{ label: "Containers", value: containers ?? "0" },
+					],
+					name: `${repository}:${tag}`,
+					size,
+					sizeBytes: parseSizeToBytes(size),
+				};
+			}),
+		),
+		volumes: sortDiskUsageDetails(
+			rows.volumes.flatMap((row) => {
+				const [name, links, size] = splitDockerTableRow(row);
+				if (!name || !size) {
+					return [];
+				}
+
+				return {
+					id: name,
+					meta: [{ label: "Links", value: links ?? "0" }],
+					name,
+					size,
+					sizeBytes: parseSizeToBytes(size),
+				};
+			}),
+		),
+	};
+};
+
+export const getDockerDiskUsage = async (): Promise<DockerDiskUsageItem[]> => {
+	const summaryCommand = "docker system df --format '{{json .}}'";
+	const verboseCommand = "docker system df -v";
+	const [summaryResult, verboseResult] = await Promise.all([
+		execAsync(summaryCommand),
+		execAsync(verboseCommand).catch(() => ({ stdout: "" })),
+	]);
+
+	const details = parseDockerDiskUsageVerbose(verboseResult.stdout);
+	return parseDockerDiskUsageSummary(summaryResult.stdout).map((item) => {
+		const detailsKey = dockerDiskUsageTypeToDetailsKey[item.type];
+		return {
+			...item,
+			details: detailsKey ? details[detailsKey].slice(0, 10) : [],
 		};
 	});
 };


### PR DESCRIPTION
## What is this PR about?

This PR adds detailed breakdown data to the existing Docker Disk Usage card on the Monitoring page. The current chart shows the high-level Docker disk categories; this change keeps that summary and adds the largest entries underneath each category so users can see what is taking space under Images, Containers, Volumes, and Build Cache.

The backend still uses `docker system df` for the summary and now also parses `docker system df -v` for per-entry details. The UI shows the top entries by size for each category, including container names, image names, volume names, build cache records, and relevant metadata such as reclaimable space, active/total counts, shared/unique image size, local volume links, and build cache usage.

The detailed breakdown can be collapsed and expanded from the card header, so the chart remains compact when users only need the total usage summary.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Testing

- [x] `corepack pnpm --dir apps/dokploy exec vitest --config __test__/vitest.config.ts __test__/monitoring/docker-disk-usage.test.ts --run`
- [x] `corepack pnpm exec biome check apps/dokploy/__test__/monitoring/docker-disk-usage.test.ts apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-usage-chart.tsx packages/server/src/utils/docker/utils.ts`
- [x] `corepack pnpm --filter=dokploy run typecheck`
- [x] `corepack pnpm --filter=server run typecheck`
- [x] `corepack pnpm --filter=dokploy run build-server`
- [x] `corepack pnpm --filter=dokploy run build-next`
- [x] `corepack pnpm --filter=server run build`
- [x] Tested locally at `http://localhost:3000/dashboard/monitoring` with Docker Disk Usage details visible for Images, Containers, Volumes, and Build Cache.
- [x] Tested the Docker Disk Usage details toggle locally: Hide details collapses the breakdown and Show details expands it again.

Note: `corepack pnpm format-and-lint` still reports existing unrelated issues outside this PR's files; the targeted Biome check for the touched files passes.

## Issues related (if applicable)

Closes #4651

## Screenshots (if applicable)

![Docker Disk Usage details toggle](https://raw.githubusercontent.com/agentHits/dokploy/pr-assets-docker-disk-usage-toggle/docker-disk-usage-details-toggle.png)

