### PR TITLE
fix(monitoring): dedupe container metrics by task suffix, not name prefix

### DIFF
--- a/apps/monitoring/containers/config.go
+++ b/apps/monitoring/containers/config.go
@@ -51,11 +51,18 @@ func ShouldMonitorContainer(containerName string) bool {
 	return true
 }
 
+// GetServiceName returns the deduplication key of a container: its name
+// without the swarm task suffix (myapp.1.abc123 → myapp), so replicas of the
+// same swarm service are stored once per tick. Names without a task suffix
+// (docker compose containers) are already unique per container and are kept
+// as-is. Splitting on "-" here used to conflate distinct services sharing a
+// name prefix (app-x-mysql and app-x-redis both mapped to "app-x"), so only
+// the first of them in `docker stats` output was stored each tick — even
+// though metrics are stored and queried by full container_name.
 func GetServiceName(containerName string) string {
 	name := strings.TrimPrefix(containerName, "/")
-	parts := strings.Split(name, "-")
-	if len(parts) > 1 {
-		return strings.Join(parts[:len(parts)-1], "-")
+	if dot := strings.Index(name, "."); dot != -1 {
+		return name[:dot]
 	}
 	return name
 }

--- a/apps/monitoring/containers/config_test.go
+++ b/apps/monitoring/containers/config_test.go
@@ -1,0 +1,27 @@
+package containers
+
+import "testing"
+
+func TestGetServiceName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"swarm replica 1", "myapp-3fa2bc.1.zxc4vplq8m0e", "myapp-3fa2bc"},
+		{"swarm replica 2 collapses to the same service", "myapp-3fa2bc.2.a1b2c3d4e5f6", "myapp-3fa2bc"},
+		{"leading slash is stripped", "/myapp-3fa2bc.1.zxc4vplq8m0e", "myapp-3fa2bc"},
+		{"compose container_name stays distinct", "app-1425-mysql", "app-1425-mysql"},
+		{"sibling compose service must not collapse with the previous one", "app-1425-redis", "app-1425-redis"},
+		{"compose default naming stays distinct", "project-web-1", "project-web-1"},
+		{"name without separators", "single", "single"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GetServiceName(tc.in); got != tc.want {
+				t.Errorf("GetServiceName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

In the monitoring service, `collectMetrics` deduplicates the `docker stats` output by `GetServiceName`, which strips the **last `-`-separated segment** of the container name:

```go
parts := strings.Split(name, "-")
return strings.Join(parts[:len(parts)-1], "-")
```

Any set of containers sharing a dash prefix therefore collapses to a single deduplication key. With explicit compose `container_name`s such as:

```
app-1425-app, app-1425-mysql, app-1425-redis, app-1425-queue
```

all four map to the key `app-1425`, so **only the first container returned by `docker stats` is stored on each tick — the metrics of every sibling container are silently dropped**, and which container "wins" depends on `docker stats` output order.

This is inconsistent with the storage and query layers, which are already keyed by the **full** container name:

- `SaveContainerMetric` stores `metric.Name` (full name) in `container_metrics.container_name`;
- `GetLastNContainerMetrics` filters with `WHERE container_name = ? OR container_name LIKE ?||'.%'`.

So the write-side dedup is the only place losing data.

## Fix

Deduplicate by the swarm task prefix (the name up to the first `.`) instead of the last dash segment:

- swarm replicas `myapp.1.taskid` / `myapp.2.taskid` still collapse to `myapp` — the original intent (one stored series per service and tick) is preserved, and reads keep matching through the existing `LIKE name||'.%'` clause;
- compose containers (`app-1425-mysql`, `project-web-1`), which have no task suffix and are unique per container, keep distinct keys and are all stored.

Added a table-driven unit test for `GetServiceName` covering swarm replicas, explicit compose names, compose default naming, and the leading-slash case.

## How to reproduce

1. Enable container monitoring with services whose container names share a dash prefix (e.g. a compose stack with `container_name: mystack-app`, `mystack-mysql`, `mystack-redis`).
2. Let the agent collect a few ticks.
3. Query `GET /metrics/containers?appName=mystack-mysql&limit=50` — empty (or nearly empty) results, while `mystack-app` (or whichever container `docker stats` lists first) has all the points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
