### PR TITLE
fix: only add compose default network when service had no explicit networks

### DIFF
--- a/apps/dokploy/__test__/compose/domain/network-service.test.ts
+++ b/apps/dokploy/__test__/compose/domain/network-service.test.ts
@@ -2,27 +2,31 @@ import { addDokployNetworkToService } from "@dokploy/server";
 import { describe, expect, it } from "vitest";
 
 describe("addDokployNetworkToService", () => {
-	it("should add network to an empty array", () => {
+	it("should add dokploy-network and default when service had no networks key", () => {
+		const result = addDokployNetworkToService(undefined);
+		expect(result).toEqual(["dokploy-network", "default"]);
+	});
+
+	it("should only add dokploy-network to an explicit empty array (no default)", () => {
 		const result = addDokployNetworkToService([]);
-		expect(result).toEqual(["dokploy-network", "default"]);
+		expect(result).toEqual(["dokploy-network"]);
 	});
 
-	it("should not add duplicate network to an array", () => {
+	it("should not add duplicate dokploy-network and not force default", () => {
 		const result = addDokployNetworkToService(["dokploy-network"]);
-		expect(result).toEqual(["dokploy-network", "default"]);
+		expect(result).toEqual(["dokploy-network"]);
 	});
 
-	it("should add network to an existing array with other networks", () => {
+	it("should add dokploy-network to an existing array with other networks (no default)", () => {
 		const result = addDokployNetworkToService(["other-network"]);
-		expect(result).toEqual(["other-network", "dokploy-network", "default"]);
+		expect(result).toEqual(["other-network", "dokploy-network"]);
 	});
 
-	it("should add network to an object if networks is an object", () => {
+	it("should add dokploy-network to an object if networks is an object (no default)", () => {
 		const result = addDokployNetworkToService({ "other-network": {} });
 		expect(result).toEqual({
 			"other-network": {},
 			"dokploy-network": {},
-			default: {},
 		});
 	});
 

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -353,6 +353,12 @@ export const addDokployNetworkToService = (
 	let networks = networkService;
 	const network = "dokploy-network";
 	const defaultNetwork = "default";
+	// If the service had no `networks` key it was relying on Compose's implicit
+	// `default` network, so we preserve that by adding it back. If it declared
+	// explicit networks (even an empty list/object), we must NOT force `default`
+	// onto it, otherwise Compose creates a new per-project default network on
+	// every deploy and eventually exhausts Docker's address pools.
+	const hadExplicitNetworks = networkService !== undefined;
 	if (!networks) {
 		networks = [];
 	}
@@ -361,14 +367,14 @@ export const addDokployNetworkToService = (
 		if (!networks.includes(network)) {
 			networks.push(network);
 		}
-		if (!networks.includes(defaultNetwork)) {
+		if (!hadExplicitNetworks && !networks.includes(defaultNetwork)) {
 			networks.push(defaultNetwork);
 		}
 	} else if (networks && typeof networks === "object") {
 		if (!(network in networks)) {
 			networks[network] = {};
 		}
-		if (!(defaultNetwork in networks)) {
+		if (!hadExplicitNetworks && !(defaultNetwork in networks)) {
 			networks[defaultNetwork] = {};
 		}
 	}


### PR DESCRIPTION
## What

`addDokployNetworkToService` (in `packages/server/src/utils/docker/domain.ts`) is called when a domain is configured on a Compose service. It previously appended **both** `dokploy-network` and `default` to every service's networks.

## Root cause

For services that already declare explicit networks (e.g. `networks: [app-network]`), forcing `default` onto them makes Docker Compose create a new per-project default network (`<project>_default`) on **every** deploy. Across many deployments this exhausts Docker's predefined address pools:

```
Error response from daemon: all predefined address pools have been fully subnetted
```

A service is only meant to get `default` if it was relying on Compose's *implicit* default network — i.e. it had no `networks` key at all.

## Fix

Add `default` only when the service had no explicit `networks` key, using `const hadExplicitNetworks = networkService !== undefined;` (strict `!== undefined`, so an explicit `[]` or `{}` still counts as explicit). Both the array and object branches are guarded. `dokploy-network` is still always added.

This preserves the #3562 fix for implicit-default services while avoiding unnecessary per-compose default networks in production environments with many deployments.

## Test

Updated `apps/dokploy/__test__/compose/domain/network-service.test.ts`:
- `addDokployNetworkToService(undefined)` -> `["dokploy-network", "default"]` (implicit default preserved)
- `addDokployNetworkToService([])` -> `["dokploy-network"]` (explicit, no default)
- `addDokployNetworkToService(["dokploy-network"])` -> `["dokploy-network"]`
- `addDokployNetworkToService(["other-network"])` -> `["other-network", "dokploy-network"]`
- `addDokployNetworkToService({ "other-network": {} })` -> `{ "other-network": {}, "dokploy-network": {} }`

```
✓ __test__/compose/domain/network-service.test.ts (6 tests) 4ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Both `pnpm --filter=@dokploy/server run typecheck` and `pnpm --filter=dokploy run typecheck` pass clean.

Fixes #4499

🤖 Generated with [Claude Code](https://claude.com/claude-code)