### PR TITLE
chore: enforce 3-day minimum release age for dependencies (supply-chain hardening)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,8 @@ packages:
   - "apps/schedules"
   - "packages/server"
 
+# Supply-chain hardening: refuse package versions younger than 3 days (4320 min),
+# so newly-published malicious versions get caught/yanked before we install them.
+minimumReleaseAge: 4320
+
 


### PR DESCRIPTION
## What

Adds `minimumReleaseAge: 4320` to `pnpm-workspace.yaml` — pnpm refuses to resolve any dependency version published less than 3 days ago.

## Why

Newly published npm versions are the highest-risk window for supply-chain attacks. Most malicious releases are detected and yanked within a day or two; a 3-day cooldown means a compromised version gets caught before it lands in CI or dev machines.

## Notes

- Uses pnpm's native [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) (10.16+); repo is on pnpm 10.22, so **no new dependency**.
- Workspace-wide — covers root, all `apps/*`, and `packages/server`.
- Only gates *new* resolutions; versions already pinned in `pnpm-lock.yaml` are unaffected, so installs from the committed lockfile keep working.
- If an urgent bump is ever needed inside the window, `minimumReleaseAgeExclude` can allowlist specific packages.

Closes #4678

🤖 Generated with [Claude Code](https://claude.com/claude-code)