### PR TITLE
fix(validation): allow hashtag in git branch names

### DIFF
--- a/packages/server/src/utils/git-branch-validation.ts
+++ b/packages/server/src/utils/git-branch-validation.ts
@@ -1,3 +1,3 @@
 // Valid git branch names per git-check-ref-format rules.
 // Rejects shell metacharacters that would enable command injection.
-export const VALID_BRANCH_REGEX = /^[a-zA-Z0-9._\-/]+$/;
+export const VALID_BRANCH_REGEX = /^[a-zA-Z0-9._\-/#]+$/;


### PR DESCRIPTION
## What

Branch names containing `#` (e.g. `feat#123`, `release/v1.0#rc`) were rejected with "Invalid branch name" when selecting a branch and saving a git provider configuration.

`VALID_BRANCH_REGEX` did not include `#`, even though `#` is a legal git ref character. This single constant is shared by the backend zod schemas and all provider UI forms, so the rejection happened on both client and server.

## Fix

Add `#` to the allowed character set:

```diff
-export const VALID_BRANCH_REGEX = /^[a-zA-Z0-9._\-/]+$/;
+export const VALID_BRANCH_REGEX = /^[a-zA-Z0-9._\-/#]+$/;
```

## Security note

`#` is **not** a shell-injection vector here:

- The regex still rejects every character needed to terminate the `git clone` command and start a new one (`;` `|` `&` `$` `` ` `` `(` `)` newline, space, quotes).
- `#` only starts a shell comment at the **beginning of a word** — never mid-argument, as in `git clone --branch feat#123`, where the shell passes `feat#123` to git verbatim.
- A branch literally starting with `#` can at most truncate (break) its own clone command into a comment; it cannot inject or execute anything.

Fixes #4585