### PR TITLE
fix: redact private keys from logged command errors

### DIFF
--- a/apps/dokploy/__test__/process/redact-secrets.test.ts
+++ b/apps/dokploy/__test__/process/redact-secrets.test.ts
@@ -1,0 +1,38 @@
+import { redactSecrets } from "@dokploy/server/utils/process/redactSecrets";
+import { describe, expect, it } from "vitest";
+
+// All key material below is synthetic: these base64 strings decode to the
+// literal text "synthetic-test-not-a-real-...-key" and are not real keys.
+
+describe("redactSecrets", () => {
+	it("redacts a PEM private key block written to /tmp/id_rsa", () => {
+		const secret = "c3ludGhldGljLXRlc3Qtbm90LWEtcmVhbC1wcml2YXRlLWtleQ==";
+		const command =
+			`echo "-----BEGIN OPENSSH PRIVATE KEY-----\n${secret}\n-----END OPENSSH PRIVATE KEY-----" > /tmp/id_rsa;` +
+			"chmod 600 /tmp/id_rsa;git clone --branch main --depth 1 git@example.com:org/repo /code";
+
+		const redacted = redactSecrets(command);
+
+		expect(redacted).not.toContain(secret);
+		expect(redacted).toContain("[REDACTED PRIVATE KEY]");
+		expect(redacted).toContain("chmod 600 /tmp/id_rsa");
+		expect(redacted).toContain("git clone --branch main");
+	});
+
+	it("redacts a base64 key piped to base64 -d", () => {
+		const secret = "c3ludGhldGljLXRlc3Qtbm90LWEtcmVhbC1jZXJ0LWtleQ==";
+		const command = `echo "${secret}" | base64 -d > "/etc/dokploy/cert.key";`;
+
+		const redacted = redactSecrets(command);
+
+		expect(redacted).not.toContain(secret);
+		expect(redacted).toContain('echo "[REDACTED]" | base64 -d');
+	});
+
+	it("leaves commands without secrets untouched", () => {
+		const command =
+			"git clone --branch main --depth 1 git@github.com:org/repo.git /tmp/code";
+
+		expect(redactSecrets(command)).toBe(command);
+	});
+});

--- a/packages/server/src/utils/process/ExecError.ts
+++ b/packages/server/src/utils/process/ExecError.ts
@@ -1,3 +1,5 @@
+import { redactErrorSecrets, redactSecrets } from "./redactSecrets";
+
 export interface ExecErrorDetails {
 	command: string;
 	stdout?: string;
@@ -16,13 +18,19 @@ export class ExecError extends Error {
 	public readonly serverId?: string | null;
 
 	constructor(message: string, details: ExecErrorDetails) {
-		super(message);
+		super(redactSecrets(message));
 		this.name = "ExecError";
-		this.command = details.command;
-		this.stdout = details.stdout;
-		this.stderr = details.stderr;
+		this.command = redactSecrets(details.command);
+		this.stdout = details.stdout
+			? redactSecrets(details.stdout)
+			: details.stdout;
+		this.stderr = details.stderr
+			? redactSecrets(details.stderr)
+			: details.stderr;
 		this.exitCode = details.exitCode;
-		this.originalError = details.originalError;
+		this.originalError = details.originalError
+			? redactErrorSecrets(details.originalError)
+			: details.originalError;
 		this.serverId = details.serverId;
 
 		// Maintains proper stack trace for where our error was thrown (only available on V8)

--- a/packages/server/src/utils/process/redactSecrets.ts
+++ b/packages/server/src/utils/process/redactSecrets.ts
@@ -1,0 +1,30 @@
+// Dokploy embeds some secrets directly into the shell commands it runs: the
+// SSH key written to /tmp/id_rsa when cloning over SSH, and the base64 TLS key
+// piped to `base64 -d` when provisioning certificates on a remote server. When
+// such a command fails, its ExecError (command/stdout/stderr) is logged, which
+// would otherwise persist the secret in plain text. These helpers strip that
+// material before it can reach the logs.
+
+const PRIVATE_KEY_BLOCK =
+	/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
+
+const BASE64_DECODE_PIPE = /echo "[A-Za-z0-9+/=]+"\s*\|\s*base64 -d/g;
+
+export const redactSecrets = (value: string): string =>
+	value
+		.replace(PRIVATE_KEY_BLOCK, "[REDACTED PRIVATE KEY]")
+		.replace(BASE64_DECODE_PIPE, 'echo "[REDACTED]" | base64 -d');
+
+// Node's child_process errors repeat the failed command on `message`, `stack`
+// and `cmd`, so redact those too when wrapping an original error.
+export const redactErrorSecrets = <T extends Error>(error: T): T => {
+	const candidate = error as T & { cmd?: string };
+	candidate.message = redactSecrets(candidate.message);
+	if (candidate.stack) {
+		candidate.stack = redactSecrets(candidate.stack);
+	}
+	if (candidate.cmd) {
+		candidate.cmd = redactSecrets(candidate.cmd);
+	}
+	return candidate;
+};


### PR DESCRIPTION
## What is this PR about?

Private keys can end up in the logs. When Dokploy clones a repository over SSH it writes the SSH key to `/tmp/id_rsa` via `echo "<key>"`, and when it provisions a TLS certificate on a remote server it pipes the base64 key to `base64 -d` — both inside shell command strings. On failure the resulting `ExecError` carries the full command (plus stdout/stderr and the wrapped original error) and is logged via `console.log(error)`, so the key lands in `docker service logs` in plain text and propagates to any forwarded log store.

This redacts private-key material at the single point every log path funnels through — `ExecError`. A small `redactSecrets` helper strips PEM private-key blocks and `echo "<base64>" | base64 -d` payloads from the command, stdout, stderr, message and any wrapped original error, so no caller or `console.log(error)` sink can leak them.

Reading these logs already requires host/root access, so this is a secret-hygiene / defense-in-depth fix (CWE-532), not a remotely exploitable issue. It follows the same direction as #4579, which kept the registry password out of the login command.

Affected sources for reference: `utils/providers/git.ts` (SSH key) and `services/certificate.ts` (TLS key); the redaction lives in `utils/process/ExecError.ts` so it also covers any future secret-bearing command.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. Added a vitest unit test (`__test__/process/redact-secrets.test.ts`) and verified the redaction against real command output captured from `docker service logs`. The change is confined to log-string redaction and does not alter any deploy path.

## Issues related (if applicable)

closes #4600
