### PR TITLE
fix(requests): chart not visible in Requests tab

### DIFF
--- a/apps/dokploy/components/dashboard/requests/request-distribution-chart.tsx
+++ b/apps/dokploy/components/dashboard/requests/request-distribution-chart.tsx
@@ -1,11 +1,4 @@
-import {
-	Area,
-	AreaChart,
-	CartesianGrid,
-	ResponsiveContainer,
-	XAxis,
-	YAxis,
-} from "recharts";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import {
 	type ChartConfig,
 	ChartContainer,
@@ -49,65 +42,60 @@ export const RequestDistributionChart = ({
 	);
 
 	return (
-		<div className="w-full h-[200px] overflow-hidden">
-			<ResponsiveContainer
-				width="100%"
-				height="100%"
-				className="overflow-hidden"
+		<ChartContainer
+			config={chartConfig}
+			className="aspect-auto h-[200px] w-full"
+		>
+			<AreaChart
+				accessibilityLayer
+				data={stats || []}
+				margin={{
+					top: 10,
+					left: 12,
+					right: 12,
+					bottom: 0,
+				}}
 			>
-				<ChartContainer config={chartConfig}>
-					<AreaChart
-						accessibilityLayer
-						data={stats || []}
-						margin={{
-							top: 10,
-							left: 12,
-							right: 12,
-							bottom: 0,
-						}}
-					>
-						<CartesianGrid vertical={false} />
-						<XAxis
-							dataKey="hour"
-							tickLine={false}
-							axisLine={false}
-							tickMargin={8}
-							tickFormatter={(value) =>
-								new Date(value).toLocaleTimeString([], {
-									hour: "2-digit",
-									minute: "2-digit",
-								})
-							}
-						/>
-						<YAxis
-							tickLine={false}
-							axisLine={false}
-							tickMargin={8}
-							allowDataOverflow={false}
-							domain={[0, "auto"]}
-						/>
-						<ChartTooltip
-							cursor={false}
-							content={<ChartTooltipContent indicator="line" />}
-							labelFormatter={(value) =>
-								new Date(value).toLocaleString([], {
-									month: "short",
-									day: "numeric",
-									hour: "2-digit",
-									minute: "2-digit",
-								})
-							}
-						/>
-						<Area
-							dataKey="count"
-							type="monotone"
-							fill="hsl(var(--chart-1))"
-							fillOpacity={0.4}
-							stroke="hsl(var(--chart-1))"
-						/>
-					</AreaChart>
-				</ChartContainer>
-			</ResponsiveContainer>
-		</div>
+				<CartesianGrid vertical={false} />
+				<XAxis
+					dataKey="hour"
+					tickLine={false}
+					axisLine={false}
+					tickMargin={8}
+					tickFormatter={(value) =>
+						new Date(value).toLocaleTimeString([], {
+							hour: "2-digit",
+							minute: "2-digit",
+						})
+					}
+				/>
+				<YAxis
+					tickLine={false}
+					axisLine={false}
+					tickMargin={8}
+					allowDataOverflow={false}
+					domain={[0, "auto"]}
+				/>
+				<ChartTooltip
+					cursor={false}
+					content={<ChartTooltipContent indicator="line" />}
+					labelFormatter={(value) =>
+						new Date(value).toLocaleString([], {
+							month: "short",
+							day: "numeric",
+							hour: "2-digit",
+							minute: "2-digit",
+						})
+					}
+				/>
+				<Area
+					dataKey="count"
+					type="monotone"
+					fill="hsl(var(--chart-1))"
+					fillOpacity={0.4}
+					stroke="hsl(var(--chart-1))"
+				/>
+			</AreaChart>
+		</ChartContainer>
 	);
 };


### PR DESCRIPTION
Closes #4749

Since the Tailwind v4 / shadcn update (#4706), `ChartContainer` renders its own `ResponsiveContainer` internally. The request distribution chart was still wrapping it in a manual outer `ResponsiveContainer`, and with recharts v3 that nesting collapses the measured size to `width(-1)/height(-1)`, hiding the chart.

- Remove the manual `ResponsiveContainer` and wrapper div
- Size the chart via `ChartContainer className="aspect-auto h-[200px] w-full"`