### PR TITLE
fix(ui): enable vertical scroll on collapsed sidebar

### DIFF
--- a/apps/dokploy/components/ui/sidebar.tsx
+++ b/apps/dokploy/components/ui/sidebar.tsx
@@ -368,7 +368,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
 			data-slot="sidebar-content"
 			data-sidebar="content"
 			className={cn(
-				"no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+				"no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## What is this PR about?
This fixes a bug where the sidebar's vertical scroll was disabled while in the collapsed (icon) state. It also explicitly removes the horizontal scrolling bug that was present in `v0.29.8`.

## How & Why
In the recent Tailwind v4 / Shadcn update, the `SidebarContent` component had `group-data-[collapsible=icon]:overflow-hidden` added to it, which hid all overflow when collapsed. 

This PR swaps `overflow-auto group-data-[collapsible=icon]:overflow-hidden` to `overflow-y-auto overflow-x-hidden`, which restores vertical scrolling capabilities while preventing the sidebar from overflowing horizontally.

## Checklist
- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file.
- [x] You have tested this PR in your local instance.

## Issues related 
closes #4754 