### PR TITLE
fix: resolve server from parent entity in deployment.readLogs

### DIFF
--- a/apps/dokploy/server/api/routers/deployment.ts
+++ b/apps/dokploy/server/api/routers/deployment.ts
@@ -243,7 +243,11 @@ export const deploymentRouter = createTRPCRouter({
 			}
 
 			const command = `tail -n ${input.tail} "${deployment.logPath}" 2>/dev/null || echo ""`;
-			const serverId = deployment.serverId || deployment.schedule?.serverId;
+			const serverId =
+				deployment.serverId ||
+				deployment.schedule?.serverId ||
+				deployment.application?.serverId ||
+				deployment.compose?.serverId;
 			if (serverId) {
 				const { stdout } = await execAsyncRemote(serverId, command);
 				return stdout;

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -84,6 +84,7 @@ export const findDeploymentById = async (deploymentId: string) => {
 		where: eq(deployments.deploymentId, deploymentId),
 		with: {
 			application: true,
+			compose: true,
 			schedule: true,
 		},
 	});


### PR DESCRIPTION
## Problem

The `deployment.readLogs` endpoint returns empty content for deployments on remote servers.

**Root cause:** The handler only checks `deployment.serverId` and `deployment.schedule?.serverId` to determine where to read the log file. For application and compose deployments, `serverId` is not stored on the deployment record — the server is resolved from the parent entity (`application.serverId`, `compose.serverId`).

When `serverId` is null, the handler falls through to local `execAsync(command)`, which runs `tail` locally. But the log file lives on the remote server, so `2>/dev/null` suppresses the "file not found" error and returns `""`.

## Fix

1. Load the `compose` relation in `findDeploymentById` (it already loads `application` and `schedule`)
2. Fall back to `application?.serverId` and `compose?.serverId` in the `readLogs` handler

## Reproduction

1. Deploy a compose app to a remote server
2. Call `GET /api/deployment.readLogs?deploymentId=xxx&tail=100`
3. Before: returns `\n` (empty)
4. After: returns actual log content

Fixes #4687
