### PR TITLE
fix: use Redis 8 as the default image instead of Redis 7

### DIFF
--- a/apps/dokploy/__test__/utils/database-default-images.test.ts
+++ b/apps/dokploy/__test__/utils/database-default-images.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { dockerImageDefaultPlaceholder } from "@/components/dashboard/project/database-default-images";
+
+describe("dockerImageDefaultPlaceholder", () => {
+	it("uses redis 8 as the default redis image", () => {
+		expect(dockerImageDefaultPlaceholder.redis).toBe("redis:8");
+	});
+});

--- a/apps/dokploy/components/dashboard/project/add-database.tsx
+++ b/apps/dokploy/components/dashboard/project/add-database.tsx
@@ -53,17 +53,9 @@ import {
 import { slugify } from "@/lib/slug";
 import { api } from "@/utils/api";
 import { APP_NAME_MESSAGE, APP_NAME_REGEX } from "@/utils/schema";
+import { dockerImageDefaultPlaceholder } from "./database-default-images";
 
 type DbType = z.infer<typeof mySchema>["type"];
-
-const dockerImageDefaultPlaceholder: Record<DbType, string> = {
-	mongo: "mongo:8",
-	libsql: "ghcr.io/tursodatabase/libsql-server:v0.24.32",
-	mariadb: "mariadb:11",
-	mysql: "mysql:8",
-	postgres: "postgres:18",
-	redis: "redis:7",
-};
 
 const databasesUserDefaultPlaceholder: Record<
 	Exclude<DbType, "redis">,

--- a/apps/dokploy/components/dashboard/project/database-default-images.ts
+++ b/apps/dokploy/components/dashboard/project/database-default-images.ts
@@ -1,0 +1,16 @@
+export type DatabaseType =
+	| "mongo"
+	| "libsql"
+	| "mariadb"
+	| "mysql"
+	| "postgres"
+	| "redis";
+
+export const dockerImageDefaultPlaceholder: Record<DatabaseType, string> = {
+	mongo: "mongo:8",
+	libsql: "ghcr.io/tursodatabase/libsql-server:v0.24.32",
+	mariadb: "mariadb:11",
+	mysql: "mysql:8",
+	postgres: "postgres:18",
+	redis: "redis:8",
+};


### PR DESCRIPTION
## What

When adding a new database, leaving the Docker image blank for Redis created a container from `redis:7` instead of Redis 8.

## Root cause

`apps/dokploy/components/dashboard/project/add-database.tsx` defined an inline `dockerImageDefaultPlaceholder` map whose `redis` value was `redis:7`. On a blank create, this UI default is sent as the `dockerImage`, overriding the server schema (which already defaults to Redis 8). It also drove the input placeholder.

## Fix

- Extracted the default-image map into a pure, importable module `apps/dokploy/components/dashboard/project/database-default-images.ts`.
- Changed the redis default to `redis:8` (explicit colon-tag form, consistent with the other entries).
- `add-database.tsx` now imports the map; both the default-used-on-create and the placeholder use the new value.

## Test

Added `apps/dokploy/__test__/utils/database-default-images.test.ts` asserting the redis default is `redis:8`.

```
✓ __test__/utils/database-default-images.test.ts (1 test)
  ✓ uses redis 8 as the default redis image
Test Files  1 passed (1)
     Tests  1 passed (1)
```

Typecheck (`pnpm --filter=dokploy run typecheck`) is clean.

Fixes #4172

🤖 Generated with [Claude Code](https://claude.com/claude-code)