### PR TITLE
fix: align project cards left on wide screens

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -290,7 +290,7 @@ export const ShowProjects = () => {
 											</span>
 										</div>
 									)}
-									<div className="w-full grid grid-cols-[repeat(auto-fill,minmax(20rem,1fr))] gap-5">
+									<div className="w-full grid grid-cols-[repeat(auto-fill,minmax(min(20rem,100%),1fr))] gap-5">
 										{filteredProjects?.map((project) => {
 											const emptyServices = project?.environments
 												.map(

--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -290,7 +290,7 @@ export const ShowProjects = () => {
 											</span>
 										</div>
 									)}
-									<div className="w-full grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 flex-wrap gap-5">
+									<div className="w-full grid grid-cols-[repeat(auto-fill,minmax(20rem,1fr))] gap-5">
 										{filteredProjects?.map((project) => {
 											const emptyServices = project?.environments
 												.map(
@@ -330,7 +330,7 @@ export const ShowProjects = () => {
 											return (
 												<div
 													key={project.projectId}
-													className="w-full lg:max-w-md"
+													className="w-full"
 												>
 													<Link
 														href={


### PR DESCRIPTION
## What
On large/wide screens (e.g. 1920px+, ultrawide), project cards on the Projects page (`/dashboard/projects`) spread far apart horizontally with large empty gaps instead of packing to the left.

## Root cause
`apps/dokploy/components/dashboard/projects/show.tsx` used fixed column counts (`grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5`) on a `w-full` container, plus a per-card `lg:max-w-md` cap (and a dead `flex-wrap` left over from a previous flex layout). On very wide screens each fixed grid track becomes much wider than the capped card, leaving big gaps between cards.

## Fix
Two className-only edits:
- Grid container: replace the fixed `grid-cols-*` and dead `flex-wrap` with an auto-fill track — `grid grid-cols-[repeat(auto-fill,minmax(20rem,1fr))] gap-5` (keeping `w-full` and `gap-5`).
- Per-card wrapper: remove `lg:max-w-md` (keeping `w-full`).

This packs cards to the left at a stable width and grows the column count naturally with screen width.

## Test
This is a pure Tailwind className change with no extractable logic, and the repo has no jsdom / React Testing Library (React components cannot be rendered in tests), so there is genuinely no unit test to add. Verified `pnpm --filter=dokploy run typecheck` passes clean:

```
> dokploy@v0.29.8 typecheck
> tsc --noEmit
```

(no errors)

Fixes #4523

🤖 Generated with [Claude Code](https://claude.com/claude-code)