### PR TITLE
fix(ai): use nullable instead of optional for configFiles in AI suggestion schema

### DIFF
--- a/packages/server/src/services/ai.ts
+++ b/packages/server/src/services/ai.ts
@@ -24,7 +24,7 @@ interface DockerOutput {
 	dockerCompose: string;
 	envVariables: Array<{ name: string; value: string }>;
 	domains: Array<{ host: string; port: number; serviceName: string }>;
-	configFiles?: Array<{ content: string; filePath: string }>;
+	configFiles?: Array<{ content: string; filePath: string }> | null;
 }
 
 export const getAiSettingsByOrganizationId = async (organizationId: string) => {
@@ -136,7 +136,7 @@ export const suggestVariants = async ({
 								filePath: z.string(),
 							}),
 						)
-						.optional(),
+						.nullable(),
 				}),
 			),
 		});


### PR DESCRIPTION
## Summary
- OpenAI strict mode for `response_format` requires every property in the JSON Schema to be listed in `required`. Optional Zod fields (`.optional()`) don't satisfy this, causing the AI Assistant template generator to fail at Step 2 with gpt-4o and other strict-mode models.
- Changed `configFiles` from `.optional()` to `.nullable()` in `packages/server/src/services/ai.ts`, which keeps the key in `required` while allowing `null`/no config files.

Fixes #4267