### PR TITLE
fix(ui): adjust button container to grid layout to prevent overflow in 2FA screen

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -310,7 +310,7 @@ export default function Home({ IS_CLOUD, enforceSSO }: Props) {
 								</button>
 							</div>
 
-							<div className="flex gap-4">
+							<div className="grid grid-cols-2 gap-4">
 								<Button
 									variant="outline"
 									className="w-full"


### PR DESCRIPTION
Before Desktop:
<img width="1919" height="912" alt="Captura de pantalla 2026-07-09 093342" src="https://github.com/user-attachments/assets/2140cdb1-d754-46ed-85d9-4e51c15836c7" />

After Desktop:
<img width="1919" height="911" alt="Captura de pantalla 2026-07-09 095732" src="https://github.com/user-attachments/assets/0978e112-f70f-4c16-b7b8-da945b5d1cb7" />

Before Mobile:
<img width="376" height="662" alt="image" src="https://github.com/user-attachments/assets/cefa8303-27d6-4962-9ba0-afc4f30054bc" />

After Mobile:
<img width="371" height="662" alt="image" src="https://github.com/user-attachments/assets/057851ae-1f2c-4a41-af30-9c94bc58b433" />

## Issues related (if applicable)
closes #4787

