### PR TITLE
feat: resolve ${{service.<name>.fqdn}} cross-service env references

### DIFF
--- a/apps/dokploy/__test__/env/environment.test.ts
+++ b/apps/dokploy/__test__/env/environment.test.ts
@@ -642,3 +642,107 @@ SPECIAL=café résumé naïve
 		expect(resolved[2]).toContain("café");
 	});
 });
+
+describe("prepareEnvironmentVariables (cross-service references)", () => {
+	const serviceFqdns = {
+		backend: "https://api.example.com",
+		database: "http://db.internal.example.com",
+	};
+
+	it("resolves ${{service.<name>.fqdn}} from the provided map", () => {
+		const serviceEnv = `
+API_URL=\${{service.backend.fqdn}}
+DB_URL=\${{service.database.fqdn}}
+PORT=4000
+`;
+
+		const resolved = prepareEnvironmentVariables(
+			serviceEnv,
+			"",
+			"",
+			serviceFqdns,
+		);
+
+		expect(resolved).toEqual([
+			"API_URL=https://api.example.com",
+			"DB_URL=http://db.internal.example.com",
+			"PORT=4000",
+		]);
+	});
+
+	it("composes service references with surrounding text", () => {
+		const serviceEnv = `
+HEALTHCHECK=\${{service.backend.fqdn}}/health
+`;
+
+		const resolved = prepareEnvironmentVariables(
+			serviceEnv,
+			"",
+			"",
+			serviceFqdns,
+		);
+
+		expect(resolved).toEqual(["HEALTHCHECK=https://api.example.com/health"]);
+	});
+
+	it("resolves service references alongside project, environment and self refs", () => {
+		const serviceEnv = `
+ENVIRONMENT=\${{project.ENVIRONMENT}}
+NODE_ENV=\${{environment.NODE_ENV}}
+API_URL=\${{service.backend.fqdn}}
+REGION=eu-west-1
+SELF=\${{REGION}}
+`;
+
+		const resolved = prepareEnvironmentVariables(
+			serviceEnv,
+			projectEnv,
+			environmentEnv,
+			serviceFqdns,
+		);
+
+		expect(resolved).toEqual([
+			"ENVIRONMENT=staging",
+			"NODE_ENV=development",
+			"API_URL=https://api.example.com",
+			"REGION=eu-west-1",
+			"SELF=eu-west-1",
+		]);
+	});
+
+	it("throws when the referenced service is not in the map", () => {
+		const serviceEnv = `
+API_URL=\${{service.unknown.fqdn}}
+`;
+
+		expect(() =>
+			prepareEnvironmentVariables(serviceEnv, "", "", serviceFqdns),
+		).toThrow("Invalid service reference: service.unknown.fqdn");
+	});
+
+	it("throws when no service map is provided", () => {
+		const serviceEnv = `
+API_URL=\${{service.backend.fqdn}}
+`;
+
+		expect(() => prepareEnvironmentVariables(serviceEnv, "", "")).toThrow(
+			"Invalid service reference: service.backend.fqdn",
+		);
+	});
+
+	it("does not affect env vars without service references", () => {
+		const serviceEnv = `
+NODE_ENV=production
+PORT=3000
+`;
+
+		const resolved = prepareEnvironmentVariables(
+			serviceEnv,
+			"",
+			"",
+			serviceFqdns,
+		);
+
+		expect(resolved).toEqual(["NODE_ENV=production", "PORT=3000"]);
+	});
+});

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -1,6 +1,9 @@
+import { db } from "@dokploy/server/db";
+import { applications } from "@dokploy/server/db/schema";
 import { findRegistryByIdWithCredentials } from "@dokploy/server/services/registry";
 import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
+import { eq } from "drizzle-orm";
 import { getRegistryTag, uploadImageRemoteCommand } from "../cluster/upload";
 import {
 	calculateResources,
@@ -75,6 +78,32 @@ export const getBuildCommand = async (application: ApplicationNested) => {
 	return command;
 };
 
+/**
+ * Builds a map of `serviceName -> public URL` for every other application in the
+ * same environment that has a domain, so env vars can reference a sibling's URL
+ * via `${{service.<name>.fqdn}}`. Skips the DB query entirely when the env has no
+ * such reference. When a service has multiple domains, its first domain is used.
+ */
+export const buildServiceFqdnMap = async (
+	application: ApplicationNested,
+): Promise<Record<string, string>> => {
+	if (!application.env?.includes("${{service.")) {
+		return {};
+	}
+	const siblings = await db.query.applications.findMany({
+		where: eq(applications.environmentId, application.environmentId),
+		with: { domains: true },
+	});
+	const map: Record<string, string> = {};
+	for (const sibling of siblings) {
+		const domain = sibling.domains?.[0];
+		if (domain?.host) {
+			map[sibling.name] = `${domain.https ? "https" : "http"}://${domain.host}`;
+		}
+	}
+	return map;
+};
+
 export const mechanizeDockerContainer = async (
 	application: ApplicationNested,
 ) => {
@@ -116,10 +145,12 @@ export const mechanizeDockerContainer = async (
 
 	const bindsMount = generateBindMounts(mounts);
 	const filesMount = generateFileMounts(appName, application);
+	const serviceFqdns = await buildServiceFqdnMap(application);
 	const envVariables = prepareEnvironmentVariables(
 		env,
 		application.environment.project.env,
 		application.environment.env,
+		serviceFqdns,
 	);
 
 	const image = await getImageName(application);

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -400,6 +400,7 @@ export const prepareEnvironmentVariables = (
 	serviceEnv: string | null,
 	projectEnv?: string | null,
 	environmentEnv?: string | null,
+	serviceFqdns?: Record<string, string> | null,
 ) => {
 	const projectVars = parse(projectEnv ?? "");
 	const environmentVars = parse(environmentEnv ?? "");
@@ -435,6 +436,20 @@ export const prepareEnvironmentVariables = (
 				},
 			);
 		}
+
+		// Replace cross-service references: ${{service.<name>.fqdn}}
+		// Resolves to the public URL of another service in the same environment.
+		// The name->fqdn map is precomputed by the caller (it requires a DB
+		// lookup); this keeps the function pure and synchronous.
+		resolvedValue = resolvedValue.replace(
+			/\$\{\{service\.(.*?)\.fqdn\}\}/g,
+			(_, name) => {
+				if (serviceFqdns && serviceFqdns[name] !== undefined) {
+					return serviceFqdns[name];
+				}
+				throw new Error(`Invalid service reference: service.${name}.fqdn`);
+			},
+		);
 
 		// Replace self-references (service variables)
 		resolvedValue = resolvedValue.replace(/\$\{\{(.*?)\}\}/g, (_, ref) => {


### PR DESCRIPTION
## What
Adds support for referencing another service's public URL from an application's environment variables, e.g. `API_URL=${{service.backend.fqdn}}`. It resolves to the referenced service's domain URL within the same environment.

## Why
Closes the core need in #2028 — services in a project (e.g. a frontend needing its backend's URL) currently can't reference each other's generated FQDN. This is the foundational building block both approaches discussed in the issue need.

## How
Extends the existing `${{project.*}}` / `${{environment.*}}` resolver in `prepareEnvironmentVariables` with an optional precomputed `name → fqdn` map. `mechanizeDockerContainer` builds that map from sibling applications + their domains, and **skips the DB lookup entirely** when the env has no `${{service.` reference. Same `${{...}}` syntax and error style as the existing references.

## Scope / notes
- Resolves `.fqdn` to a service's **first domain** (`https://host`). Multi-domain "primary" selection and extra attributes (internal host/port) can be follow-ups.
- Backend-only, no schema change, no new endpoints.

## Testing
Added 6 cases to `__test__/env/environment.test.ts` (resolution, composition with surrounding text, alongside project/env/self refs, unknown-service error, no-map error, no-op when absent). Full env suite green: **74/74**.

Refs #2028

/claim #2028

---
*Disclosure: implemented with AI assistance (Claude), authored + verified locally by the submitter.*
