### PR TITLE
feat(ci): pin install.sh release asset to the released version

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -156,6 +156,9 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/Dokploy/website/main/apps/website/public/install.sh -o install.sh
           head -1 install.sh | grep -q '^#!' || { echo "Downloaded install.sh is not a shell script"; exit 1; }
+          grep -q 'DOKPLOY_VERSION' install.sh || { echo "install.sh no longer supports DOKPLOY_VERSION pinning"; exit 1; }
+          { head -1 install.sh; echo "DOKPLOY_VERSION=\"\${DOKPLOY_VERSION:-${{ steps.get_version.outputs.version }}}\""; tail -n +2 install.sh; } > install-pinned.sh
+          mv install-pinned.sh install.sh
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
The install.sh attached to each release previously installed whatever version was current at run time (`latest` / GitHub auto-detection). This pins `DOKPLOY_VERSION` to the release's own version before attaching, so running a release's install.sh installs exactly that version. Env override still works (`DOKPLOY_VERSION=canary bash install.sh`).

All 163 existing release assets were re-uploaded with the same pinning applied (old scripts: image pinned to the release tag; modern scripts: `DOKPLOY_VERSION` default injected).