### PR TITLE
fix(notifications): use real server name in remote threshold alerts

### DIFF
--- a/apps/dokploy/server/api/routers/notification.ts
+++ b/apps/dokploy/server/api/routers/notification.ts
@@ -535,7 +535,7 @@ export const notificationRouter = createTRPCRouter({
 					}
 
 					organizationId = result?.[0]?.organizationId;
-					ServerName = "Remote";
+					ServerName = result?.[0]?.name ?? "Remote";
 				}
 
 				await sendServerThresholdNotifications(organizationId, {


### PR DESCRIPTION
## Describe your changes

Server **CPU/Memory threshold** notifications for **remote servers** always render `Server Name: Remote` instead of the actual server name. When more than one remote server is registered, every alert is identical and it's impossible to tell which server actually breached the threshold.

The remote branch of `receiveNotification` already fetches the matching `server` row (looked up by its metrics token), but it throws the row away and hardcodes the literal string `"Remote"`:

```ts
organizationId = result?.[0]?.organizationId;
ServerName = "Remote";           // <- before
```

This uses the fetched row's `name` instead, falling back to `"Remote"` if it is somehow absent:

```ts
organizationId = result?.[0]?.organizationId;
ServerName = result?.[0]?.name ?? "Remote";   // <- after
```

The `Dokploy` (web server) branch is unaffected — it already reports `"Dokploy"`, which is unambiguous. All channels (Telegram/Discord/Slack/etc.) share the same `payload.ServerName`, so they are all fixed by this change.

## Issue ticket number and link

No issue reports this exact bug. Related to #3589 — the same "which server?" problem, but for the *server restart* notification (a separate notification and a feature request); this PR addresses it for the *monitoring threshold* notification.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The change is a minimal, backwards-compatible bug fix (single line)

### How was it tested?

On a self-hosted instance with 5 remote servers, sending a synthetic threshold POST to `notification.receiveNotification` with a given server's metrics token now delivers a Telegram alert reading e.g. `Server Name: panda-aggregator` instead of `Server Name: Remote`. Discord/Slack/other channels use the same `payload.ServerName`, so they are fixed identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)