### PR TITLE
fix: use github owner login for webhook deploy matching

### DIFF
--- a/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
+++ b/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
@@ -1,0 +1,316 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	eq: vi.fn((field: string, value: unknown) => ({ field, value })),
+	and: vi.fn((...conditions: Array<{ field: string; value: unknown }>) => ({
+		conditions,
+	})),
+	githubFindFirst: vi.fn(),
+	applicationsFindMany: vi.fn(),
+	composeFindMany: vi.fn(),
+	queueAdd: vi.fn(),
+	verify: vi.fn(),
+	shouldDeploy: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+	eq: mocks.eq,
+	and: mocks.and,
+}));
+
+vi.mock("@/server/db/schema", () => ({
+	applications: {
+		sourceType: "application.sourceType",
+		autoDeploy: "application.autoDeploy",
+		triggerType: "application.triggerType",
+		branch: "application.branch",
+		repository: "application.repository",
+		owner: "application.owner",
+		githubId: "application.githubId",
+		isPreviewDeploymentsActive: "application.isPreviewDeploymentsActive",
+	},
+	compose: {
+		sourceType: "compose.sourceType",
+		autoDeploy: "compose.autoDeploy",
+		triggerType: "compose.triggerType",
+		branch: "compose.branch",
+		repository: "compose.repository",
+		owner: "compose.owner",
+		githubId: "compose.githubId",
+	},
+	github: {
+		githubInstallationId: "github.githubInstallationId",
+	},
+}));
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			github: {
+				findFirst: mocks.githubFindFirst,
+			},
+			applications: {
+				findMany: mocks.applicationsFindMany,
+			},
+			compose: {
+				findMany: mocks.composeFindMany,
+			},
+		},
+	},
+}));
+
+vi.mock("@dokploy/server", () => ({
+	IS_CLOUD: false,
+	shouldDeploy: mocks.shouldDeploy,
+	checkUserRepositoryPermissions: vi.fn(),
+	createPreviewDeployment: vi.fn(),
+	createSecurityBlockedComment: vi.fn(),
+	findGithubById: vi.fn(),
+	findPreviewDeploymentByApplicationId: vi.fn(),
+	findPreviewDeploymentsByPullRequestId: vi.fn(),
+	getBitbucketHeaders: vi.fn(() => ({})),
+	removePreviewDeployment: vi.fn(),
+}));
+
+vi.mock("@octokit/webhooks", () => ({
+	Webhooks: vi.fn().mockImplementation(function Webhooks() {
+		return {
+			verify: mocks.verify,
+		};
+	}),
+}));
+
+vi.mock("@/server/queues/queueSetup", () => ({
+	myQueue: {
+		add: mocks.queueAdd,
+	},
+}));
+
+vi.mock("@/server/utils/deploy", () => ({
+	deploy: vi.fn(),
+}));
+
+import handler from "@/pages/api/deploy/github";
+
+const getConditionValue = (
+	where: { conditions?: Array<{ field: string; value: unknown }> } | undefined,
+	field: string,
+) => where?.conditions?.find((condition) => condition.field === field)?.value;
+
+const createResponse = () => {
+	const res = {
+		status: vi.fn(),
+		json: vi.fn(),
+	} as unknown as NextApiResponse & {
+		status: ReturnType<typeof vi.fn>;
+		json: ReturnType<typeof vi.fn>;
+	};
+
+	res.status.mockImplementation(() => res);
+	res.json.mockImplementation(() => res);
+
+	return res;
+};
+
+const createPushRequest = (branch: string) =>
+	({
+		headers: {
+			"x-hub-signature-256": "sha256=test-signature",
+			"x-github-event": "push",
+		},
+		body: {
+			installation: {
+				id: 12345,
+			},
+			ref: `refs/heads/${branch}`,
+			after: "abc123",
+			head_commit: {
+				message: "fix: trigger deployment",
+			},
+			commits: [
+				{
+					modified: ["src/index.ts"],
+				},
+			],
+			repository: {
+				name: "dokploy",
+				full_name: "agentHits/dokploy",
+				clone_url: "https://github.com/agentHits/dokploy.git",
+				html_url: "https://github.com/agentHits/dokploy",
+				owner: {
+					login: "agentHits",
+				},
+			},
+		},
+	}) as unknown as NextApiRequest;
+
+const createTagRequest = (tagName: string) => {
+	const req = createPushRequest("main") as unknown as {
+		body: { ref: string; head_commit: { message: string } };
+	};
+
+	req.body.ref = `refs/tags/${tagName}`;
+	req.body.head_commit.message = `release: ${tagName}`;
+
+	return req as unknown as NextApiRequest;
+};
+
+describe("GitHub app webhook auto-deploy", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.githubFindFirst.mockResolvedValue({
+			githubId: "github-provider-id",
+			githubInstallationId: 12345,
+			githubWebhookSecret: "webhook-secret",
+		});
+		mocks.verify.mockResolvedValue(true);
+		mocks.shouldDeploy.mockReturnValue(true);
+		mocks.composeFindMany.mockResolvedValue([]);
+		mocks.queueAdd.mockResolvedValue({ id: "job-id" });
+
+		mocks.applicationsFindMany.mockImplementation(({ where }) => {
+			const matches =
+				getConditionValue(where, "application.sourceType") === "github" &&
+				getConditionValue(where, "application.autoDeploy") === true &&
+				getConditionValue(where, "application.triggerType") === "push" &&
+				getConditionValue(where, "application.branch") === "main" &&
+				getConditionValue(where, "application.repository") === "dokploy" &&
+				getConditionValue(where, "application.owner") === "agentHits" &&
+				getConditionValue(where, "application.githubId") ===
+					"github-provider-id";
+
+			return Promise.resolve(
+				matches
+					? [
+							{
+								applicationId: "application-id",
+								serverId: null,
+								watchPaths: null,
+							},
+						]
+					: [],
+			);
+		});
+	});
+
+	it("matches push events using repository owner login", async () => {
+		const res = createResponse();
+
+		await handler(createPushRequest("main"), res);
+
+		expect(mocks.queueAdd).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationId: "application-id",
+				applicationType: "application",
+				type: "deploy",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ message: "Deployed 1 apps" });
+	});
+
+	it("matches compose push events using repository owner login", async () => {
+		mocks.applicationsFindMany.mockResolvedValue([]);
+		mocks.composeFindMany.mockImplementation(({ where }) => {
+			const matches =
+				getConditionValue(where, "compose.sourceType") === "github" &&
+				getConditionValue(where, "compose.autoDeploy") === true &&
+				getConditionValue(where, "compose.triggerType") === "push" &&
+				getConditionValue(where, "compose.branch") === "main" &&
+				getConditionValue(where, "compose.repository") === "dokploy" &&
+				getConditionValue(where, "compose.owner") === "agentHits" &&
+				getConditionValue(where, "compose.githubId") === "github-provider-id";
+
+			return Promise.resolve(
+				matches
+					? [
+							{
+								composeId: "compose-id",
+								serverId: null,
+								watchPaths: null,
+							},
+						]
+					: [],
+			);
+		});
+		const res = createResponse();
+
+		await handler(createPushRequest("main"), res);
+
+		expect(mocks.queueAdd).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationType: "compose",
+				composeId: "compose-id",
+				type: "deploy",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ message: "Deployed 1 apps" });
+	});
+
+	it("matches tag events using repository owner login", async () => {
+		mocks.applicationsFindMany.mockImplementation(({ where }) => {
+			const matches =
+				getConditionValue(where, "application.sourceType") === "github" &&
+				getConditionValue(where, "application.autoDeploy") === true &&
+				getConditionValue(where, "application.triggerType") === "tag" &&
+				getConditionValue(where, "application.repository") === "dokploy" &&
+				getConditionValue(where, "application.owner") === "agentHits" &&
+				getConditionValue(where, "application.githubId") ===
+					"github-provider-id";
+
+			return Promise.resolve(
+				matches
+					? [
+							{
+								applicationId: "application-id",
+								serverId: null,
+							},
+						]
+					: [],
+			);
+		});
+		const res = createResponse();
+
+		await handler(createTagRequest("v1.0.0"), res);
+
+		expect(mocks.queueAdd).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationId: "application-id",
+				applicationType: "application",
+				titleLog: "Tag created: v1.0.0",
+				type: "deploy",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({
+			message: "Deployed 1 apps based on tag v1.0.0",
+		});
+	});
+
+	it("does not deploy when the pushed branch does not match", async () => {
+		const res = createResponse();
+
+		await handler(createPushRequest("feature"), res);
+
+		expect(mocks.queueAdd).not.toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ message: "No apps to deploy" });
+	});
+});

--- a/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
+++ b/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
@@ -113,7 +113,10 @@ const createResponse = () => {
 	return res;
 };
 
-const createPushRequest = (branch: string) =>
+const createPushRequest = (
+	branch: string,
+	owner: { login?: string; name?: string } = { login: "agentHits" },
+) =>
 	({
 		headers: {
 			"x-hub-signature-256": "sha256=test-signature",
@@ -138,9 +141,7 @@ const createPushRequest = (branch: string) =>
 				full_name: "agentHits/dokploy",
 				clone_url: "https://github.com/agentHits/dokploy.git",
 				html_url: "https://github.com/agentHits/dokploy",
-				owner: {
-					login: "agentHits",
-				},
+				owner,
 			},
 		},
 	}) as unknown as NextApiRequest;
@@ -194,10 +195,16 @@ describe("GitHub app webhook auto-deploy", () => {
 		});
 	});
 
-	it("matches push events using repository owner login", async () => {
+	it("matches push events using repository owner name when available", async () => {
 		const res = createResponse();
 
-		await handler(createPushRequest("main"), res);
+		await handler(
+			createPushRequest("main", {
+				login: "agentHits-login",
+				name: "agentHits",
+			}),
+			res,
+		);
 
 		expect(mocks.queueAdd).toHaveBeenCalledWith(
 			"deployments",
@@ -215,7 +222,7 @@ describe("GitHub app webhook auto-deploy", () => {
 		expect(res.json).toHaveBeenCalledWith({ message: "Deployed 1 apps" });
 	});
 
-	it("matches compose push events using repository owner login", async () => {
+	it("matches compose push events using repository owner login fallback", async () => {
 		mocks.applicationsFindMany.mockResolvedValue([]);
 		mocks.composeFindMany.mockImplementation(({ where }) => {
 			const matches =
@@ -259,7 +266,7 @@ describe("GitHub app webhook auto-deploy", () => {
 		expect(res.json).toHaveBeenCalledWith({ message: "Deployed 1 apps" });
 	});
 
-	it("matches tag events using repository owner login", async () => {
+	it("matches tag events using repository owner login fallback", async () => {
 		mocks.applicationsFindMany.mockImplementation(({ where }) => {
 			const matches =
 				getConditionValue(where, "application.sourceType") === "github" &&

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -24,7 +24,7 @@ import {
 } from "./[refreshToken]";
 
 const getGithubRepositoryOwner = (githubBody: any) =>
-	githubBody?.repository?.owner?.login ?? githubBody?.repository?.owner?.name;
+	githubBody?.repository?.owner?.name ?? githubBody?.repository?.owner?.login;
 
 export default async function handler(
 	req: NextApiRequest,

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -23,6 +23,9 @@ import {
 	logWebhookError,
 } from "./[refreshToken]";
 
+const getGithubRepositoryOwner = (githubBody: any) =>
+	githubBody?.repository?.owner?.login ?? githubBody?.repository?.owner?.name;
+
 export default async function handler(
 	req: NextApiRequest,
 	res: NextApiResponse,
@@ -109,7 +112,7 @@ export default async function handler(
 		try {
 			const tagName = githubBody?.ref.replace("refs/tags/", "");
 			const repository = githubBody?.repository?.name;
-			const owner = githubBody?.repository?.owner?.name;
+			const owner = getGithubRepositoryOwner(githubBody);
 			const deploymentTitle = `Tag created: ${tagName}`;
 			const deploymentHash = extractHash(req.headers, githubBody);
 
@@ -219,7 +222,7 @@ export default async function handler(
 
 			const deploymentTitle = extractCommitMessage(req.headers, req.body);
 			const deploymentHash = extractHash(req.headers, req.body);
-			const owner = githubBody?.repository?.owner?.name;
+			const owner = getGithubRepositoryOwner(githubBody);
 			const normalizedCommits = githubBody?.commits?.flatMap(
 				(commit: any) => commit.modified,
 			);
@@ -372,7 +375,7 @@ export default async function handler(
 			const repository = githubBody?.repository?.name;
 			const deploymentHash = githubBody?.pull_request?.head?.sha;
 			const branch = githubBody?.pull_request?.base?.ref;
-			const owner = githubBody?.repository?.owner?.login;
+			const owner = getGithubRepositoryOwner(githubBody);
 			const prAuthor = githubBody?.pull_request?.user?.login;
 
 			// Validate PR author information is present


### PR DESCRIPTION
## What is this PR about?

This PR fixes GitHub auto-deploy matching for GitHub App webhooks. Dokploy
stores the selected GitHub repository owner from `repo.owner.login`, but the
push/tag webhook handler matched configured applications and compose projects
against `repository.owner.name`. GitHub push payloads can omit `owner.name`, so
valid pushes could be received and verified but still find zero deployable
resources, leaving auto-deploy inactive after new GitHub commits.

The handler now resolves the repository owner as
`repository.owner.login ?? repository.owner.name` and uses the same value for
tag, push, and preview-deployment matching. The regression test covers push
application, push compose, tag deploy, and a branch mismatch negative case
using a payload with `owner.login` and no `owner.name`.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Testing

- `pnpm --dir apps/dokploy exec vitest --config __test__/vitest.config.ts run __test__/deploy/github-webhook-handler.test.ts __test__/deploy/github.test.ts __test__/deploy/should-deploy.test.ts`
- `pnpm --dir apps/dokploy run typecheck`
- `pnpm exec biome check apps/dokploy/pages/api/deploy/github.ts apps/dokploy/__test__/deploy/github-webhook-handler.test.ts`
- `git diff --check upstream/canary...HEAD`

## Issues related (if applicable)

Fixes #4675

## Screenshots (if applicable)

N/A - webhook/API behavior only.
