### PR TITLE
fix(traefik): preserve remote YAML shell quotes

### DIFF
--- a/apps/dokploy/__test__/traefik/traefik.test.ts
+++ b/apps/dokploy/__test__/traefik/traefik.test.ts
@@ -1,6 +1,11 @@
 import type { ApplicationNested, Domain, Redirect } from "@dokploy/server";
 import { createRouterConfig } from "@dokploy/server";
-import { expect, test } from "vitest";
+import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
+import { expect, test, vi } from "vitest";
+
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsyncRemote: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
+}));
 
 const baseApp: ApplicationNested = {
 	railpackVersion: "0.15.4",
@@ -172,6 +177,40 @@ test("Web entrypoint on http domain", async () => {
 
 	expect(router.middlewares).not.toContain("redirect-to-https");
 	expect(router.rule).not.toContain("PathPrefix");
+});
+
+test("Remote Traefik writer preserves shell-sensitive YAML values", async () => {
+	const { writeTraefikConfigRemote } = await import("@dokploy/server");
+	const csp =
+		"default-src * 'unsafe-inline' 'unsafe-eval' data: blob: https:; frame-ancestors 'self'; object-src 'none';";
+
+	await writeTraefikConfigRemote(
+		{
+			http: {
+				middlewares: {
+					"secure-headers": {
+						headers: {
+							customResponseHeaders: {
+								"Content-Security-Policy": csp,
+							},
+						},
+					},
+				},
+			},
+		},
+		"middlewares",
+		"server-1",
+	);
+
+	const command = vi.mocked(execAsyncRemote).mock.calls.at(-1)?.[1] ?? "";
+	const encoded = command.match(/echo "([^"]+)"/)?.[1] ?? "";
+	const decoded = Buffer.from(encoded, "base64").toString("utf8");
+
+	expect(command).toContain('base64 -d > "');
+	expect(decoded).toContain("'unsafe-inline'");
+	expect(decoded).toContain("'unsafe-eval'");
+	expect(decoded).toContain("frame-ancestors 'self'");
+	expect(decoded).toContain("object-src 'none'");
 });
 
 test("Web entrypoint on http domain with custom path", async () => {

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -272,7 +272,11 @@ export const writeTraefikConfigRemote = async (
 		const { DYNAMIC_TRAEFIK_PATH } = paths(true);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
 		const yamlStr = stringify(traefikConfig);
-		await execAsyncRemote(serverId, `echo '${yamlStr}' > ${configPath}`);
+		const encoded = Buffer.from(yamlStr).toString("base64");
+		await execAsyncRemote(
+			serverId,
+			`echo "${encoded}" | base64 -d > "${configPath}"`,
+		);
 	} catch (e) {
 		console.error("Error saving the YAML config file:", e);
 	}


### PR DESCRIPTION
## Summary
- write remote Traefik YAML via a base64 payload instead of single-quoted `echo`
- preserve shell-sensitive YAML values such as CSP keywords (`'unsafe-inline'`, `'self'`, `'none'`)
- add a regression test that decodes the generated remote command payload and asserts the quotes survive

## Why
`writeTraefikConfigRemote` currently serializes YAML and sends it through:

```sh
echo '${yaml}' > ${configPath}
```

If the YAML contains single quotes, the remote shell consumes them before writing the file. This corrupts valid values such as Content-Security-Policy directives.

## Verification
- `git diff --check`
- Node self-check confirmed the base64 command decodes to a CSP value containing `'unsafe-inline'` and `'self'`

Could not run the focused Vitest/Biome checks locally because dependency installation failed before dev binaries were available:

```text
ERR_NUB_TRUST_DOWNGRADE for @octokit/plugin-paginate-rest@9.2.2
```
