### PR TITLE
fix(traefik): load uploaded custom certificates from top-level dynamic dir

### DIFF
--- a/apps/dokploy/__test__/traefik/certificate.test.ts
+++ b/apps/dokploy/__test__/traefik/certificate.test.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { getCertificateConfigPath } from "@dokploy/server/services/certificate";
+import { describe, expect, test } from "vitest";
+
+describe("getCertificateConfigPath", () => {
+	const dynamicTraefikPath = path.join("/etc", "dokploy", "traefik", "dynamic");
+
+	test("writes the certificate config at the TOP LEVEL of the dynamic dir", () => {
+		const certificatePath = "my-cert";
+		const result = getCertificateConfigPath(dynamicTraefikPath, certificatePath);
+
+		// Must be the top-level file, NOT nested under a per-cert subdirectory.
+		expect(result).toBe(
+			path.join(dynamicTraefikPath, `${certificatePath}-certificate.yml`),
+		);
+	});
+
+	test("does NOT place the config inside the certificates/ subdirectory", () => {
+		const result = getCertificateConfigPath(dynamicTraefikPath, "my-cert");
+
+		// Traefik's file.directory provider is non-recursive, so the config must
+		// not live under a subdirectory like /certificates/<id>/.
+		expect(result).not.toContain(`${path.sep}certificates${path.sep}`);
+		expect(path.dirname(result)).toBe(dynamicTraefikPath);
+	});
+
+	test("produces a unique filename per certificatePath", () => {
+		const a = getCertificateConfigPath(dynamicTraefikPath, "cert-a");
+		const b = getCertificateConfigPath(dynamicTraefikPath, "cert-b");
+
+		expect(a).not.toBe(b);
+		expect(a).toBe(
+			path.join(dynamicTraefikPath, "cert-a-certificate.yml"),
+		);
+		expect(b).toBe(
+			path.join(dynamicTraefikPath, "cert-b-certificate.yml"),
+		);
+	});
+});

--- a/packages/server/src/services/certificate.ts
+++ b/packages/server/src/services/certificate.ts
@@ -84,7 +84,7 @@ export const removeCertificateById = async (certificateId: string) => {
 	if (certificate.serverId) {
 		await execAsyncRemote(
 			certificate.serverId,
-			`rm -rf ${certDir}; rm -f ${configFile}`,
+			`rm -rf "${certDir}"; rm -f "${configFile}"`,
 		);
 	} else {
 		await removeDirectoryIfExistsContent(certDir);
@@ -141,7 +141,7 @@ const createCertificateFiles = async (certificate: Certificate) => {
 		const certificateData = encodeBase64(certificate.certificateData);
 		const privateKey = encodeBase64(certificate.privateKey);
 		const command = `
-			mkdir -p ${certDir};
+			mkdir -p "${certDir}";
 			echo "${certificateData}" | base64 -d > "${crtPath}";
 			echo "${privateKey}" | base64 -d > "${keyPath}";
 			echo "${yamlConfig}" > "${configFile}";

--- a/packages/server/src/services/certificate.ts
+++ b/packages/server/src/services/certificate.ts
@@ -16,6 +16,19 @@ import { execAsyncRemote } from "../utils/process/execAsync";
 
 export type Certificate = typeof certificates.$inferSelect;
 
+/**
+ * Returns the path to the per-certificate Traefik registration YAML.
+ *
+ * The file MUST live at the TOP LEVEL of the dynamic Traefik directory, because
+ * Traefik's `file.directory` provider is non-recursive and never loads files
+ * nested in subdirectories. The PEM files referenced by this YAML can still live
+ * in a per-certificate subdirectory since they are referenced by absolute path.
+ */
+export const getCertificateConfigPath = (
+	dynamicTraefikPath: string,
+	certificatePath: string,
+) => path.join(dynamicTraefikPath, `${certificatePath}-certificate.yml`);
+
 export const findCertificateById = async (certificateId: string) => {
 	const certificate = await db.query.certificates.findFirst({
 		where: eq(certificates.certificateId, certificateId),
@@ -59,13 +72,25 @@ export const createCertificate = async (
 
 export const removeCertificateById = async (certificateId: string) => {
 	const certificate = await findCertificateById(certificateId);
-	const { CERTIFICATES_PATH } = paths(!!certificate.serverId);
+	const { CERTIFICATES_PATH, DYNAMIC_TRAEFIK_PATH } = paths(
+		!!certificate.serverId,
+	);
 	const certDir = path.join(CERTIFICATES_PATH, certificate.certificatePath);
+	const configFile = getCertificateConfigPath(
+		DYNAMIC_TRAEFIK_PATH,
+		certificate.certificatePath,
+	);
 
 	if (certificate.serverId) {
-		await execAsyncRemote(certificate.serverId, `rm -rf ${certDir}`);
+		await execAsyncRemote(
+			certificate.serverId,
+			`rm -rf ${certDir}; rm -f ${configFile}`,
+		);
 	} else {
 		await removeDirectoryIfExistsContent(certDir);
+		if (fs.existsSync(configFile)) {
+			fs.rmSync(configFile);
+		}
 	}
 
 	const result = await db
@@ -84,7 +109,9 @@ export const removeCertificateById = async (certificateId: string) => {
 };
 
 const createCertificateFiles = async (certificate: Certificate) => {
-	const { CERTIFICATES_PATH } = paths(!!certificate.serverId);
+	const { CERTIFICATES_PATH, DYNAMIC_TRAEFIK_PATH } = paths(
+		!!certificate.serverId,
+	);
 	const certDir = path.join(CERTIFICATES_PATH, certificate.certificatePath);
 	const crtPath = path.join(certDir, "chain.crt");
 	const keyPath = path.join(certDir, "privkey.key");
@@ -102,7 +129,13 @@ const createCertificateFiles = async (certificate: Certificate) => {
 		},
 	};
 	const yamlConfig = stringify(traefikConfig);
-	const configFile = path.join(certDir, "certificate.yml");
+	// The registration YAML must live at the top level of the dynamic Traefik
+	// directory; Traefik's file.directory provider does not recurse into the
+	// per-certificate subdirectory where the PEM files live.
+	const configFile = getCertificateConfigPath(
+		DYNAMIC_TRAEFIK_PATH,
+		certificate.certificatePath,
+	);
 
 	if (certificate.serverId) {
 		const certificateData = encodeBase64(certificate.certificateData);


### PR DESCRIPTION
## What

Uploaded custom certificates (e.g. Cloudflare Origin CA) were never presented by Traefik over SNI, even though they appeared in the Dokploy UI under Certificates.

## Root cause

The per-certificate Traefik registration YAML was written into a subdirectory:

```
/etc/dokploy/traefik/dynamic/certificates/<certificatePath>/certificate.yml
```

But Traefik's file provider is configured with `directory: /etc/dokploy/traefik/dynamic` and `watch: true`. The `file.directory` provider is **non-recursive**, so it never reads files nested in subdirectories. As a result the cert YAML was never loaded into Traefik's TLS store and SNI matching never picked it up.

## Fix

- Add an exported pure helper `getCertificateConfigPath(dynamicTraefikPath, certificatePath)` that returns the registration YAML path at the **top level** of the dynamic Traefik directory: `<dynamicTraefikPath>/<certificatePath>-certificate.yml`.
- `createCertificateFiles` now pulls `DYNAMIC_TRAEFIK_PATH` from `paths()` and writes the YAML to the top-level path. The PEM files (`chain.crt` / `privkey.key`) stay in the per-certificate subdirectory — the YAML references them by **absolute path**, so this keeps working. The subdir `mkdir` for PEMs is unchanged.
- `removeCertificateById` now also deletes the top-level YAML (`rm -f` for remote servers, `fs.rmSync` if it exists for local) in addition to removing the per-cert subdirectory.

## Test

New test `apps/dokploy/__test__/traefik/certificate.test.ts` covers the `getCertificateConfigPath` contract: the path is top-level, is not under a `certificates/` subdirectory, and is unique per `certificatePath` (expected values built with `path.join` to avoid Windows separator flakiness).

RED (before adding the helper): `getCertificateConfigPath is not a function` — 3 failed.

GREEN (after fix):

```
 ✓ __test__/traefik/certificate.test.ts (3 tests) 3ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Both typechecks clean: `pnpm --filter=@dokploy/server run typecheck` and `pnpm --filter=dokploy run typecheck`.

Fixes #4503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
