### PR TITLE
fix(sso): apply trusted origin changes without server restart

### DIFF
--- a/apps/dokploy/server/api/routers/proprietary/sso.ts
+++ b/apps/dokploy/server/api/routers/proprietary/sso.ts
@@ -8,6 +8,7 @@ import {
 	requestToHeaders,
 } from "@dokploy/server/index";
 import { auth } from "@dokploy/server/lib/auth";
+import { invalidateTrustedOriginsCache } from "@dokploy/server/services/admin";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
 import { TRPCError } from "@trpc/server";
 import { and, asc, eq } from "drizzle-orm";
@@ -319,6 +320,7 @@ export const ssoRouter = createTRPCRouter({
 				.update(user)
 				.set({ trustedOrigins: next })
 				.where(eq(user.id, ownerId));
+			invalidateTrustedOriginsCache();
 			return { success: true };
 		}),
 	removeTrustedOrigin: enterpriseProcedure
@@ -346,6 +348,7 @@ export const ssoRouter = createTRPCRouter({
 				.update(user)
 				.set({ trustedOrigins: next })
 				.where(eq(user.id, ownerId));
+			invalidateTrustedOriginsCache();
 			return { success: true };
 		}),
 	updateTrustedOrigin: enterpriseProcedure
@@ -379,6 +382,7 @@ export const ssoRouter = createTRPCRouter({
 				.update(user)
 				.set({ trustedOrigins: next })
 				.where(eq(user.id, ownerId));
+			invalidateTrustedOriginsCache();
 			return { success: true };
 		}),
 });

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -4,7 +4,7 @@ import { sso } from "@better-auth/sso";
 import * as bcrypt from "bcrypt";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { APIError } from "better-auth/api";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { admin, organization, twoFactor } from "better-auth/plugins";
 import { and, desc, eq } from "drizzle-orm";
 import { IS_CLOUD } from "../constants";
@@ -28,6 +28,37 @@ import {
 import { getPublicIpWithFallback } from "../wss/utils";
 import { ac, adminRole, memberRole, ownerRole } from "./access-control";
 import { betterAuthSecret } from "./auth-secret";
+
+const resolveTrustedOrigins = async () => {
+	try {
+		if (IS_CLOUD) {
+			return await getTrustedOrigins();
+		}
+		const [trustedOrigins, settings] = await Promise.all([
+			getTrustedOrigins(),
+			getWebServerSettings(),
+		]);
+
+		if (!settings) return [];
+
+		const devOrigins =
+			process.env.NODE_ENV === "development"
+				? [
+						"http://localhost:3000",
+						"https://absolutely-handy-falcon.ngrok-free.app",
+					]
+				: [];
+		return [
+			...(settings?.serverIp ? [`http://${settings?.serverIp}:3000`] : []),
+			...(settings?.host ? [`https://${settings?.host}`] : []),
+			...devOrigins,
+			...trustedOrigins,
+		];
+	} catch (error) {
+		console.error("Failed to resolve trusted origins:", error);
+		return [];
+	}
+};
 
 const { handler, api } = betterAuth({
 	database: drizzleAdapter(db, {
@@ -80,33 +111,14 @@ const { handler, api } = betterAuth({
 	logger: {
 		disabled: process.env.NODE_ENV === "production",
 	},
-	async trustedOrigins() {
-		try {
-			if (IS_CLOUD) {
-				return await getTrustedOrigins();
-			}
-			const [trustedOrigins, settings] = await Promise.all([
-				getTrustedOrigins(),
-				getWebServerSettings(),
-			]);
-			if (!settings) return [];
-			const devOrigins =
-				process.env.NODE_ENV === "development"
-					? [
-							"http://localhost:3000",
-							"https://absolutely-handy-falcon.ngrok-free.app",
-						]
-					: [];
-			return [
-				...(settings?.serverIp ? [`http://${settings?.serverIp}:3000`] : []),
-				...(settings?.host ? [`https://${settings?.host}`] : []),
-				...devOrigins,
-				...trustedOrigins,
-			];
-		} catch (error) {
-			console.error("Failed to resolve trusted origins:", error);
-			return [];
-		}
+	trustedOrigins: resolveTrustedOrigins,
+	hooks: {
+		before: createAuthMiddleware(async (ctx) => {
+			ctx.context.trustedOrigins = [
+				...(ctx.context.baseURL ? [new URL(ctx.context.baseURL).origin] : []),
+				...(await resolveTrustedOrigins()),
+			].filter(Boolean);
+		}),
 	},
 	emailVerification: {
 		sendOnSignUp: true,

--- a/packages/server/src/services/admin.ts
+++ b/packages/server/src/services/admin.ts
@@ -120,6 +120,10 @@ export const getDokployUrl = async () => {
 const TRUSTED_ORIGINS_CACHE_TTL_MS = 30 * 60_000;
 let trustedOriginsCache: { data: string[]; expiresAt: number } | null = null;
 
+export const invalidateTrustedOriginsCache = () => {
+	trustedOriginsCache = null;
+};
+
 export const getTrustedOrigins = async () => {
 	const runQuery = async () => {
 		const rows = await db


### PR DESCRIPTION
### Problem
Adding a trusted origin in the SSO settings had no effect until the Dokploy server was restarted — registering an OIDC provider kept failing with `Untrusted OIDC discovery URL: ... is not trusted by your trusted origins configuration` even after the origin was added. Reported with Google OIDC, whose discovery document spans 4 origins (`accounts.google.com`, `oauth2.googleapis.com`, `www.googleapis.com`, `openidconnect.googleapis.com`), so the error → add origin → restart cycle repeated several times.

### Root cause
better-auth resolves the function-form `trustedOrigins` once at `betterAuth()` init and stores the result in `ctx.context.trustedOrigins`. Direct `auth.api.*` calls (like `registerSSOProvider` from the tRPC router) read that frozen snapshot through `ctx.context.isTrustedOrigin()`, so origins added at runtime stayed invisible until the process restarted. Only the HTTP handler path re-resolves them per request.

### Fix
- A global `hooks.before` in `auth.ts` rebuilds `ctx.context.trustedOrigins` on each auth call with the same composition better-auth uses at init (baseURL origin + resolved origins + `BETTER_AUTH_TRUSTED_ORIGINS`), so additions and removals apply immediately.
- `invalidateTrustedOriginsCache()` clears the 30-min cloud cache from the trusted-origin mutations.

Verified against better-auth 1.5.4 (canary) and 1.6.23: registering a provider with untrusted origins still fails as expected, and succeeds right after the origins are added — same instance, no restart.