### PR TITLE
fix: add method="post" to auth forms to prevent credential leak in URL

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -182,6 +182,7 @@ export default function Home({ IS_CLOUD, enforceSSO }: Props) {
 			{IS_CLOUD && <SignInWithGoogle />}
 			<Form {...loginForm}>
 				<form
+					method="post"
 					onSubmit={loginForm.handleSubmit(onSubmit)}
 					className="space-y-4"
 					id="login-form"
@@ -263,6 +264,7 @@ export default function Home({ IS_CLOUD, enforceSSO }: Props) {
 				) : (
 					<>
 						<form
+							method="post"
 							onSubmit={onTwoFactorSubmit}
 							className="space-y-4"
 							id="two-factor-form"
@@ -326,7 +328,11 @@ export default function Home({ IS_CLOUD, enforceSSO }: Props) {
 									</DialogDescription>
 								</DialogHeader>
 
-								<form onSubmit={onBackupCodeSubmit} className="space-y-4">
+								<form
+									method="post"
+									onSubmit={onBackupCodeSubmit}
+									className="space-y-4"
+								>
 									<div className="flex flex-col gap-2">
 										<Label>Backup Code</Label>
 										<Input

--- a/apps/dokploy/pages/register.tsx
+++ b/apps/dokploy/pages/register.tsx
@@ -172,6 +172,7 @@ const Register = ({ isCloud }: Props) => {
 							)}
 							<Form {...form}>
 								<form
+									method="post"
 									onSubmit={form.handleSubmit(onSubmit)}
 									className="grid gap-4"
 								>

--- a/apps/dokploy/pages/reset-password.tsx
+++ b/apps/dokploy/pages/reset-password.tsx
@@ -123,6 +123,7 @@ export default function Home({ tokenResetPassword }: Props) {
 						)}
 						<Form {...form}>
 							<form
+								method="post"
 								onSubmit={form.handleSubmit(onSubmit)}
 								className="grid gap-4"
 							>

--- a/apps/dokploy/pages/send-reset-password.tsx
+++ b/apps/dokploy/pages/send-reset-password.tsx
@@ -110,6 +110,7 @@ export default function Home() {
 						{!temp.is2FAEnabled ? (
 							<Form {...form}>
 								<form
+									method="post"
 									onSubmit={form.handleSubmit(onSubmit)}
 									className="grid gap-4"
 								>


### PR DESCRIPTION
## What

Adds `method="post"` to all auth `<form>` elements:

- `pages/index.tsx` — login, 2FA, and backup-code forms
- `pages/register.tsx` — signup form
- `pages/send-reset-password.tsx` — reset-request form
- `pages/reset-password.tsx` — new-password form

## Why

These forms had no `method`, defaulting to `method="get"` with `action=""` (current URL). The normal path is fine — `react-hook-form`'s `handleSubmit` calls `preventDefault()` and better-auth sends a `fetch` **POST**. But `preventDefault()` only runs *after hydration*. Submitting in the pre-hydration window (JS still loading, fast Enter press, or JS disabled/errored) triggers the browser's native default submit:

```
GET /?email=user@example.com&password=hunter2
```

…leaking credentials into the **URL, browser history, server access logs, and the `Referer` header**.

`method="post"` makes the native fallback a POST, so the fields go in the request body instead. The JS submit path is completely unchanged.

## Verification

Reproduced and verified in a real browser (Chromium via CDP) with a JS-free copy of the form (= the no-JS / pre-hydration state):

| Form | Browser submit | Resulting URL |
|---|---|---|
| no `method` (before) | `GET` | `/submit?email=…&password=hunter2-secret` 🔴 leak |
| `method="post"` (after) | `POST` | `/submit` (clean, creds in body) 🟢 |

Closes #4682

🤖 Generated with [Claude Code](https://claude.com/claude-code)