### PR TITLE
fix: validate API key prefixes before creation

### DIFF
--- a/apps/dokploy/__test__/user/create-api-key-errors.test.ts
+++ b/apps/dokploy/__test__/user/create-api-key-errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	apiKeyPrefixErrorMessage,
+	getCreateApiKeyErrorMessage,
+	getCreateApiKeyPrefixError,
+} from "@/components/dashboard/settings/api/api-key-errors";
+
+describe("create API key error helpers", () => {
+	it("extracts prefix validation errors from tRPC zod errors", () => {
+		const error = {
+			data: {
+				zodError: {
+					fieldErrors: {
+						prefix: [apiKeyPrefixErrorMessage],
+					},
+				},
+			},
+			message: "Invalid input",
+		};
+
+		expect(getCreateApiKeyPrefixError(error)).toBe(apiKeyPrefixErrorMessage);
+		expect(getCreateApiKeyErrorMessage(error)).toBe(apiKeyPrefixErrorMessage);
+	});
+
+	it("treats server-side prefix validation as a field error", () => {
+		const error = {
+			message: apiKeyPrefixErrorMessage,
+		};
+
+		expect(getCreateApiKeyPrefixError(error)).toBe(apiKeyPrefixErrorMessage);
+		expect(getCreateApiKeyErrorMessage(error)).toBe(apiKeyPrefixErrorMessage);
+	});
+
+	it("uses mutation messages for non-prefix errors", () => {
+		const error = {
+			message: "You are not a member of this organization",
+		};
+
+		expect(getCreateApiKeyPrefixError(error)).toBeUndefined();
+		expect(getCreateApiKeyErrorMessage(error)).toBe(
+			"You are not a member of this organization",
+		);
+	});
+
+	it("falls back to a generic message when no server message exists", () => {
+		expect(getCreateApiKeyPrefixError({})).toBeUndefined();
+		expect(getCreateApiKeyErrorMessage({})).toBe("Failed to generate API key");
+	});
+});

--- a/apps/dokploy/__test__/user/create-api-key.test.ts
+++ b/apps/dokploy/__test__/user/create-api-key.test.ts
@@ -1,0 +1,144 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateApiKey } = vi.hoisted(() => ({
+	mockCreateApiKey: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/lib/auth", () => ({
+	auth: {
+		createApiKey: mockCreateApiKey,
+	},
+}));
+
+vi.mock("bcrypt", () => ({
+	compare: vi.fn(),
+	hash: vi.fn(),
+}));
+
+const { createApiKey } = await import("@dokploy/server/services/user");
+
+const apiKeyInput = {
+	name: "Deploy key",
+	metadata: {
+		organizationId: "org-1",
+	},
+};
+
+const prefixErrorMessage =
+	"Prefix can only contain ASCII letters, numbers, underscores, and hyphens";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockCreateApiKey.mockImplementation(async ({ body }) => {
+		if (body.prefix !== undefined && !/^[A-Za-z0-9_-]+$/.test(body.prefix)) {
+			throw new Error(
+				"[body.prefix] Invalid prefix format, must be alphanumeric and contain only underscores and hyphens.",
+			);
+		}
+
+		return {
+			id: "api-key-1",
+			key: "dokploy_test_key",
+		};
+	});
+});
+
+describe("createApiKey prefix validation", () => {
+	it("allows missing prefix", async () => {
+		await expect(createApiKey("user-1", apiKeyInput)).resolves.toMatchObject({
+			id: "api-key-1",
+		});
+
+		expect(mockCreateApiKey).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.objectContaining({
+					prefix: undefined,
+				}),
+			}),
+		);
+	});
+
+	it.each(["dokploy_", "github-actions", "ci_cd"])(
+		"allows valid prefix %s",
+		async (prefix) => {
+			await expect(
+				createApiKey("user-1", {
+					...apiKeyInput,
+					prefix,
+				}),
+			).resolves.toMatchObject({
+				id: "api-key-1",
+			});
+
+			expect(mockCreateApiKey).toHaveBeenCalledWith(
+				expect.objectContaining({
+					body: expect.objectContaining({
+						prefix,
+					}),
+				}),
+			);
+		},
+	);
+
+	it.each(["prod deploy", "prod.deploy", "prod/deploy", "прод_"])(
+		"rejects invalid prefix %s with BAD_REQUEST",
+		async (prefix) => {
+			await createApiKey("user-1", {
+				...apiKeyInput,
+				prefix,
+			}).then(
+				() => {
+					throw new Error("Expected createApiKey to reject");
+				},
+				(error) => {
+					expect(error).toBeInstanceOf(TRPCError);
+					expect(error).toMatchObject({
+						code: "BAD_REQUEST",
+						message: prefixErrorMessage,
+					});
+				},
+			);
+
+			expect(mockCreateApiKey).not.toHaveBeenCalled();
+		},
+	);
+
+	it("trims leading and trailing spaces before creating the API key", async () => {
+		await expect(
+			createApiKey("user-1", {
+				...apiKeyInput,
+				prefix: "  github-actions  ",
+			}),
+		).resolves.toMatchObject({
+			id: "api-key-1",
+		});
+
+		expect(mockCreateApiKey).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.objectContaining({
+					prefix: "github-actions",
+				}),
+			}),
+		);
+	});
+
+	it("treats an empty trimmed prefix as undefined", async () => {
+		await expect(
+			createApiKey("user-1", {
+				...apiKeyInput,
+				prefix: "   ",
+			}),
+		).resolves.toMatchObject({
+			id: "api-key-1",
+		});
+
+		expect(mockCreateApiKey).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.objectContaining({
+					prefix: undefined,
+				}),
+			}),
+		);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/api/add-api-key.tsx
+++ b/apps/dokploy/components/dashboard/settings/api/add-api-key.tsx
@@ -33,10 +33,12 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { api } from "@/utils/api";
-
-const apiKeyPrefixRegex = /^[A-Za-z0-9_-]+$/;
-const apiKeyPrefixErrorMessage =
-	"Prefix can only contain ASCII letters, numbers, underscores, and hyphens";
+import {
+	apiKeyPrefixErrorMessage,
+	apiKeyPrefixRegex,
+	getCreateApiKeyErrorMessage,
+	getCreateApiKeyPrefixError,
+} from "./api-key-errors";
 
 const formSchema = z.object({
 	name: z.string().min(1, "Name is required"),
@@ -104,8 +106,16 @@ export const AddApiKey = () => {
 			form.reset();
 			void refetch();
 		},
-		onError: () => {
-			toast.error("Failed to generate API key");
+		onError: (error) => {
+			const prefixError = getCreateApiKeyPrefixError(error);
+			if (prefixError) {
+				form.setError("prefix", {
+					type: "server",
+					message: prefixError,
+				});
+			}
+
+			toast.error(getCreateApiKeyErrorMessage(error));
 		},
 	});
 

--- a/apps/dokploy/components/dashboard/settings/api/add-api-key.tsx
+++ b/apps/dokploy/components/dashboard/settings/api/add-api-key.tsx
@@ -34,9 +34,19 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { api } from "@/utils/api";
 
+const apiKeyPrefixRegex = /^[A-Za-z0-9_-]+$/;
+const apiKeyPrefixErrorMessage =
+	"Prefix can only contain ASCII letters, numbers, underscores, and hyphens";
+
 const formSchema = z.object({
 	name: z.string().min(1, "Name is required"),
-	prefix: z.string().optional(),
+	prefix: z
+		.string()
+		.trim()
+		.refine((value) => value === "" || apiKeyPrefixRegex.test(value), {
+			message: apiKeyPrefixErrorMessage,
+		})
+		.optional(),
 	expiresIn: z.number().nullable(),
 	organizationId: z.string().min(1, "Organization is required"),
 	// Rate limiting fields

--- a/apps/dokploy/components/dashboard/settings/api/api-key-errors.ts
+++ b/apps/dokploy/components/dashboard/settings/api/api-key-errors.ts
@@ -1,0 +1,51 @@
+export const apiKeyPrefixRegex = /^[A-Za-z0-9_-]+$/;
+export const apiKeyPrefixErrorMessage =
+	"Prefix can only contain ASCII letters, numbers, underscores, and hyphens";
+
+const defaultCreateApiKeyErrorMessage = "Failed to generate API key";
+
+const getErrorMessage = (error: unknown) => {
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"message" in error &&
+		typeof error.message === "string"
+	) {
+		return error.message;
+	}
+};
+
+export const getCreateApiKeyPrefixError = (error: unknown) => {
+	if (typeof error !== "object" || error === null) {
+		return;
+	}
+
+	const prefixFieldErrors = (
+		error as {
+			data?: {
+				zodError?: {
+					fieldErrors?: {
+						prefix?: string[];
+					};
+				};
+			};
+		}
+	).data?.zodError?.fieldErrors?.prefix;
+
+	if (prefixFieldErrors?.[0]) {
+		return prefixFieldErrors[0];
+	}
+
+	const message = getErrorMessage(error);
+	if (message === apiKeyPrefixErrorMessage) {
+		return message;
+	}
+};
+
+export const getCreateApiKeyErrorMessage = (error: unknown) => {
+	return (
+		getCreateApiKeyPrefixError(error) ??
+		getErrorMessage(error) ??
+		defaultCreateApiKeyErrorMessage
+	);
+};

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -44,9 +44,22 @@ import {
 	withPermission,
 } from "../trpc";
 
+const apiKeyPrefixRegex = /^[A-Za-z0-9_-]+$/;
+const apiKeyPrefixErrorMessage =
+	"Prefix can only contain ASCII letters, numbers, underscores, and hyphens";
+
+const apiKeyPrefixSchema = z
+	.string()
+	.trim()
+	.transform((value) => (value === "" ? undefined : value))
+	.refine((value) => value === undefined || apiKeyPrefixRegex.test(value), {
+		message: apiKeyPrefixErrorMessage,
+	})
+	.optional();
+
 const apiCreateApiKey = z.object({
 	name: z.string().min(1),
-	prefix: z.string().optional(),
+	prefix: apiKeyPrefixSchema,
 	expiresIn: z.number().optional(),
 	metadata: z.object({
 		organizationId: z.string(),

--- a/packages/server/src/services/user.ts
+++ b/packages/server/src/services/user.ts
@@ -509,6 +509,30 @@ export const updateUser = async (userId: string, userData: Partial<User>) => {
 	return userResult;
 };
 
+const apiKeyPrefixRegex = /^[A-Za-z0-9_-]+$/;
+const apiKeyPrefixErrorMessage =
+	"Prefix can only contain ASCII letters, numbers, underscores, and hyphens";
+
+const normalizeApiKeyPrefix = (prefix?: string) => {
+	if (prefix === undefined) {
+		return undefined;
+	}
+
+	const trimmedPrefix = prefix.trim();
+	if (trimmedPrefix === "") {
+		return undefined;
+	}
+
+	if (!apiKeyPrefixRegex.test(trimmedPrefix)) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: apiKeyPrefixErrorMessage,
+		});
+	}
+
+	return trimmedPrefix;
+};
+
 export const createApiKey = async (
 	userId: string,
 	input: {
@@ -526,11 +550,13 @@ export const createApiKey = async (
 		refillInterval?: number;
 	},
 ) => {
+	const prefix = normalizeApiKeyPrefix(input.prefix);
+
 	const result = await auth.createApiKey({
 		body: {
 			name: input.name,
 			expiresIn: input.expiresIn,
-			prefix: input.prefix,
+			prefix,
 			rateLimitEnabled: input.rateLimitEnabled,
 			rateLimitTimeWindow: input.rateLimitTimeWindow,
 			rateLimitMax: input.rateLimitMax,


### PR DESCRIPTION
## Summary
- Validate and trim API key prefixes before calling `better-auth`.
- Treat empty trimmed prefixes as `undefined`.
- Surface API key creation errors in the UI instead of showing only a generic failure toast.
- Add client-side form validation with a clear prefix message.
- Add regression coverage for missing, valid, invalid, trimmed, empty, and server-returned prefix errors.

## Root Cause
`user.createApiKey` accepted any `prefix` string and passed it through to `better-auth`. Invalid prefixes were rejected there as a generic error, which surfaced through tRPC as `INTERNAL_SERVER_ERROR` / HTTP 500 instead of a client validation error. The UI also discarded server error details and always showed `Failed to generate API key`.

## Validation
- `npx --yes pnpm@10.22.0 --dir apps/dokploy exec vitest --config __test__/vitest.config.ts __test__/user/create-api-key-errors.test.ts __test__/user/create-api-key.test.ts --run`
- `npx --yes pnpm@10.22.0 exec biome check apps/dokploy/__test__/user/create-api-key-errors.test.ts apps/dokploy/__test__/user/create-api-key.test.ts apps/dokploy/components/dashboard/settings/api/api-key-errors.ts apps/dokploy/components/dashboard/settings/api/add-api-key.tsx apps/dokploy/server/api/routers/user.ts packages/server/src/services/user.ts`
- `npx --yes pnpm@10.22.0 --filter=dokploy typecheck`
- `npx --yes pnpm@10.22.0 --filter=@dokploy/server typecheck`

Note: local checks ran under Node v18.19.1, while `.nvmrc` specifies Node 24.4.0, so pnpm emitted engine warnings.