### PR TITLE
fix: skip dependency lifecycle scripts during MCP sync

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -189,7 +189,7 @@ jobs:
           mv package.json.tmp package.json
 
           npm install -g pnpm
-          pnpm install
+          pnpm install --ignore-scripts
           pnpm run fetch-openapi
           pnpm run generate
 


### PR DESCRIPTION
## Summary

- Install MCP dependencies with `pnpm install --ignore-scripts` in the `sync-version` job.
- Restore Dokploy-to-MCP version and generated OpenAPI tool synchronization without pinning pnpm to an older release.
- Keep this pull request scoped to `Dokploy/dokploy` so the currently failing release workflow can be unblocked independently.

## Root cause

The workflow installs the latest pnpm globally and then runs `pnpm install` in a fresh clone of `Dokploy/mcp`. With pnpm v11, that install exits with `ERR_PNPM_IGNORED_BUILDS` for `esbuild@0.27.7`, so the MCP version bump and generated tool update are never committed.

The sync step only needs the explicitly invoked `fetch-openapi` and `generate` scripts. Dependency lifecycle scripts are not required for those commands, so this change disables them during installation instead of pinning the package manager to pnpm v10.

## Preferred long-term fix in Dokploy/mcp

The more complete project-level fix belongs in `Dokploy/mcp`: migrate its build approval configuration to pnpm v11's `allowBuilds` format and ensure that configuration is included in the Docker build context.

```yaml
allowBuilds:
  esbuild: true
```

This was tested with pnpm `11.13.1` and `docker compose build --no-cache`. With the lockfile included in the build context and `pnpm-workspace.yaml` copied into the image, the `esbuild` postinstall script ran successfully, both MCP images built, and both Compose services became healthy.

A follow-up pull request in `Dokploy/mcp` should add that configuration, reference this pull request and `Dokploy/mcp#59`, and be merged as the preferred long-term project-level solution. This pull request intentionally uses `--ignore-scripts` because it is the self-contained fix available in `Dokploy/dokploy` alone.

## Validation

- Reproduced the current MCP Docker Compose failure from a clean `main` checkout.
- Verified `allowBuilds.esbuild: true` with pnpm `11.13.1` using a no-cache Linux Docker Compose build.
- Verified both resulting MCP services start and report healthy.
- Verified the exact workaround in a clean `node:lts-alpine` container:
  - `pnpm install --frozen-lockfile --ignore-scripts`
  - fetched 541 OpenAPI endpoints
  - generated 541 MCP tools with 0 errors
- `git diff --check`

Closes #4837

Related: Dokploy/mcp#59, Dokploy/mcp#60
