### PR TITLE
fix(setup): install Docker 29.4.2 on Ubuntu 26.04 to fix failed setup

### DIFF
--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -162,6 +162,17 @@ else
 	OS_VERSION=$(grep -w "VERSION_ID" /etc/os-release | cut -d "=" -f 2 | tr -d '"')
 fi
 
+# Ubuntu 26.04 (resolute) ships a docker-ce repo that has no 28.5.0, so the
+# default pin is absent from apt-cache madison and get.docker.com aborts before
+# installing Docker. Repin to a version present on every architecture Docker
+# ships resolute for: amd64/arm64/armhf start at 29.3.1, but s390x only carries
+# 29.4.0-29.4.2, so 29.4.2 is the newest version common to all of them. This
+# must run after OS_VERSION is resolved and before the banner so the reported
+# Docker version stays accurate.
+if [ "$OS_TYPE" = "ubuntu" ] && [ "$OS_VERSION" = "26.04" ]; then
+	DOCKER_VERSION=29.4.2
+fi
+
 if [ "$OS_TYPE" = 'amzn' ]; then
     $SUDO_CMD dnf install -y findutils >/dev/null
 fi


### PR DESCRIPTION
### What

Ubuntu 26.04 (Plucky Puffin / `resolute`) installs fail because the provisioning script pins `DOCKER_VERSION=28.5.0` and passes it to `get.docker.com` via `--version`. The `resolute` docker-ce repo has no `28.5.0`, so the convenience script's `apt-cache madison docker-ce | grep "$VERSION"` finds nothing and exits:

```
INFO: Searching repository for VERSION '28.5.0'
ERROR: '28.5.0' not found amongst apt-cache madison results
sh: 214: docker: not found
Error: Failed to initialize Docker Swarm
```

Docker is never installed and setup aborts.

### Root cause

Not missing upstream support (Docker's repo does support `resolute`) — it's a version-pin mismatch. The pinned `28.5.0` simply isn't in the `resolute` pool. Correctly diagnosed in #4501.

### Fix

Repin the Docker version for Ubuntu 26.04 only, to a version present on **every architecture** Docker ships `resolute` for:

```sh
if [ "$OS_TYPE" = "ubuntu" ] && [ "$OS_VERSION" = "26.04" ]; then
	DOCKER_VERSION=29.4.2
fi
```

Why `29.4.2` and not the amd64 floor (`29.3.1`): the per-arch `resolute` pools don't agree. `s390x` is the binding architecture.

| Arch | Available docker-ce in resolute pool |
| --- | --- |
| amd64 / arm64 / armhf | 29.3.1 -> 29.5.3 |
| **s390x** | **29.4.0 -> 29.4.2** (no 29.3.1, no 29.5.x) |
| ppc64le | not shipped for resolute |

`29.3.1` would still fail on s390x; `29.5.x` would fail on s390x too. `29.4.2` is the newest version common to all shipped arches, so a single pin works without `SYS_ARCH` gating. Verified against the live `download.docker.com/.../dists/resolute/pool/stable/<arch>/` listings.

- Scoped to `OS_TYPE=ubuntu` + `OS_VERSION=26.04`; every other OS/release keeps `28.5.0` byte-for-byte.
- Detects via `VERSION_ID` (consistent with the rest of the script; codenames are never parsed).
- Placed after `OS_VERSION` is resolved and before the install banner, so the reported Docker version stays accurate and both the full-server and build-server paths are covered.
- POSIX `sh`-safe (verified with `sh -n`).

### Note for maintainers

The standalone `install.sh` served from `dokploy.com/install.sh` (single-host bootstrap) carries the same `DOCKER_VERSION=28.5.0` pin and will hit the identical failure. It lives outside this repo, so it needs the same override applied wherever that asset is built.

Fixes #4327, #4349. Closes #4501.