### PR TITLE
fix: show API key field for Ollama providers and pass apiKey to createOllama

### DIFF
--- a/apps/dokploy/components/dashboard/settings/handle-ai.tsx
+++ b/apps/dokploy/components/dashboard/settings/handle-ai.tsx
@@ -275,36 +275,34 @@ export const HandleAi = ({ aiId }: Props) => {
 							)}
 						/>
 
-						{!isOllama && (
-							<FormField
-								control={form.control}
-								name="apiKey"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>API Key</FormLabel>
-										<FormControl>
-											<Input
-												type="password"
-												placeholder="sk-..."
-												autoComplete="one-time-code"
-												{...field}
-												onChange={(e) => {
-													field.onChange(e);
-													// Reset model when user changes API Key
-													if (form.getValues("model")) {
-														form.setValue("model", "");
-													}
-												}}
-											/>
-										</FormControl>
-										<FormDescription>
-											Your API key for authentication
-										</FormDescription>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						)}
+						<FormField
+							control={form.control}
+							name="apiKey"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>API Key</FormLabel>
+									<FormControl>
+										<Input
+											type="password"
+											placeholder="sk-..."
+											autoComplete="one-time-code"
+											{...field}
+											onChange={(e) => {
+												field.onChange(e);
+												// Reset model when user changes API Key
+												if (form.getValues("model")) {
+													form.setValue("model", "");
+												}
+											}}
+										/>
+									</FormControl>
+									<FormDescription>
+										Your API key for authentication
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 
 						{isLoadingServerModels && (
 							<span className="text-sm text-muted-foreground">

--- a/packages/server/src/utils/ai/select-ai-provider.ts
+++ b/packages/server/src/utils/ai/select-ai-provider.ts
@@ -74,8 +74,8 @@ export function selectAIProvider(config: { apiUrl: string; apiKey: string }) {
 			});
 		case "ollama":
 			return createOllama({
-				// optional settings, e.g.
 				baseURL: config.apiUrl,
+				apiKey: config.apiKey,
 			});
 		case "deepinfra":
 			return createDeepInfra({


### PR DESCRIPTION
  ## What is this PR about?
 This PR fixes the AI provider configuration for Ollama Cloud and other authenticated Ollama endpoints. Previously, the API key input was hidden whenever the provider URL was detected as Ollama, preventing users from entering credentials. The backend also never forwarded the stored API key to `createOllama`. This change renders the API key field unconditionally and passes the key to the Ollama provider.


## Checklist

Before submitting this PR, please make sure that:

- [X] You created a dedicated branch based on the `canary` branch.
- [X] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [X] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4684


## Screenshots (if applicable)

### Before fix
<img width="736" height="631" alt="old-behavior" src="https://github.com/user-attachments/assets/843b74b5-98b3-4aeb-a37e-776fc7dbca0c" />

### After fix
<img width="1283" height="756" alt="post-change" src="https://github.com/user-attachments/assets/1cd04674-d93e-458c-b61d-20456fee3082" />

<img width="1341" height="450" alt="test-ai-feature" src="https://github.com/user-attachments/assets/8a904d4a-c5c8-48fa-9720-edadee891f56" />