### PR TITLE
fix: validate API key name length to prevent opaque 500

### DIFF
--- a/apps/dokploy/__test__/api/api-key-name.test.ts
+++ b/apps/dokploy/__test__/api/api-key-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { API_KEY_NAME_MAX_LENGTH, apiKeyNameSchema } from "@/lib/api-keys";
+
+describe("apiKeyNameSchema", () => {
+	it("rejects an empty name", () => {
+		const result = apiKeyNameSchema.safeParse("");
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts a name at the maximum length", () => {
+		const name = "a".repeat(API_KEY_NAME_MAX_LENGTH);
+		const result = apiKeyNameSchema.safeParse(name);
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a name over the maximum length instead of passing it to better-auth", () => {
+		const name = "a".repeat(API_KEY_NAME_MAX_LENGTH + 1);
+		const result = apiKeyNameSchema.safeParse(name);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				`Name must be at most ${API_KEY_NAME_MAX_LENGTH} characters`,
+			);
+		}
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/api/add-api-key.tsx
+++ b/apps/dokploy/components/dashboard/settings/api/add-api-key.tsx
@@ -32,10 +32,11 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { API_KEY_NAME_MAX_LENGTH, apiKeyNameSchema } from "@/lib/api-keys";
 import { api } from "@/utils/api";
 
 const formSchema = z.object({
-	name: z.string().min(1, "Name is required"),
+	name: apiKeyNameSchema,
 	prefix: z.string().optional(),
 	expiresIn: z.number().nullable(),
 	organizationId: z.string().min(1, "Organization is required"),
@@ -159,8 +160,15 @@ export const AddApiKey = () => {
 									<FormItem>
 										<FormLabel>Name</FormLabel>
 										<FormControl>
-											<Input placeholder="My API Key" {...field} />
+											<Input
+												placeholder="My API Key"
+												maxLength={API_KEY_NAME_MAX_LENGTH}
+												{...field}
+											/>
 										</FormControl>
+										<FormDescription>
+											Maximum {API_KEY_NAME_MAX_LENGTH} characters
+										</FormDescription>
 										<FormMessage />
 									</FormItem>
 								)}

--- a/apps/dokploy/lib/api-keys.ts
+++ b/apps/dokploy/lib/api-keys.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/**
+ * Maximum length allowed for an API key name.
+ *
+ * This mirrors the default `maximumNameLength` enforced by the
+ * `@better-auth/api-key` plugin. Names longer than this are rejected by
+ * better-auth with a 400, so we validate against it up front to surface a
+ * clear field-level error instead of an opaque 500.
+ */
+export const API_KEY_NAME_MAX_LENGTH = 32;
+
+/**
+ * Shared validation for an API key name, used by both the tRPC input schema
+ * and the client form so the two can't drift.
+ */
+export const apiKeyNameSchema = z
+	.string()
+	.min(1, "Name is required")
+	.max(
+		API_KEY_NAME_MAX_LENGTH,
+		`Name must be at most ${API_KEY_NAME_MAX_LENGTH} characters`,
+	);

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -35,6 +35,7 @@ import { TRPCError } from "@trpc/server";
 import * as bcrypt from "bcrypt";
 import { and, asc, eq, gt, ne } from "drizzle-orm";
 import { z } from "zod";
+import { apiKeyNameSchema } from "@/lib/api-keys";
 import { audit } from "@/server/api/utils/audit";
 import {
 	adminProcedure,
@@ -45,7 +46,7 @@ import {
 } from "../trpc";
 
 const apiCreateApiKey = z.object({
-	name: z.string().min(1),
+	name: apiKeyNameSchema,
 	prefix: z.string().optional(),
 	expiresIn: z.number().optional(),
 	metadata: z.object({


### PR DESCRIPTION
## Summary

Creating an API key with a name longer than 32 characters returned an opaque **500** with a generic "Failed to generate API key" toast, instead of a clear validation error.

Fixes #4798

## Root cause

The tRPC input for `user.createApiKey` validated the name with only `z.string().min(1)`:

```ts
const apiCreateApiKey = z.object({
  name: z.string().min(1),
  ...
});
```

The `@better-auth/api-key` plugin, however, enforces a default `maximumNameLength` of **32** (Dokploy does not override it in the `apiKey()` config). A name over 32 characters passes our validation but is rejected inside better-auth with `INVALID_NAME_LENGTH` ("The name length is either too large or too small."). better-auth throws this as a `BAD_REQUEST` (400), but because the service calls `auth.createApiKey()` and does not map that error, tRPC re-wraps it as an unknown `INTERNAL_SERVER_ERROR`, hence the opaque 500 and generic toast.

## Changes

- Add a shared `apiKeyNameSchema` (and `API_KEY_NAME_MAX_LENGTH = 32`) in `apps/dokploy/lib/api-keys.ts`, matching better-auth's default so the two limits cannot drift.
- Use it in both the tRPC input schema (`apps/dokploy/server/api/routers/user.ts`) and the client form (`add-api-key.tsx`). Over-length names now fail as a clean, field-level validation error before any request is sent, no more 500.
- Surface the limit in the UI: `maxLength={32}` on the Name input plus a "Maximum 32 characters" helper line, so users see the constraint up front (the issue asked for this too).

The accepted range (1–32) is identical to what better-auth already accepts, so no previously valid input is affected; only the previously-500 case now returns a proper validation message.

## Testing

- Added `apps/dokploy/__test__/api/api-key-name.test.ts` covering the shared schema used by both layers: empty name rejected, 32 chars accepted, 33 chars rejected with the expected message. Passing:
  ```
  ✓ __test__/api/api-key-name.test.ts (3 tests)
  Test Files  1 passed (1)
  Tests  3 passed (3)
  ```
- `tsc --noEmit` (app `typecheck`) passes with the changes.

## Notes

Related but different (already resolved): #4024, #4026.
