### PR TITLE
fix: honor triggerType on refresh-token webhook deploys (#3710)

### DIFF
--- a/apps/dokploy/__test__/deploy/github.test.ts
+++ b/apps/dokploy/__test__/deploy/github.test.ts
@@ -4,6 +4,7 @@ import {
 	extractImageName,
 	extractImageTag,
 	extractImageTagFromRequest,
+	extractTagName,
 } from "@/pages/api/deploy/[refreshToken]";
 
 describe("GitHub Webhook Skip CI", () => {
@@ -110,6 +111,73 @@ describe("GitHub Webhook Skip CI", () => {
 		expect(extractCommitMessage({ "x-softserve-event": "push" }, {})).toBe(
 			"NEW COMMIT",
 		);
+	});
+});
+
+describe("extractTagName", () => {
+	it("should extract the tag name from a GitHub tag push", () => {
+		expect(
+			extractTagName({ "x-github-event": "push" }, { ref: "refs/tags/v1.0.0" }),
+		).toBe("v1.0.0");
+	});
+
+	it("should return null for a GitHub branch push", () => {
+		expect(
+			extractTagName({ "x-github-event": "push" }, { ref: "refs/heads/main" }),
+		).toBeNull();
+	});
+
+	it("should extract the tag name from a Gitea tag push", () => {
+		expect(
+			extractTagName({ "x-gitea-event": "push" }, { ref: "refs/tags/v2.3.4" }),
+		).toBe("v2.3.4");
+	});
+
+	it("should extract the tag name from a GitLab tag push", () => {
+		expect(
+			extractTagName(
+				{ "x-gitlab-event": "Tag Push Hook" },
+				{ ref: "refs/tags/release-1" },
+			),
+		).toBe("release-1");
+	});
+
+	it("should return null for a GitLab branch push", () => {
+		expect(
+			extractTagName(
+				{ "x-gitlab-event": "Push Hook" },
+				{ ref: "refs/heads/develop" },
+			),
+		).toBeNull();
+	});
+
+	it("should extract the tag name from a Bitbucket tag push", () => {
+		expect(
+			extractTagName(
+				{ "x-event-key": "repo:push" },
+				{ push: { changes: [{ new: { type: "tag", name: "v9.9.9" } }] } },
+			),
+		).toBe("v9.9.9");
+	});
+
+	it("should return null for a Bitbucket branch push", () => {
+		expect(
+			extractTagName(
+				{ "x-event-key": "repo:push" },
+				{ push: { changes: [{ new: { type: "branch", name: "main" } }] } },
+			),
+		).toBeNull();
+	});
+
+	it("should return null when ref is missing or empty", () => {
+		expect(extractTagName({ "x-github-event": "push" }, {})).toBeNull();
+		expect(
+			extractTagName({ "x-github-event": "push" }, { ref: "" }),
+		).toBeNull();
+	});
+
+	it("should return null for unknown providers", () => {
+		expect(extractTagName({}, { ref: "refs/tags/v1.0.0" })).toBeNull();
 	});
 });
 

--- a/apps/dokploy/pages/api/deploy/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/[refreshToken].ts
@@ -65,7 +65,7 @@ export default async function handler(
 			return;
 		}
 
-		const deploymentTitle = extractCommitMessage(req.headers, req.body);
+		let deploymentTitle = extractCommitMessage(req.headers, req.body);
 
 		const deploymentHash = extractHash(req.headers, req.body);
 		const sourceType = application.sourceType;
@@ -119,24 +119,46 @@ export default async function handler(
 			}
 			// If webhook doesn't provide image info, we'll use the configured image (old behavior)
 		} else if (sourceType === "github") {
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
-			);
+			const tagName = extractTagName(req.headers, req.body);
+			const isTagEvent = !!tagName;
 
-			const shouldDeployPaths = shouldDeploy(
-				application.watchPaths,
-				normalizedCommits,
-			);
+			if (application.triggerType === "tag") {
+				if (!isTagEvent) {
+					res.status(301).json({
+						message: "Trigger type is 'tag'; ignoring non-tag push",
+					});
+					return;
+				}
+				// Tag event: deploy without branch/watchPaths checks (tags are not
+				// branch-scoped and the UI hides watchPaths for the tag trigger).
+				deploymentTitle = `Tag created: ${tagName}`;
+			} else {
+				if (isTagEvent) {
+					res.status(301).json({
+						message: "Trigger type is 'push'; ignoring tag event",
+					});
+					return;
+				}
 
-			if (!shouldDeployPaths) {
-				res.status(301).json({ message: "Watch Paths Not Match" });
-				return;
-			}
+				const normalizedCommits = req.body?.commits?.flatMap(
+					(commit: any) => commit.modified,
+				);
 
-			const branchName = extractBranchName(req.headers, req.body);
-			if (!branchName || branchName !== application.branch) {
-				res.status(301).json({ message: "Branch Not Match" });
-				return;
+				const shouldDeployPaths = shouldDeploy(
+					application.watchPaths,
+					normalizedCommits,
+				);
+
+				if (!shouldDeployPaths) {
+					res.status(301).json({ message: "Watch Paths Not Match" });
+					return;
+				}
+
+				const branchName = extractBranchName(req.headers, req.body);
+				if (!branchName || branchName !== application.branch) {
+					res.status(301).json({ message: "Branch Not Match" });
+					return;
+				}
 			}
 		} else if (sourceType === "git") {
 			const branchName = extractBranchName(req.headers, req.body);
@@ -530,6 +552,35 @@ export const extractBranchName = (headers: any, body: any) => {
 
 	if (headers["x-event-key"]?.includes("repo:push")) {
 		return body?.push?.changes[0]?.new?.name;
+	}
+
+	return null;
+};
+
+/**
+ * Return the tag name for a tag-creation webhook event, or null when the event
+ * is not a tag push. Used to honor the application/compose `triggerType` ("tag"
+ * vs "push") on the refresh-token webhook path, mirroring the GitHub App handler.
+ */
+export const extractTagName = (headers: any, body: any) => {
+	// GitHub / Gitea: ref = refs/tags/<tag>
+	if (headers["x-github-event"] || headers["x-gitea-event"]) {
+		return body?.ref?.startsWith("refs/tags/")
+			? body.ref.replace("refs/tags/", "")
+			: null;
+	}
+
+	// GitLab: Tag Push Hook, ref = refs/tags/<tag>
+	if (headers["x-gitlab-event"]) {
+		return body?.ref?.startsWith("refs/tags/")
+			? body.ref.replace("refs/tags/", "")
+			: null;
+	}
+
+	// Bitbucket: push change with new.type === "tag"
+	if (headers["x-event-key"]?.includes("repo:push")) {
+		const change = body?.push?.changes?.[0]?.new;
+		return change?.type === "tag" ? change?.name : null;
 	}
 
 	return null;

--- a/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
+++ b/apps/dokploy/pages/api/deploy/compose/[refreshToken].ts
@@ -11,6 +11,7 @@ import {
 	extractCommitMessage,
 	extractCommittedPaths,
 	extractHash,
+	extractTagName,
 	getProviderByHeader,
 	logWebhookError,
 } from "../[refreshToken]";
@@ -48,29 +49,51 @@ export default async function handler(
 			return;
 		}
 
-		const deploymentTitle = extractCommitMessage(req.headers, req.body);
+		let deploymentTitle = extractCommitMessage(req.headers, req.body);
 		const deploymentHash = extractHash(req.headers, req.body);
 		const sourceType = composeResult.sourceType;
 
 		if (sourceType === "github") {
-			const branchName = extractBranchName(req.headers, req.body);
-			const normalizedCommits = req.body?.commits?.flatMap(
-				(commit: any) => commit.modified,
-			);
+			const tagName = extractTagName(req.headers, req.body);
+			const isTagEvent = !!tagName;
 
-			const shouldDeployPaths = shouldDeploy(
-				composeResult.watchPaths,
-				normalizedCommits,
-			);
+			if (composeResult.triggerType === "tag") {
+				if (!isTagEvent) {
+					res.status(301).json({
+						message: "Trigger type is 'tag'; ignoring non-tag push",
+					});
+					return;
+				}
+				// Tag event: deploy without branch/watchPaths checks (tags are not
+				// branch-scoped and the UI hides watchPaths for the tag trigger).
+				deploymentTitle = `Tag created: ${tagName}`;
+			} else {
+				if (isTagEvent) {
+					res.status(301).json({
+						message: "Trigger type is 'push'; ignoring tag event",
+					});
+					return;
+				}
 
-			if (!shouldDeployPaths) {
-				res.status(301).json({ message: "Watch Paths Not Match" });
-				return;
-			}
+				const branchName = extractBranchName(req.headers, req.body);
+				const normalizedCommits = req.body?.commits?.flatMap(
+					(commit: any) => commit.modified,
+				);
 
-			if (!branchName || branchName !== composeResult.branch) {
-				res.status(301).json({ message: "Branch Not Match" });
-				return;
+				const shouldDeployPaths = shouldDeploy(
+					composeResult.watchPaths,
+					normalizedCommits,
+				);
+
+				if (!shouldDeployPaths) {
+					res.status(301).json({ message: "Watch Paths Not Match" });
+					return;
+				}
+
+				if (!branchName || branchName !== composeResult.branch) {
+					res.status(301).json({ message: "Branch Not Match" });
+					return;
+				}
 			}
 		} else if (sourceType === "gitlab") {
 			const branchName = extractBranchName(req.headers, req.body);


### PR DESCRIPTION
## What is this PR about?

Fixes #3710, where a project with **Trigger Type = "On tag"** still builds on every regular commit/push (and real tag pushes don't deploy).

The GitHub **App** webhook handler (`pages/api/deploy/github.ts`) already respects `triggerType`. But the **refresh-token** webhook handlers — the URL Dokploy shows for manual webhook setup — never looked at it:

- `apps/dokploy/pages/api/deploy/[refreshToken].ts` (applications)
- `apps/dokploy/pages/api/deploy/compose/[refreshToken].ts` (compose)

For a GitHub source they only checked `watchPaths` + branch match, so:
1. A `triggerType: "tag"` app/compose **still deployed on every branch push** — the field was ignored (the exact bug reported, on Docker Compose).
2. A real tag push (`ref = refs/tags/x`, which `extractBranchName` leaves unstripped) failed the branch match → **tag pushes never deployed** via this path.

### Change

- Add an exported `extractTagName` helper in `[refreshToken].ts` (detects tag events for GitHub/Gitea/GitLab/Bitbucket).
- Gate the `sourceType === "github"` branch of both handlers on `triggerType`, mirroring `github.ts` semantics:
  - **tag**: deploy only on tag events (skip branch/watchPaths — tags aren't branch-scoped and the UI hides watchPaths for tags), titled `Tag created: <tag>`; ignore non-tag pushes.
  - **push** (default): ignore tag events; keep the existing branch + watchPaths checks unchanged.

Scope is **GitHub only**, matching the issue and the original feature (PR #1613). No schema, migration, or UI changes — the `triggerType` column and GitHub UI selector already exist.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file.
- [x] You have tested this PR in your local instance.

Testing: added `extractTagName` unit tests in `__test__/deploy/github.test.ts` (40/40 pass) and verified `biome check` is clean on the touched files. Also exercised the handlers manually against a local instance with simulated branch-push vs tag-push payloads for both `triggerType` settings.

## Issues related (if applicable)

closes #3710