### PR TITLE
fix(ui): make interactive icons inside badges clickable again

### DIFF
--- a/apps/dokploy/components/ui/badge.tsx
+++ b/apps/dokploy/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg:not(.cursor-pointer)]:pointer-events-none [&>svg]:size-3!",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
Since the Tailwind v4 / shadcn update (#4706), the badge base class includes `[&>svg]:pointer-events-none`. The watch-path badges render their remove `X` (lucide) as a direct svg child of `Badge`, so the icon's `onClick` never fired — watch paths could not be deleted in any of the git provider forms (application and compose variants). The remove handlers themselves are correct; the click just never reached them. Note that a plain `pointer-events-auto` on the icons would lose to the badge rule on specificity, which is why the rule itself is scoped.

Scope the badge rule to non-interactive icons: `[&>svg:not(.cursor-pointer)]:pointer-events-none`. All the removable-badge icons already carry `cursor-pointer`, so they become clickable again, while decorative badge icons keep passing events through. Verified the generated CSS with the project's Tailwind build.

Fixes #4780