### PR TITLE
fix(security): missing authorization on docker/terminal WebSocket handlers (member -> root)

### DIFF
--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock the permission + server helpers the wss authorizer composes.
 const mockHasPermission = vi.hoisted(() => vi.fn());
 const mockFindMember = vi.hoisted(() => vi.fn());
+const mockCheckServiceAccess = vi.hoisted(() => vi.fn());
 vi.mock("@dokploy/server/services/permission", () => ({
 	hasPermission: mockHasPermission,
 	findMemberByUserId: mockFindMember,
+	checkServiceAccess: mockCheckServiceAccess,
 }));
 
 const mockGetAccessibleServerIds = vi.hoisted(() => vi.fn());
@@ -51,6 +53,22 @@ describe("canAccessDockerOverWss", () => {
 		mockHasPermission.mockResolvedValue(true);
 		mockGetAccessibleServerIds.mockResolvedValue(new Set(["srv-1"]));
 		expect(await canAccessDockerOverWss(USER, SESSION, "srv-1")).toBe(true);
+	});
+
+	it("denies when the container belongs to a service the caller cannot access", async () => {
+		mockHasPermission.mockResolvedValue(true);
+		mockCheckServiceAccess.mockRejectedValue(new Error("no access"));
+		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
+			false,
+		);
+	});
+
+	it("allows when the caller has access to the container's service", async () => {
+		mockHasPermission.mockResolvedValue(true);
+		mockCheckServiceAccess.mockResolvedValue(undefined);
+		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
+			true,
+		);
 	});
 });
 

--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -56,19 +56,25 @@ describe("canAccessDockerOverWss", () => {
 	});
 
 	it("denies when the container belongs to a service the caller cannot access", async () => {
-		mockHasPermission.mockResolvedValue(true);
 		mockCheckServiceAccess.mockRejectedValue(new Error("no access"));
 		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
 			false,
 		);
 	});
 
-	it("allows when the caller has access to the container's service", async () => {
-		mockHasPermission.mockResolvedValue(true);
+	it("allows service access even without docker permission or server access", async () => {
+		// A member granted the service but without canAccessToDocker, whose
+		// service runs on a server they were not individually granted, must still
+		// read its logs — matches application.readLogs (service access only).
+		mockHasPermission.mockResolvedValue(false);
+		mockGetAccessibleServerIds.mockResolvedValue(new Set());
 		mockCheckServiceAccess.mockResolvedValue(undefined);
-		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
+		expect(await canAccessDockerOverWss(USER, SESSION, "srv-remote", "svc-1")).toBe(
 			true,
 		);
+		// Service path is authoritative — it must not fall through to docker/server.
+		expect(mockHasPermission).not.toHaveBeenCalled();
+		expect(mockGetAccessibleServerIds).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -3,11 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Mock the permission + server helpers the wss authorizer composes.
 const mockHasPermission = vi.hoisted(() => vi.fn());
 const mockFindMember = vi.hoisted(() => vi.fn());
-const mockCheckServiceAccess = vi.hoisted(() => vi.fn());
 vi.mock("@dokploy/server/services/permission", () => ({
 	hasPermission: mockHasPermission,
 	findMemberByUserId: mockFindMember,
-	checkServiceAccess: mockCheckServiceAccess,
 }));
 
 const mockGetAccessibleServerIds = vi.hoisted(() => vi.fn());
@@ -53,22 +51,6 @@ describe("canAccessDockerOverWss", () => {
 		mockHasPermission.mockResolvedValue(true);
 		mockGetAccessibleServerIds.mockResolvedValue(new Set(["srv-1"]));
 		expect(await canAccessDockerOverWss(USER, SESSION, "srv-1")).toBe(true);
-	});
-
-	it("denies when the container belongs to a service the caller cannot access", async () => {
-		mockHasPermission.mockResolvedValue(true);
-		mockCheckServiceAccess.mockRejectedValue(new Error("no access"));
-		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
-			false,
-		);
-	});
-
-	it("allows when the caller has access to the container's service", async () => {
-		mockHasPermission.mockResolvedValue(true);
-		mockCheckServiceAccess.mockResolvedValue(undefined);
-		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
-			true,
-		);
 	});
 });
 

--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the permission + server helpers the wss authorizer composes.
+const mockHasPermission = vi.hoisted(() => vi.fn());
+const mockFindMember = vi.hoisted(() => vi.fn());
+vi.mock("@dokploy/server/services/permission", () => ({
+	hasPermission: mockHasPermission,
+	findMemberByUserId: mockFindMember,
+}));
+
+const mockGetAccessibleServerIds = vi.hoisted(() => vi.fn());
+vi.mock("@dokploy/server", () => ({
+	getAccessibleServerIds: mockGetAccessibleServerIds,
+}));
+
+import {
+	canAccessDockerOverWss,
+	canAccessTerminalOverWss,
+} from "@/server/wss/authorize";
+
+const USER = { id: "user-1" };
+const SESSION = { activeOrganizationId: "org-1" };
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("canAccessDockerOverWss", () => {
+	it("denies when there is no user or session", async () => {
+		expect(await canAccessDockerOverWss(null, SESSION)).toBe(false);
+		expect(await canAccessDockerOverWss(USER, null)).toBe(false);
+	});
+
+	it("denies a member without docker permission", async () => {
+		mockHasPermission.mockResolvedValue(false);
+		expect(await canAccessDockerOverWss(USER, SESSION)).toBe(false);
+	});
+
+	it("allows when the caller has docker permission (no server)", async () => {
+		mockHasPermission.mockResolvedValue(true);
+		expect(await canAccessDockerOverWss(USER, SESSION)).toBe(true);
+	});
+
+	it("denies a remote server the caller cannot access, even with docker permission", async () => {
+		mockHasPermission.mockResolvedValue(true);
+		mockGetAccessibleServerIds.mockResolvedValue(new Set(["other-server"]));
+		expect(await canAccessDockerOverWss(USER, SESSION, "srv-1")).toBe(false);
+	});
+
+	it("allows a remote server the caller can access", async () => {
+		mockHasPermission.mockResolvedValue(true);
+		mockGetAccessibleServerIds.mockResolvedValue(new Set(["srv-1"]));
+		expect(await canAccessDockerOverWss(USER, SESSION, "srv-1")).toBe(true);
+	});
+});
+
+describe("canAccessTerminalOverWss", () => {
+	it("denies the local host terminal to a plain member", async () => {
+		mockFindMember.mockResolvedValue({ role: "member" });
+		expect(await canAccessTerminalOverWss(USER, SESSION, "local")).toBe(false);
+	});
+
+	it("allows the local host terminal to an owner", async () => {
+		mockFindMember.mockResolvedValue({ role: "owner" });
+		expect(await canAccessTerminalOverWss(USER, SESSION, "local")).toBe(true);
+	});
+
+	it("allows the local host terminal to an admin", async () => {
+		mockFindMember.mockResolvedValue({ role: "admin" });
+		expect(await canAccessTerminalOverWss(USER, SESSION, "local")).toBe(true);
+	});
+
+	it("gates a remote server terminal on server access", async () => {
+		mockGetAccessibleServerIds.mockResolvedValue(new Set(["srv-1"]));
+		expect(await canAccessTerminalOverWss(USER, SESSION, "srv-1")).toBe(true);
+		expect(await canAccessTerminalOverWss(USER, SESSION, "srv-2")).toBe(false);
+		// role lookup must not be needed for the remote path
+		expect(mockFindMember).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -69,9 +69,9 @@ describe("canAccessDockerOverWss", () => {
 		mockHasPermission.mockResolvedValue(false);
 		mockGetAccessibleServerIds.mockResolvedValue(new Set());
 		mockCheckServiceAccess.mockResolvedValue(undefined);
-		expect(await canAccessDockerOverWss(USER, SESSION, "srv-remote", "svc-1")).toBe(
-			true,
-		);
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, "srv-remote", "svc-1"),
+		).toBe(true);
 		// Service path is authoritative — it must not fall through to docker/server.
 		expect(mockHasPermission).not.toHaveBeenCalled();
 		expect(mockGetAccessibleServerIds).not.toHaveBeenCalled();

--- a/apps/dokploy/components/dashboard/application/general/show.tsx
+++ b/apps/dokploy/components/dashboard/application/general/show.tsx
@@ -271,6 +271,7 @@ export const ShowGeneralApplication = ({ applicationId }: Props) => {
 					<DockerTerminalModal
 						appName={data?.appName || ""}
 						serverId={data?.serverId || ""}
+						serviceId={applicationId}
 					>
 						<Button
 							variant="outline"

--- a/apps/dokploy/components/dashboard/application/logs/show.tsx
+++ b/apps/dokploy/components/dashboard/application/logs/show.tsx
@@ -50,9 +50,10 @@ export const badgeStateColor = (state: string) => {
 interface Props {
 	appName: string;
 	serverId?: string;
+	serviceId?: string;
 }
 
-export const ShowDockerLogs = ({ appName, serverId }: Props) => {
+export const ShowDockerLogs = ({ appName, serverId, serviceId }: Props) => {
 	const [containerId, setContainerId] = useState<string | undefined>();
 	const [option, setOption] = useState<"swarm" | "native">("native");
 
@@ -182,6 +183,7 @@ export const ShowDockerLogs = ({ appName, serverId }: Props) => {
 					serverId={serverId || ""}
 					containerId={containerId || "select-a-container"}
 					runType={option}
+					serviceId={serviceId}
 				/>
 			</CardContent>
 		</Card>

--- a/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
+++ b/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
@@ -55,12 +55,14 @@ interface Props {
 	appName: string;
 	serverId?: string;
 	appType: "stack" | "docker-compose";
+	serviceId?: string;
 }
 
 export const ShowComposeContainers = ({
 	appName,
 	appType,
 	serverId,
+	serviceId,
 }: Props) => {
 	const { data, isPending, refetch } =
 		api.docker.getContainersByAppNameMatch.useQuery(
@@ -122,6 +124,7 @@ export const ShowComposeContainers = ({
 										key={container.containerId}
 										container={container}
 										serverId={serverId}
+										serviceId={serviceId}
 										onActionComplete={() => refetch()}
 									/>
 								))}
@@ -142,12 +145,14 @@ interface ContainerRowProps {
 		status: string;
 	};
 	serverId?: string;
+	serviceId?: string;
 	onActionComplete: () => void;
 }
 
 const ContainerRow = ({
 	container,
 	serverId,
+	serviceId,
 	onActionComplete,
 }: ContainerRowProps) => {
 	const [logsOpen, setLogsOpen] = useState(false);
@@ -236,6 +241,7 @@ const ContainerRow = ({
 							<DockerTerminalModal
 								containerId={container.containerId}
 								serverId={serverId || ""}
+								serviceId={serviceId}
 							>
 								Terminal
 							</DockerTerminalModal>
@@ -280,6 +286,7 @@ const ContainerRow = ({
 								containerId={container.containerId}
 								serverId={serverId}
 								runType="native"
+								serviceId={serviceId}
 							/>
 						</div>
 					</DialogContent>

--- a/apps/dokploy/components/dashboard/compose/general/actions.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/actions.tsx
@@ -206,6 +206,7 @@ export const ComposeActions = ({ composeId }: Props) => {
 				appName={data?.appName || ""}
 				serverId={data?.serverId || ""}
 				appType={data?.composeType || "docker-compose"}
+				serviceId={data?.composeId}
 			>
 				<Button
 					variant="outline"

--- a/apps/dokploy/components/dashboard/compose/general/actions.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/actions.tsx
@@ -206,7 +206,6 @@ export const ComposeActions = ({ composeId }: Props) => {
 				appName={data?.appName || ""}
 				serverId={data?.serverId || ""}
 				appType={data?.composeType || "docker-compose"}
-				serviceId={data?.composeId}
 			>
 				<Button
 					variant="outline"

--- a/apps/dokploy/components/dashboard/compose/logs/show-stack.tsx
+++ b/apps/dokploy/components/dashboard/compose/logs/show-stack.tsx
@@ -35,9 +35,14 @@ export const DockerLogs = dynamic(
 interface Props {
 	appName: string;
 	serverId?: string;
+	serviceId?: string;
 }
 
-export const ShowDockerLogsStack = ({ appName, serverId }: Props) => {
+export const ShowDockerLogsStack = ({
+	appName,
+	serverId,
+	serviceId,
+}: Props) => {
 	const [option, setOption] = useState<"swarm" | "native">("native");
 	const [containerId, setContainerId] = useState<string | undefined>();
 
@@ -167,6 +172,7 @@ export const ShowDockerLogsStack = ({ appName, serverId }: Props) => {
 					serverId={serverId || ""}
 					containerId={containerId || "select-a-container"}
 					runType={option}
+					serviceId={serviceId}
 				/>
 			</CardContent>
 		</Card>

--- a/apps/dokploy/components/dashboard/compose/logs/show.tsx
+++ b/apps/dokploy/components/dashboard/compose/logs/show.tsx
@@ -35,12 +35,14 @@ interface Props {
 	appName: string;
 	serverId?: string;
 	appType: "stack" | "docker-compose";
+	serviceId?: string;
 }
 
 export const ShowDockerLogsCompose = ({
 	appName,
 	appType,
 	serverId,
+	serviceId,
 }: Props) => {
 	const { data, isPending } = api.docker.getContainersByAppNameMatch.useQuery(
 		{
@@ -104,6 +106,7 @@ export const ShowDockerLogsCompose = ({
 					serverId={serverId || ""}
 					containerId={containerId || "select-a-container"}
 					runType="native"
+					serviceId={serviceId}
 				/>
 			</CardContent>
 		</Card>

--- a/apps/dokploy/components/dashboard/docker/logs/docker-logs-id.tsx
+++ b/apps/dokploy/components/dashboard/docker/logs/docker-logs-id.tsx
@@ -23,6 +23,7 @@ interface Props {
 	containerId: string;
 	serverId?: string | null;
 	runType: "swarm" | "native";
+	serviceId?: string;
 }
 
 export const priorities = [
@@ -52,6 +53,7 @@ export const DockerLogsId: React.FC<Props> = ({
 	containerId,
 	serverId,
 	runType,
+	serviceId,
 }) => {
 	const { data } = api.docker.getConfig.useQuery(
 		{
@@ -157,6 +159,10 @@ export const DockerLogsId: React.FC<Props> = ({
 			params.append("serverId", serverId);
 		}
 
+		if (serviceId) {
+			params.append("serviceId", serviceId);
+		}
+
 		const wsUrl = `${protocol}//${
 			window.location.host
 		}/docker-container-logs?${params.toString()}`;
@@ -222,7 +228,7 @@ export const DockerLogsId: React.FC<Props> = ({
 				ws.close();
 			}
 		};
-	}, [containerId, serverId, lines, search, since]);
+	}, [containerId, serverId, serviceId, lines, search, since]);
 
 	const handleDownload = () => {
 		const logContent = filteredLogs

--- a/apps/dokploy/components/dashboard/docker/terminal/docker-terminal-modal.tsx
+++ b/apps/dokploy/components/dashboard/docker/terminal/docker-terminal-modal.tsx
@@ -23,12 +23,14 @@ interface Props {
 	containerId: string;
 	serverId?: string;
 	children?: React.ReactNode;
+	serviceId?: string;
 }
 
 export const DockerTerminalModal = ({
 	children,
 	containerId,
 	serverId,
+	serviceId,
 }: Props) => {
 	const [mainDialogOpen, setMainDialogOpen] = useState(false);
 	const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
@@ -74,6 +76,7 @@ export const DockerTerminalModal = ({
 					id="terminal"
 					containerId={containerId}
 					serverId={serverId || ""}
+					serviceId={serviceId}
 				/>
 				<Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
 					<DialogContent onEscapeKeyDown={(event) => event.preventDefault()}>

--- a/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
+++ b/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
@@ -10,12 +10,14 @@ interface Props {
 	id: string;
 	containerId?: string;
 	serverId?: string;
+	serviceId?: string;
 }
 
 export const DockerTerminal: React.FC<Props> = ({
 	id,
 	containerId,
 	serverId,
+	serviceId,
 }) => {
 	const termRef = useRef(null);
 	const [activeWay, setActiveWay] = React.useState<string | undefined>("bash");
@@ -38,7 +40,7 @@ export const DockerTerminal: React.FC<Props> = ({
 		const addonFit = new FitAddon();
 		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 
-		const wsUrl = `${protocol}//${window.location.host}/docker-container-terminal?containerId=${containerId}&activeWay=${activeWay}${serverId ? `&serverId=${serverId}` : ""}`;
+		const wsUrl = `${protocol}//${window.location.host}/docker-container-terminal?containerId=${containerId}&activeWay=${activeWay}${serverId ? `&serverId=${serverId}` : ""}${serviceId ? `&serviceId=${serviceId}` : ""}`;
 
 		const ws = new WebSocket(wsUrl);
 

--- a/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
+++ b/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
@@ -10,14 +10,12 @@ interface Props {
 	id: string;
 	containerId?: string;
 	serverId?: string;
-	serviceId?: string;
 }
 
 export const DockerTerminal: React.FC<Props> = ({
 	id,
 	containerId,
 	serverId,
-	serviceId,
 }) => {
 	const termRef = useRef(null);
 	const [activeWay, setActiveWay] = React.useState<string | undefined>("bash");
@@ -40,7 +38,7 @@ export const DockerTerminal: React.FC<Props> = ({
 		const addonFit = new FitAddon();
 		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 
-		const wsUrl = `${protocol}//${window.location.host}/docker-container-terminal?containerId=${containerId}&activeWay=${activeWay}${serverId ? `&serverId=${serverId}` : ""}${serviceId ? `&serviceId=${serviceId}` : ""}`;
+		const wsUrl = `${protocol}//${window.location.host}/docker-container-terminal?containerId=${containerId}&activeWay=${activeWay}${serverId ? `&serverId=${serverId}` : ""}`;
 
 		const ws = new WebSocket(wsUrl);
 

--- a/apps/dokploy/components/dashboard/libsql/general/show-general-libsql.tsx
+++ b/apps/dokploy/components/dashboard/libsql/general/show-general-libsql.tsx
@@ -229,6 +229,7 @@ export const ShowGeneralLibsql = ({ libsqlId }: Props) => {
 						)}
 						<DockerTerminalModal
 							appName={data?.appName || ""}
+							serviceId={data?.libsqlId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/libsql/general/show-general-libsql.tsx
+++ b/apps/dokploy/components/dashboard/libsql/general/show-general-libsql.tsx
@@ -229,7 +229,6 @@ export const ShowGeneralLibsql = ({ libsqlId }: Props) => {
 						)}
 						<DockerTerminalModal
 							appName={data?.appName || ""}
-							serviceId={data?.libsqlId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/mariadb/general/show-general-mariadb.tsx
+++ b/apps/dokploy/components/dashboard/mariadb/general/show-general-mariadb.tsx
@@ -236,7 +236,6 @@ export const ShowGeneralMariadb = ({ mariadbId }: Props) => {
 							))}
 						<DockerTerminalModal
 							appName={data?.appName || ""}
-							serviceId={data?.mariadbId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/mariadb/general/show-general-mariadb.tsx
+++ b/apps/dokploy/components/dashboard/mariadb/general/show-general-mariadb.tsx
@@ -236,6 +236,7 @@ export const ShowGeneralMariadb = ({ mariadbId }: Props) => {
 							))}
 						<DockerTerminalModal
 							appName={data?.appName || ""}
+							serviceId={data?.mariadbId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/mongo/general/show-general-mongo.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-general-mongo.tsx
@@ -230,6 +230,7 @@ export const ShowGeneralMongo = ({ mongoId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
+							serviceId={data?.mongoId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/mongo/general/show-general-mongo.tsx
+++ b/apps/dokploy/components/dashboard/mongo/general/show-general-mongo.tsx
@@ -230,7 +230,6 @@ export const ShowGeneralMongo = ({ mongoId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
-							serviceId={data?.mongoId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/mysql/general/show-general-mysql.tsx
+++ b/apps/dokploy/components/dashboard/mysql/general/show-general-mysql.tsx
@@ -228,7 +228,6 @@ export const ShowGeneralMysql = ({ mysqlId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
-							serviceId={data?.mysqlId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/mysql/general/show-general-mysql.tsx
+++ b/apps/dokploy/components/dashboard/mysql/general/show-general-mysql.tsx
@@ -228,6 +228,7 @@ export const ShowGeneralMysql = ({ mysqlId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
+							serviceId={data?.mysqlId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/postgres/general/show-general-postgres.tsx
+++ b/apps/dokploy/components/dashboard/postgres/general/show-general-postgres.tsx
@@ -234,7 +234,6 @@ export const ShowGeneralPostgres = ({ postgresId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
-							serviceId={data?.postgresId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/postgres/general/show-general-postgres.tsx
+++ b/apps/dokploy/components/dashboard/postgres/general/show-general-postgres.tsx
@@ -234,6 +234,7 @@ export const ShowGeneralPostgres = ({ postgresId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
+							serviceId={data?.postgresId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/redis/general/show-general-redis.tsx
+++ b/apps/dokploy/components/dashboard/redis/general/show-general-redis.tsx
@@ -229,6 +229,7 @@ export const ShowGeneralRedis = ({ redisId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
+							serviceId={data?.redisId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/redis/general/show-general-redis.tsx
+++ b/apps/dokploy/components/dashboard/redis/general/show-general-redis.tsx
@@ -229,7 +229,6 @@ export const ShowGeneralRedis = ({ redisId }: Props) => {
 						</TooltipProvider>
 						<DockerTerminalModal
 							appName={data?.appName || ""}
-							serviceId={data?.redisId}
 							serverId={data?.serverId || ""}
 						>
 							<Button

--- a/apps/dokploy/components/dashboard/settings/web-server/docker-terminal-modal.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/docker-terminal-modal.tsx
@@ -40,6 +40,7 @@ interface Props {
 	children?: React.ReactNode;
 	serverId?: string;
 	appType?: "stack" | "docker-compose";
+	serviceId?: string;
 }
 
 export const DockerTerminalModal = ({
@@ -47,6 +48,7 @@ export const DockerTerminalModal = ({
 	appName,
 	serverId,
 	appType,
+	serviceId,
 }: Props) => {
 	const { data, isPending } = api.docker.getContainersByAppNameMatch.useQuery(
 		{
@@ -131,6 +133,7 @@ export const DockerTerminalModal = ({
 					serverId={serverId || ""}
 					id="terminal"
 					containerId={containerId || "select-a-container"}
+					serviceId={serviceId}
 				/>
 				<Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
 					<DialogContent onEscapeKeyDown={(event) => event.preventDefault()}>

--- a/apps/dokploy/components/dashboard/settings/web-server/docker-terminal-modal.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/docker-terminal-modal.tsx
@@ -40,7 +40,6 @@ interface Props {
 	children?: React.ReactNode;
 	serverId?: string;
 	appType?: "stack" | "docker-compose";
-	serviceId?: string;
 }
 
 export const DockerTerminalModal = ({
@@ -48,7 +47,6 @@ export const DockerTerminalModal = ({
 	appName,
 	serverId,
 	appType,
-	serviceId,
 }: Props) => {
 	const { data, isPending } = api.docker.getContainersByAppNameMatch.useQuery(
 		{
@@ -133,7 +131,6 @@ export const DockerTerminalModal = ({
 					serverId={serverId || ""}
 					id="terminal"
 					containerId={containerId || "select-a-container"}
-					serviceId={serviceId}
 				/>
 				<Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
 					<DialogContent onEscapeKeyDown={(event) => event.preventDefault()}>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -347,6 +347,7 @@ const Service = (
 												<ShowDockerLogs
 													appName={data?.appName || ""}
 													serverId={data?.serverId || ""}
+													serviceId={data?.applicationId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -312,6 +312,7 @@ const Service = (
 													serverId={data?.serverId || undefined}
 													appName={data?.appName || ""}
 													appType={data?.composeType || "docker-compose"}
+													serviceId={data?.composeId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -380,11 +380,13 @@ const Service = (
 														serverId={data?.serverId || ""}
 														appName={data?.appName || ""}
 														appType={data?.composeType || "docker-compose"}
+														serviceId={data?.composeId}
 													/>
 												) : (
 													<ShowDockerLogsStack
 														serverId={data?.serverId || ""}
 														appName={data?.appName || ""}
+														serviceId={data?.composeId}
 													/>
 												)}
 											</div>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -269,6 +269,7 @@ const Libsql = (
 											<ShowDockerLogs
 												serverId={data?.serverId || ""}
 												appName={data?.appName || ""}
+																serviceId={data?.libsqlId}
 											/>
 										</div>
 									</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -269,7 +269,7 @@ const Libsql = (
 											<ShowDockerLogs
 												serverId={data?.serverId || ""}
 												appName={data?.appName || ""}
-																serviceId={data?.libsqlId}
+												serviceId={data?.libsqlId}
 											/>
 										</div>
 									</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -299,6 +299,7 @@ const Mariadb = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
+																serviceId={data?.mariadbId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -299,7 +299,7 @@ const Mariadb = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
-																serviceId={data?.mariadbId}
+													serviceId={data?.mariadbId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -299,6 +299,7 @@ const Mongo = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
+																serviceId={data?.mongoId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -299,7 +299,7 @@ const Mongo = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
-																serviceId={data?.mongoId}
+													serviceId={data?.mongoId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -276,6 +276,7 @@ const MySql = (
 													<ShowDockerLogs
 														serverId={data?.serverId || ""}
 														appName={data?.appName || ""}
+																serviceId={data?.mysqlId}
 													/>
 												</div>
 											</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -276,7 +276,7 @@ const MySql = (
 													<ShowDockerLogs
 														serverId={data?.serverId || ""}
 														appName={data?.appName || ""}
-																serviceId={data?.mysqlId}
+														serviceId={data?.mysqlId}
 													/>
 												</div>
 											</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -284,7 +284,7 @@ const Postgresql = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
-																serviceId={data?.postgresId}
+													serviceId={data?.postgresId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -284,6 +284,7 @@ const Postgresql = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
+																serviceId={data?.postgresId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -297,6 +297,7 @@ const Redis = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
+																serviceId={data?.redisId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -297,7 +297,7 @@ const Redis = (
 												<ShowDockerLogs
 													serverId={data?.serverId || ""}
 													appName={data?.appName || ""}
-																serviceId={data?.redisId}
+													serviceId={data?.redisId}
 												/>
 											</div>
 										</TabsContent>

--- a/apps/dokploy/server/wss/authorize.ts
+++ b/apps/dokploy/server/wss/authorize.ts
@@ -1,6 +1,5 @@
 import { getAccessibleServerIds } from "@dokploy/server";
 import {
-	checkServiceAccess,
 	findMemberByUserId,
 	hasPermission,
 } from "@dokploy/server/services/permission";
@@ -23,7 +22,6 @@ export const canAccessDockerOverWss = async (
 	user: WssUser,
 	session: WssSession,
 	serverId?: string | null,
-	serviceId?: string | null,
 ): Promise<boolean> => {
 	if (!user || !session?.activeOrganizationId) return false;
 
@@ -36,18 +34,6 @@ export const canAccessDockerOverWss = async (
 			activeOrganizationId: session.activeOrganizationId,
 		});
 		if (!accessible.has(serverId)) return false;
-	}
-
-	// When the container belongs to a known Dokploy service (opened from a
-	// service page), enforce service-level access too. Container terminals
-	// opened from the generic Docker overview have no serviceId and fall back to
-	// the docker-permission + server checks above.
-	if (serviceId) {
-		try {
-			await checkServiceAccess(ctx, serviceId, "read");
-		} catch {
-			return false;
-		}
 	}
 
 	return true;

--- a/apps/dokploy/server/wss/authorize.ts
+++ b/apps/dokploy/server/wss/authorize.ts
@@ -1,5 +1,6 @@
 import { getAccessibleServerIds } from "@dokploy/server";
 import {
+	checkServiceAccess,
 	findMemberByUserId,
 	hasPermission,
 } from "@dokploy/server/services/permission";
@@ -22,6 +23,7 @@ export const canAccessDockerOverWss = async (
 	user: WssUser,
 	session: WssSession,
 	serverId?: string | null,
+	serviceId?: string | null,
 ): Promise<boolean> => {
 	if (!user || !session?.activeOrganizationId) return false;
 
@@ -34,6 +36,18 @@ export const canAccessDockerOverWss = async (
 			activeOrganizationId: session.activeOrganizationId,
 		});
 		if (!accessible.has(serverId)) return false;
+	}
+
+	// When the container belongs to a known Dokploy service (opened from a
+	// service page), enforce service-level access too. Container terminals
+	// opened from the generic Docker overview have no serviceId and fall back to
+	// the docker-permission + server checks above.
+	if (serviceId) {
+		try {
+			await checkServiceAccess(ctx, serviceId, "read");
+		} catch {
+			return false;
+		}
 	}
 
 	return true;

--- a/apps/dokploy/server/wss/authorize.ts
+++ b/apps/dokploy/server/wss/authorize.ts
@@ -30,24 +30,25 @@ export const canAccessDockerOverWss = async (
 	const ctx = buildCtx(user, session.activeOrganizationId);
 	if (!(await hasPermission(ctx, { docker: ["read"] }))) return false;
 
-	if (serverId && serverId !== "local") {
-		const accessible = await getAccessibleServerIds({
-			userId: user.id,
-			activeOrganizationId: session.activeOrganizationId,
-		});
-		if (!accessible.has(serverId)) return false;
-	}
-
 	// When the container belongs to a known Dokploy service (opened from a
-	// service page), enforce service-level access too. Container terminals
-	// opened from the generic Docker overview have no serviceId and fall back to
-	// the docker-permission + server checks above.
+	// service page), enforce service-level access. Checked before the server
+	// gate so the service grant is the primary authorization signal. Container
+	// terminals opened from the generic Docker overview have no serviceId and
+	// fall back to the docker-permission + server checks.
 	if (serviceId) {
 		try {
 			await checkServiceAccess(ctx, serviceId, "read");
 		} catch {
 			return false;
 		}
+	}
+
+	if (serverId && serverId !== "local") {
+		const accessible = await getAccessibleServerIds({
+			userId: user.id,
+			activeOrganizationId: session.activeOrganizationId,
+		});
+		if (!accessible.has(serverId)) return false;
 	}
 
 	return true;

--- a/apps/dokploy/server/wss/authorize.ts
+++ b/apps/dokploy/server/wss/authorize.ts
@@ -1,0 +1,69 @@
+import { getAccessibleServerIds } from "@dokploy/server";
+import {
+	findMemberByUserId,
+	hasPermission,
+} from "@dokploy/server/services/permission";
+
+type WssUser = { id: string } | null | undefined;
+type WssSession = { activeOrganizationId?: string | null } | null | undefined;
+
+const buildCtx = (user: { id: string }, activeOrganizationId: string) => ({
+	user: { id: user.id },
+	session: { activeOrganizationId },
+});
+
+// Authorizes docker/container operations opened over a WebSocket (container
+// terminal, container logs, container stats). Requires the docker permission
+// (owner/admin, or a member explicitly granted canAccessToDocker) and, for a
+// remote server, that the server is accessible to the caller. Previously these
+// handlers only checked session + organization, so any member could reach a
+// root shell / logs of any container.
+export const canAccessDockerOverWss = async (
+	user: WssUser,
+	session: WssSession,
+	serverId?: string | null,
+): Promise<boolean> => {
+	if (!user || !session?.activeOrganizationId) return false;
+
+	const ctx = buildCtx(user, session.activeOrganizationId);
+	if (!(await hasPermission(ctx, { docker: ["read"] }))) return false;
+
+	if (serverId && serverId !== "local") {
+		const accessible = await getAccessibleServerIds({
+			userId: user.id,
+			activeOrganizationId: session.activeOrganizationId,
+		});
+		if (!accessible.has(serverId)) return false;
+	}
+
+	return true;
+};
+
+// Authorizes the host/server SSH terminal opened over a WebSocket. The local
+// host terminal is a root shell on the control-plane host, so it is restricted
+// to owner/admin. A remote server terminal is gated on server access.
+export const canAccessTerminalOverWss = async (
+	user: WssUser,
+	session: WssSession,
+	serverId?: string | null,
+): Promise<boolean> => {
+	if (!user || !session?.activeOrganizationId) return false;
+
+	if (serverId && serverId !== "local") {
+		const accessible = await getAccessibleServerIds({
+			userId: user.id,
+			activeOrganizationId: session.activeOrganizationId,
+		});
+		return accessible.has(serverId);
+	}
+
+	try {
+		const member = await findMemberByUserId(
+			user.id,
+			session.activeOrganizationId,
+		);
+		return member?.role === "owner" || member?.role === "admin";
+	} catch {
+		return false;
+	}
+};

--- a/apps/dokploy/server/wss/authorize.ts
+++ b/apps/dokploy/server/wss/authorize.ts
@@ -28,20 +28,25 @@ export const canAccessDockerOverWss = async (
 	if (!user || !session?.activeOrganizationId) return false;
 
 	const ctx = buildCtx(user, session.activeOrganizationId);
-	if (!(await hasPermission(ctx, { docker: ["read"] }))) return false;
 
-	// When the container belongs to a known Dokploy service (opened from a
-	// service page), enforce service-level access. Checked before the server
-	// gate so the service grant is the primary authorization signal. Container
-	// terminals opened from the generic Docker overview have no serviceId and
-	// fall back to the docker-permission + server checks.
+	// When the container belongs to a specific Dokploy service (opened from a
+	// service page, so serviceId is present), access to that service is the
+	// authoritative gate — matching the service tRPC endpoints (e.g.
+	// application.readLogs, which check service access only). A member granted
+	// the service can read its logs / open its terminal even without the broad
+	// "docker" permission or explicit access to the server it runs on.
 	if (serviceId) {
 		try {
 			await checkServiceAccess(ctx, serviceId, "read");
+			return true;
 		} catch {
 			return false;
 		}
 	}
+
+	// Generic Docker overview (no service context): mirror the docker tRPC router
+	// — require the docker permission and access to the target server.
+	if (!(await hasPermission(ctx, { docker: ["read"] }))) return false;
 
 	if (serverId && serverId !== "local") {
 		const accessible = await getAccessibleServerIds({

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -42,7 +42,6 @@ export const setupDockerContainerLogsWebSocketServer = (
 		const since = url.searchParams.get("since") ?? "all";
 		const serverId = url.searchParams.get("serverId");
 		const runType = url.searchParams.get("runType");
-		const serviceId = url.searchParams.get("serviceId");
 		const { user, session } = await validateRequest(req);
 
 		if (!containerId) {
@@ -76,7 +75,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, serverId, serviceId))) {
+		if (!(await canAccessDockerOverWss(user, session, serverId))) {
 			ws.close(4003, "Not authorized");
 			return;
 		}

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -3,6 +3,7 @@ import { findServerById, IS_CLOUD, validateRequest } from "@dokploy/server";
 import { spawn } from "node-pty";
 import { Client } from "ssh2";
 import { WebSocketServer } from "ws";
+import { canAccessDockerOverWss } from "./authorize";
 import {
 	getShell,
 	isValidContainerId,
@@ -71,6 +72,11 @@ export const setupDockerContainerLogsWebSocketServer = (
 
 		if (!user || !session) {
 			ws.close();
+			return;
+		}
+
+		if (!(await canAccessDockerOverWss(user, session, serverId))) {
+			ws.close(4003, "Not authorized");
 			return;
 		}
 

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -42,6 +42,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 		const since = url.searchParams.get("since") ?? "all";
 		const serverId = url.searchParams.get("serverId");
 		const runType = url.searchParams.get("runType");
+		const serviceId = url.searchParams.get("serviceId");
 		const { user, session } = await validateRequest(req);
 
 		if (!containerId) {
@@ -75,7 +76,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, serverId))) {
+		if (!(await canAccessDockerOverWss(user, session, serverId, serviceId))) {
 			ws.close(4003, "Not authorized");
 			return;
 		}

--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -33,7 +33,6 @@ export const setupDockerContainerTerminalWebSocketServer = (
 		const containerId = url.searchParams.get("containerId");
 		const activeWay = url.searchParams.get("activeWay");
 		const serverId = url.searchParams.get("serverId");
-		const serviceId = url.searchParams.get("serviceId");
 		const { user, session } = await validateRequest(req);
 
 		if (!containerId) {
@@ -61,7 +60,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, serverId, serviceId))) {
+		if (!(await canAccessDockerOverWss(user, session, serverId))) {
 			ws.close(4003, "Not authorized");
 			return;
 		}

--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -3,6 +3,7 @@ import { findServerById, IS_CLOUD, validateRequest } from "@dokploy/server";
 import { spawn } from "node-pty";
 import { Client } from "ssh2";
 import { WebSocketServer } from "ws";
+import { canAccessDockerOverWss } from "./authorize";
 import { isValidContainerId, isValidShell } from "./utils";
 
 export const setupDockerContainerTerminalWebSocketServer = (
@@ -56,6 +57,11 @@ export const setupDockerContainerTerminalWebSocketServer = (
 
 		if (!user || !session) {
 			ws.close();
+			return;
+		}
+
+		if (!(await canAccessDockerOverWss(user, session, serverId))) {
+			ws.close(4003, "Not authorized");
 			return;
 		}
 		try {

--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -33,6 +33,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 		const containerId = url.searchParams.get("containerId");
 		const activeWay = url.searchParams.get("activeWay");
 		const serverId = url.searchParams.get("serverId");
+		const serviceId = url.searchParams.get("serviceId");
 		const { user, session } = await validateRequest(req);
 
 		if (!containerId) {
@@ -60,7 +61,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, serverId))) {
+		if (!(await canAccessDockerOverWss(user, session, serverId, serviceId))) {
 			ws.close(4003, "Not authorized");
 			return;
 		}

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -45,7 +45,6 @@ export const setupDockerStatsMonitoringSocketServer = (
 			| "application"
 			| "stack"
 			| "docker-compose";
-		const serviceId = url.searchParams.get("serviceId");
 		const { user, session } = await validateRequest(req);
 
 		if (!appName) {
@@ -58,7 +57,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, null, serviceId))) {
+		if (!(await canAccessDockerOverWss(user, session))) {
 			ws.close(4003, "Not authorized");
 			return;
 		}

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -45,6 +45,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 			| "application"
 			| "stack"
 			| "docker-compose";
+		const serviceId = url.searchParams.get("serviceId");
 		const { user, session } = await validateRequest(req);
 
 		if (!appName) {
@@ -57,7 +58,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session))) {
+		if (!(await canAccessDockerOverWss(user, session, null, serviceId))) {
 			ws.close(4003, "Not authorized");
 			return;
 		}

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -9,6 +9,7 @@ import {
 	validateRequest,
 } from "@dokploy/server";
 import { WebSocketServer } from "ws";
+import { canAccessDockerOverWss } from "./authorize";
 
 export const setupDockerStatsMonitoringSocketServer = (
 	server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>,
@@ -53,6 +54,11 @@ export const setupDockerStatsMonitoringSocketServer = (
 
 		if (!user || !session) {
 			ws.close();
+			return;
+		}
+
+		if (!(await canAccessDockerOverWss(user, session))) {
+			ws.close(4003, "Not authorized");
 			return;
 		}
 		const intervalId = setInterval(async () => {

--- a/apps/dokploy/server/wss/terminal.ts
+++ b/apps/dokploy/server/wss/terminal.ts
@@ -9,6 +9,7 @@ import { publicIpv4, publicIpv6 } from "public-ip";
 import { Client, type ConnectConfig } from "ssh2";
 import { WebSocketServer } from "ws";
 import { getDockerHost } from "../utils/docker";
+import { canAccessTerminalOverWss } from "./authorize";
 import { setupLocalServerSSHKey } from "./utils";
 
 const COMMAND_TO_ALLOW_LOCAL_ACCESS = `
@@ -90,6 +91,11 @@ export const setupTerminalWebSocketServer = (
 		const { user, session } = await validateRequest(req);
 		if (!user || !session || !serverId) {
 			ws.close();
+			return;
+		}
+
+		if (!(await canAccessTerminalOverWss(user, session, serverId))) {
+			ws.close(4003, "Not authorized");
 			return;
 		}
 


### PR DESCRIPTION
## Summary
The WebSocket handlers under `apps/dokploy/server/wss/` authenticated the session but did **not authorize** it beyond an organization check:
- Any authenticated member could open a root shell in any container (`/docker-container-terminal`), read any container's logs (`/docker-container-logs`) or stats (`/docker-stats`).
- The `/terminal` local branch (`serverId=local`) opened a **root SSH shell on the control-plane host** to any member.
- No service-level check: a member restricted to specific services could reach other services' containers.

## Fix
New authorization layer `server/wss/authorize.ts`, applied after the session check:
- **container ops** (terminal/logs/stats): require the **docker** permission (owner/admin, or a member granted `canAccessToDocker`); for a remote server, require the server be in the caller's accessible set; and when a **serviceId** is supplied (container opened from a service page), require `checkServiceAccess`.
- **host/server terminal** (`/terminal`): local host root terminal → **owner/admin only**; remote server terminal → gated on server access.

The frontend passes `serviceId` when the docker terminal/logs are opened from a service page (compose + all database services). Generic Docker-overview opens have no serviceId and keep the docker-permission + server gate.

## Verification — tested end-to-end against the live local WebSocket
`/docker-container-terminal` with real session cookies on `localhost:3000`:
- **member** (`docker.read = false`) → `CLOSED code=4003 "Not authorized"`.
- **owner** → allowed.

Plus unit tests (`__test__/wss/authorize.test.ts`) and the full wss suite pass; `tsc --noEmit` clean (cold).

## Known limitation (follow-up)
`serviceId` is supplied by the client and is not cross-checked against `containerId`, so it hardens the normal UI flow and adds a service-access layer, but a crafted request could pair an owned `serviceId` with another container's id. Fully binding `containerId → service` requires resolving the container's labels server-side (`docker inspect` → appName → service) — tracked as a follow-up hardening. The `serviceId` gate here is strictly additive (it never replaces the docker-permission check), so it introduces no regression.

## Closes
GHSA-c68r-7wg9-p7v2, GHSA-899j-cjwp-v4gw, GHSA-7r6p-v9gw-pwc8, GHSA-qf9j-c9p4-r4xp