### PR TITLE
feat(compose): opt-in skipDefaultNetwork to avoid Traefik multi-network routing issues

### DIFF
--- a/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
+++ b/apps/dokploy/__test__/compose/domain/host-rule-format.test.ts
@@ -35,6 +35,7 @@ describe("Host rule format regression tests", () => {
 		customEntrypoint: null,
 		middlewares: null,
 		forwardAuthEnabled: false,
+		skipDefaultNetwork: false,
 	};
 
 	describe("Host rule format validation", () => {

--- a/apps/dokploy/__test__/compose/domain/labels.test.ts
+++ b/apps/dokploy/__test__/compose/domain/labels.test.ts
@@ -24,6 +24,7 @@ describe("createDomainLabels", () => {
 		stripPath: false,
 		middlewares: null,
 		forwardAuthEnabled: false,
+		skipDefaultNetwork: false,
 	};
 
 	it("should create basic labels for web entrypoint", async () => {

--- a/apps/dokploy/__test__/compose/domain/network-service.test.ts
+++ b/apps/dokploy/__test__/compose/domain/network-service.test.ts
@@ -30,4 +30,34 @@ describe("addDokployNetworkToService", () => {
 		const result = addDokployNetworkToService(["default", "dokploy-network"]);
 		expect(result).toEqual(["default", "dokploy-network"]);
 	});
+
+	describe("skipDefaultNetwork option", () => {
+		it("should still add dokploy-network but skip default when true (array)", () => {
+			const result = addDokployNetworkToService(["dokploy-network"], true);
+			expect(result).toEqual(["dokploy-network"]);
+		});
+
+		it("should skip default on an empty array when true", () => {
+			const result = addDokployNetworkToService([], true);
+			expect(result).toEqual(["dokploy-network"]);
+		});
+
+		it("should preserve other existing networks while skipping default", () => {
+			const result = addDokployNetworkToService(["other-network"], true);
+			expect(result).toEqual(["other-network", "dokploy-network"]);
+		});
+
+		it("should still add dokploy-network but skip default when true (object)", () => {
+			const result = addDokployNetworkToService({ "other-network": {} }, true);
+			expect(result).toEqual({
+				"other-network": {},
+				"dokploy-network": {},
+			});
+		});
+
+		it("should default to false and preserve existing behavior when omitted", () => {
+			const result = addDokployNetworkToService(["dokploy-network"]);
+			expect(result).toEqual(["dokploy-network", "default"]);
+		});
+	});
 });

--- a/apps/dokploy/__test__/traefik/forward-auth.test.ts
+++ b/apps/dokploy/__test__/traefik/forward-auth.test.ts
@@ -35,6 +35,7 @@ const baseDomain: Domain = {
 	stripPath: false,
 	middlewares: null,
 	forwardAuthEnabled: false,
+	skipDefaultNetwork: false,
 };
 
 describe("forwardAuthMiddlewareName", () => {

--- a/apps/dokploy/__test__/traefik/traefik.test.ts
+++ b/apps/dokploy/__test__/traefik/traefik.test.ts
@@ -149,6 +149,7 @@ const baseDomain: Domain = {
 	stripPath: false,
 	middlewares: null,
 	forwardAuthEnabled: false,
+	skipDefaultNetwork: false,
 };
 
 const baseRedirect: Redirect = {

--- a/apps/dokploy/drizzle/0175_skip_default_network.sql
+++ b/apps/dokploy/drizzle/0175_skip_default_network.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "domain" ADD COLUMN "skipDefaultNetwork" boolean DEFAULT false NOT NULL;

--- a/apps/dokploy/drizzle/meta/_journal.json
+++ b/apps/dokploy/drizzle/meta/_journal.json
@@ -1226,6 +1226,13 @@
       "when": 1783674181297,
       "tag": "0174_great_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 175,
+      "version": "7",
+      "when": 1783860223772,
+      "tag": "0175_skip_default_network",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema/domain.ts
+++ b/packages/server/src/db/schema/domain.ts
@@ -56,6 +56,16 @@ export const domains = pgTable("domain", {
 	stripPath: boolean("stripPath").notNull().default(false),
 	middlewares: text("middlewares").array().default(sql`ARRAY[]::text[]`),
 	forwardAuthEnabled: boolean("forwardAuthEnabled").notNull().default(false),
+	// When a domain is attached to a compose service, Dokploy always attaches
+	// that service to BOTH "dokploy-network" and the project's implicit
+	// "default" network (see addDokployNetworkToService) so it keeps talking
+	// to sibling services (fix for #3562). For single-service compose apps
+	// (or any service that doesn't need default-network connectivity), being
+	// on two networks can make Traefik's Docker provider pick the wrong
+	// network's IP for routing, causing persistent 502s that don't self-heal.
+	// Opt-in escape hatch, defaults to false so existing behavior/tests are
+	// unchanged.
+	skipDefaultNetwork: boolean("skipDefaultNetwork").notNull().default(false),
 });
 
 export const domainsRelations = relations(domains, ({ one }) => ({
@@ -96,6 +106,7 @@ export const apiCreateDomain = createSchema.pick({
 	stripPath: true,
 	middlewares: true,
 	forwardAuthEnabled: true,
+	skipDefaultNetwork: true,
 });
 
 export const apiFindDomain = z.object({
@@ -129,5 +140,6 @@ export const apiUpdateDomain = createSchema
 		stripPath: true,
 		middlewares: true,
 		forwardAuthEnabled: true,
+		skipDefaultNetwork: true,
 	})
 	.merge(createSchema.pick({ domainId: true }).required());

--- a/packages/server/src/db/validations/domain.ts
+++ b/packages/server/src/db/validations/domain.ts
@@ -95,6 +95,7 @@ export const domainCompose = z
 		customCertResolver: z.string(),
 		serviceName: z.string().min(1, { message: "Service name is required" }),
 		middlewares: z.array(z.string()).optional(),
+		skipDefaultNetwork: z.boolean().optional(),
 	})
 	.superRefine((input, ctx) => {
 		if (input.https && !input.certificateType) {

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -224,6 +224,7 @@ export const addDomainToCompose = async (
 			// Add the dokploy-network to the service
 			result.services[serviceName].networks = addDokployNetworkToService(
 				result.services[serviceName].networks,
+				domain.skipDefaultNetwork ?? false,
 			);
 		}
 	}
@@ -349,6 +350,15 @@ export const createDomainLabels = (
 
 export const addDokployNetworkToService = (
 	networkService: DefinitionsService["networks"],
+	// Opt-in escape hatch for #<issue-number>: attaching a domain-linked
+	// service to both dokploy-network AND the implicit "default" network
+	// (added in #3562 so sibling services stay reachable) can make Traefik's
+	// Docker provider pick the wrong network's IP for routing, causing 502s
+	// that don't self-heal on restart. Services that don't rely on the
+	// default network for inter-service connectivity (e.g. single-service
+	// compose apps) can set this to skip the "default" attachment. Defaults
+	// to false so existing behavior is unchanged.
+	skipDefaultNetwork = false,
 ) => {
 	let networks = networkService;
 	const network = "dokploy-network";
@@ -361,14 +371,14 @@ export const addDokployNetworkToService = (
 		if (!networks.includes(network)) {
 			networks.push(network);
 		}
-		if (!networks.includes(defaultNetwork)) {
+		if (!skipDefaultNetwork && !networks.includes(defaultNetwork)) {
 			networks.push(defaultNetwork);
 		}
 	} else if (networks && typeof networks === "object") {
 		if (!(network in networks)) {
 			networks[network] = {};
 		}
-		if (!(defaultNetwork in networks)) {
+		if (!skipDefaultNetwork && !(defaultNetwork in networks)) {
 			networks[defaultNetwork] = {};
 		}
 	}


### PR DESCRIPTION
Fixes #4807

### Problem

`addDokployNetworkToService` unconditionally attaches every domain-linked compose service to both `dokploy-network` and the project's implicit `default` network (the fix for #3562). For services that don't need default-network connectivity (single-service compose apps, or apps managing their own explicit network topology), this dual attachment can make Traefik's Docker provider pick the wrong network's IP for routing — producing a persistent 502 that neither a same-container restart nor a Traefik config reload fixes, only a full container recreate does. Full repro/evidence in #4807.

### Change

Adds an opt-in, backward-compatible per-domain boolean `skipDefaultNetwork` (default `false`) that lets a domain skip the `default` network attachment while keeping `dokploy-network`. Mirrors the existing `stripPath`-style per-domain flag pattern (same schema/validation/pick-list shape).

- `packages/server/src/db/schema/domain.ts` — new `skipDefaultNetwork` column (NOT NULL, default false) + added to `apiCreateDomain`/`apiUpdateDomain` pick lists
- `packages/server/src/db/validations/domain.ts` — added to the `domainCompose` zod schema (compose-only, since this only matters for compose deployments)
- `packages/server/src/utils/docker/domain.ts` — `addDokployNetworkToService` takes an optional `skipDefaultNetwork` param (defaults to `false`, i.e. unchanged behavior); call site passes `domain.skipDefaultNetwork ?? false`
- `apps/dokploy/drizzle/0175_skip_default_network.sql` + journal entry — migration for the new column
- New tests in `network-service.test.ts` covering the opt-in path (5 new cases); all existing cases for the default/unchanged path still pass as-is
- Updated 4 existing test fixtures (`Domain` mock objects in `host-rule-format.test.ts`, `labels.test.ts`, `forward-auth.test.ts`, `traefik.test.ts`) that needed the new required field for typecheck

### Testing

```
pnpm --filter=@dokploy/server run typecheck   # clean
pnpm --filter=dokploy run typecheck           # clean (pre-existing, unrelated handle-tag.tsx Zod-version error only, confirmed present on canary before this change too)
npx vitest run --config __test__/vitest.config.ts __test__/compose/
# Test Files  26 passed (26)
#      Tests  146 passed (146)
```

### Note on the migration snapshot

I don't have a local Postgres/drizzle-kit toolchain to regenerate `apps/dokploy/drizzle/meta/*_snapshot.json`. The `schema.ts` change and migration SQL are minimal and correct (single boolean column, matching the style of the existing `0174` migration) — happy to update the snapshot if you can point me at how you'd like it generated, or if this is something CI/your usual flow regenerates.

### Open to discussion

This is meant as a starting point, not a final word on the design — happy to adjust naming (`skipDefaultNetwork` vs something else), whether this belongs on `Domain` vs `Compose`, or add a UI toggle if you'd like one wired in as a follow-up. Wanted to keep this PR focused on the minimal backend capability + tests first.