### PR TITLE
fix: exit cleanly on fatal startup errors instead of crash-looping (#4253)

### DIFF
--- a/apps/dokploy/server/server.ts
+++ b/apps/dokploy/server/server.ts
@@ -28,53 +28,106 @@ const PORT = Number.parseInt(process.env.PORT || "3000", 10);
 const HOST = process.env.HOST || "0.0.0.0";
 const dev = process.env.NODE_ENV !== "production";
 
+// Tracks whether the HTTP server has reached the "listening" state. Until then,
+// any fatal error means the process can never serve requests and MUST exit(1) so
+// the orchestrator restarts it cleanly. Without this, a startup failure (e.g. a
+// rejected `app.prepare()`) leaves background handles — the Redis reconnect loop,
+// open sockets — keeping the event loop alive, so the process never exits: it
+// spins at ~100% CPU, the healthcheck never passes, and Docker Swarm crash-loops
+// the container with only an opaque "ELIFECYCLE  Command failed." See issue #4253.
+let isServerListening = false;
+
+// Node terminates the process on an uncaught exception by default; preserve that
+// but log the cause first so the failure point is never silent.
+process.on("uncaughtException", (error) => {
+	console.error("Uncaught exception:", error);
+	process.exit(1);
+});
+
+// A stray unhandled rejection BEFORE the server is listening means startup has
+// failed — exit so we don't spin forever (see above). Once we are serving
+// requests we only log, to avoid crashing an otherwise-healthy instance.
+process.on("unhandledRejection", (reason) => {
+	console.error("Unhandled rejection:", reason);
+	if (!isServerListening) {
+		process.exit(1);
+	}
+});
+
 // Initialize critical directories and Traefik config BEFORE Next.js starts
 // This prevents race conditions with the install script
 if (process.env.NODE_ENV === "production" && !IS_CLOUD) {
-	setupDirectories();
-	createDefaultTraefikConfig();
-	createDefaultServerTraefikConfig();
-	console.log("✅ initialization complete");
+	try {
+		setupDirectories();
+		createDefaultTraefikConfig();
+		createDefaultServerTraefikConfig();
+		console.log("✅ initialization complete");
+	} catch (error) {
+		console.error("Failed to initialize directories/Traefik config:", error);
+		process.exit(1);
+	}
 }
 
 const app = next({ dev, turbopack: process.env.TURBOPACK === "1" });
 const handle = app.getRequestHandler();
-void app.prepare().then(async () => {
-	try {
-		console.log("Running DokployVersion: ", packageInfo.version);
-		const server = http.createServer((req, res) => {
-			handle(req, res);
-		});
+void app
+	.prepare()
+	.then(async () => {
+		try {
+			console.log("Running DokployVersion: ", packageInfo.version);
+			const server = http.createServer((req, res) => {
+				handle(req, res);
+			});
 
-		// WEBSOCKET
-		setupDrawerLogsWebSocketServer(server);
-		setupDeploymentLogsWebSocketServer(server);
-		setupDockerContainerLogsWebSocketServer(server);
-		setupDockerContainerTerminalWebSocketServer(server);
-		setupTerminalWebSocketServer(server);
-		if (!IS_CLOUD) {
-			setupDockerStatsMonitoringSocketServer(server);
-		}
+			// WEBSOCKET
+			setupDrawerLogsWebSocketServer(server);
+			setupDeploymentLogsWebSocketServer(server);
+			setupDockerContainerLogsWebSocketServer(server);
+			setupDockerContainerTerminalWebSocketServer(server);
+			setupTerminalWebSocketServer(server);
+			if (!IS_CLOUD) {
+				setupDockerStatsMonitoringSocketServer(server);
+			}
 
-		server.listen(PORT, HOST);
-		console.log(`Server Started on: http://${HOST}:${PORT}`);
-		if (process.env.NODE_ENV === "production" && !IS_CLOUD) {
-			createDefaultMiddlewares();
-			await initializeNetwork();
-			await initCronJobs();
-			await initSchedules();
-			await initCancelDeployments();
-			await initVolumeBackupsCronJobs();
-			await sendDokployRestartNotifications();
-		}
-		await initEnterpriseBackupCronJobs();
+			// Wait for the bind to succeed (or fail, e.g. EADDRINUSE) before
+			// continuing, so a listen failure exits cleanly instead of spinning.
+			await new Promise<void>((resolve, reject) => {
+				const onError = (error: Error) => reject(error);
+				server.once("error", onError);
+				server.listen(PORT, HOST, () => {
+					server.removeListener("error", onError);
+					resolve();
+				});
+			});
+			isServerListening = true;
+			console.log(`Server Started on: http://${HOST}:${PORT}`);
 
-		if (!IS_CLOUD) {
-			console.log("Starting Deployment Worker");
-			const { deploymentWorker } = await import("./queues/deployments-queue");
-			await deploymentWorker.run();
+			if (process.env.NODE_ENV === "production" && !IS_CLOUD) {
+				createDefaultMiddlewares();
+				await initializeNetwork();
+				await initCronJobs();
+				await initSchedules();
+				await initCancelDeployments();
+				await initVolumeBackupsCronJobs();
+				await sendDokployRestartNotifications();
+			}
+			await initEnterpriseBackupCronJobs();
+
+			if (!IS_CLOUD) {
+				console.log("Starting Deployment Worker");
+				const { deploymentWorker } = await import("./queues/deployments-queue");
+				await deploymentWorker.run();
+			}
+		} catch (e) {
+			console.error("Main Server Error", e);
+			// If we failed before binding, the process can never serve traffic —
+			// exit so the orchestrator restarts us instead of leaving it spinning.
+			if (!isServerListening) {
+				process.exit(1);
+			}
 		}
-	} catch (e) {
-		console.error("Main Server Error", e);
-	}
-});
+	})
+	.catch((error) => {
+		console.error("Failed to prepare Next.js app server:", error);
+		process.exit(1);
+	});


### PR DESCRIPTION
## Problem

Fixes #4253. After `Migration complete`, a fatal error in the server startup window did **not** terminate the process. Background handles — the ioredis reconnect loop, open sockets — keep the event loop alive, so instead of exiting, the process **spins at high CPU**, never passes the healthcheck (`/api/trpc/settings.health`), and Docker Swarm crash-loops the container showing only:

```
Using Docker socket (Standard Docker socket): /var/run/docker.sock
ELIFECYCLE  Command failed.
```

This matches every detail the reporter described: the crash loop pegging CPU (their 700–900%), the server never reaching "Server Started", and Swarm marking the task `non-zero exit (1): unhealthy container`.

## Root cause

In `apps/dokploy/server/server.ts`:
- The top-level `setupDirectories()` / `createDefaultTraefikConfig()` block had no `try/catch`.
- `app.prepare()` had error handling *inside* its `.then()` but **no `.catch()`** — a rejected `prepare()` became an unhandled rejection.
- There were no process-level `uncaughtException` / `unhandledRejection` handlers, and a dependency registers a logging-only `unhandledRejection` listener that suppresses Node's default "crash on unhandled rejection". So a fatal startup error is logged (or not) but the process never exits — it just spins.

## Fix

Phase-gated error handling, so a failed startup exits cleanly **without** destabilizing a healthy server:

- **Before the HTTP server is listening** → an uncaught exception / unhandled rejection / sync-init throw / `prepare()` rejection / bind failure logs the cause and `exit(1)`s, so the orchestrator restarts cleanly instead of spinning.
- **After it is listening** → a stray unhandled rejection is only logged, so an otherwise-healthy serving instance is never killed.
- `await` the `listen()` bind so a bind failure (e.g. `EADDRINUSE`) exits instead of spinning; mark the server ready only once actually listening.
- `try/catch` around the synchronous directory/Traefik init; `.catch()` on `app.prepare()` with a labeled diagnostic.

## Verification (real compiled bundle)

Built the real `dist/migration.mjs` + `dist/server.mjs` from this branch (`node:24.4.0-slim`, real Postgres 16 + Redis on a Docker network) and exercised the actual `migration → server` boot:

| Scenario | `canary` | This PR |
|---|---|---|
| Pre-listen `prepare()` failure | **spins forever**, high CPU, killed at timeout (exit 124) | logs `Failed to prepare…`, **clean exit 1 in ~5s** |
| Normal boot | — | reaches `Server Started on`, healthcheck **HTTP 200**, running |
| Real post-listen rejection (`docker.sock` ENOENT) | — | logged, **server survives** and stays healthy |

The post-listen case is why the handlers are phase-gated: a naive "always `exit(1)` on unhandled rejection" would kill a healthy server on that exact background `docker.sock` rejection.

## Scope

This fixes the **crash-loop mechanism** — any fatal startup failure now produces a clean, logged `exit(1)` instead of a silent high-CPU spin. The separate report in the comments (the `dokploy-postgres` role disappearing after ~1–2h) is a distinct database-lifecycle issue this PR does not address; with this change, that failure would surface as a clean diagnostic exit rather than a silent spin.

## Testing

- `tsc --noEmit` clean; `biome check` clean.
- Reproduced before/after with the real bundle as above.
