### PR TITLE
fix: add sourceType to apiCreateCompose and apiCreateApplication

### DIFF
--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -387,6 +387,7 @@ export const apiCreateApplication = createSchema.pick({
 	description: true,
 	environmentId: true,
 	serverId: true,
+	sourceType: true,
 });
 
 export const apiFindOneApplication = z.object({

--- a/packages/server/src/db/schema/compose.ts
+++ b/packages/server/src/db/schema/compose.ts
@@ -179,6 +179,7 @@ export const apiCreateCompose = createSchema.pick({
 	appName: true,
 	serverId: true,
 	composeFile: true,
+	sourceType: true,
 });
 
 export const apiCreateComposeByTemplate = createSchema


### PR DESCRIPTION
## Problem

`apiCreateCompose` and `apiCreateApplication` use `createSchema.pick({...})` but **omit `sourceType`** from the pick list. Because the DB column defaults to `"github"`:

```ts
sourceType: sourceTypeCompose("sourceType").notNull().default("github")
```

Every compose/application created via the API gets `sourceType: "github"` regardless of intention. Users must manually update it after creation via the compose/application update endpoint.

## Fix

Add `sourceType: true` to both `.pick()` schemas:

- `packages/server/src/db/schema/compose.ts` — `apiCreateCompose`
- `packages/server/src/db/schema/application.ts` — `apiCreateApplication`

## Why it's safe

`sourceType` is already defined as `.optional()` in both `createSchema`s, so callers that don't send it will still get the DB default (`"github"`). This is purely additive — no breaking change.

Template-based creation (`createComposeByTemplate`) and the `/compose.update` endpoint are unaffected (they already handle `sourceType` correctly).

## Impact

- ✅ `POST /compose.create` now accepts an optional `sourceType` field
- ✅ `POST /application.create` now accepts an optional `sourceType` field  
- ✅ OpenAPI spec auto-fixes on regeneration (generated via `trpc-openapi` from Zod schemas)
- ✅ Backward compatible — existing callers continue to work unchanged