### PR TITLE
fix(projects): make project cards grid fill available width

### DIFF
--- a/apps/dokploy/components/dashboard/projects/show.tsx
+++ b/apps/dokploy/components/dashboard/projects/show.tsx
@@ -290,7 +290,7 @@ export const ShowProjects = () => {
 											</span>
 										</div>
 									)}
-									<div className="w-full grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 flex-wrap gap-5">
+									<div className="w-full grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-5">
 										{filteredProjects?.map((project) => {
 											const emptyServices = project?.environments
 												.map(


### PR DESCRIPTION
## Summary
- The projects grid used fixed column counts per breakpoint (up to `3xl:grid-cols-5`), so on ultra-wide screens the cards stayed capped at 5 columns and left empty space instead of filling the row.
- Switched to `grid-cols-[repeat(auto-fill,minmax(300px,1fr))]` so columns are computed automatically and cards stretch to fill the available width.

Fixes #4523