### PR TITLE
SAN-954: add exact Swarm service removal API

### DIFF
--- a/apps/dokploy/__test__/server/removeSwarmService.test.ts
+++ b/apps/dokploy/__test__/server/removeSwarmService.test.ts
@@ -1,0 +1,58 @@
+import { removeSwarmService } from "@dokploy/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execAsyncMock, execAsyncRemoteMock } = vi.hoisted(() => ({
+	execAsyncMock: vi.fn(),
+	execAsyncRemoteMock: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsync: execAsyncMock,
+	execAsyncRemote: execAsyncRemoteMock,
+}));
+
+describe("removeSwarmService", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("removes exactly the requested service locally", async () => {
+		execAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+		await removeSwarmService("abcdefghijklmnopqrstuvwxy");
+
+		expect(execAsyncMock).toHaveBeenCalledWith(
+			"docker service rm abcdefghijklmnopqrstuvwxy",
+		);
+		expect(execAsyncRemoteMock).not.toHaveBeenCalled();
+	});
+
+	it("dispatches removal to the selected remote server", async () => {
+		execAsyncRemoteMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+		await removeSwarmService("abcdefghijklmnopqrstuvwxy", "server-456");
+
+		expect(execAsyncRemoteMock).toHaveBeenCalledWith(
+			"server-456",
+			"docker service rm abcdefghijklmnopqrstuvwxy",
+		);
+		expect(execAsyncMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects option-like input without calling an executor", async () => {
+		await expect(removeSwarmService("--help")).rejects.toThrow(
+			"Invalid Docker Swarm service ID: expected 25 lowercase alphanumeric characters.",
+		);
+		expect(execAsyncMock).not.toHaveBeenCalled();
+		expect(execAsyncRemoteMock).not.toHaveBeenCalled();
+	});
+
+	it("propagates local command failures", async () => {
+		const error = new Error("docker service rm failed");
+		execAsyncMock.mockRejectedValue(error);
+
+		await expect(removeSwarmService("abcdefghijklmnopqrstuvwxy")).rejects.toBe(
+			error,
+		);
+	});
+});

--- a/apps/dokploy/server/api/routers/swarm.ts
+++ b/apps/dokploy/server/api/routers/swarm.ts
@@ -5,9 +5,12 @@ import {
 	getNodeApplications,
 	getNodeInfo,
 	getSwarmNodes,
+	removeSwarmService,
+	swarmServiceIdRegex,
 } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { audit } from "@/server/api/utils/audit";
 import { createTRPCRouter, withPermission } from "../trpc";
 import { containerIdRegex } from "./docker";
 
@@ -34,6 +37,33 @@ export const swarmRouter = createTRPCRouter({
 		)
 		.query(async ({ input }) => {
 			return getNodeApplications(input.serverId);
+		}),
+	removeService: withPermission("docker", "read")
+		.input(
+			z.object({
+				serviceId: z
+					.string()
+					.regex(
+						swarmServiceIdRegex,
+						"Invalid Docker Swarm service ID: expected 25 lowercase alphanumeric characters.",
+					),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			await removeSwarmService(input.serviceId, input.serverId);
+			await audit(ctx, {
+				action: "delete",
+				resourceType: "docker",
+				resourceId: input.serviceId,
+				resourceName: input.serviceId,
+			});
 		}),
 	getAppInfos: withPermission("server", "read")
 		.meta({

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -3,6 +3,25 @@ import {
 	execAsyncRemote,
 } from "@dokploy/server/utils/process/execAsync";
 
+export const swarmServiceIdRegex = /^[a-z0-9]{25}$/;
+
+export const removeSwarmService = async (
+	serviceId: string,
+	serverId?: string | null,
+) => {
+	if (!swarmServiceIdRegex.test(serviceId)) {
+		throw new Error(
+			"Invalid Docker Swarm service ID: expected 25 lowercase alphanumeric characters.",
+		);
+	}
+
+	const command = `docker service rm ${serviceId}`;
+	if (serverId) {
+		return await execAsyncRemote(serverId, command);
+	}
+	return await execAsync(command);
+};
+
 export const getContainers = async (serverId?: string | null) => {
 	try {
 		const command =


### PR DESCRIPTION
## Summary
- add POST /swarm.removeService for exact Docker Swarm service IDs
- validate full 25-character service IDs before local or remote command dispatch
- enforce remote-server organization access and audit successful removals
- propagate Docker removal failures and cover safe dispatch and validation with unit tests

## Verification
- targeted Vitest: 4 tests passed
- Dokploy app typecheck: passed
- server package typecheck: passed
- focused Biome and git diff check: passed
- generated OpenAPI inspection confirmed POST /swarm.removeService; the generated file is omitted because the current checked-in spec has broad unrelated drift

No production control-plane or Docker service-removal operation was executed.