### PR TITLE
fix: disable refetchOnWindowFocus globally to prevent modal close on tab switch

### DIFF
--- a/apps/dokploy/components/ui/dialog.tsx
+++ b/apps/dokploy/components/ui/dialog.tsx
@@ -51,6 +51,7 @@ function DialogContent({
 	showCloseButton = true,
 	onPointerDownOutside,
 	onEscapeKeyDown,
+	onFocusOutside,
 	...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
 	showCloseButton?: boolean;
@@ -77,6 +78,10 @@ function DialogContent({
 						return;
 					}
 					onEscapeKeyDown?.(event);
+				}}
+				onFocusOutside={(event) => {
+					event.preventDefault();
+					onFocusOutside?.(event);
 				}}
 				{...props}
 			>

--- a/apps/dokploy/components/ui/dialog.tsx
+++ b/apps/dokploy/components/ui/dialog.tsx
@@ -51,7 +51,6 @@ function DialogContent({
 	showCloseButton = true,
 	onPointerDownOutside,
 	onEscapeKeyDown,
-	onFocusOutside,
 	...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
 	showCloseButton?: boolean;
@@ -78,10 +77,6 @@ function DialogContent({
 						return;
 					}
 					onEscapeKeyDown?.(event);
-				}}
-				onFocusOutside={(event) => {
-					event.preventDefault();
-					onFocusOutside?.(event);
 				}}
 				{...props}
 			>

--- a/apps/dokploy/utils/api.ts
+++ b/apps/dokploy/utils/api.ts
@@ -73,7 +73,16 @@ const links =
 
 export const api = createTRPCNext<AppRouter>({
 	config() {
-		return { links };
+		return {
+			links,
+			queryClientConfig: {
+				defaultOptions: {
+					queries: {
+						refetchOnWindowFocus: false,
+					},
+				},
+			},
+		};
 	},
 	ssr: false,
 	transformer: superjson,


### PR DESCRIPTION

## Summary

Disables TanStack Query's `refetchOnWindowFocus` globally to prevent dialog/modal forms from closing and losing data when the browser tab or window regains focus.

Fixes #4851
Fixes #4907

## Root Cause

TanStack Query's `refetchOnWindowFocus` defaults to `true`. When the user switches away from Dokploy and returns:

1. The `focus` event fires on the window
2. TanStack Query refetches **all active queries** (e.g., `project.one`, `environment.one`, `project.all`)
3. On remote servers with network latency, the refetch response returns a new data reference (timestamps/status may differ)
4. React re-renders the component tree
5. Dialog components remount, resetting their `useState(false)` → **modal closes, form data lost**

This is timing/latency dependent — it reproduces reliably on **remote servers** but rarely on localhost (where queries complete instantly and `structuralSharing` returns the same reference).

## Changes

### `apps/dokploy/utils/api.ts`
- Added `queryClientConfig.defaultOptions.queries.refetchOnWindowFocus: false` to the global tRPC config
- This is consistent with **14+ individual queries** in the codebase that already set `refetchOnWindowFocus: false` per-query (e.g., in `use-whitelabeling.ts`, `dashboard-layout.tsx`, `side.tsx`, `handle-destinations.tsx`, etc.)

### `apps/dokploy/components/ui/dialog.tsx`
- Reverted a previously added `onFocusOutside` handler that was redundant — Radix UI's `DialogContentModal` already calls `event.preventDefault()` on `onFocusOutside` internally for modal dialogs ([source](https://github.com/radix-ui/primitives/blob/main/packages/react/dialog/src/dialog.tsx))

## Testing

- Verified that the `refetchOnWindowFocus: false` config is correctly accepted by `createTRPCNext`'s `queryClientConfig` option
- Traced through Radix UI source code (`@radix-ui/react-dialog`, `@radix-ui/react-dismissable-layer`, `@radix-ui/primitive`) to confirm the `onFocusOutside` handler was redundant

