### PR TITLE
style: fix biome lint issues

### DIFF
--- a/apps/dokploy/__test__/deploy/application.command.test.ts
+++ b/apps/dokploy/__test__/deploy/application.command.test.ts
@@ -16,6 +16,7 @@ vi.mock("@dokploy/server/db", () => {
 			returning: vi.fn().mockResolvedValue([{}] as any),
 			from: vi.fn(() => chain),
 			innerJoin: vi.fn(() => chain),
+			// biome-ignore lint/suspicious/noThenProperty: Drizzle query mocks intentionally emulate thenable query builders.
 			then: (resolve: (v: any) => void) => {
 				resolve([]);
 			},

--- a/apps/dokploy/__test__/deploy/application.real.test.ts
+++ b/apps/dokploy/__test__/deploy/application.real.test.ts
@@ -17,6 +17,7 @@ vi.mock("@dokploy/server/db", () => {
 			returning: vi.fn().mockResolvedValue([{}]),
 			from: vi.fn(() => chain),
 			innerJoin: vi.fn(() => chain),
+			// biome-ignore lint/suspicious/noThenProperty: Drizzle query mocks intentionally emulate thenable query builders.
 			then: (resolve: (v: any) => void) => {
 				resolve([]);
 			},

--- a/apps/dokploy/__test__/git-provider/git-provider-access.test.ts
+++ b/apps/dokploy/__test__/git-provider/git-provider-access.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	canEditDeployGitSource,
 	getAccessibleGitProviderIds,
 } from "@dokploy/server/services/git-provider";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDb = vi.hoisted(() => ({
 	query: {

--- a/apps/dokploy/__test__/setup.ts
+++ b/apps/dokploy/__test__/setup.ts
@@ -14,6 +14,7 @@ vi.mock("@dokploy/server/db", () => {
 	chain.returning = () => Promise.resolve([{}]);
 	chain.from = () => chain;
 	chain.innerJoin = () => chain;
+	// biome-ignore lint/suspicious/noThenProperty: Drizzle query mocks intentionally emulate thenable query builders.
 	chain.then = (resolve: (value: unknown) => void) => {
 		resolve([]);
 	};

--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -16,7 +16,7 @@ import { AlertBlock } from "@/components/shared/alert-block";
 import { DateTooltip } from "@/components/shared/date-tooltip";
 import { DialogAction } from "@/components/shared/dialog-action";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
-import { Badge } from "@/components/ui/badge";
+import { Badge, badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -25,6 +25,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import { api, type RouterOutputs } from "@/utils/api";
 import { ShowRollbackSettings } from "../rollbacks/show-rollback-settings";
 import { CancelQueues } from "./cancel-queues";
@@ -232,19 +233,13 @@ export const ShowDeployments = ({
 						<div className="flex flex-row items-center gap-2 flex-wrap">
 							<span>Webhook URL: </span>
 							<div className="flex flex-row items-center gap-2">
-								<Badge
-									role="button"
-									tabIndex={0}
+								<button
+									type="button"
 									aria-label="Copy webhook URL to clipboard"
-									className="p-2 rounded-md ml-1 mr-1 hover:border-primary hover:text-primary-foreground hover:bg-primary hover:cursor-pointer whitespace-normal break-all"
-									variant="outline"
-									onKeyDown={(event) => {
-										if (event.key === "Enter" || event.key === " ") {
-											event.preventDefault();
-											copy(webhookUrl);
-											toast.success("Copied to clipboard.");
-										}
-									}}
+									className={cn(
+										badgeVariants({ variant: "outline" }),
+										"p-2 rounded-md ml-1 mr-1 hover:border-primary hover:text-primary-foreground hover:bg-primary hover:cursor-pointer whitespace-normal break-all",
+									)}
 									onClick={() => {
 										copy(webhookUrl);
 										toast.success("Copied to clipboard.");
@@ -252,7 +247,7 @@ export const ShowDeployments = ({
 								>
 									{webhookUrl}
 									<Copy className="h-4 w-4 ml-2" />
-								</Badge>
+								</button>
 								{(type === "application" || type === "compose") && (
 									<RefreshToken id={id} type={type} />
 								)}

--- a/apps/dokploy/components/dashboard/project/add-template.tsx
+++ b/apps/dokploy/components/dashboard/project/add-template.tsx
@@ -147,7 +147,7 @@ export const AddTemplate = ({ environmentId, baseUrl }: Props) => {
 
 				return { previousBookmarks };
 			},
-			onError: (err, variables, context) => {
+			onError: (_err, _variables, context) => {
 				if (context?.previousBookmarks) {
 					utils.user.getBookmarkedTemplates.setData(
 						undefined,

--- a/apps/dokploy/components/dashboard/settings/certificates/utils.ts
+++ b/apps/dokploy/components/dashboard/settings/certificates/utils.ts
@@ -115,13 +115,13 @@ export const extractCommonName = (certData: string): string | null => {
 
 		// Helper: read ASN.1 length field
 		function readLength(pos: number): { length: number; offset: number } {
-			// biome-ignore lint/style/noParameterAssign: <explanation>
+			// biome-ignore lint/style/noParameterAssign: parsing DER advances the local cursor.
 			let len = der[pos++];
 			if (len & 0x80) {
 				const bytes = len & 0x7f;
 				len = 0;
 				for (let i = 0; i < bytes; i++) {
-					// biome-ignore lint/style/noParameterAssign: <explanation>
+					// biome-ignore lint/style/noParameterAssign: parsing DER advances the local cursor.
 					len = (len << 8) + der[pos++];
 				}
 			}
@@ -130,7 +130,7 @@ export const extractCommonName = (certData: string): string | null => {
 
 		// Helper: skip a field
 		function skipField(pos: number): number {
-			// biome-ignore lint/style/noParameterAssign: <explanation>
+			// biome-ignore lint/style/noParameterAssign: parsing DER advances the local cursor.
 			pos++;
 			const fieldLen = readLength(pos);
 			return fieldLen.offset + fieldLen.length;

--- a/apps/dokploy/components/proprietary/whitelabeling/whitelabeling-preview.tsx
+++ b/apps/dokploy/components/proprietary/whitelabeling/whitelabeling-preview.tsx
@@ -32,6 +32,7 @@ export function WhitelabelingPreview({ config }: WhitelabelingPreviewProps) {
 					{/* Simulated sidebar header */}
 					<div className="flex items-center gap-3 p-4 border-b bg-sidebar">
 						{config.logoUrl ? (
+							// biome-ignore lint/performance/noImgElement: Logo previews use arbitrary configured URLs that may not be known to Next Image.
 							<img
 								src={config.logoUrl}
 								alt="Preview Logo"

--- a/apps/dokploy/server/queues/concurrency.ts
+++ b/apps/dokploy/server/queues/concurrency.ts
@@ -1,5 +1,5 @@
 import { db } from "@dokploy/server/db";
-import { organization, server } from "@dokploy/server/db/schema";
+import { server } from "@dokploy/server/db/schema";
 import { hasValidLicense } from "@dokploy/server/services/proprietary/license-key";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
 import { TRPCError } from "@trpc/server";

--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -1,8 +1,8 @@
 import { findAllDeploymentsByApplicationId } from "@dokploy/server/services/deployment";
 import {
 	findRegistryByIdWithCredentials,
-	safeDockerLoginCommand,
 	type Registry,
+	safeDockerLoginCommand,
 } from "@dokploy/server/services/registry";
 import { createRollback } from "@dokploy/server/services/rollbacks";
 import type { ApplicationNested } from "../builders";


### PR DESCRIPTION
## What is this PR about?

This PR restores Biome compliance with a narrow lint-only cleanup. It adds explicit Biome suppression reasons for intentional test mocks and parser cursor updates, removes unused/import-order diagnostics, and changes the webhook URL copy affordance from a div-based badge button to a semantic button while preserving the existing badge styling.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR locally with the checks listed below.

## Checks

- `pnpm format-and-lint`
- `git diff --check`
- `pnpm --dir apps/dokploy exec vitest --config __test__/vitest.config.ts run __test__/deploy/application.command.test.ts __test__/git-provider/git-provider-access.test.ts __test__/queues/in-memory-queue.test.ts __test__/queues/concurrency.test.ts`
- `pnpm --dir apps/dokploy run typecheck`
- `pnpm --dir packages/server run typecheck`

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A - lint-only cleanup; no intended visual changes.
