### PR TITLE
fix: prevent registry password from appearing in error messages and shell commands

### DIFF
--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -27,6 +27,16 @@ export function safeDockerLoginCommand(
 	return `printf %s ${escapedPassword} | docker login ${escapedRegistry} -u ${escapedUser} --password-stdin`;
 }
 
+function sanitizeRegistryError(
+	error: unknown,
+	password: string | null | undefined,
+): string {
+	const message =
+		error instanceof Error ? error.message : "Error with registry login";
+	if (!password) return message;
+	return message.split(password).join("***");
+}
+
 export const createRegistry = async (
 	input: z.infer<typeof apiCreateRegistry>,
 	organizationId: string,
@@ -59,10 +69,15 @@ export const createRegistry = async (
 			input.username,
 			input.password,
 		);
-		if (input.serverId && input.serverId !== "none") {
-			await execAsyncRemote(input.serverId, loginCommand);
-		} else if (newRegistry.registryType === "cloud") {
-			await execAsync(loginCommand);
+		try {
+			if (input.serverId && input.serverId !== "none") {
+				await execAsyncRemote(input.serverId, loginCommand);
+			} else if (newRegistry.registryType === "cloud") {
+				await execAsync(loginCommand);
+			}
+		} catch (error) {
+			const sanitized = sanitizeRegistryError(error, input.password);
+			throw new TRPCError({ code: "BAD_REQUEST", message: sanitized });
 		}
 
 		return newRegistry;
@@ -129,16 +144,24 @@ export const updateRegistry = async (
 			});
 		}
 
-		if (registryData?.serverId && registryData?.serverId !== "none") {
-			await execAsyncRemote(registryData.serverId, loginCommand);
-		} else if (response?.registryType === "cloud") {
-			await execAsync(loginCommand);
+		try {
+			if (registryData?.serverId && registryData?.serverId !== "none") {
+				await execAsyncRemote(registryData.serverId, loginCommand);
+			} else if (response?.registryType === "cloud") {
+				await execAsync(loginCommand);
+			}
+		} catch (execError) {
+			throw new Error(sanitizeRegistryError(execError, response?.password));
 		}
 
 		return response;
 	} catch (error) {
 		const message =
-			error instanceof Error ? error.message : "Error updating this registry";
+			error instanceof TRPCError
+				? error.message
+				: error instanceof Error
+					? error.message
+					: "Error updating this registry";
 		throw new TRPCError({
 			code: "BAD_REQUEST",
 			message,

--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -1,6 +1,7 @@
 import { findAllDeploymentsByApplicationId } from "@dokploy/server/services/deployment";
 import {
 	findRegistryByIdWithCredentials,
+	safeDockerLoginCommand,
 	type Registry,
 } from "@dokploy/server/services/registry";
 import { createRollback } from "@dokploy/server/services/rollbacks";
@@ -117,9 +118,14 @@ const getRegistryCommands = (
 	imageName: string,
 	registryTag: string,
 ): string => {
+	const loginCmd = safeDockerLoginCommand(
+		registry.registryUrl,
+		registry.username,
+		registry.password,
+	);
 	return `
 echo "📦 [Enabled Registry] Uploading image to '${registry.registryType}' | '${registryTag}'" ;
-echo "${registry.password}" | docker login ${registry.registryUrl} -u '${registry.username}' --password-stdin || {
+${loginCmd} || {
 	echo "❌ DockerHub Failed" ;
 	exit 1;
 }

--- a/packages/server/src/utils/providers/docker.ts
+++ b/packages/server/src/utils/providers/docker.ts
@@ -1,3 +1,4 @@
+import { safeDockerLoginCommand } from "@dokploy/server/services/registry";
 import type { ApplicationNested } from "../builders";
 
 export const buildRemoteDocker = async (application: ApplicationNested) => {
@@ -13,7 +14,7 @@ echo "Pulling ${dockerImage}";
 
 		if (username && password) {
 			command += `
-if ! echo "${password}" | docker login --username "${username}" --password-stdin "${registryUrl || ""}" 2>&1; then
+if ! ${safeDockerLoginCommand(registryUrl || "", username, password)} 2>&1; then
 	echo "❌ Login failed";
 	exit 1;
 fi


### PR DESCRIPTION
## Summary

- `registry.ts`: Added `sanitizeRegistryError()` that replaces the password with `***` in error messages before propagating them to the client. Both `createRegistry` and `updateRegistry` now catch exec errors and sanitize them.
- `upload.ts`: `getRegistryCommands()` now uses `safeDockerLoginCommand()` with `printf %s` instead of `echo "${registry.password}"`.
- `docker.ts`: `buildRemoteDocker()` now also uses `safeDockerLoginCommand()` instead of `echo "${password}"`.

The root cause was that when Docker login failed (e.g. wrong URL like `hub.docker.com` instead of `registry-1.docker.io`), the full shell command including the password was included in the error message shown to the user.