### PR TITLE
fix(tags): show create button in empty filter

### DIFF
--- a/apps/dokploy/components/shared/tag-filter.tsx
+++ b/apps/dokploy/components/shared/tag-filter.tsx
@@ -91,14 +91,24 @@ export function TagFilter({
 							)}
 						</div>
 						<CommandList>
-							<CommandEmpty>
+							{tags.length > 0 && (
+								<CommandEmpty>
+									<div className="flex flex-col items-center gap-2 py-1">
+										<span className="text-sm text-muted-foreground">
+											No tags found.
+										</span>
+										<HandleTag />
+									</div>
+								</CommandEmpty>
+							)}
+							{tags.length === 0 && (
 								<div className="flex flex-col items-center gap-2 py-1">
 									<span className="text-sm text-muted-foreground">
 										No tags found.
 									</span>
 									<HandleTag />
 								</div>
-							</CommandEmpty>
+							)}
 							<CommandGroup>
 								{tags.map((tag) => {
 									const isSelected = selectedTags.includes(tag.id);


### PR DESCRIPTION
## Summary
- show the tag filter empty state immediately when no tags exist
- keep the cmdk empty state for search results when tags exist

Closes #4741

## Validation
- `pnpm exec biome check apps/dokploy/components/shared/tag-filter.tsx`
- `pnpm --filter=dokploy run typecheck`
