### PR TITLE
fix(auth): allow password reset on self-hosted (remove IS_CLOUD gate on reset pages)

### DIFF
--- a/apps/dokploy/pages/reset-password.tsx
+++ b/apps/dokploy/pages/reset-password.tsx
@@ -1,4 +1,3 @@
-import { IS_CLOUD } from "@dokploy/server";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
@@ -187,14 +186,6 @@ Home.getLayout = (page: ReactElement) => {
 	return <OnboardingLayout>{page}</OnboardingLayout>;
 };
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-	if (!IS_CLOUD) {
-		return {
-			redirect: {
-				permanent: false,
-				destination: "/",
-			},
-		};
-	}
 	const { token } = context.query;
 
 	if (typeof token !== "string") {

--- a/apps/dokploy/pages/send-reset-password.tsx
+++ b/apps/dokploy/pages/send-reset-password.tsx
@@ -1,4 +1,3 @@
-import { IS_CLOUD } from "@dokploy/server";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
@@ -165,15 +164,6 @@ Home.getLayout = (page: ReactElement) => {
 	return <OnboardingLayout>{page}</OnboardingLayout>;
 };
 export async function getServerSideProps(_context: GetServerSidePropsContext) {
-	if (!IS_CLOUD) {
-		return {
-			redirect: {
-				permanent: false,
-				destination: "/",
-			},
-		};
-	}
-
 	return {
 		props: {},
 	};


### PR DESCRIPTION
## What

Removes the `!IS_CLOUD` redirect in `getServerSideProps` of `reset-password.tsx` and `send-reset-password.tsx` (and the now-unused `IS_CLOUD` import), so the password-reset flow works on self-hosted, not only on cloud.

Closes #4664

## Why

The reset email is already sent on-prem (`sendResetPassword` / `emailAndPassword` are not cloud-gated), but the page the link points to redirected to `/`, making the whole flow a dead end for self-hosted users.

## Safety

- `/reset-password` still redirects to `/` when no `token` query param is present (guard kept). The new-password submit calls better-auth `resetPassword`, which validates the token and its expiry server-side — no new server surface is exposed.
- `/send-reset-password` is a public "enter email" form; submit calls the existing `requestPasswordReset` (no account-existence disclosure).
- No user data is rendered on either page; only client-route reachability changes.

## Notes

Admins who haven't configured SMTP simply won't receive emails (unchanged); those who have now get a working end-to-end reset.
