### PR TITLE
fix(ai): allow configFiles to be null in template generator Details type

### DIFF
--- a/apps/dokploy/components/dashboard/project/ai/template-generator.tsx
+++ b/apps/dokploy/components/dashboard/project/ai/template-generator.tsx
@@ -47,7 +47,7 @@ interface Details {
 	envVariables: EnvVariable[];
 	shortDescription: string;
 	domains: Domain[];
-	configFiles?: Mount[];
+	configFiles?: Mount[] | null;
 }
 
 interface Mount {


### PR DESCRIPTION
## Problem
`apps/dokploy` typecheck fails on `canary` since #4732, which changed `configFiles` from optional to nullable in the AI suggestion schema (`packages/server/src/services/ai.ts`). The `Details` type in `template-generator.tsx` was not updated to match, so assigning AI suggestions to it fails type checking in `step-two.tsx`.

## Solution
Update `Details.configFiles` to `Mount[] | null | undefined` to match the nullable schema.