### PR TITLE
fix(registry): preserve username case for ECR compatibility

### DIFF
--- a/apps/dokploy/__test__/registry/registry-schema.test.ts
+++ b/apps/dokploy/__test__/registry/registry-schema.test.ts
@@ -1,0 +1,75 @@
+import { apiCreateRegistry, apiTestRegistry } from "@dokploy/server/db/schema";
+import { describe, expect, it } from "vitest";
+
+describe("Registry Schema - Username case preservation (#4632)", () => {
+	const validBase = {
+		registryName: "AWS ECR",
+		password: "dXNlcm5hbWU6cGFzc3dvcmQ=", // dummy base64 token
+		registryUrl: "123456789.dkr.ecr.us-east-1.amazonaws.com",
+		registryType: "cloud" as const,
+		imagePrefix: null,
+	};
+
+	it("should preserve uppercase username (AWS ECR requires 'AWS')", () => {
+		const result = apiCreateRegistry.safeParse({
+			...validBase,
+			username: "AWS",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.username).toBe("AWS");
+		}
+	});
+
+	it("should not lowercase mixed-case usernames", () => {
+		const result = apiCreateRegistry.safeParse({
+			...validBase,
+			username: "MyUser",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.username).toBe("MyUser");
+		}
+	});
+
+	it("should still trim whitespace from username", () => {
+		const result = apiCreateRegistry.safeParse({
+			...validBase,
+			username: "  AWS  ",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.username).toBe("AWS");
+		}
+	});
+
+	it("should reject empty username", () => {
+		const result = apiCreateRegistry.safeParse({
+			...validBase,
+			username: "",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("should also preserve case in apiTestRegistry", () => {
+		const result = apiTestRegistry.safeParse({
+			...validBase,
+			username: "AWS",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.username).toBe("AWS");
+		}
+	});
+
+	it("should accept lowercase usernames too (backward compat)", () => {
+		const result = apiCreateRegistry.safeParse({
+			...validBase,
+			username: "myuser",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.username).toBe("myuser");
+		}
+	});
+});

--- a/packages/server/src/db/schema/registry.ts
+++ b/packages/server/src/db/schema/registry.ts
@@ -44,12 +44,11 @@ export const registryRelations = relations(registry, ({ many }) => ({
 	}),
 }));
 
-// Image references require a lowercase namespace (e.g. Docker Hub username).
-const registryUsernameSchema = z
-	.string()
-	.trim()
-	.min(1)
-	.transform((s) => s.toLowerCase());
+// Registry usernames should NOT be lowercased.
+// Some registries (e.g. AWS ECR) require a specific case: the username must be
+// exactly "AWS" (uppercase) for ECR authentication. Docker Hub usernames are
+// case-insensitive for login, so preserving case is safe for all providers.
+const registryUsernameSchema = z.string().trim().min(1);
 
 // Registry URLs must be hostname[:port] only — no shell metacharacters
 // Empty string is allowed (means default/Docker Hub registry)


### PR DESCRIPTION
## Problem
Closes #4632

The registry username schema applied a `.toLowerCase()` transform, which breaks AWS ECR authentication. ECR requires the username to be exactly `AWS` (uppercase). With the current code, `AWS` becomes `aws` and authentication fails.

## Solution
Removed the `.toLowerCase()` transform from `registryUsernameSchema`. The schema now only trims whitespace and validates non-empty.

This is safe because:
- AWS ECR requires `AWS` (uppercase) — now preserved
- Docker Hub usernames are case-insensitive for login
- Self-hosted registries typically accept case as-is

## Testing
Added 6 unit tests in `__test__/registry/registry-schema.test.ts`:
- Preserves uppercase (AWS ECR case)
- Preserves mixed-case
- Trims whitespace
- Rejects empty username
- Preserves case in `apiTestRegistry` too
- Accepts lowercase (backward compat)