### PR TITLE
fix(logs): don't classify explicit non-error key/values as error

### DIFF
--- a/apps/dokploy/__test__/logs/log-classification.test.ts
+++ b/apps/dokploy/__test__/logs/log-classification.test.ts
@@ -2,9 +2,7 @@ import { getLogType } from "@/components/dashboard/docker/logs/utils";
 import { expect, test } from "vitest";
 
 test("classifies real failures as error", () => {
-	expect(getLogType("Error: connection refused at db:5432").type).toBe(
-		"error",
-	);
+	expect(getLogType("Error: connection refused at db:5432").type).toBe("error");
 	expect(getLogType("[ERROR] something went wrong").type).toBe("error");
 	expect(getLogType("Deployment failed").type).toBe("error");
 	expect(

--- a/apps/dokploy/__test__/logs/log-classification.test.ts
+++ b/apps/dokploy/__test__/logs/log-classification.test.ts
@@ -1,0 +1,33 @@
+import { getLogType } from "@/components/dashboard/docker/logs/utils";
+import { expect, test } from "vitest";
+
+test("classifies real failures as error", () => {
+	expect(getLogType("Error: connection refused at db:5432").type).toBe(
+		"error",
+	);
+	expect(getLogType("[ERROR] something went wrong").type).toBe("error");
+	expect(getLogType("Deployment failed").type).toBe("error");
+	expect(
+		getLogType(
+			'NOTICE [Job "sync-1m" (e1305c5b54b1)] Finished in "326ms", failed: true, skipped: false, error: exit code 1',
+		).type,
+	).toBe("error");
+});
+
+test("does not classify explicit non-error key/values as error (#4538)", () => {
+	// ofelia job-completion summary for a successful run
+	expect(
+		getLogType(
+			'NOTICE [Job "sync-1m" (e1305c5b54b1)] Finished in "326.16795ms", failed: false, skipped: false, error: none',
+		).type,
+	).not.toBe("error");
+
+	expect(getLogType("request done, error: null").type).not.toBe("error");
+	expect(getLogType("checks passed, failures=0").type).not.toBe("error");
+	expect(getLogType('shutdown clean, error=""').type).not.toBe("error");
+});
+
+test("keeps statusCode-based classification", () => {
+	expect(getLogType('{"statusCode": "500"}').type).toBe("error");
+	expect(getLogType('{"statusCode": "204"}').type).toBe("success");
+});

--- a/apps/dokploy/__test__/logs/log-classification.test.ts
+++ b/apps/dokploy/__test__/logs/log-classification.test.ts
@@ -23,6 +23,17 @@ test("does not classify explicit non-error key/values as error (#4538)", () => {
 	expect(getLogType("request done, error: null").type).not.toBe("error");
 	expect(getLogType("checks passed, failures=0").type).not.toBe("error");
 	expect(getLogType('shutdown clean, error=""').type).not.toBe("error");
+	expect(getLogType('job done failed=false error=""').type).not.toBe("error");
+});
+
+test("keeps errors whose value merely starts with a no-error word", () => {
+	expect(getLogType("connect failed: no route to host").type).toBe("error");
+	expect(getLogType("connection failed: no such host").type).toBe("error");
+	expect(getLogType("error: none of the configured nodes are available").type).toBe(
+		"error",
+	);
+	expect(getLogType("error: nil pointer dereference").type).toBe("error");
+	expect(getLogType("request failed: 0 bytes received").type).toBe("error");
 });
 
 test("keeps statusCode-based classification", () => {

--- a/apps/dokploy/__test__/logs/log-classification.test.ts
+++ b/apps/dokploy/__test__/logs/log-classification.test.ts
@@ -29,9 +29,9 @@ test("does not classify explicit non-error key/values as error (#4538)", () => {
 test("keeps errors whose value merely starts with a no-error word", () => {
 	expect(getLogType("connect failed: no route to host").type).toBe("error");
 	expect(getLogType("connection failed: no such host").type).toBe("error");
-	expect(getLogType("error: none of the configured nodes are available").type).toBe(
-		"error",
-	);
+	expect(
+		getLogType("error: none of the configured nodes are available").type,
+	).toBe("error");
 	expect(getLogType("error: nil pointer dereference").type).toBe("error");
 	expect(getLogType("request failed: 0 bytes received").type).toBe("error");
 });

--- a/apps/dokploy/components/dashboard/docker/logs/utils.ts
+++ b/apps/dokploy/components/dashboard/docker/logs/utils.ts
@@ -97,17 +97,23 @@ export const getLogType = (message: string): LogStyle => {
 		return LOG_STYLES.info;
 	}
 
+	// Key/value pairs that explicitly report a non-error (e.g. "error: none",
+	// "failed: false") must not trigger the error keyword patterns below
+	const nonErrorKeyValues =
+		/\b(?:error|err|errors|failed|failure|failures)s?\s*[:=]\s*(?:none|null|nil|false|0|no|-|""|'')(?=[\s,;.)\]]|$)/gi;
+	const errorScope = lowerMessage.replace(nonErrorKeyValues, "");
+
 	if (
-		/(?:^|\s)(?:error|err):?\s/i.test(lowerMessage) ||
-		/\b(?:exception|failed|failure)\b/i.test(lowerMessage) ||
-		/(?:stack\s?trace):\s*$/i.test(lowerMessage) ||
-		/^\s*at\s+[\w.]+\s*\(?.+:\d+:\d+\)?/.test(lowerMessage) ||
-		/\b(?:uncaught|unhandled)\s+(?:exception|error)\b/i.test(lowerMessage) ||
-		/Error:\s.*(?:in|at)\s+.*:\d+(?::\d+)?/.test(lowerMessage) ||
-		/\b(?:errno|code):\s*(?:\d+|[A-Z_]+)\b/i.test(lowerMessage) ||
-		/\[(?:error|err|fatal)\]/i.test(lowerMessage) ||
-		/\b(?:crash|critical|fatal)\b/i.test(lowerMessage) ||
-		/\b(?:fail(?:ed|ure)?|broken|dead)\b/i.test(lowerMessage)
+		/(?:^|\s)(?:error|err):?\s/i.test(errorScope) ||
+		/\b(?:exception|failed|failure)\b/i.test(errorScope) ||
+		/(?:stack\s?trace):\s*$/i.test(errorScope) ||
+		/^\s*at\s+[\w.]+\s*\(?.+:\d+:\d+\)?/.test(errorScope) ||
+		/\b(?:uncaught|unhandled)\s+(?:exception|error)\b/i.test(errorScope) ||
+		/Error:\s.*(?:in|at)\s+.*:\d+(?::\d+)?/.test(errorScope) ||
+		/\b(?:errno|code):\s*(?:\d+|[A-Z_]+)\b/i.test(errorScope) ||
+		/\[(?:error|err|fatal)\]/i.test(errorScope) ||
+		/\b(?:crash|critical|fatal)\b/i.test(errorScope) ||
+		/\b(?:fail(?:ed|ure)?|broken|dead)\b/i.test(errorScope)
 	) {
 		return LOG_STYLES.error;
 	}

--- a/apps/dokploy/components/dashboard/docker/logs/utils.ts
+++ b/apps/dokploy/components/dashboard/docker/logs/utils.ts
@@ -99,9 +99,13 @@ export const getLogType = (message: string): LogStyle => {
 
 	// Key/value pairs that explicitly report a non-error (e.g. "error: none",
 	// "failed: false") must not trigger the error keyword patterns below
-	const nonErrorKeyValues =
-		/\b(?:error|err|errors|failed|failure|failures)s?\s*[:=]\s*(?:none|null|nil|false|0|no|-|""|'')(?=[\s,;.)\]]|$)/gi;
-	const errorScope = lowerMessage.replace(nonErrorKeyValues, "");
+	const nonErrorColonPairs =
+		/\b(?:error|err|errors|failed|failure|failures)\s*:\s*(?:none|null|nil|false|0|no|-|""|'')(?=[,;.)\]]|$)/gi;
+	const nonErrorLogfmtPairs =
+		/\b(?:error|err|errors|failed|failure|failures)\s*=\s*(?:none|null|nil|false|0|no|-|""|'')(?=[\s,;.)\]]|$)/gi;
+	const errorScope = lowerMessage
+		.replace(nonErrorColonPairs, "")
+		.replace(nonErrorLogfmtPairs, "");
 
 	if (
 		/(?:^|\s)(?:error|err):?\s/i.test(errorScope) ||


### PR DESCRIPTION
The log viewer's `getLogType` matched error keywords against the key of a key/value pair while ignoring its value, so successful lines like ofelia's job summary:

```
NOTICE [Job "sync-1m"] Finished in "326ms", failed: false, skipped: false, error: none
```

rendered red as errors. Reproduced with a unit test against the current classifier.

Now key/value pairs whose value explicitly reports a non-error (`error: none|null|nil|false|0|-|""`, `failed: false|no|0`, `failures=0`, `:` or `=` separators) are stripped before the error patterns run. Real failures (`failed: true`, `error: exit code 1`) still classify as errors, and statusCode-based classification is untouched.

Related #4589 — keyword-based inference still applies when a line carries no explicit level; this PR removes the false positives where the line itself states success.

Fixes #4538

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows keyword-based log severity inference by removing explicit non-error key/value pairs before applying error patterns and adds classifier regression coverage.
- Supports colon- and equals-separated non-error values.
- Preserves genuine failure and status-code classification.
- Leaves quoted structured-log keys outside the new sanitization.

<h3>Confidence Score: 4/5</h3>

The quoted-key classification gap should be fixed before merging because structured logs that explicitly report `failed: false` are still rendered and filtered as errors.

Raw structured container logs reach the classifier unchanged, while the new sanitizers require unquoted keys and therefore leave a quoted `failed` key for the generic failure pattern to match.

**Files Needing Attention:** apps/dokploy/components/dashboard/docker/logs/utils.ts and apps/dokploy/__test__/logs/log-classification.test.ts

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/9f1ba37e13879c8f8533048ef739a812bfa9c9ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49629805)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Monitoring and Live Terminal/Log Streaming](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/monitoring-and-terminal.md)

<!-- /greptile_comment -->