### PR TITLE
fix: resolve traefik container dynamically in access-log cleanup (swarm mode)

### DIFF
--- a/packages/server/src/utils/access-log/handler.ts
+++ b/packages/server/src/utils/access-log/handler.ts
@@ -32,7 +32,19 @@ export const startLogCleanup = async (
 				await execAsync(
 					`tail -n 1000 ${accessLogPath} > ${accessLogPath}.tmp && mv ${accessLogPath}.tmp ${accessLogPath}`,
 				);
-				await execAsync("docker exec dokploy-traefik kill -USR1 1");
+
+				// Traefik can run as a standalone container ("dokploy-traefik") or a
+				// swarm service task ("dokploy-traefik.1.<task-id>"), so resolve the
+				// running container id dynamically instead of assuming the name.
+				const { stdout: containerId } = await execAsync(
+					'docker ps -q --filter "name=dokploy-traefik" --filter "status=running" | head -n 1',
+				);
+				const traefikContainerId = containerId.trim();
+				if (!traefikContainerId) {
+					console.error("Traefik container not found, skipping log reopen");
+					return;
+				}
+				await execAsync(`docker exec ${traefikContainerId} kill -USR1 1`);
 			} catch (error) {
 				console.error("Error during log cleanup:", error);
 			}


### PR DESCRIPTION
## What is this PR about?

The nightly `access-log-cleanup` job in `packages/server/src/utils/access-log/handler.ts` hardcoded `dokploy-traefik` as the container name when sending `SIGUSR1`. In Docker Swarm mode Traefik runs as a service task named `dokploy-traefik.1.<task-id>`, so `docker exec dokploy-traefik kill -USR1 1` fails every night with `No such container`. The log file gets rotated (`tail ... > .tmp && mv`, which changes the inode) but Traefik never receives the signal to reopen it, so the on-disk `access.log` stays frozen at 1000 lines while real traffic logs accumulate in a deleted file handle.

This is a supported deployment mode — `writeTraefikSetup` still branches to `initializeTraefikService` (swarm service) and `checkTraefikHealth` explicitly handles both standalone and swarm Traefik.

The fix resolves the running container id dynamically with `docker ps -q --filter "name=dokploy-traefik" --filter "status=running"`, the same pattern already used in `compose.ts` and `settings.ts`. It works for both standalone (`dokploy-traefik`) and swarm (`dokploy-traefik.1.<task-id>`) deployments, and skips gracefully if no running container is found.

## Issues related (if applicable)

closes #4620
