### PR TITLE
fix: open deployments tab when opening a service from the deployments list

### DIFF
--- a/apps/dokploy/components/dashboard/deployments/show-deployments-table.tsx
+++ b/apps/dokploy/components/dashboard/deployments/show-deployments-table.tsx
@@ -76,7 +76,7 @@ function getServiceInfo(d: DeploymentRow) {
 			projectName: app.environment.project.name,
 			environmentName: app.environment.name,
 			serviceId: app.applicationId,
-			href: `/dashboard/project/${app.environment.project.projectId}/environment/${app.environment.environmentId}/services/application/${app.applicationId}`,
+			href: `/dashboard/project/${app.environment.project.projectId}/environment/${app.environment.environmentId}/services/application/${app.applicationId}?tab=deployments`,
 		};
 	}
 	if (comp?.environment?.project && comp.environment) {
@@ -88,7 +88,7 @@ function getServiceInfo(d: DeploymentRow) {
 			projectName: comp.environment.project.name,
 			environmentName: comp.environment.name,
 			serviceId: comp.composeId,
-			href: `/dashboard/project/${comp.environment.project.projectId}/environment/${comp.environment.environmentId}/services/compose/${comp.composeId}`,
+			href: `/dashboard/project/${comp.environment.project.projectId}/environment/${comp.environment.environmentId}/services/compose/${comp.composeId}?tab=deployments`,
 		};
 	}
 	return null;


### PR DESCRIPTION
## What is this PR about?

In the centralized **Deployments** list (`/dashboard/deployments`), the **Open** action on each row navigated to the related application/compose page but landed on its **General** tab — forcing you to manually click into the **Deployments** tab to reach the deployment you came from. This appends `?tab=deployments` to the generated link so **Open** opens the **Deployments** tab directly.

Tested locally: **Open** now lands on the Deployments tab for both applications and compose services. It uses the same `?tab=deployments` deep-link the app already applies after a deploy (`application/general/show.tsx`, `compose/general/actions.tsx`), so the behavior is consistent with the rest of the app.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Screenshots (if applicable)

_Before:_ **Open** on a deployment row landed on the service's **General** tab.
_After:_ **Open** lands directly on the **Deployments** tab.
