### PR TITLE
fix: prevent request path truncation in request logs

### DIFF
--- a/apps/dokploy/components/dashboard/requests/columns.tsx
+++ b/apps/dokploy/components/dashboard/requests/columns.tsx
@@ -69,14 +69,12 @@ export const columns: ColumnDef<LogEntry>[] = [
 			const log = row.original;
 			return (
 				<div className="flex flex-col gap-2">
-					<div className="flex items-center flex-row gap-3 ">
+					<div className="flex items-center flex-row flex-wrap gap-3 ">
 						{log.RequestMethod}{" "}
 						<div className="inline-flex items-center gap-2 bg-muted px-1.5 py-1 rounded-lg">
 							<span>{log.RequestAddr}</span>
 						</div>
-						{log.RequestPath.length > 100
-							? `${log.RequestPath.slice(0, 82)}...`
-							: log.RequestPath}
+						<span className="break-all">{log.RequestPath}</span>
 					</div>
 					<div className="flex flex-row gap-3 w-full">
 						<Badge


### PR DESCRIPTION
## What changed

The request path in the request logs table was truncated to 82 characters with an ellipsis when it exceeded 100 characters, hiding part of the route. This shows the full path and lets it wrap onto multiple lines instead.

- Removed the `slice(0, 82) + "..."` truncation on `RequestPath`
- Added `flex-wrap` to the row container so content wraps when it doesn't fit
- Wrapped the path in a `<span className="break-all">` so long paths break cleanly across lines

## Why

Per the issue, the path should always be fully visible — whether via line breaks or scrolling — rather than being cut off.

Fixes #4642
