### PR TITLE
fix(registry): preserve registry username casing

### DIFF
--- a/packages/server/src/db/schema/registry.ts
+++ b/packages/server/src/db/schema/registry.ts
@@ -48,8 +48,8 @@ export const registryRelations = relations(registry, ({ many }) => ({
 const registryUsernameSchema = z
 	.string()
 	.trim()
-	.min(1)
-	.transform((s) => s.toLowerCase());
+	.min(1);
+
 
 // Registry URLs must be hostname[:port] only — no shell metacharacters
 // Empty string is allowed (means default/Docker Hub registry)


### PR DESCRIPTION
## Summary

Preserve registry username casing during authentication by removing schema-level lowercasing from `registryUsernameSchema`.

AWS ECR requires the username to be exactly `AWS` during `docker login`. Lowercasing the username causes authentication to fail.

## Changes

* Removed `.transform((s) => s.toLowerCase())` from `registryUsernameSchema`

## Notes

Image namespace normalization is still handled separately in:

`packages/server/src/utils/cluster/upload.ts`

via:

`(imagePrefix || username).toLowerCase()`

so existing image naming behavior remains unchanged.

Fixes #4632
