### PR TITLE
fix: certificate.yml not discovered by Traefik file provider, breaks manually uploaded certs (#4707)

### DIFF
--- a/packages/server/src/services/certificate.ts
+++ b/packages/server/src/services/certificate.ts
@@ -59,13 +59,25 @@ export const createCertificate = async (
 
 export const removeCertificateById = async (certificateId: string) => {
 	const certificate = await findCertificateById(certificateId);
-	const { CERTIFICATES_PATH } = paths(!!certificate.serverId);
+	const { CERTIFICATES_PATH, DYNAMIC_TRAEFIK_PATH } = paths(
+		!!certificate.serverId,
+	);
 	const certDir = path.join(CERTIFICATES_PATH, certificate.certificatePath);
+	const configFile = path.join(
+		DYNAMIC_TRAEFIK_PATH,
+		`${certificate.certificatePath}.yml`,
+	);
 
 	if (certificate.serverId) {
-		await execAsyncRemote(certificate.serverId, `rm -rf ${certDir}`);
+		await execAsyncRemote(
+			certificate.serverId,
+			`rm -rf ${certDir}; rm -f ${configFile}`,
+		);
 	} else {
 		await removeDirectoryIfExistsContent(certDir);
+		if (fs.existsSync(configFile)) {
+			fs.rmSync(configFile);
+		}
 	}
 
 	const result = await db
@@ -84,7 +96,9 @@ export const removeCertificateById = async (certificateId: string) => {
 };
 
 const createCertificateFiles = async (certificate: Certificate) => {
-	const { CERTIFICATES_PATH } = paths(!!certificate.serverId);
+	const { CERTIFICATES_PATH, DYNAMIC_TRAEFIK_PATH } = paths(
+		!!certificate.serverId,
+	);
 	const certDir = path.join(CERTIFICATES_PATH, certificate.certificatePath);
 	const crtPath = path.join(certDir, "chain.crt");
 	const keyPath = path.join(certDir, "privkey.key");
@@ -102,7 +116,12 @@ const createCertificateFiles = async (certificate: Certificate) => {
 		},
 	};
 	const yamlConfig = stringify(traefikConfig);
-	const configFile = path.join(certDir, "certificate.yml");
+	// Traefik's file provider does not watch subdirectories, so the pointer
+	// config must live at the top level alongside other dynamic configs.
+	const configFile = path.join(
+		DYNAMIC_TRAEFIK_PATH,
+		`${certificate.certificatePath}.yml`,
+	);
 
 	if (certificate.serverId) {
 		const certificateData = encodeBase64(certificate.certificateData);


### PR DESCRIPTION
## Problem

Traefik's file provider is non-recursive — it only watches the top-level
`/etc/dokploy/traefik/dynamic/` directory for configuration files.

Dokploy was writing `certificate.yml` into a nested subdirectory:
/etc/dokploy/traefik/dynamic/certificates/<id>/certificate.yml

Traefik never discovers files inside subdirectories, so it never loads
the certificate, never performs SNI matching, and always falls back to
`TRAEFIK DEFAULT CERT` — even when the certificate files are correctly
written to disk and the `tls=true` label is confirmed present on the
container.

This silently breaks HTTPS for anyone using manually uploaded
certificates (e.g. Cloudflare Origin CA) with Cloudflare Full (Strict)
mode, resulting in Error 526 at the origin.

## Root Cause Verification

Confirmed via direct origin test, bypassing Cloudflare entirely:
Before fix:
$ openssl s_client -connect <ORIGIN_IP>:443 -servername <DOMAIN> | openssl x509 -noout -issuer
issuer=CN = TRAEFIK DEFAULT CERT
After fix:
issuer=C = US, O = "CloudFlare, Inc.", OU = CloudFlare Origin SSL Certificate Authority

The certificate files (`chain.crt`, `privkey.key`) and the contents of
`certificate.yml` were always correct — only the file's location was
unreachable by Traefik's file provider.

## Fix

Write `certificate.yml` directly to the top-level `DYNAMIC_TRAEFIK_PATH`
instead of the nested certificates subdirectory:
Before: /etc/dokploy/traefik/dynamic/certificates/<id>/certificate.yml
After:  /etc/dokploy/traefik/dynamic/<id>-certificate.yml

Since `watch: true` is enabled in `traefik.yml`, Traefik picks up the
new file instantly with no restart required. The actual PEM files
(`chain.crt` and `privkey.key`) remain unchanged in their original
subdirectory — only the location of the pointer config file changes.

## Testing

- Verified on a live server with two certificates covering 5 domains
  across two separate Docker Compose deployments
- Confirmed Traefik correctly served the uploaded Cloudflare Origin CA
  certificate (not the default cert) on all affected domains after fix
- Confirmed Cloudflare Full (Strict) mode works end-to-end with no
  Error 526

Closes #4707