### PR TITLE
feat(ci): attach install.sh to each GitHub release

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -152,6 +152,11 @@ jobs:
           VERSION=$(node -p "require('./apps/dokploy/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Fetch install.sh
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/Dokploy/website/main/apps/website/public/install.sh -o install.sh
+          head -1 install.sh | grep -q '^#!' || { echo "Downloaded install.sh is not a shell script"; exit 1; }
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -160,6 +165,7 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+          files: install.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Adds a step to the `generate-release` job that downloads the current `install.sh` from the website repo (`Dokploy/website` main) and attaches it as a release asset, so every release keeps a historical record of the install script that was live at release time.

Includes a shebang check so the job fails instead of attaching an HTML error page if the download breaks.

All 163 existing releases were already backfilled with their historically-correct `install.sh`; this keeps future releases consistent.