### PR TITLE
chore(tsconfig): drop deprecated baseUrl in favor of relative paths

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -8,7 +8,6 @@
 		"outDir": "dist",
 		"jsx": "react-jsx",
 		"jsxImportSource": "hono/jsx",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./*"],
 			"@dokploy/server/*": ["../../packages/server/src/*"]

--- a/apps/dokploy/tsconfig.json
+++ b/apps/dokploy/tsconfig.json
@@ -25,7 +25,6 @@
 		],
 		"incremental": true,
 		/* Path Aliases */
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./*"],
 			"@dokploy/server/*": ["../../packages/server/src/*"]

--- a/apps/dokploy/tsconfig.server.json
+++ b/apps/dokploy/tsconfig.server.json
@@ -7,7 +7,6 @@
 		"isolatedModules": false,
 		"noEmit": false,
 		"moduleResolution": "Node",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./*"],
 			"@dokploy/server/*": ["../../packages/server/src/*"]

--- a/apps/schedules/tsconfig.json
+++ b/apps/schedules/tsconfig.json
@@ -8,7 +8,6 @@
 		"outDir": "dist",
 		"jsx": "react-jsx",
 		"declaration": false,
-		"baseUrl": ".",
 		"paths": {
 			"@dokploy/server/*": ["../../packages/server/src/*"]
 		}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -21,7 +21,6 @@
 		"plugins": [{ "name": "next" }],
 		"outDir": "./dist",
 		/* Path Aliases */
-		"baseUrl": ".",
 		"paths": {
 			"@dokploy/server/*": ["./src/*"]
 		}

--- a/packages/server/tsconfig.server.json
+++ b/packages/server/tsconfig.server.json
@@ -10,7 +10,6 @@
 		"declaration": true,
 		"moduleResolution": "Node",
 		"rootDir": "./src",
-		"baseUrl": ".",
 		"jsx": "react-jsx",
 		"paths": {
 			"@dokploy/server/*": ["./src/*"]


### PR DESCRIPTION
## What is this PR about?

`baseUrl` is deprecated in TypeScript and will stop working in TypeScript 7.0 — newer TypeScript versions surface a *"Option 'baseUrl' is deprecated… Specify compilerOption '\"ignoreDeprecations\": \"6.0\"'"* warning in the editor.

Every tsconfig in the repo only uses `baseUrl` together with `paths`, and all of those path mappings are already **relative** (`./*`, `../../packages/server/src/*`, `./src/*`). Since TypeScript 4.1 relative `paths` resolve from each tsconfig's own directory without `baseUrl`, so this simply removes `baseUrl` from all 6 tsconfig files. That clears the deprecation cleanly, without resorting to `ignoreDeprecations`.

Files touched:
- `apps/dokploy/tsconfig.json`, `apps/dokploy/tsconfig.server.json`
- `packages/server/tsconfig.json`, `packages/server/tsconfig.server.json`
- `apps/api/tsconfig.json`
- `apps/schedules/tsconfig.json`

No behavior change — only the now-redundant `baseUrl` option is removed.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. Verified that path-alias resolution is unaffected: `packages/server` / `apps/api` / `apps/schedules` typecheck cleanly, the server build (`tsc` + `tsc-alias`) succeeds, `@/` and `@dokploy/*` still resolve in `apps/dokploy`, and the vitest suite passes.

## Issues related (if applicable)

_n/a_

## Screenshots (if applicable)

_n/a — config-only change._
