### PR TITLE
fix(ui): constrain organization menu width when sidebar is collapsed

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -648,7 +648,7 @@ function SidebarLogo() {
 								</SidebarMenuButton>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent
-								className="rounded-lg max-h-[min(70vh,28rem)] flex flex-col"
+								className="w-(--radix-dropdown-menu-trigger-width) min-w-64 rounded-lg max-h-[min(70vh,28rem)] flex flex-col"
 								align="start"
 								side={isMobile ? "bottom" : "right"}
 								sideOffset={4}


### PR DESCRIPTION
## Summary

Closes #4840

When the sidebar is collapsed, the Organizations dropdown renders as a cramped, partially-broken popover: the org name column collapses to nothing, the row action buttons (star/edit/delete) get crammed together, and the *Add organization* item wraps onto two lines.

## Cause

The organization `DropdownMenuContent` in `apps/dokploy/components/layouts/side.tsx` has no width constraint. The popover therefore sizes against its trigger, and with the sidebar collapsed the trigger is only the narrow icon rail. Inside the menu, each org name span uses `min-w-0 flex-1 truncate` — classes that assume a constrained container — so with no width floor the flex layout squeezes the name to zero and the content implodes.

With the sidebar expanded the trigger is ~16rem wide, which is why the layout only accidentally looked correct in that state.

## Fix

Apply the same width pattern already used by the user-nav dropdown (`user-nav.tsx`):

```tsx
w-(--radix-dropdown-menu-trigger-width) min-w-64
```

`min-w-64` (16rem) matches `SIDEBAR_WIDTH`, so the menu renders at the same width whether the sidebar is collapsed or expanded. A slightly larger floor than user-nav's `min-w-56` because org rows carry a logo, name, and three action buttons.

## Verification

- Reproduced on a live v0.29.12 instance (collapsed sidebar → broken popover, matching the issue screenshot).
- One-line class change; `biome check` clean on the file.
- Same pattern as the existing `user-nav.tsx` dropdown and the stock shadcn sidebar team-switcher.