### PR TITLE
feat: enhance TLS certificate selection UI in AddDomain component

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -780,9 +780,8 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 															)}
 															{field.value === "letsencrypt" && (
 																<>
-																	<strong>Let's Encrypt</strong>{" "}
-																	auto-provisions a certificate automatically
-																	for this host.
+																	<strong>Let's Encrypt</strong> auto-provisions
+																	a certificate automatically for this host.
 																</>
 															)}
 															{field.value === "custom" && (

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -763,6 +763,38 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 																<SelectItem value={"custom"}>Custom</SelectItem>
 															</SelectContent>
 														</Select>
+														<FormDescription>
+															{field.value === "none" && (
+																<>
+																	<strong>None</strong> serves TLS using any
+																	certificate you created in the{" "}
+																	<Link
+																		href="/dashboard/settings/certificates"
+																		className="text-primary"
+																	>
+																		Certificates
+																	</Link>{" "}
+																	section whose CN/SAN matches this host —
+																	Traefik selects it automatically via SNI.
+																</>
+															)}
+															{field.value === "letsencrypt" && (
+																<>
+																	<strong>Let's Encrypt</strong>{" "}
+																	auto-provisions a certificate automatically
+																	for this host.
+																</>
+															)}
+															{field.value === "custom" && (
+																<>
+																	<strong>Custom</strong> uses a Traefik cert
+																	resolver by name (defined in your static
+																	configuration).
+																</>
+															)}
+															{!field.value &&
+																"Select a certificate provider to see how TLS will be served for this host."}
+														</FormDescription>
 														<FormMessage />
 													</FormItem>
 												);
@@ -777,10 +809,19 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 													return (
 														<FormItem>
 															<FormLabel>Custom Certificate Resolver</FormLabel>
+															<FormDescription>
+																Enter the <strong>name</strong> of a Traefik
+																cert resolver defined in your static
+																configuration (e.g. <code>letsencrypt</code>) —
+																not certificate or private key content. To use a
+																certificate you pasted in the Certificates
+																section, choose <strong>None</strong> instead
+																and Traefik will match it by SNI.
+															</FormDescription>
 															<FormControl>
 																<Input
 																	className="w-full"
-																	placeholder="Enter your custom certificate resolver"
+																	placeholder="e.g. letsencrypt"
 																	{...field}
 																	value={field.value || ""}
 																	onChange={(e) => {


### PR DESCRIPTION
- Added descriptive FormDescriptions for different TLS certificate options (None, Let's Encrypt, Custom) to improve user understanding of certificate provisioning.
- Updated placeholder text for the custom certificate resolver input field to provide clearer guidance on expected input format.

This update enhances the user experience by providing contextual information directly within the form.

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4704

## Screenshots (if applicable)

