### PR TITLE
chore(ui): fix biome formatting issues from #4761

### DIFF
--- a/apps/dokploy/components/ui/command.tsx
+++ b/apps/dokploy/components/ui/command.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import * as React from "react";
 import { Command as CommandPrimitive } from "cmdk";
-
-import { cn } from "@/lib/utils";
+import { CheckIcon, SearchIcon } from "lucide-react";
+import type * as React from "react";
 import {
 	Dialog,
 	DialogContent,
@@ -12,7 +11,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { InputGroup, InputGroupAddon } from "@/components/ui/input-group";
-import { SearchIcon, CheckIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 function Command({
 	className,
@@ -56,9 +55,7 @@ function CommandDialog({
 					<DialogTitle>{title}</DialogTitle>
 					<DialogDescription>{description}</DialogDescription>
 				</DialogHeader>
-				<Command>
-					{children}
-				</Command>
+				<Command>{children}</Command>
 			</DialogContent>
 		</Dialog>
 	);


### PR DESCRIPTION
## What is this PR about?

This PR fixes the `biome` formatting issues (unorganized imports and missing `import type`) introduced in PR #4761. These minor formatting issues were causing the CI pipeline (`pnpm format-and-lint`) to fail on the `canary` branch, which was blocking other PRs from passing their checks.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

Follow-up fix for #4761. 

## Screenshots (if applicable)

N/A
