### PR TITLE
fix: allow members with git providers permission to create/delete their own providers

### DIFF
--- a/apps/dokploy/__test__/permissions/check-permission.test.ts
+++ b/apps/dokploy/__test__/permissions/check-permission.test.ts
@@ -183,4 +183,29 @@ describe("legacy boolean overrides for member", () => {
 		memberToReturn = mockMemberData("member");
 		await expect(checkPermission(ctx, { docker: ["read"] })).rejects.toThrow();
 	});
+
+	it("member passes gitProviders.create with canAccessToGitProviders=true", async () => {
+		memberToReturn = mockMemberData("member", {
+			canAccessToGitProviders: true,
+		});
+		await expect(
+			checkPermission(ctx, { gitProviders: ["create"] }),
+		).resolves.toBeUndefined();
+	});
+
+	it("member passes gitProviders.delete with canAccessToGitProviders=true", async () => {
+		memberToReturn = mockMemberData("member", {
+			canAccessToGitProviders: true,
+		});
+		await expect(
+			checkPermission(ctx, { gitProviders: ["delete"] }),
+		).resolves.toBeUndefined();
+	});
+
+	it("member fails gitProviders.create with canAccessToGitProviders=false", async () => {
+		memberToReturn = mockMemberData("member");
+		await expect(
+			checkPermission(ctx, { gitProviders: ["create"] }),
+		).rejects.toThrow();
+	});
 });

--- a/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
+++ b/apps/dokploy/__test__/permissions/resolve-permissions.test.ts
@@ -143,6 +143,24 @@ describe("free-tier resources for member", () => {
 		const perms = await resolvePermissions(ctx);
 		expect(perms.docker.read).toBe(true);
 	});
+
+	it("member gets gitProviders create/delete=false without legacy override", async () => {
+		memberToReturn = mockMemberData("member");
+		const perms = await resolvePermissions(ctx);
+		expect(perms.gitProviders.read).toBe(false);
+		expect(perms.gitProviders.create).toBe(false);
+		expect(perms.gitProviders.delete).toBe(false);
+	});
+
+	it("member gets gitProviders read/create/delete=true with canAccessToGitProviders", async () => {
+		memberToReturn = mockMemberData("member", {
+			canAccessToGitProviders: true,
+		});
+		const perms = await resolvePermissions(ctx);
+		expect(perms.gitProviders.read).toBe(true);
+		expect(perms.gitProviders.create).toBe(true);
+		expect(perms.gitProviders.delete).toBe(true);
+	});
 });
 
 describe("free-tier resources for owner", () => {

--- a/apps/dokploy/server/api/routers/git-provider.ts
+++ b/apps/dokploy/server/api/routers/git-provider.ts
@@ -5,6 +5,7 @@ import {
 	updateGitProvider,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import { findMemberByUserId } from "@dokploy/server/services/permission";
 import { hasValidLicense } from "@dokploy/server/services/proprietary/license-key";
 import { TRPCError } from "@trpc/server";
 import { desc, eq, inArray } from "drizzle-orm";
@@ -142,6 +143,19 @@ export const gitProviderRouter = createTRPCRouter({
 					throw new TRPCError({
 						code: "UNAUTHORIZED",
 						message: "You are not allowed to delete this Git provider",
+					});
+				}
+
+				const memberRecord = await findMemberByUserId(
+					ctx.user.id,
+					ctx.session.activeOrganizationId,
+				);
+				const isPrivileged =
+					memberRecord.role === "owner" || memberRecord.role === "admin";
+				if (!isPrivileged && gitProvider.userId !== ctx.session.userId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You can only delete your own Git providers",
 					});
 				}
 				await audit(ctx, {

--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -170,6 +170,8 @@ const getLegacyOverrides = (
 		},
 		gitProviders: {
 			read: !!memberRecord.canAccessToGitProviders,
+			create: !!memberRecord.canAccessToGitProviders,
+			delete: !!memberRecord.canAccessToGitProviders,
 		},
 	};
 };


### PR DESCRIPTION
## Problem

Closes #4695

In the free / self-hosted permission model, the **Git Providers** toggle (`canAccessToGitProviders`) only granted `read` access. A member with that toggle enabled could not add a git provider, because the create/delete endpoints require `gitProviders.create` / `gitProviders.delete`, and the frontend hides the "Add" buttons when `permissions.gitProviders.create` is `false`.

This was inconsistent with the **SSH Keys** toggle (`canAccessToSSHKeys`), which already grants `read` + `create` + `delete` from a single switch with the same "access to the … section" wording.

## Changes

- `gitProviders` legacy override now grants `read`, `create` and `delete` when the toggle is on, matching SSH Keys.
- The `gitProvider.remove` endpoint now restricts non owner/admin roles to deleting **only their own** providers (consistent with the existing ownership model used for visibility and sharing). Owner/admin can still delete any provider in the organization.
- Added unit tests in `check-permission` and `resolve-permissions` covering create/delete via the toggle and the off case.
