### PR TITLE
feat(volume-backups): add gzip compression to volume backups

### DIFF
--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -37,7 +37,7 @@ export const backupVolume = async (
 		volumeBackup.application?.serverId || volumeBackup.compose?.serverId;
 	const { VOLUME_BACKUPS_PATH, VOLUME_BACKUP_LOCK_PATH } = paths(!!serverId);
 	const s3AppName = getVolumeServiceAppName(volumeBackup);
-	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar`;
+	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar.gz`;
 	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
 	const rcloneFlags = getS3Credentials(destination);
 	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
@@ -56,7 +56,7 @@ export const backupVolume = async (
   -v ${volumeName}:/volume_data \
   -v ${volumeBackupPath}:/backup \
   ubuntu \
-  bash -c "cd /volume_data && tar cvf /backup/${backupFileName} ."
+  bash -c "cd /volume_data && tar czf /backup/${backupFileName} ."
   echo "Volume backup done ✅"
   `;
 

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -87,7 +87,7 @@ const cleanupOldVolumeBackups = async (
 		const rcloneFlags = getS3Credentials(destination);
 		const s3AppName = getVolumeServiceAppName(volumeBackup);
 		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
-		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
+		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar.gz\" ${backupFilesPath}`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
 		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
 		const fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
@@ -156,8 +156,8 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 			VOLUME_BACKUPS_PATH,
 			volumeBackup.appName,
 		);
-		// delete all the .tar files
-		const command = `rm -rf ${volumeBackupPath}/*.tar`;
+		// delete all the .tar.gz files
+		const command = `rm -rf ${volumeBackupPath}/*.tar.gz`;
 		if (serverId) {
 			await execAsyncRemote(serverId, command);
 		} else {


### PR DESCRIPTION
## Summary

Volume backups currently create uncompressed `.tar` archives using `tar cvf`. This PR changes to `tar czf` (gzip compression) creating `.tar.gz` files, significantly reducing backup size and S3 storage costs.

## Changes

- **`backup.ts`**: Changed `tar cvf` → `tar czf` and extension `.tar` → `.tar.gz`
- **`utils.ts`**: Updated retention filter `--include "*.tar"` → `--include "*.tar.gz"` and error cleanup `*.tar` → `*.tar.gz`

## Impact

- **Backup size**: ~3-4x smaller for SQLite databases (which compress very well with gzip)
- **Compatibility**: `gzip` is pre-installed in the `ubuntu` container used for volume backups — no additional dependencies needed
- **Restore**: `tar xf` auto-detects gzip compression, so existing restore logic continues to work for both `.tar` and `.tar.gz` files
- **Breaking note**: Old `.tar` files in S3 will not be cleaned up by the new retention policy (which now filters `*.tar.gz`). They will need manual cleanup.

## Testing

- [x] Verified `gzip` is available in the `ubuntu` Docker image
- [ ] Created volume backup with gzip compression
- [ ] Verified `.tar.gz` file appears in S3 destination
- [ ] Restored from `.tar.gz` backup successfully
- [ ] Verified `keepLatestCount` retention works with `.tar.gz` extension

Closes #3566