### PR TITLE
fix(ui): resolve unclickable watch path removal button 

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -440,7 +440,8 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 												{path}
 												<button
 													type="button"
-													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+													aria-label="Remove watch path"
+													className="ml-1 cursor-pointer hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
@@ -496,14 +497,14 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -438,14 +438,17 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 										{field.value?.map((path, index) => (
 											<Badge key={index} variant="secondary">
 												{path}
-												<X
-													className="ml-1 size-3 cursor-pointer"
+												<button
+													type="button"
+													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
-												/>
+												>
+													<X className="size-3" />
+												</button>
 											</Badge>
 										))}
 									</div>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -441,14 +441,14 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 												<button
 													type="button"
 													aria-label="Remove watch path"
-													className="ml-1 cursor-pointer hover:text-destructive"
+													className="inline-flex items-center focus-visible:ring-2"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
 												>
-													<X className="size-3" />
+													<X className="ml-1 size-3 cursor-pointer" />
 												</button>
 											</Badge>
 										))}

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -245,14 +245,14 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 											<button
 												type="button"
 												aria-label="Remove watch path"
-												className="ml-1 cursor-pointer hover:text-destructive"
+												className="inline-flex items-center focus-visible:ring-2"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);
 													form.setValue("watchPaths", newPaths);
 												}}
 											>
-												<X className="size-3" />
+												<X className="ml-1 size-3 cursor-pointer" />
 											</button>
 										</Badge>
 									))}

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -244,7 +244,8 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 											{path}
 											<button
 												type="button"
-												className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+												aria-label="Remove watch path"
+												className="ml-1 cursor-pointer hover:text-destructive"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);
@@ -301,14 +302,14 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 						control={form.control}
 						name="enableSubmodules"
 						render={({ field }) => (
-							<FormItem className="flex items-center space-x-2">
+							<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 								<FormControl>
 									<Switch
 										checked={field.value}
 										onCheckedChange={field.onChange}
 									/>
 								</FormControl>
-								<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+								<FormLabel>Enable Submodules</FormLabel>
 							</FormItem>
 						)}
 					/>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -242,14 +242,17 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 									{field.value?.map((path, index) => (
 										<Badge key={index} variant="secondary">
 											{path}
-											<X
-												className="ml-1 size-3 cursor-pointer"
+											<button
+												type="button"
+												className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);
 													form.setValue("watchPaths", newPaths);
 												}}
-											/>
+											>
+												<X className="size-3" />
+											</button>
 										</Badge>
 									))}
 								</div>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
@@ -469,14 +469,14 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 												<button
 													type="button"
 													aria-label="Remove watch path"
-													className="cursor-pointer hover:text-destructive"
+													className="inline-flex items-center focus-visible:ring-2"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														field.onChange(newPaths);
 													}}
 												>
-													<X className="size-3" />
+													<X className="size-3 cursor-pointer hover:text-destructive" />
 												</button>
 											</Badge>
 										))}

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
@@ -466,14 +466,17 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 												className="flex items-center gap-1"
 											>
 												{path}
-												<X
-													className="size-3 cursor-pointer hover:text-destructive"
+												<button
+													type="button"
+													className="cursor-pointer hover:text-destructive focus:outline-none"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														field.onChange(newPaths);
 													}}
-												/>
+												>
+													<X className="size-3" />
+												</button>
 											</Badge>
 										))}
 									</div>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
@@ -468,7 +468,8 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 												{path}
 												<button
 													type="button"
-													className="cursor-pointer hover:text-destructive focus:outline-none"
+													aria-label="Remove watch path"
+													className="cursor-pointer hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
@@ -523,14 +524,14 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -480,7 +480,8 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 													{path}
 													<button
 														type="button"
-														className="cursor-pointer hover:text-destructive focus:outline-none"
+														aria-label="Remove watch path"
+														className="cursor-pointer hover:text-destructive"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);
@@ -537,14 +538,14 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -481,14 +481,14 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 													<button
 														type="button"
 														aria-label="Remove watch path"
-														className="cursor-pointer hover:text-destructive"
+														className="inline-flex items-center focus-visible:ring-2"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);
 															field.onChange(newPaths);
 														}}
 													>
-														<X className="size-3" />
+														<X className="size-3 cursor-pointer hover:text-destructive" />
 													</button>
 												</Badge>
 											))}

--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -478,14 +478,17 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 													className="flex items-center gap-1"
 												>
 													{path}
-													<X
-														className="size-3 cursor-pointer hover:text-destructive"
+													<button
+														type="button"
+														className="cursor-pointer hover:text-destructive focus:outline-none"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);
 															field.onChange(newPaths);
 														}}
-													/>
+													>
+														<X className="size-3" />
+													</button>
 												</Badge>
 											))}
 										</div>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -462,14 +462,14 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 												<button
 													type="button"
 													aria-label="Remove watch path"
-													className="cursor-pointer hover:text-destructive"
+													className="inline-flex items-center focus-visible:ring-2"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														field.onChange(newPaths);
 													}}
 												>
-													<X className="size-3" />
+													<X className="size-3 cursor-pointer hover:text-destructive" />
 												</button>
 											</Badge>
 										))}

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -459,14 +459,17 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 												className="flex items-center gap-1"
 											>
 												{path}
-												<X
-													className="size-3 cursor-pointer hover:text-destructive"
+												<button
+													type="button"
+													className="cursor-pointer hover:text-destructive focus:outline-none"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														field.onChange(newPaths);
 													}}
-												/>
+												>
+													<X className="size-3" />
+												</button>
 											</Badge>
 										))}
 									</div>

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -461,7 +461,8 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 												{path}
 												<button
 													type="button"
-													className="cursor-pointer hover:text-destructive focus:outline-none"
+													aria-label="Remove watch path"
+													className="cursor-pointer hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
@@ -516,14 +517,14 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
@@ -442,14 +442,17 @@ export const SaveBitbucketProviderCompose = ({ composeId }: Props) => {
 										{field.value?.map((path, index) => (
 											<Badge key={index} variant="secondary">
 												{path}
-												<X
-													className="ml-1 size-3 cursor-pointer"
+												<button
+													type="button"
+													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
-												/>
+												>
+													<X className="size-3" />
+												</button>
 											</Badge>
 										))}
 									</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
@@ -444,7 +444,8 @@ export const SaveBitbucketProviderCompose = ({ composeId }: Props) => {
 												{path}
 												<button
 													type="button"
-													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+													aria-label="Remove watch path"
+													className="ml-1 cursor-pointer hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
@@ -500,14 +501,14 @@ export const SaveBitbucketProviderCompose = ({ composeId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
@@ -445,14 +445,14 @@ export const SaveBitbucketProviderCompose = ({ composeId }: Props) => {
 												<button
 													type="button"
 													aria-label="Remove watch path"
-													className="ml-1 cursor-pointer hover:text-destructive"
+													className="inline-flex items-center focus-visible:ring-2"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
 												>
-													<X className="size-3" />
+													<X className="ml-1 size-3 cursor-pointer" />
 												</button>
 											</Badge>
 										))}

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
@@ -251,14 +251,17 @@ export const SaveGitProviderCompose = ({ composeId }: Props) => {
 									{field.value?.map((path, index) => (
 										<Badge key={index} variant="secondary">
 											{path}
-											<X
-												className="ml-1 size-3 cursor-pointer"
+											<button
+												type="button"
+												className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);
 													form.setValue("watchPaths", newPaths);
 												}}
-											/>
+											>
+												<X className="size-3" />
+											</button>
 										</Badge>
 									))}
 								</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
@@ -254,14 +254,14 @@ export const SaveGitProviderCompose = ({ composeId }: Props) => {
 											<button
 												type="button"
 												aria-label="Remove watch path"
-												className="ml-1 cursor-pointer hover:text-destructive"
+												className="inline-flex items-center focus-visible:ring-2"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);
 													form.setValue("watchPaths", newPaths);
 												}}
 											>
-												<X className="size-3" />
+												<X className="ml-1 size-3 cursor-pointer" />
 											</button>
 										</Badge>
 									))}

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
@@ -253,7 +253,8 @@ export const SaveGitProviderCompose = ({ composeId }: Props) => {
 											{path}
 											<button
 												type="button"
-												className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+												aria-label="Remove watch path"
+												className="ml-1 cursor-pointer hover:text-destructive"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);
@@ -309,14 +310,14 @@ export const SaveGitProviderCompose = ({ composeId }: Props) => {
 						control={form.control}
 						name="enableSubmodules"
 						render={({ field }) => (
-							<FormItem className="flex items-center space-x-2">
+							<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 								<FormControl>
 									<Switch
 										checked={field.value}
 										onCheckedChange={field.onChange}
 									/>
 								</FormControl>
-								<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+								<FormLabel>Enable Submodules</FormLabel>
 							</FormItem>
 						)}
 					/>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
@@ -434,14 +434,14 @@ export const SaveGiteaProviderCompose = ({ composeId }: Props) => {
 												<button
 													type="button"
 													aria-label="Remove watch path"
-													className="ml-1 cursor-pointer hover:text-destructive"
+													className="inline-flex items-center focus-visible:ring-2"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
 												>
-													<X className="size-3" />
+													<X className="ml-1 size-3 cursor-pointer" />
 												</button>
 											</Badge>
 										))}

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
@@ -431,14 +431,17 @@ export const SaveGiteaProviderCompose = ({ composeId }: Props) => {
 										{field.value?.map((path, index) => (
 											<Badge key={index} variant="secondary">
 												{path}
-												<X
-													className="ml-1 size-3 cursor-pointer"
+												<button
+													type="button"
+													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
-												/>
+												>
+													<X className="size-3" />
+												</button>
 											</Badge>
 										))}
 									</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
@@ -433,7 +433,8 @@ export const SaveGiteaProviderCompose = ({ composeId }: Props) => {
 												{path}
 												<button
 													type="button"
-													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+													aria-label="Remove watch path"
+													className="ml-1 cursor-pointer hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
@@ -489,14 +490,14 @@ export const SaveGiteaProviderCompose = ({ composeId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -470,14 +470,17 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 											{field.value?.map((path, index) => (
 												<Badge key={index} variant="secondary">
 													{path}
-													<X
-														className="ml-1 size-3 cursor-pointer"
+													<button
+														type="button"
+														className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);
 															form.setValue("watchPaths", newPaths);
 														}}
-													/>
+													>
+														<X className="size-3" />
+													</button>
 												</Badge>
 											))}
 										</div>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -472,7 +472,8 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 													{path}
 													<button
 														type="button"
-														className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+														aria-label="Remove watch path"
+														className="ml-1 cursor-pointer hover:text-destructive"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);
@@ -532,14 +533,14 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -473,14 +473,14 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 													<button
 														type="button"
 														aria-label="Remove watch path"
-														className="ml-1 cursor-pointer hover:text-destructive"
+														className="inline-flex items-center focus-visible:ring-2"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);
 															form.setValue("watchPaths", newPaths);
 														}}
 													>
-														<X className="size-3" />
+														<X className="ml-1 size-3 cursor-pointer" />
 													</button>
 												</Badge>
 											))}

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
@@ -463,14 +463,14 @@ export const SaveGitlabProviderCompose = ({ composeId }: Props) => {
 												<button
 													type="button"
 													aria-label="Remove watch path"
-													className="ml-1 cursor-pointer hover:text-destructive"
+													className="inline-flex items-center focus-visible:ring-2"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
 												>
-													<X className="size-3" />
+													<X className="ml-1 size-3 cursor-pointer" />
 												</button>
 											</Badge>
 										))}

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
@@ -462,7 +462,8 @@ export const SaveGitlabProviderCompose = ({ composeId }: Props) => {
 												{path}
 												<button
 													type="button"
-													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
+													aria-label="Remove watch path"
+													className="ml-1 cursor-pointer hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
@@ -518,14 +519,14 @@ export const SaveGitlabProviderCompose = ({ composeId }: Props) => {
 							control={form.control}
 							name="enableSubmodules"
 							render={({ field }) => (
-								<FormItem className="flex items-center space-x-2">
+								<FormItem className="flex flex-row items-center space-x-2 space-y-0">
 									<FormControl>
 										<Switch
 											checked={field.value}
 											onCheckedChange={field.onChange}
 										/>
 									</FormControl>
-									<FormLabel className="mt-0!">Enable Submodules</FormLabel>
+									<FormLabel>Enable Submodules</FormLabel>
 								</FormItem>
 							)}
 						/>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
@@ -460,14 +460,17 @@ export const SaveGitlabProviderCompose = ({ composeId }: Props) => {
 										{field.value?.map((path, index) => (
 											<Badge key={index} variant="secondary">
 												{path}
-												<X
-													className="ml-1 size-3 cursor-pointer"
+												<button
+													type="button"
+													className="ml-1 cursor-pointer hover:text-destructive focus:outline-none"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);
 														form.setValue("watchPaths", newPaths);
 													}}
-												/>
+												>
+													<X className="size-3" />
+												</button>
 											</Badge>
 										))}
 									</div>


### PR DESCRIPTION
## What is this PR about?

This PR fixes an issue where the "X" button used to remove watch paths was completely unclickable across all Git provider forms (both Application and Compose). 

It also includes a minor UI tweak to perfectly vertically align the `Enable Submodules` toggle switch and label.

**Why the issue existed:**
The native Shadcn `Badge` component comes with a default CSS rule (`[&>svg]:pointer-events-none`). Because the `<X>` icon was rendered as a direct SVG child of the badge, the browser was applying this rule, which mathematically swallowed all click events and made the "X" strictly non-interactive.

**How it was solved:**
Instead of fighting CSS specificity with `!important` utility class overrides, this PR takes a native structural approach. The `<X>` icon is now wrapped in a standard `<button>` element. This naturally prevents the parent badge's SVG CSS rule from targeting the icon, fully restoring interactivity in a clean, HTML-native way.

## Checklist
Before submitting this PR, please make sure that:
- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)
closes #4780

## Screenshots & Recordings

- **Watchpath Badge Removal Working Properly:**

https://github.com/user-attachments/assets/cfa98e07-ddd6-4b28-bf27-52d960da05d4

- **Before vs After: Enable Submodules Alignment Fix:**

<img width="800" height="150" alt="Enable Submodules Alignment Comparison" src="https://github.com/user-attachments/assets/b2ce5cae-c75e-47d4-b454-c6c27dfbb13b" />
