### PR TITLE
fix: reduce SSR payload size by scoping user.get columns

### DIFF
--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -137,8 +137,31 @@ export const userRouter = createTRPCRouter({
 			),
 			with: {
 				user: {
+					columns: {
+						id: true,
+						firstName: true,
+						lastName: true,
+						email: true,
+						image: true,
+						allowImpersonation: true,
+						twoFactorEnabled: true,
+						stripeCustomerId: true,
+						stripeSubscriptionId: true,
+						serversQuantity: true,
+						isEnterpriseCloud: true,
+						sendInvoiceNotifications: true,
+					},
 					with: {
-						apiKeys: true,
+						apiKeys: {
+							columns: {
+								id: true,
+								name: true,
+								prefix: true,
+								enabled: true,
+								expiresAt: true,
+								createdAt: true,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- `user.get` returned the nested `user` and `apiKeys` relations with no column projection, shipping unused fields (and API key secrets: `key`, `permissions`, `metadata`) to every page that prefetches it via `getServerSideProps`
- This caused the `/dashboard/home` page (and others) to exceed Next.js's 128kB page-data warning threshold, reported in #4700 as a 713kB payload
- Scoped both relations to only the columns actually consumed by the frontend

Fixes #4700