### PR TITLE
fix(security): SSH private key disclosure via server read endpoints

### DIFF
--- a/apps/dokploy/__test__/server/server-sshkey-redaction.test.ts
+++ b/apps/dokploy/__test__/server/server-sshkey-redaction.test.ts
@@ -1,0 +1,43 @@
+import { redactServerSshKey } from "@dokploy/server/services/server";
+import { describe, expect, it } from "vitest";
+
+describe("redactServerSshKey (server SSH private key disclosure guard)", () => {
+	it("blanks the private key while keeping the rest of the ssh key intact", () => {
+		const server = {
+			serverId: "srv-1",
+			name: "prod",
+			sshKey: {
+				sshKeyId: "key-1",
+				publicKey: "ssh-ed25519 AAAA...",
+				privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n",
+			},
+		};
+
+		const redacted = redactServerSshKey(server);
+
+		expect(redacted.sshKey.privateKey).toBe("");
+		// Non-secret fields and the surrounding record must survive untouched.
+		expect(redacted.sshKey.publicKey).toBe("ssh-ed25519 AAAA...");
+		expect(redacted.serverId).toBe("srv-1");
+		expect(redacted.name).toBe("prod");
+	});
+
+	it("does not mutate the original record", () => {
+		const server = {
+			serverId: "srv-1",
+			sshKey: { privateKey: "top-secret" },
+		};
+		redactServerSshKey(server);
+		expect(server.sshKey.privateKey).toBe("top-secret");
+	});
+
+	it("is a no-op when the server has no ssh key", () => {
+		const server = { serverId: "srv-2", sshKey: null };
+		expect(redactServerSshKey(server)).toEqual(server);
+	});
+
+	it("handles a record without an sshKey property at all", () => {
+		const server = { serverId: "srv-3" };
+		expect(redactServerSshKey(server)).toEqual(server);
+	});
+});

--- a/apps/dokploy/__test__/server/server-sshkey-redaction.test.ts
+++ b/apps/dokploy/__test__/server/server-sshkey-redaction.test.ts
@@ -36,8 +36,9 @@ describe("redactServerSshKey (server SSH private key disclosure guard)", () => {
 		expect(redactServerSshKey(server)).toEqual(server);
 	});
 
-	it("handles a record without an sshKey property at all", () => {
-		const server = { serverId: "srv-3" };
+	it("handles a record without a loaded sshKey relation", () => {
+		// e.g. server.update returns the plain row where sshKey is not populated.
+		const server: { serverId: string; sshKey?: null } = { serverId: "srv-3" };
 		expect(redactServerSshKey(server)).toEqual(server);
 	});
 });

--- a/apps/dokploy/server/api/routers/server.ts
+++ b/apps/dokploy/server/api/routers/server.ts
@@ -9,6 +9,7 @@ import {
 	getPublicIpWithFallback,
 	haveActiveServices,
 	IS_CLOUD,
+	redactServerSshKey,
 	removeDeploymentsByServerId,
 	serverAudit,
 	serverSetup,
@@ -105,7 +106,7 @@ export const serverRouter = createTRPCRouter({
 				});
 			}
 
-			return server;
+			return redactServerSshKey(server);
 		}),
 	getDefaultCommand: withPermission("server", "read")
 		.input(apiFindOneServer)
@@ -436,7 +437,7 @@ export const serverRouter = createTRPCRouter({
 					await updateServersBasedOnQuantity(admin.id, admin.serversQuantity);
 				}
 
-				return currentServer;
+				return redactServerSshKey(currentServer);
 			} catch (error) {
 				throw error;
 			}

--- a/packages/server/src/services/server.ts
+++ b/packages/server/src/services/server.ts
@@ -53,6 +53,27 @@ export const findServerById = async (serverId: string) => {
 	return currentServer;
 };
 
+/**
+ * Removes the SSH private key material from a server record before it is sent
+ * to a client. `findServerById` eagerly loads the `sshKey` relation (needed for
+ * server-side SSH operations), but the private key must never leave the server:
+ * no client feature consumes it, and returning it exposed it to any member with
+ * only `server:read`. Server-side callers keep using `findServerById` directly.
+ */
+export const redactServerSshKey = <
+	T extends { sshKey?: { privateKey: string } | null },
+>(
+	serverRecord: T,
+): T => {
+	if (!serverRecord.sshKey) {
+		return serverRecord;
+	}
+	return {
+		...serverRecord,
+		sshKey: { ...serverRecord.sshKey, privateKey: "" },
+	};
+};
+
 export const findServersByUserId = async (userId: string) => {
 	const orgs = await db.query.organization.findMany({
 		where: eq(organization.ownerId, userId),


### PR DESCRIPTION
## Summary
`findServerById` eagerly loads the `sshKey` relation — which includes the **plaintext `privateKey`** — because server-side SSH operations need it. But `server.one` and `server.remove` returned that record straight to the client, so any member with `server:read` could read the server's SSH private key regardless of whether they had `canAccessToSSHKeys`.

## Fix
Adds `redactServerSshKey()` in the server service (blanks `sshKey.privateKey`, immutably) and applies it to the `server.one` and `server.remove` responses.

Safe by construction:
- No client feature consumes the server's nested private key — the SSH key management UI uses the dedicated `sshKey` router, verified by grepping the frontend.
- Server-side callers keep calling `findServerById` directly (unredacted), so SSH connections, setup, and monitoring are unaffected.
- `server.setup` / `server.setupMonitoring` return `void`, and `server.update` returns the plain row without the relation — none of them leak the key, so they're left untouched (confirmed via typecheck).

## Verification
- New unit test (`__test__/server/server-sshkey-redaction.test.ts`, 4 cases): private key blanked, other fields preserved, original not mutated, no-op when there's no key.
- `tsc --noEmit` clean on both `apps/dokploy` and `@dokploy/server` (run cold, no incremental cache).

## Closes
GHSA-w9cp-jqfw-4xj9

Also addresses the SSH-key-leak portion of the `server.remove` response noted in GHSA-3rpx-c3j9-q99x (the cross-org deletion authorization aspect of that report is handled separately).