### PR TITLE
feat(i18n): add missing keys to Korean translation

### DIFF
--- a/apps/dokploy/public/locales/ko/settings.json
+++ b/apps/dokploy/public/locales/ko/settings.json
@@ -1,5 +1,6 @@
 {
 	"settings.common.save": "저장",
+	"settings.common.enterTerminal": "터미널",
 	"settings.server.domain.title": "서버 도메인",
 	"settings.server.domain.description": "서버 애플리케이션에 도메인을 추가합니다.",
 	"settings.server.domain.form.domain": "도메인",
@@ -18,6 +19,14 @@
 	"settings.server.webServer.server.label": "서버",
 	"settings.server.webServer.traefik.label": "Traefik",
 	"settings.server.webServer.traefik.modifyEnv": "환경 변수 수정",
+	"settings.server.webServer.traefik.managePorts": "추가 포트 매핑",
+	"settings.server.webServer.traefik.managePortsDescription": "Traefik의 추가 포트를 추가하거나 제거합니다",
+	"settings.server.webServer.traefik.targetPort": "대상 포트",
+	"settings.server.webServer.traefik.publishedPort": "게시된 포트",
+	"settings.server.webServer.traefik.addPort": "포트 추가",
+	"settings.server.webServer.traefik.portsUpdated": "포트가 성공적으로 업데이트되었습니다",
+	"settings.server.webServer.traefik.portsUpdateError": "포트 업데이트에 실패했습니다",
+	"settings.server.webServer.traefik.publishMode": "게시 모드",
 	"settings.server.webServer.storage.label": "저장 공간",
 	"settings.server.webServer.storage.cleanUnusedImages": "사용하지 않는 이미지 정리",
 	"settings.server.webServer.storage.cleanUnusedVolumes": "사용하지 않는 볼륨 정리",
@@ -40,5 +49,10 @@
 	"settings.appearance.themes.dark": "다크",
 	"settings.appearance.themes.system": "시스템",
 	"settings.appearance.language": "언어",
-	"settings.appearance.languageDescription": "대시보드에서 사용할 언어 선택"
+	"settings.appearance.languageDescription": "대시보드에서 사용할 언어 선택",
+
+	"settings.terminal.connectionSettings": "연결 설정",
+	"settings.terminal.ipAddress": "IP 주소",
+	"settings.terminal.port": "포트",
+	"settings.terminal.username": "사용자 이름"
 }


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Completed `apps/dokploy/public/locales/ko/settings.json`, which was missing 13 keys (39/52) compared to `en`:
  - `settings.common.enterTerminal`
  - `settings.server.webServer.traefik.managePorts`, `.managePortsDescription`, `.targetPort`, `.publishedPort`, `.addPort`, `.portsUpdated`, `.portsUpdateError`, `.publishMode`
  - `settings.terminal.connectionSettings`, `.ipAddress`, `.port`, `.username`
- Verified `apps/dokploy/public/locales/ko/common.json` has no gap versus `en` (both are empty `{}`).
- Existing Korean translations were left untouched; only the missing keys were added, in natural Korean and matching the existing tone/terminology already used in the file.

## Testing

- Wrote a small script to flatten and diff every key in `en` vs `ko` across both `common.json` and `settings.json`; confirmed `ko` now matches `en` key-for-key (52/52 in `settings.json`, 0/0 in `common.json`) with no missing and no extra keys.
- Validated the edited file is valid JSON.
- Checked for i18next placeholders (e.g. `{{var}}`) in both files — none exist, so no placeholder-preservation issues apply here.
- Ran `npx @biomejs/biome check` on the changed file — no formatting/lint issues.