### PR TITLE
feat(notifications): allow SMTP without authentication

### DIFF
--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -89,8 +89,8 @@ export const notificationSchema = z.discriminatedUnion("type", [
 			type: z.literal("email"),
 			smtpServer: z.string().min(1, { message: "SMTP Server is required" }),
 			smtpPort: z.number().min(1, { message: "SMTP Port is required" }),
-			username: z.string().min(1, { message: "Username is required" }),
-			password: z.string().min(1, { message: "Password is required" }),
+			username: z.string().optional(),
+			password: z.string().optional(),
 			fromAddress: z.string().min(1, { message: "From Address is required" }),
 			toAddresses: z
 				.array(
@@ -640,8 +640,8 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 				volumeBackup: volumeBackup,
 				smtpServer: data.smtpServer,
 				smtpPort: data.smtpPort,
-				username: data.username,
-				password: data.password,
+				username: data.username || "",
+				password: data.password || "",
 				fromAddress: data.fromAddress,
 				toAddresses: data.toAddresses,
 				name: data.name,
@@ -1127,9 +1127,16 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 													<FormItem className="w-full">
 														<FormLabel>Username</FormLabel>
 														<FormControl>
-															<Input placeholder="username" {...field} />
+															<Input
+																placeholder="username"
+																{...field}
+																value={field.value ?? ""}
+															/>
 														</FormControl>
-
+														<FormDescription>
+															Optional. Leave blank if your SMTP server does not
+															require authentication.
+														</FormDescription>
 														<FormMessage />
 													</FormItem>
 												)}
@@ -1146,9 +1153,13 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 																type="password"
 																placeholder="******************"
 																{...field}
+																value={field.value ?? ""}
 															/>
 														</FormControl>
-
+														<FormDescription>
+															Optional. Leave blank if your SMTP server does not
+															require authentication.
+														</FormDescription>
 														<FormMessage />
 													</FormItem>
 												)}
@@ -2041,8 +2052,8 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 										await testEmailConnection({
 											smtpServer: data.smtpServer,
 											smtpPort: data.smtpPort,
-											username: data.username,
-											password: data.password,
+											username: data.username || "",
+											password: data.password || "",
 											fromAddress: data.fromAddress,
 											toAddresses: data.toAddresses,
 										});

--- a/packages/server/src/db/schema/notification.ts
+++ b/packages/server/src/db/schema/notification.ts
@@ -370,8 +370,8 @@ export const apiCreateEmail = notificationsSchema
 	.extend({
 		smtpServer: z.string().min(1),
 		smtpPort: z.number().min(1),
-		username: z.string().min(1),
-		password: z.string().min(1),
+		username: z.string(),
+		password: z.string(),
 		fromAddress: z.string().min(1),
 		toAddresses: z.array(z.string()).min(1),
 	})

--- a/packages/server/src/utils/notifications/utils.ts
+++ b/packages/server/src/utils/notifications/utils.ts
@@ -33,7 +33,9 @@ export const sendEmailNotification = async (
 		const transporter = nodemailer.createTransport({
 			host: smtpServer,
 			port: smtpPort,
-			auth: { user: username, pass: password },
+			...(username && password
+				? { auth: { user: username, pass: password } }
+				: {}),
 		});
 
 		await transporter.sendMail({


### PR DESCRIPTION
## Summary

Closes #4842

Some SMTP relays — e.g. Google SMTP Relay configured with IP allowlisting — do not use username/password authentication. Dokploy currently force-requires both fields when configuring an email notification, which makes those relays unusable.

This PR makes SMTP credentials optional:

- **`handle-notifications.tsx`**: `username` and `password` are now optional in the email form schema, with a hint that they can be left blank when the server doesn't require authentication. Empty values are sent as `""` so no DB migration is needed (columns stay `NOT NULL`).
- **`packages/server/src/db/schema/notification.ts`**: dropped `.min(1)` from `username`/`password` in `apiCreateEmail` (inherited by `apiUpdateEmail` and `apiTestEmailConnection`).
- **`packages/server/src/utils/notifications/utils.ts`**: `sendEmailNotification` only passes `auth` to `nodemailer.createTransport` when both credentials are non-empty; nodemailer treats a missing `auth` key as unauthenticated SMTP. This covers both real notifications and the Test Connection button, which routes through the same function.

## Behavior

- Credentials provided → identical behavior to today (authenticated SMTP).
- Both fields left blank → transporter is created without `auth`, so unauthenticated relays work.

## Testing

- `pnpm --filter=@dokploy/server typecheck` and `pnpm --filter=dokploy typecheck` pass.
- `biome check` clean on the touched files (one pre-existing formatting drift elsewhere in `handle-notifications.tsx` left untouched).