### PR TITLE
fix(api): disable default body parser on OpenAPI catch-all route

### DIFF
--- a/apps/dokploy/pages/api/[...trpc].ts
+++ b/apps/dokploy/pages/api/[...trpc].ts
@@ -28,3 +28,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 };
 
 export default handler;
+
+export const config = {
+	api: {
+		bodyParser: false,
+	},
+};


### PR DESCRIPTION
## Problem

Drop deployment uploads via the OpenAPI route (`POST /api/drop-deployment`) fail with HTTP 413 for zip files larger than ~1MB. This affects direct API consumers (curl, external tools, custom panels) but not the Dokploy frontend UI.

Fixes #4236

## Root Cause

The OpenAPI catch-all handler at `pages/api/[...trpc].ts` was missing the Next.js API route config to disable the built-in body parser. Without `bodyParser: false`, Next.js applies its default JSON body parser with a **1MB size limit**, which rejects multipart file uploads before they reach tRPC's content-type handler.

The tRPC-specific route at `pages/api/trpc/[trpc].ts` already had this config ([lines 19-24](https://github.com/Dokploy/dokploy/blob/canary/apps/dokploy/pages/api/trpc/%5Btrpc%5D.ts#L19-L24)), so uploads through the frontend UI worked correctly. Only the OpenAPI catch-all route was affected.

## Fix

Added `export const config = { api: { bodyParser: false } }` to `pages/api/[...trpc].ts`, matching the existing config in the tRPC route handler.

## Files Changed

- `apps/dokploy/pages/api/[...trpc].ts` — added body parser config (6 lines added)

## Manual Test Steps

1. Start Dokploy locally or build a custom image
2. Create an application with `sourceType: drop`
3. Upload a zip **< 1MB** via direct API — verify success (no regression)
4. Upload a zip **> 1MB** (e.g., 5MB) via direct API:
   ```bash
   curl -X POST http://<server>:3000/api/drop-deployment \
     -H "Authorization: Bearer <token>" \
     -F "applicationId=<id>" \
     -F "zip=@large-file.zip"
   ```
   → Verify **no 413 error**, deployment proceeds
5. Upload via Dokploy UI drag-and-drop — verify still works (no regression)
6. Confirm deployment record and logs appear normally in the dashboard