### PR TITLE
ci: skip dependency lifecycle scripts during MCP sync

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -189,7 +189,7 @@ jobs:
           mv package.json.tmp package.json
 
           npm install -g pnpm
-          pnpm install
+          pnpm install --ignore-scripts
           pnpm run fetch-openapi
           pnpm run generate
 


### PR DESCRIPTION
## Summary

- Install MCP dependencies with `pnpm install --ignore-scripts` in the `sync-version` job.
- Unblock Dokploy-to-MCP version and generated tool synchronization without pinning pnpm to an older release.
- Keep the core change focused to one CI command.

## Root cause

The release workflow installs the latest pnpm and then runs `pnpm install` in a fresh `Dokploy/mcp` clone. With pnpm v11, the current MCP configuration causes installation to exit with `ERR_PNPM_IGNORED_BUILDS` for `esbuild@0.27.7`. The workflow stops before updating the MCP package version or generated OpenAPI tools.

The sync step only needs the explicitly invoked `fetch-openapi` and `generate` scripts. Dependency lifecycle scripts are not required for those commands, so this repository-local change disables them during installation.

## Related MCP fix

The preferred project-level fix is Dokploy/mcp#62. It migrates MCP from the deprecated `onlyBuiltDependencies` configuration to pnpm v11's `allowBuilds`, includes the required configuration in the Docker build, and fixes Dokploy/mcp#59 without pinning pnpm.

Merging Dokploy/mcp#62 is the better long-term fix for MCP's normal install and Docker workflows. This PR remains intentionally limited to `Dokploy/dokploy`, where `--ignore-scripts` is the self-contained way to restore the release sync and avoid executing unnecessary dependency lifecycle scripts in a job that pushes to another repository.

## Validation

Tested from a clean, unmodified `Dokploy/mcp` main checkout in a Linux container using the Node version recommended by `CONTRIBUTING.md`:

- Node `24.4.0`
- pnpm `11.13.1`
- `pnpm install --ignore-scripts`: passed
- `pnpm run fetch-openapi`: fetched 541 endpoints
- `pnpm run generate`: generated 541 tools with 0 errors
- `git diff --check`: passed

Closes #4837

Related: Dokploy/mcp#62, Dokploy/mcp#59, Dokploy/mcp#60

Supersedes #4838, which was closed and recreated from `canary` according to `CONTRIBUTING.md`.
