### PR TITLE
fix(compose): preserve raw remote mounts

### DIFF
--- a/apps/dokploy/__test__/compose/domain/raw-compose.test.ts
+++ b/apps/dokploy/__test__/compose/domain/raw-compose.test.ts
@@ -1,0 +1,59 @@
+import { addDomainToCompose } from "@dokploy/server/utils/docker/domain";
+import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => ({
+	...(await importOriginal<
+		typeof import("@dokploy/server/utils/process/execAsync")
+	>()),
+	execAsyncRemote: vi.fn(),
+}));
+
+describe("raw remote compose conversion (#4794)", () => {
+	it("uses the saved raw source and preserves supported mount syntax", async () => {
+		vi.mocked(execAsyncRemote).mockResolvedValue({
+			stdout: "services:\n  test:\n    image: alpine:latest\n",
+			stderr: "",
+		});
+
+		const compose = {
+			appName: "raw-stack",
+			composeFile: `
+services:
+  test:
+    image: alpine:latest
+    volumes:
+      - type: tmpfs
+        target: /scratch
+      - type: volume
+        source: test-data
+        target: /data
+    tmpfs:
+      - /cache
+volumes:
+  test-data:
+`,
+			composePath: "./docker-compose.yml",
+			composeType: "stack",
+			isolatedDeployment: false,
+			isolatedDeploymentsVolume: false,
+			randomize: false,
+			serverId: "remote-server",
+			sourceType: "raw",
+			suffix: "",
+		} as unknown as Parameters<typeof addDomainToCompose>[0];
+
+		const converted = await addDomainToCompose(compose, []);
+
+		expect(converted?.services?.test?.volumes).toEqual([
+			{ type: "tmpfs", target: "/scratch" },
+			{
+				type: "volume",
+				source: "test-data",
+				target: "/data",
+			},
+		]);
+		expect(converted?.services?.test?.tmpfs).toEqual(["/cache"]);
+		expect(execAsyncRemote).not.toHaveBeenCalled();
+	});
+});

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -139,7 +139,11 @@ export const addDomainToCompose = async (
 
 	let result: ComposeSpecification | null;
 
-	if (compose.serverId) {
+	if (compose.sourceType === "raw") {
+		result = parse(compose.composeFile, {
+			maxAliasCount: 10000,
+		}) as ComposeSpecification;
+	} else if (compose.serverId) {
 		result = await loadDockerComposeRemote(compose);
 	} else {
 		result = await loadDockerCompose(compose);


### PR DESCRIPTION
## Summary

- use the saved raw compose source as the conversion source of truth
- preserve tmpfs declarations and long-syntax named-volume mounts
- add regression coverage for raw stack compose on remote servers

Fixes #4794

## Verification

- `biome check packages/server/src/utils/docker/domain.ts apps/dokploy/__test__/compose/domain/raw-compose.test.ts` (passes with one pre-existing `@ts-ignore` warning in `domain.ts`)
- `git diff --check`
- focused Vitest execution could not run locally because the dependency installer stopped at `ERR_NUB_TRUST_DOWNGRADE` for `@octokit/webhooks@12.3.2`; no trust policy was weakened