### PR TITLE
fix: keep legacy auth-secret key as a decrypt fallback so migrating BETTER_AUTH_SECRET does not orphan encrypted env vars

### DIFF
--- a/apps/dokploy/__test__/env/encryption.test.ts
+++ b/apps/dokploy/__test__/env/encryption.test.ts
@@ -49,6 +49,37 @@ describe("encryptValue / decryptValue", () => {
 	});
 });
 
+describe("migrating off the hardcoded legacy BETTER_AUTH_SECRET", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.resetModules();
+	});
+
+	const loadWithAuthSecret = async (secret: string) => {
+		vi.stubEnv("BETTER_AUTH_SECRET", secret);
+		vi.resetModules();
+		return await import("@dokploy/server/lib/encryption");
+	};
+
+	it("still decrypts values written under the legacy secret", async () => {
+		// Encrypted while the install was still on the hardcoded default
+		const legacyEncrypted = encryptValue("KEY=legacy-value");
+
+		const migrated = await loadWithAuthSecret("a-real-auth-secret");
+		expect(migrated.decryptValue(legacyEncrypted)).toBe("KEY=legacy-value");
+	});
+
+	it("encrypts new values with the new secret, not the legacy one", async () => {
+		const migrated = await loadWithAuthSecret("a-real-auth-secret");
+		const encrypted = migrated.encryptValue("KEY=post-migration");
+
+		// The legacy-derived key alone cannot read it, proving the write used
+		// the migrated secret
+		expect(() => decryptValue(encrypted)).toThrow(/BETTER_AUTH_SECRET/);
+		expect(migrated.decryptValue(encrypted)).toBe("KEY=post-migration");
+	});
+});
+
 describe("dedicated ENCRYPTION_KEY", () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();

--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -1932,8 +1932,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 											<div className="space-y-0.5">
 												<FormLabel>Docker Cleanup</FormLabel>
 												<FormDescription>
-													Trigger the action when Docker cleanup is
-													performed.
+													Trigger the action when Docker cleanup is performed.
 												</FormDescription>
 											</div>
 											<FormControl>

--- a/packages/server/src/lib/auth-secret.ts
+++ b/packages/server/src/lib/auth-secret.ts
@@ -1,6 +1,6 @@
 import { readSecret } from "../db/constants";
 
-const HARDCODED_LEGACY_SECRET = "better-auth-secret-123456789";
+export const HARDCODED_LEGACY_SECRET = "better-auth-secret-123456789";
 
 const { BETTER_AUTH_SECRET, BETTER_AUTH_SECRET_FILE } = process.env;
 

--- a/packages/server/src/lib/encryption.ts
+++ b/packages/server/src/lib/encryption.ts
@@ -7,7 +7,7 @@ import {
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
-import { betterAuthSecret } from "./auth-secret";
+import { betterAuthSecret, HARDCODED_LEGACY_SECRET } from "./auth-secret";
 import { encryptionSecret } from "./encryption-secret";
 
 export const ENCRYPTION_KEY_BACKUP_FILE = "encryption.key";
@@ -21,12 +21,35 @@ const deriveKey = (secret: string) =>
 
 const primaryKey = deriveKey(encryptionSecret ?? betterAuthSecret);
 
+const dedupeKeys = (keys: Buffer[]) => {
+	const seen = new Set<string>();
+	return keys.filter((key) => {
+		const hex = key.toString("hex");
+		if (seen.has(hex)) {
+			return false;
+		}
+		seen.add(hex);
+		return true;
+	});
+};
+
 // Installs that adopt a dedicated ENCRYPTION_KEY still hold values encrypted
 // with the auth-secret-derived key; keep it as a decrypt fallback so they
 // lazily re-encrypt on the next write instead of becoming unreadable.
-const decryptionKeys = encryptionSecret
-	? [primaryKey, deriveKey(betterAuthSecret)]
-	: [primaryKey];
+//
+// The same applies to installs migrating off the deprecated hardcoded auth
+// secret, which the startup banner asks every affected user to do: their
+// values are encrypted with the legacy-derived key. HARDCODED_LEGACY_SECRET
+// is a published constant, so keeping it as a decrypt-only fallback discloses
+// nothing that was not already derivable from the source, while stopping the
+// migration from orphaning existing values. Encryption always uses
+// primaryKey, so values written after the migration are protected by the
+// real secret.
+const decryptionKeys = dedupeKeys([
+	primaryKey,
+	...(encryptionSecret ? [deriveKey(betterAuthSecret)] : []),
+	deriveKey(HARDCODED_LEGACY_SECRET),
+]);
 
 // Derived keys only — never the raw secrets. A leaked key can decrypt
 // stored values, but the raw BETTER_AUTH_SECRET could also forge sessions.


### PR DESCRIPTION
## What is this PR about?

Environment variables are encrypted at rest with a key derived from `BETTER_AUTH_SECRET`. The decryption keyring had no slot for a previous secret, so replacing the deprecated hardcoded default with a real one made every existing `env`, `buildArgs` and `buildSecrets` value permanently undecryptable. The startup banner asks every affected install to make exactly that change ("CRITICAL SECURITY RISK... Please migrate to Docker Secrets"), so following Dokploy's own security advice was enough to trigger it.

Because decryption fails open, the damage was silent: the raw `enc:v1:...` ciphertext is returned, passed to `prepareEnvironmentVariables`, and `dotenv.parse` turns it into `{}`. The service is then redeployed with no environment variables at all and the deployment still reports success. Same end symptom as #4817, different trigger.

This PR keeps `deriveKey(HARDCODED_LEGACY_SECRET)` in the decryption keyring as a decrypt-only fallback. That constant is published in this repository, so it discloses nothing that was not already derivable by anyone with the source and a database dump, and it only ever applies to values that were already encrypted under it. Encryption still always uses `primaryKey`, so values written after the migration are protected by the real secret, and existing values lazily re-encrypt under the new key on the next write. This mirrors the fallback already in place for the `ENCRYPTION_KEY` adoption path, and the keyring is deduplicated so installs still on the legacy default are unaffected.

Scope note: this fixes the migration path the product actively tells users to take. It does not add a general previous-secret rotation mechanism, and it does not change the fail-open polarity. Both are discussed in #4833 and I am happy to follow up on either if you want them addressed separately.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. Added a regression test that reproduces the bug: it fails on canary (the migrated instance cannot read values written under the legacy secret) and passes with this change. Full `__test__/env` suite passes (80 tests), `@dokploy/server` typecheck is clean, and Biome reports no lint findings on the touched files.

## Issues related (if applicable)

closes #4833

## Screenshots (if applicable)

Not applicable (backend encryption keyring). Behavior is covered by the added regression tests.
