### PR TITLE
feat: add copy button to User and Database Name in database credentials

### DIFF
--- a/apps/dokploy/__test__/utils/copy-input.test.ts
+++ b/apps/dokploy/__test__/utils/copy-input.test.ts
@@ -1,0 +1,32 @@
+import copy from "copy-to-clipboard";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { copyToClipboard } from "@/components/shared/copy-input";
+
+vi.mock("copy-to-clipboard", () => ({ default: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));
+
+describe("copyToClipboard", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	test("copies the value to the clipboard", () => {
+		copyToClipboard("admin");
+		expect(copy).toHaveBeenCalledWith("admin");
+	});
+
+	test("shows a success toast", () => {
+		copyToClipboard("admin");
+		expect(toast.success).toHaveBeenCalledWith("Value is copied to clipboard");
+	});
+
+	test("returns the copied value", () => {
+		expect(copyToClipboard("admin")).toBe("admin");
+	});
+
+	test("falls back to an empty string for undefined", () => {
+		expect(copyToClipboard(undefined)).toBe("");
+		expect(copy).toHaveBeenCalledWith("");
+	});
+});

--- a/apps/dokploy/components/dashboard/libsql/general/show-internal-libsql-credentials.tsx
+++ b/apps/dokploy/components/dashboard/libsql/general/show-internal-libsql-credentials.tsx
@@ -1,4 +1,5 @@
 import { SelectGroup } from "@radix-ui/react-select";
+import { CopyInput } from "@/components/shared/copy-input";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -28,7 +29,7 @@ export const ShowInternalLibsqlCredentials = ({ libsqlId }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4 md:gap-8">
 							<div className="flex flex-col gap-2">
 								<Label>User</Label>
-								<Input disabled value={data?.databaseUser} />
+								<CopyInput disabled value={data?.databaseUser} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Sqld Node</Label>

--- a/apps/dokploy/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mariadb/general/show-internal-mariadb-credentials.tsx
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { CopyInput } from "@/components/shared/copy-input";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,11 +26,11 @@ export const ShowInternalMariadbCredentials = ({ mariadbId }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4 md:gap-8">
 							<div className="flex flex-col gap-2">
 								<Label>User</Label>
-								<Input disabled value={data?.databaseUser} />
+								<CopyInput disabled value={data?.databaseUser} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Database Name</Label>
-								<Input disabled value={data?.databaseName} />
+								<CopyInput disabled value={data?.databaseName} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>

--- a/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-internal-mongo-credentials.tsx
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { CopyInput } from "@/components/shared/copy-input";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,7 +26,7 @@ export const ShowInternalMongoCredentials = ({ mongoId }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4 md:gap-8">
 							<div className="flex flex-col gap-2">
 								<Label>User</Label>
-								<Input disabled value={data?.databaseUser} />
+								<CopyInput disabled value={data?.databaseUser} />
 							</div>
 
 							<div className="flex flex-col gap-2">

--- a/apps/dokploy/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
+++ b/apps/dokploy/components/dashboard/mysql/general/show-internal-mysql-credentials.tsx
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { CopyInput } from "@/components/shared/copy-input";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,11 +26,11 @@ export const ShowInternalMysqlCredentials = ({ mysqlId }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4 md:gap-8">
 							<div className="flex flex-col gap-2">
 								<Label>User</Label>
-								<Input disabled value={data?.databaseUser} />
+								<CopyInput disabled value={data?.databaseUser} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Database Name</Label>
-								<Input disabled value={data?.databaseName} />
+								<CopyInput disabled value={data?.databaseName} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>

--- a/apps/dokploy/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
+++ b/apps/dokploy/components/dashboard/postgres/general/show-internal-postgres-credentials.tsx
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { CopyInput } from "@/components/shared/copy-input";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,11 +26,11 @@ export const ShowInternalPostgresCredentials = ({ postgresId }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4 md:gap-8">
 							<div className="flex flex-col gap-2">
 								<Label>User</Label>
-								<Input disabled value={data?.databaseUser} />
+								<CopyInput disabled value={data?.databaseUser} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Database Name</Label>
-								<Input disabled value={data?.databaseName} />
+								<CopyInput disabled value={data?.databaseName} />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>

--- a/apps/dokploy/components/dashboard/redis/general/show-internal-redis-credentials.tsx
+++ b/apps/dokploy/components/dashboard/redis/general/show-internal-redis-credentials.tsx
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { CopyInput } from "@/components/shared/copy-input";
 import { ToggleVisibilityInput } from "@/components/shared/toggle-visibility-input";
 import { UpdateDatabasePassword } from "@/components/shared/update-database-password";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,7 +26,7 @@ export const ShowInternalRedisCredentials = ({ redisId }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4 md:gap-8">
 							<div className="flex flex-col gap-2">
 								<Label>User</Label>
-								<Input disabled value="default" />
+								<CopyInput disabled value="default" />
 							</div>
 							<div className="flex flex-col gap-2">
 								<Label>Password</Label>

--- a/apps/dokploy/components/shared/copy-input.tsx
+++ b/apps/dokploy/components/shared/copy-input.tsx
@@ -1,0 +1,26 @@
+import copy from "copy-to-clipboard";
+import { Clipboard } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "../ui/button";
+import { Input, type InputProps } from "../ui/input";
+
+export const copyToClipboard = (value: string | undefined): string => {
+	const text = value ?? "";
+	copy(text);
+	toast.success("Value is copied to clipboard");
+	return text;
+};
+
+export const CopyInput = ({ ...props }: InputProps) => {
+	return (
+		<div className="flex w-full items-center space-x-2">
+			<Input {...props} />
+			<Button
+				variant={"secondary"}
+				onClick={() => copyToClipboard(props.value?.toString())}
+			>
+				<Clipboard className="size-4 text-muted-foreground" />
+			</Button>
+		</div>
+	);
+};

--- a/apps/dokploy/components/shared/copy-input.tsx
+++ b/apps/dokploy/components/shared/copy-input.tsx
@@ -16,6 +16,7 @@ export const CopyInput = ({ ...props }: InputProps) => {
 		<div className="flex w-full items-center space-x-2">
 			<Input {...props} />
 			<Button
+				type="button"
 				variant={"secondary"}
 				onClick={() => copyToClipboard(props.value?.toString())}
 			>


### PR DESCRIPTION
## What

Adds a copy-to-clipboard button to the **User** and **Database Name** fields in the Internal Credentials cards across all database types, making them consistent with the existing copy buttons on the Password and Internal Host fields.

Fixes #4495

## Root cause

The Internal Credentials cards rendered User and Database Name as plain `<Input disabled value=... />` with no copy affordance, while Password and Internal Connection URL already used `ToggleVisibilityInput` (which includes a copy button). `ToggleVisibilityInput` cannot be reused here because it masks the value as a password.

## Fix

- New component `apps/dokploy/components/shared/copy-input.tsx`: a visible `Input` paired with a copy `Button`, mirroring `toggle-visibility-input.tsx`. It exports a pure, testable helper `copyToClipboard(value)` that copies the value (via `copy-to-clipboard`), shows a `sonner` toast, and returns the value (falling back to `""` for `undefined`).
- Swapped the plain `<Input>` for `<CopyInput>` on the User / Database Name fields in the 6 credential components (postgres, mysql, mariadb — User + Database Name; mongo, redis, libsql — User only), keeping `disabled` and the existing `value`. The `Input` import is retained since other fields still use it.

## Test

New TDD test `apps/dokploy/__test__/utils/copy-input.test.ts` mocks `copy-to-clipboard` and `sonner`, then asserts `copyToClipboard` copies the value, shows a toast, returns the value, and falls back to `""` for `undefined`.

Confirmed RED first (module absent), then GREEN:

```
 ✓ __test__/utils/copy-input.test.ts (4 tests) 4ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Typecheck clean: `pnpm --filter=dokploy run typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)