### PR TITLE
fix(editor): consistent YAML auto-indent on newline

### DIFF
--- a/apps/dokploy/components/shared/code-editor.tsx
+++ b/apps/dokploy/components/shared/code-editor.tsx
@@ -7,7 +7,11 @@ import {
 import { css } from "@codemirror/lang-css";
 import { json } from "@codemirror/lang-json";
 import { yaml } from "@codemirror/lang-yaml";
-import { StreamLanguage } from "@codemirror/language";
+import {
+	getIndentUnit,
+	indentService,
+	StreamLanguage,
+} from "@codemirror/language";
 import { properties } from "@codemirror/legacy-modes/mode/properties";
 import { shell } from "@codemirror/legacy-modes/mode/shell";
 import { search, searchKeymap } from "@codemirror/search";
@@ -98,6 +102,27 @@ const dockerComposeServiceOptions = [
 	},
 }));
 
+// The indentNodeProp shipped with @codemirror/lang-yaml computes wrong
+// column-based indents on Enter (odd/inconsistent amounts, see #4650), so
+// indentation is resolved line-based here: keep the current indent, align
+// list-entry keys after the dash marker, and go one unit deeper after a
+// line that opens a block (ending in ":", "|" or ">").
+const yamlIndent = indentService.of((context, pos) => {
+	const line = context.state.doc.lineAt(pos);
+	const before = context.state.doc.sliceString(line.from, pos);
+	const indent = /^ */.exec(before)?.[0].length ?? 0;
+	const trimmed = before.trim();
+	if (!trimmed || trimmed.startsWith("#")) {
+		return indent;
+	}
+	const base =
+		trimmed.startsWith("- ") && /:\s/.test(trimmed) ? indent + 2 : indent;
+	if (/[:|>]$/.test(trimmed)) {
+		return base + getIndentUnit(context.state);
+	}
+	return base;
+});
+
 function dockerComposeComplete(
 	context: CompletionContext,
 ): CompletionResult | null {
@@ -160,7 +185,7 @@ export const CodeEditor = ({
 					search(),
 					keymap.of(searchKeymap),
 					language === "yaml"
-						? yaml()
+						? [yamlIndent, yaml()]
 						: language === "json"
 							? json()
 							: language === "css"


### PR DESCRIPTION
Pressing Enter in the raw compose editor produced inconsistent and odd-numbered indents (#4650). Reproduced headlessly with the project's exact CodeMirror packages by running `insertNewlineAndIndent` over a compose document — the indents came out as:

| Enter after | current | expected |
|---|---|---|
| `services:` | 0 | 2 |
| `  web:` | **9** | 4 |
| `    image: nginx:alpine` | 6 | 4 |
| `    ports:` | 6 | 6 |
| `      - "8080:80"` | 6 | 6 |

The culprit is the `indentNodeProp` shipped with `@codemirror/lang-yaml`, which resolves indentation from parse-tree node columns; configuring `indentUnit` does not change the result. This PR overrides it with a line-based `indentService` (the `indentService` facet takes precedence over the language's node prop): keep the current line's indent, align list-entry keys after the `- ` marker, and indent one unit deeper after a line that opens a block (ending in `:`, `|` or `>`).

With the override, all the cases above — plus `- name: web` (→ 4) and `run: |` (→ one unit deeper) — produce the expected indent in the same headless harness.

Fixes #4650