### PR TITLE
ci: update pull request actions for node 24

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup biomeJs
         uses: biomejs/setup-biome@v2  
@@ -19,4 +19,4 @@ jobs:
       - name: Run Biome formatter
         run:  biome format --write
 
-      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         job: [build, test, typecheck]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24.4.0
           cache: "pnpm"


### PR DESCRIPTION
## What is this PR about?

This PR updates the Pull Request workflow actions used by the pr-check jobs to Node.js 24-compatible major versions. It removes Node.js 20 deprecation annotations without changing the workflow commands, matrix, Node version, or pnpm cache behavior.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

Local verification:

- Verified `actions/checkout@v5`, `actions/setup-node@v5`, and `pnpm/action-setup@v5` declare `runs.using: node24`.
- `git diff --check`
- Ruby YAML parse for `.github/workflows/pull-request.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/pull-request.yml`

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A