### PR TITLE
fix(databases): resolve crash when opening rebuild database dialog

### DIFF
--- a/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
+++ b/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
@@ -87,29 +87,29 @@ export const RebuildDatabase = ({ id, type }: Props) => {
 									<AlertTriangle className="h-5 w-5 text-destructive" />
 									Are you absolutely sure?
 								</AlertDialogTitle>
-								<AlertDialogDescription className="space-y-2">
-									<p>This action will:</p>
-									<ul className="list-disc list-inside space-y-1">
-										<li>Stop the current database service</li>
-										<li>Delete all existing data and volumes</li>
-										<li>Reset to the default configuration</li>
-										<li>Restart the service with a clean state</li>
-									</ul>
-									<p className="font-medium text-destructive mt-4">
-										This action cannot be undone.
-									</p>
+								<AlertDialogDescription asChild>
+									<div className="space-y-2">
+										<p>This action will:</p>
+										<ul className="list-disc list-inside space-y-1">
+											<li>Stop the current database service</li>
+											<li>Delete all existing data and volumes</li>
+											<li>Reset to the default configuration</li>
+											<li>Restart the service with a clean state</li>
+										</ul>
+										<p className="font-medium text-destructive mt-4">
+											This action cannot be undone.
+										</p>
+									</div>
 								</AlertDialogDescription>
 							</AlertDialogHeader>
 							<AlertDialogFooter>
 								<AlertDialogCancel>Cancel</AlertDialogCancel>
 								<AlertDialogAction
 									onClick={handleRebuild}
-									className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-									asChild
+									disabled={isPending}
+									variant="destructive"
 								>
-									<Button isLoading={isPending} type="submit">
-										Yes, rebuild database
-									</Button>
+									Yes, rebuild database
 								</AlertDialogAction>
 							</AlertDialogFooter>
 						</AlertDialogContent>


### PR DESCRIPTION
## What is this PR about?

Opening the **Rebuild Database** dialog crashed the page with `Error: Primitive.button failed to slot onto its children. Expected a single React element child or \`Slottable\`.` — a regression from the Tailwind v4 / shadcn update (#4706) shipped in v0.29.10.

### Changes

- **Fixed the crash:** `AlertDialogAction` now wraps its children in `<Button asChild>` internally, so passing `asChild` with a nested `<Button>` made the Radix Slot receive an array of children and throw. Replaced it with a plain `AlertDialogAction` using `variant="destructive"` + `disabled`, matching the idiom used by the rest of the alert dialogs (e.g. `dialog-action.tsx`). The loading state is still visible on the trigger button while the rebuild runs.
- **Fixed invalid markup:** `AlertDialogDescription` renders a `<p>`, but contained `<p>` and `<ul>` children (hydration warnings). It now uses `asChild` with a `<div>` wrapper.

## Issues related

Closes #4760