### PR TITLE
fix(backups): prevent S3 credentials from being exposed in logs

### DIFF
--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -63,7 +63,10 @@ export const runComposeBackup = async (
 
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.error(
+			"Compose backup failed:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -13,6 +13,7 @@ import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup"
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
 
+
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
 
@@ -153,6 +154,9 @@ export const keepLatestNBackups = async (
 			await execAsync(rcloneCommand);
 		}
 	} catch (error) {
-		console.error(error);
+		console.error(
+			"Failed to cleanup old backups:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
 	}
 };

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -60,7 +60,10 @@ export const runMariadbBackup = async (
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.error(
+			"MariaDB backup failed:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -58,7 +58,10 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.error(
+			"MongoDB backup failed:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -59,7 +59,10 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.error(
+			"MySQL backup failed:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -260,10 +260,8 @@ export const getBackupCommand = (
 
 	logger.info(
 		{
-			containerSearch,
-			backupCommand,
-			rcloneCommand,
-			logPath,
+
+			logPath
 		},
 		`Executing backup command: ${backup.databaseType} ${backup.backupType}`,
 	);

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -113,11 +113,19 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 			try {
 				await rm(tempDir, { recursive: true, force: true });
 			} catch (cleanupError) {
-				console.error("Cleanup error:", cleanupError);
+				console.error(
+					"Cleanup error:",
+					cleanupError instanceof Error
+						? cleanupError.message
+						: "Unknown error",
+				);
 			}
 		}
 	} catch (error) {
-		console.error("Backup error:", error);
+		console.error(
+			"Backup error:",
+			error instanceof Error ? error.message : "Unknown error",
+		);
 		writeStream.write("Backup error❌\n");
 		writeStream.write(
 			error instanceof Error ? error.message : "Unknown error\n",


### PR DESCRIPTION
## What is this PR about?

This PR fixes an issue where S3 backup credentials could be exposed through backup logging.

The backup flow was logging `rcloneCommand`, which contains S3 access keys and secret access keys passed as command-line flags. This change removes credential-bearing command data from logger output and sanitizes backup-related error logging to reduce the risk of secrets being written to service stdout.

## Checklist

* [x] Created a dedicated branch based on `canary`
* [x] Read the contribution guidelines
* [x] Tested changes locally

## Issues related

Fixes #4621
