### PR TITLE
fix(server): safely expand zip path regex for Next.js static exports

### DIFF
--- a/apps/dokploy/__test__/wss/readValidDirectory.test.ts
+++ b/apps/dokploy/__test__/wss/readValidDirectory.test.ts
@@ -94,4 +94,27 @@ describe("readValidDirectory (path traversal)", () => {
 			),
 		).toBe(true);
 	});
+
+	it("returns true for Next.js static export chunk paths", () => {
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/out/_next/static/chunks/0.qc0y~mo5hro.js`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/out/_next/static/chunks/__next.!KGFwcCk.txt`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/out/(app)/$id.js`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/out/components=page,chunk+1.js`,
+			),
+		).toBe(true);
+	});
 });

--- a/packages/server/src/wss/utils.ts
+++ b/packages/server/src/wss/utils.ts
@@ -40,7 +40,7 @@ export const readValidDirectory = (
 	directory: string,
 	serverId?: string | null,
 ) => {
-	if (!/^[\w/. :[\]-]{1,500}$/.test(directory)) {
+	if (!/^[\w/. :()[\]~@!$=%+,.-]{1,500}$/.test(directory)) {
 		return false;
 	}
 


### PR DESCRIPTION
### What is this PR about?

This is a direct continuation of PR https://github.com/Dokploy/dokploy/pull/4468. While https://github.com/Dokploy/dokploy/pull/4468 successfully added
support for Next.js dynamic routing square brackets ( [] ) during source
code uploads, it did not account for compiled Next.js Static Exports.

When Next.js compiles a static export (especially using App Router Route
Groups), it generates highly complex chunk filenames containing characters
like ~ , $ , ! , and () . Dokploy's strict regex whitelist in
readValidDirectory currently rejects these valid files, throwing a 500
Internal Server Error (Path Traversal detected) on zip drops.

This PR safely expands the allowed regex character set ( ~ , $ , ! , ()
, = , % , + , , , . ) to fully support Next.js static builds.

**Security Analysis:**
In expanding this regex, I strictly followed the Principle of Least Privilege.
I explicitly removed shell chainers (like ; and & ) from the allowed characters.
While I verified that Dokploy is immune to shell injection here because it uses
pure-memory Node buffers via AdmZip rather than child_process.exec() ,
restricting shell operators in the regex maintains a hardened defense-in-depth
security posture.

**Checklist**
[✓] I created a dedicated branch based on the canary branch.
[✓] I have read the suggestions in the CONTRIBUTING.md file.
[✓] I have tested this PR in my local instance by successfully deploying a
compiled Next.js static export ( out/ folder).