### PR TITLE
fix: preserve named volume access mode in compose randomize transform

### DIFF
--- a/apps/dokploy/__test__/compose/volume/volume-services.test.ts
+++ b/apps/dokploy/__test__/compose/volume/volume-services.test.ts
@@ -42,6 +42,40 @@ test("Add suffix to volumes declared directly in services", () => {
 	);
 });
 
+const composeFileReadOnly = `
+version: "3.8"
+
+services:
+  db:
+    image: postgres:latest
+    volumes:
+      - db_data:/var/lib/postgresql/data:ro
+      - config/nginx:/etc/nginx/conf.d:z
+`;
+
+test("Preserve access mode when adding suffix to named volumes", () => {
+	const composeData = parse(composeFileReadOnly) as ComposeSpecification;
+
+	const suffix = generateRandomHash();
+
+	if (!composeData.services) {
+		return;
+	}
+
+	const updatedComposeData = addSuffixToVolumesInServices(
+		composeData.services,
+		suffix,
+	);
+	const actualComposeData = { ...composeData, services: updatedComposeData };
+
+	expect(actualComposeData.services?.db?.volumes).toContain(
+		`db_data-${suffix}:/var/lib/postgresql/data:ro`,
+	);
+	expect(actualComposeData.services?.db?.volumes).toContain(
+		`config-${suffix}/nginx:/etc/nginx/conf.d:z`,
+	);
+});
+
 const composeFileTypeVolume = `
 version: "3.8"
 

--- a/packages/server/src/utils/docker/compose/volume.ts
+++ b/packages/server/src/utils/docker/compose/volume.ts
@@ -26,7 +26,7 @@ export const addSuffixToVolumesInServices = (
 		if (_.has(newServiceConfig, "volumes")) {
 			newServiceConfig.volumes = _.map(newServiceConfig.volumes, (volume) => {
 				if (_.isString(volume)) {
-					const [volumeName, path] = volume.split(":");
+					const [volumeName, path, ...modeParts] = volume.split(":");
 
 					// skip bind mounts and variables (e.g. $PWD)
 					if (
@@ -38,15 +38,18 @@ export const addSuffixToVolumesInServices = (
 						return volume;
 					}
 
+					// Preserve the access mode (e.g. :ro, :z, :Z) if present
+					const mode = modeParts.length > 0 ? `:${modeParts.join(":")}` : "";
+
 					// Handle volume paths with subdirectories
 					const parts = volumeName.split("/");
 					if (parts.length > 1) {
 						const baseName = parts[0];
 						const rest = parts.slice(1).join("/");
-						return `${baseName}-${suffix}/${rest}:${path}`;
+						return `${baseName}-${suffix}/${rest}:${path}${mode}`;
 					}
 
-					return `${volumeName}-${suffix}:${path}`;
+					return `${volumeName}-${suffix}:${path}${mode}`;
 				}
 				if (_.isObject(volume) && volume.type === "volume" && volume.source) {
 					return {


### PR DESCRIPTION
## What is this PR about?

When a Compose service is deployed with "Randomize" or "Isolated Deployment" (with volume isolation), Dokploy appends a suffix to volume names. The transform split each short-syntax volume mount on ":" and kept only the name and path, which silently dropped the access mode. A named read-only volume like `data:/var/lib/mysql:ro` became `data-<suffix>:/var/lib/mysql`, so a read-only mount turned read-write, and the SELinux `:z` / `:Z` relabel flags were lost.

This PR preserves any segments after the container path and re-appends them, so `data:/var/lib/mysql:ro` becomes `data-<suffix>:/var/lib/mysql:ro`. Bind mounts and long-form (`type: volume`) entries are unchanged. A regression test is added covering `:ro` on a named volume and `:z` on a subdirectory volume.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. Verified via the compose test suite (142 tests pass, including the new mode-preservation regression test) and `tsc --noEmit` on both `@dokploy/server` and `apps/dokploy`.

## Issues related (if applicable)

closes #4818

## Screenshots (if applicable)

Not applicable (backend compose transform). Behavior is covered by the added unit test.
