### PR TITLE
fix(ui): prevent scrollbar layout shift

### DIFF
--- a/apps/dokploy/styles/globals.css
+++ b/apps/dokploy/styles/globals.css
@@ -113,6 +113,10 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
+	html {
+		scrollbar-gutter: stable;
+	}
+
 	*,
 	::after,
 	::before,


### PR DESCRIPTION
## Summary
- reserve a stable scrollbar gutter on the root element
- prevent layout width changes when dropdowns/overlays hide the page scrollbar

Closes #4743

## Validation
- `pnpm exec biome check apps/dokploy/styles/globals.css`
- `pnpm --filter=dokploy run typecheck`
