### PR TITLE
fix: rename compose "Reload" action to "Rebuild" 

### DIFF
--- a/apps/dokploy/components/dashboard/compose/general/actions.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/actions.tsx
@@ -84,19 +84,19 @@ export const ComposeActions = ({ composeId }: Props) => {
 				)}
 				{canDeploy && (
 					<DialogAction
-						title="Reload Compose"
-						description="Are you sure you want to reload this compose?"
+						title="Rebuild Compose"
+						description="Are you sure you want to rebuild this compose?"
 						type="default"
 						onClick={async () => {
 							await redeploy({
 								composeId: composeId,
 							})
 								.then(() => {
-									toast.success("Compose reloaded successfully");
+									toast.success("Compose rebuilt successfully");
 									refetch();
 								})
 								.catch(() => {
-									toast.error("Error reloading compose");
+									toast.error("Error rebuilding compose");
 								});
 						}}
 					>
@@ -109,12 +109,14 @@ export const ComposeActions = ({ composeId }: Props) => {
 								<TooltipTrigger asChild>
 									<div className="flex items-center">
 										<RefreshCcw className="size-4 mr-1" />
-										Reload
+										Rebuild
 									</div>
 								</TooltipTrigger>
 								<TooltipPrimitive.Portal>
 									<TooltipContent sideOffset={5} className="z-60">
-										<p>Reload the compose without rebuilding it</p>
+										<p>
+											Rebuilds the compose without downloading the source code
+										</p>
 									</TooltipContent>
 								</TooltipPrimitive.Portal>
 							</Tooltip>


### PR DESCRIPTION
### Summary
Renames the compose "Reload" action button, confirmations, tooltips, and toast messages to "Rebuild" on the Compose general page.

### Problem
As reported in #4666, the terminology "Reload" is highly misleading. Users expect a lightweight container reload or restart, but the button actually performs a full compose redeployment/rebuild. In the backend:
- The UI triggers the `redeploy` mutation.
- The queue worker executes `rebuildCompose()`.
- The command generated executes `docker compose -p <appName> -f <composePath> up -d --build --remove-orphans`.

Because the `--build` flag is present, Docker rebuilds the images, which wipes any custom/manual container modifications made directly in the terminal. The tooltip stating *"Reload the compose without rebuilding it"* was factually incorrect.

### Solution
- Renamed the button label from **Reload** to **Rebuild**.
- Updated confirmation dialog title to **Rebuild Compose** and description to **"Are you sure you want to rebuild this compose?"**.
- Corrected success toast to **"Compose rebuilt successfully"** and error toast to **"Error rebuilding compose"**.
- Updated tooltip to **"Rebuilds the compose without downloading the source code"** to correctly describe its behavior (analogous to the Application page rebuild flow and tooltip description).

Closes #4666
