### PR TITLE
fix(env): fail safely on undecrypted environment ciphertext

### DIFF
--- a/apps/dokploy/__test__/env/shared.test.ts
+++ b/apps/dokploy/__test__/env/shared.test.ts
@@ -1,4 +1,5 @@
 import { prepareEnvironmentVariables } from "@dokploy/server/index";
+import { encryptValue } from "@dokploy/server/lib/encryption";
 import { describe, expect, it } from "vitest";
 
 const projectEnv = `
@@ -13,6 +14,20 @@ SERVICE_PORT=4000
 `;
 
 describe("prepareEnvironmentVariables", () => {
+	it("rejects encrypted values that were not decrypted by the database layer", () => {
+		const encrypted = encryptValue("SECRET=value");
+
+		expect(() => prepareEnvironmentVariables(encrypted, "", "")).toThrow(
+			"Unable to decrypt environment variables for the service scope",
+		);
+		expect(() => prepareEnvironmentVariables("", encrypted, "")).toThrow(
+			"Unable to decrypt environment variables for the project scope",
+		);
+		expect(() => prepareEnvironmentVariables("", "", encrypted)).toThrow(
+			"Unable to decrypt environment variables for the environment scope",
+		);
+	});
+
 	it("resolves project variables correctly", () => {
 		const resolved = prepareEnvironmentVariables(serviceEnv, projectEnv);
 

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { docker, paths } from "@dokploy/server/constants";
+import { isEncrypted } from "@dokploy/server/lib/encryption";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { ContainerInfo, ResourceRequirements } from "dockerode";
 import { parse } from "dotenv";
@@ -396,14 +397,32 @@ export const removeService = async (
 	}
 };
 
+// encryptedText intentionally returns raw ciphertext when decryption fails.
+// Never let dotenv interpret that ciphertext as an empty environment block.
+const parseDecryptedEnvironmentVariables = (
+	value: string | null | undefined,
+	scope: "service" | "project" | "environment",
+) => {
+	const input = value ?? "";
+	if (isEncrypted(input)) {
+		throw new Error(
+			`Unable to decrypt environment variables for the ${scope} scope. Ensure ENCRYPTION_KEY or BETTER_AUTH_SECRET is consistent across all Dokploy services.`,
+		);
+	}
+	return parse(input);
+};
+
 export const prepareEnvironmentVariables = (
 	serviceEnv: string | null,
 	projectEnv?: string | null,
 	environmentEnv?: string | null,
 ) => {
-	const projectVars = parse(projectEnv ?? "");
-	const environmentVars = parse(environmentEnv ?? "");
-	const serviceVars = parse(serviceEnv ?? "");
+	const projectVars = parseDecryptedEnvironmentVariables(projectEnv, "project");
+	const environmentVars = parseDecryptedEnvironmentVariables(
+		environmentEnv,
+		"environment",
+	);
+	const serviceVars = parseDecryptedEnvironmentVariables(serviceEnv, "service");
 
 	const resolvedVars = Object.entries(serviceVars).map(([key, value]) => {
 		let resolvedValue = value;


### PR DESCRIPTION
## Summary

- reject raw `enc:v1:` values before they reach dotenv parsing
- fail remote deployments with an actionable encryption-key consistency error instead of silently producing an empty environment
- cover service, project, and environment-level variable scopes with regression tests

## Root cause and impact

Environment encryption added in #4789 intentionally returns raw ciphertext from the Drizzle custom type when decryption fails. That keeps database reads available, but deployment code then passes the ciphertext to `dotenv.parse()`.

An `enc:v1:...` payload is not a valid dotenv assignment, so it parses to an empty object. The Swarm application builder subsequently writes `TaskTemplate.ContainerSpec.Env: []`, silently removing every configured runtime variable while the deployment can still finish successfully.

This was observed on Dokploy Cloud v0.29.12 with a Dockerfile Application targeting a remote single-node Swarm:

1. `application.one` returned all 9 configured environment keys.
2. The same block parsed as all 9 keys with Dokploy's dotenv 16.4.5 dependency.
3. Deploy and redeploy both completed with status `done`.
4. Immediately afterward, the remote service had `ContainerSpec.Env: []` and the container was missing all configured variables.
5. A manual `docker service update --env-add ...` restored the service, but the next Dokploy deployment removed the variables again.

Because Dokploy Cloud dispatches remote deployments to the separate deployment service, the likely trigger is a web/worker version mismatch or inconsistent `ENCRYPTION_KEY` / `BETTER_AUTH_SECRET`. That infrastructure condition still needs to be corrected. This patch provides a safe execution boundary: undecrypted ciphertext can no longer be mistaken for an intentionally empty environment.

No secret values are included here.

## Validation

- `pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts run __test__/env` — 79 tests passed
- `pnpm --filter=@dokploy/server typecheck`
- `pnpm --filter=dokploy typecheck`
- `pnpm exec biome check packages/server/src/utils/docker/utils.ts apps/dokploy/__test__/env/shared.test.ts`
- `git diff --check`

Related context: #4516
