### PR TITLE
feat: show swap usage in monitoring

### DIFF
--- a/apps/dokploy/__test__/monitoring/memory-swap.test.ts
+++ b/apps/dokploy/__test__/monitoring/memory-swap.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { paths } from "@dokploy/server/constants";
+import {
+	parseMacOsSwapUsage,
+	readStatsFile,
+	recordAdvancedStats,
+} from "@dokploy/server/monitoring/utils";
+import { afterEach, describe, expect, it } from "vitest";
+
+const appName = "monitoring-swap-test";
+const appMonitoringPath = path.join(paths().MONITORING_PATH, appName);
+
+describe("memory swap monitoring", () => {
+	afterEach(async () => {
+		await fs.rm(appMonitoringPath, { recursive: true, force: true });
+	});
+
+	it("records swap usage with memory stats when swap data is available", async () => {
+		await recordAdvancedStats(
+			{
+				BlockIO: "0B / 0B",
+				CPUPerc: "0%",
+				Container: "dokploy",
+				ID: "host-system",
+				MemPerc: "25.00%",
+				MemUsage: "1.00GiB / 4.00GiB",
+				Name: "dokploy",
+				NetIO: "0MB / 0MB",
+				SwapUsage: "512.00MiB / 2.00GiB",
+			},
+			appName,
+		);
+
+		const memoryStats = await readStatsFile(appName, "memory");
+
+		expect(memoryStats).toHaveLength(1);
+		expect(memoryStats[0].value).toEqual({
+			used: "1.00GiB",
+			total: "4.00GiB",
+			swap: {
+				used: "512.00MiB",
+				total: "2.00GiB",
+			},
+		});
+	});
+
+	it("parses macOS sysctl swap output", () => {
+		expect(
+			parseMacOsSwapUsage(
+				"total = 18432.00M  used = 16698.75M  free = 1733.25M  (encrypted)",
+			),
+		).toEqual({
+			totalBytes: 18_432 * 1024 * 1024,
+			usedBytes: 16_698.75 * 1024 * 1024,
+		});
+	});
+});

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx
@@ -30,7 +30,6 @@ export const DockerMemoryChart = ({
 	const transformedData = accumulativeData.map((item, index) => ({
 		time: item.time,
 		name: `Point ${index + 1}`,
-		// @ts-ignore
 		usage: (convertMemoryToBytes(item.value.used) / 1024 ** 3).toFixed(2),
 	}));
 

--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -16,8 +16,8 @@ const defaultData = {
 	},
 	memory: {
 		value: {
-			used: 0,
-			total: 0,
+			used: "0B",
+			total: "0B",
 		},
 		time: "",
 	},
@@ -45,16 +45,24 @@ interface Props {
 	appName: string;
 	appType?: "application" | "stack" | "docker-compose";
 }
+
+type MemorySize = number | string;
+type MemoryUsageValue = {
+	used: MemorySize;
+	total: MemorySize;
+	swap?: {
+		used: MemorySize;
+		total: MemorySize;
+	};
+};
+
 export interface DockerStats {
 	cpu: {
 		value: string;
 		time: string;
 	};
 	memory: {
-		value: {
-			used: number;
-			total: number;
-		};
+		value: MemoryUsageValue;
 		time: string;
 	};
 	block: {
@@ -92,8 +100,12 @@ export type DockerStatsJSON = {
 };
 
 export const convertMemoryToBytes = (
-	memoryString: string | undefined,
+	memoryString: MemorySize | undefined,
 ): number => {
+	if (typeof memoryString === "number") {
+		return memoryString;
+	}
+
 	if (!memoryString || typeof memoryString !== "string") {
 		return 0;
 	}
@@ -113,6 +125,19 @@ export const convertMemoryToBytes = (
 		default:
 			return value;
 	}
+};
+
+const getMemoryUsagePercentage = (
+	used: MemorySize | undefined,
+	total: MemorySize | undefined,
+): number => {
+	const totalBytes = convertMemoryToBytes(total);
+
+	if (totalBytes <= 0) {
+		return 0;
+	}
+
+	return Math.min((convertMemoryToBytes(used) / totalBytes) * 100, 100);
 };
 
 export const ContainerFreeMonitoring = ({
@@ -201,6 +226,10 @@ export const ContainerFreeMonitoring = ({
 		return () => ws.close();
 	}, [appName]);
 
+	const memoryValue = currentData.memory.value;
+	const swapValue = memoryValue.swap;
+	const showSwapUsage = convertMemoryToBytes(swapValue?.total) > 0;
+
 	return (
 		<div className="rounded-xl bg-background flex flex-col gap-4">
 			<header className="flex items-center justify-between">
@@ -240,24 +269,33 @@ export const ContainerFreeMonitoring = ({
 					<CardContent>
 						<div className="flex flex-col gap-2 w-full">
 							<span className="text-sm text-muted-foreground">
-								{`Used:  ${currentData.memory.value.used} / Limit: ${currentData.memory.value.total} `}
+								{`Used:  ${memoryValue.used} / Limit: ${memoryValue.total} `}
 							</span>
 							<Progress
-								value={
-									// @ts-ignore
-									(convertMemoryToBytes(currentData.memory.value.used) /
-										// @ts-ignore
-										convertMemoryToBytes(currentData.memory.value.total)) *
-									100
-								}
+								value={getMemoryUsagePercentage(
+									memoryValue.used,
+									memoryValue.total,
+								)}
 								className="w-[100%]"
 							/>
+							{showSwapUsage && swapValue && (
+								<div className="mt-1 flex flex-col gap-2">
+									<span className="text-sm text-muted-foreground">
+										{`Swap:  ${swapValue.used} / Limit: ${swapValue.total} `}
+									</span>
+									<Progress
+										value={getMemoryUsagePercentage(
+											swapValue.used,
+											swapValue.total,
+										)}
+										className="w-[100%]"
+									/>
+								</div>
+							)}
 							<DockerMemoryChart
 								accumulativeData={accumulativeData.memory}
 								memoryLimitGB={
-									// @ts-ignore
-									convertMemoryToBytes(currentData.memory.value.total) /
-									1024 ** 3
+									convertMemoryToBytes(memoryValue.total) / 1024 ** 3
 								}
 							/>
 						</div>

--- a/packages/server/src/monitoring/utils.ts
+++ b/packages/server/src/monitoring/utils.ts
@@ -1,6 +1,11 @@
+import { execFile } from "node:child_process";
 import { promises } from "node:fs";
+import os from "node:os";
+import { promisify } from "node:util";
 import { OSUtils } from "node-os-utils";
 import { paths } from "../constants";
+
+const execFileAsync = promisify(execFile);
 
 export interface Container {
 	BlockIO: string;
@@ -11,7 +16,100 @@ export interface Container {
 	MemUsage: string;
 	Name: string;
 	NetIO: string;
+	SwapUsage?: string;
 }
+
+const formatBytes = (bytes: number): string => {
+	if (bytes >= 1024 * 1024 * 1024) {
+		return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GiB`;
+	}
+	if (bytes >= 1024 * 1024) {
+		return `${(bytes / (1024 * 1024)).toFixed(2)}MiB`;
+	}
+	if (bytes >= 1024) {
+		return `${(bytes / 1024).toFixed(2)}KiB`;
+	}
+	return `${bytes}B`;
+};
+
+const formatSwapUsage = (usedBytes: number, totalBytes: number): string =>
+	`${formatBytes(usedBytes)} / ${formatBytes(totalBytes)}`;
+
+const parseMacOsSwapSize = (value: string, unit: string): number => {
+	const parsedValue = Number.parseFloat(value);
+
+	if (!Number.isFinite(parsedValue)) {
+		return 0;
+	}
+
+	switch (unit.toUpperCase()) {
+		case "G":
+			return parsedValue * 1024 * 1024 * 1024;
+		case "M":
+			return parsedValue * 1024 * 1024;
+		case "K":
+			return parsedValue * 1024;
+		default:
+			return parsedValue;
+	}
+};
+
+export const parseMacOsSwapUsage = (
+	output: string,
+): { totalBytes: number; usedBytes: number } | null => {
+	const match = output.match(
+		/total\s*=\s*([0-9.]+)([KMG]?)\s+used\s*=\s*([0-9.]+)([KMG]?)/i,
+	);
+
+	if (!match) {
+		return null;
+	}
+
+	return {
+		totalBytes: parseMacOsSwapSize(match[1] ?? "0", match[2] ?? ""),
+		usedBytes: parseMacOsSwapSize(match[3] ?? "0", match[4] ?? ""),
+	};
+};
+
+const getMacOsSwapUsage = async (): Promise<string | undefined> => {
+	try {
+		const { stdout } = await execFileAsync("sysctl", ["-n", "vm.swapusage"]);
+		const parsedSwap = parseMacOsSwapUsage(stdout);
+
+		if (!parsedSwap) {
+			return undefined;
+		}
+
+		return formatSwapUsage(parsedSwap.usedBytes, parsedSwap.totalBytes);
+	} catch {
+		return undefined;
+	}
+};
+
+const getSwapUsage = async (osutils: OSUtils): Promise<string | undefined> => {
+	const swapResult = await osutils.memory.swap();
+
+	if (swapResult.success && swapResult.data.total.toBytes() > 0) {
+		return formatSwapUsage(
+			swapResult.data.used.toBytes(),
+			swapResult.data.total.toBytes(),
+		);
+	}
+
+	if (os.platform() === "darwin") {
+		return getMacOsSwapUsage();
+	}
+
+	if (swapResult.success) {
+		return formatSwapUsage(
+			swapResult.data.used.toBytes(),
+			swapResult.data.total.toBytes(),
+		);
+	}
+
+	return undefined;
+};
+
 export const recordAdvancedStats = async (
 	stats: Container,
 	appName: string,
@@ -21,11 +119,29 @@ export const recordAdvancedStats = async (
 
 	await promises.mkdir(path, { recursive: true });
 
-	await updateStatsFile(appName, "cpu", stats.CPUPerc);
-	await updateStatsFile(appName, "memory", {
+	const memoryStats: {
+		used: string | undefined;
+		total: string | undefined;
+		swap?: {
+			used: string;
+			total: string;
+		};
+	} = {
 		used: stats.MemUsage.split(" ")[0],
 		total: stats.MemUsage.split(" ")[2],
-	});
+	};
+	const swapUsed = stats.SwapUsage?.split(" ")[0];
+	const swapTotal = stats.SwapUsage?.split(" ")[2];
+
+	if (swapUsed && swapTotal) {
+		memoryStats.swap = {
+			used: swapUsed,
+			total: swapTotal,
+		};
+	}
+
+	await updateStatsFile(appName, "cpu", stats.CPUPerc);
+	await updateStatsFile(appName, "memory", memoryStats);
 
 	await updateStatsFile(appName, "block", {
 		readMb: stats.BlockIO.split(" ")[0],
@@ -84,6 +200,8 @@ export const getHostSystemStats = async (): Promise<Container> => {
 		memUsedPercent = memResult.data.usagePercentage;
 	}
 
+	const swapUsageFormatted = await getSwapUsage(osutils);
+
 	// Get network stats from network.overview()
 	let netInputBytes = 0;
 	let netOutputBytes = 0;
@@ -114,20 +232,6 @@ export const getHostSystemStats = async (): Promise<Container> => {
 		}
 	}
 
-	// Format values similar to docker stats
-	const formatBytes = (bytes: number): string => {
-		if (bytes >= 1024 * 1024 * 1024) {
-			return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)}GiB`;
-		}
-		if (bytes >= 1024 * 1024) {
-			return `${(bytes / (1024 * 1024)).toFixed(2)}MiB`;
-		}
-		if (bytes >= 1024) {
-			return `${(bytes / 1024).toFixed(2)}KiB`;
-		}
-		return `${bytes}B`;
-	};
-
 	// Format memory usage similar to docker stats format: "used / total"
 	const memUsedFormatted = `${memUsedGB.toFixed(2)}GiB`;
 	const memTotalFormatted = `${memTotalGB.toFixed(2)}GiB`;
@@ -146,6 +250,7 @@ export const getHostSystemStats = async (): Promise<Container> => {
 		CPUPerc: `${cpuUsage.toFixed(2)}%`,
 		MemPerc: `${memUsedPercent.toFixed(2)}%`,
 		MemUsage: memUsageFormatted,
+		SwapUsage: swapUsageFormatted,
 		BlockIO: blockIOFormatted,
 		NetIO: netIOFormatted,
 		Container: "dokploy",


### PR DESCRIPTION
## What is this PR about?

This PR adds optional swap usage visibility to the free Monitoring page's Memory Usage card. When swap data is available, the card now shows a second progress bar below the existing memory bar so users can see both RAM usage and swap usage at a glance.

The backend stores swap usage alongside the existing memory stats without changing the existing RAM fields, so older monitoring entries without swap data remain compatible. It uses `node-os-utils` swap data when available and falls back to `sysctl -n vm.swapusage` on macOS, where `node-os-utils` can report `0B / 0B` even when macOS has active swap.

The UI only renders the Swap row when the reported swap total is greater than zero, keeping the current card unchanged on systems without swap.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Testing

- [x] `corepack pnpm --dir apps/dokploy exec vitest --config __test__/vitest.config.ts __test__/monitoring/memory-swap.test.ts --run`
- [x] `corepack pnpm exec biome check apps/dokploy/__test__/monitoring/memory-swap.test.ts apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx packages/server/src/monitoring/utils.ts`
- [x] `corepack pnpm --filter=server run typecheck`
- [x] `corepack pnpm --filter=dokploy run typecheck`
- [x] `git diff --check`
- [x] Tested locally at `http://localhost:3000/dashboard/monitoring` with swap displayed in the Memory Usage card.

## Issues related (if applicable)

Closes #4652

## Screenshots (if applicable)

![Monitoring swap usage](https://raw.githubusercontent.com/agentHits/dokploy/pr-assets-monitoring-swap-usage/monitoring-swap-usage.png)

