### PR TITLE
fix(settings): allow clearing the server domain

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-domain.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-domain.tsx
@@ -43,7 +43,8 @@ const addServerDomain = z
 			.string()
 			.trim()
 			.toLowerCase()
-			.refine((val) => VALID_HOSTNAME_REGEX.test(val), {
+			// empty clears the server domain and reverts to IP-only access
+			.refine((val) => val === "" || VALID_HOSTNAME_REGEX.test(val), {
 				message: INVALID_HOSTNAME_MESSAGE,
 			}),
 		letsEncryptEmail: z.string(),
@@ -51,7 +52,7 @@ const addServerDomain = z
 		certificateType: z.enum(["letsencrypt", "none", "custom"]),
 	})
 	.superRefine((data, ctx) => {
-		if (data.https && !data.certificateType) {
+		if (data.domain && data.https && !data.certificateType) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				path: ["certificateType"],
@@ -59,6 +60,7 @@ const addServerDomain = z
 			});
 		}
 		if (
+			data.domain &&
 			data.https &&
 			data.certificateType === "letsencrypt" &&
 			!data.letsEncryptEmail


### PR DESCRIPTION
Settings → Web Server rejected an empty "Server Domain" with "Invalid domain name…", so once a domain was assigned there was no way back to IP-only access (#4821).

The backend already supports removal end-to-end: `assignDomainServer` accepts an empty host and `updateServerTraefik` calls `removeTraefikConfig` when the host is empty. Verified on a local instance: assigning `panel-test.example.com` and then submitting an empty host clears the stored host correctly.

The only blocker was the client-side zod `.refine`, which ran the hostname regex on the empty string. Now an empty domain is accepted as "clear the domain", and the https/letsencrypt `superRefine` requirements are skipped when the domain is being removed.

Fixes #4821