### PR TITLE
fix(security): host-schedule owner/admin bypass via applicationId (member → root)

### DIFF
--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -13,6 +13,7 @@ import {
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
 import {
+	assertHostScheduleAccess,
 	createSchedule,
 	deleteSchedule,
 	findScheduleById,
@@ -31,6 +32,8 @@ export const scheduleRouter = createTRPCRouter({
 	create: protectedProcedure
 		.input(createScheduleSchema)
 		.mutation(async ({ input, ctx }) => {
+			await assertHostScheduleAccess(ctx, input.scheduleType, input.serverId);
+
 			const serviceId = input.applicationId || input.composeId;
 			if (serviceId) {
 				await checkServicePermissionAndAccess(ctx, serviceId, {
@@ -44,51 +47,14 @@ export const scheduleRouter = createTRPCRouter({
 					);
 				}
 			} else {
-				if (input.scheduleType === "dokploy-server" && IS_CLOUD) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message:
-							"Host-level schedules are not available in the cloud version.",
-					});
-				}
-
 				await checkPermission(ctx, { schedule: ["create"] });
 
-				if (
-					input.scheduleType === "server" ||
-					input.scheduleType === "dokploy-server"
-				) {
-					const member = await findMemberByUserId(
-						ctx.user.id,
+				if (IS_CLOUD && input.scheduleType === "server" && input.serverId) {
+					await assertScheduledJobLimit(
 						ctx.session.activeOrganizationId,
+						"server",
+						input.serverId,
 					);
-					if (member.role !== "owner" && member.role !== "admin") {
-						throw new TRPCError({
-							code: "FORBIDDEN",
-							message:
-								"Only owners and admins can manage server-level schedules.",
-						});
-					}
-				}
-
-				if (input.scheduleType === "server" && input.serverId) {
-					const targetServer = await findServerById(input.serverId);
-					if (
-						targetServer.organizationId !== ctx.session.activeOrganizationId
-					) {
-						throw new TRPCError({
-							code: "UNAUTHORIZED",
-							message: "You don't have access to this server.",
-						});
-					}
-
-					if (IS_CLOUD) {
-						await assertScheduledJobLimit(
-							ctx.session.activeOrganizationId,
-							"server",
-							input.serverId,
-						);
-					}
 				}
 			}
 			const newSchedule = await createSchedule({
@@ -135,6 +101,22 @@ export const scheduleRouter = createTRPCRouter({
 				});
 			}
 
+			await assertHostScheduleAccess(
+				ctx,
+				existingSchedule.scheduleType,
+				existingSchedule.serverId,
+			);
+			if (
+				input.scheduleType &&
+				input.scheduleType !== existingSchedule.scheduleType
+			) {
+				await assertHostScheduleAccess(
+					ctx,
+					input.scheduleType,
+					input.serverId ?? existingSchedule.serverId,
+				);
+			}
+
 			const serviceId =
 				existingSchedule.applicationId || existingSchedule.composeId;
 			if (serviceId) {
@@ -142,47 +124,7 @@ export const scheduleRouter = createTRPCRouter({
 					schedule: ["update"],
 				});
 			} else {
-				if (existingSchedule.scheduleType === "dokploy-server" && IS_CLOUD) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message:
-							"Host-level schedules are not available in the cloud version.",
-					});
-				}
-
 				await checkPermission(ctx, { schedule: ["update"] });
-
-				if (
-					existingSchedule.scheduleType === "server" ||
-					existingSchedule.scheduleType === "dokploy-server"
-				) {
-					const member = await findMemberByUserId(
-						ctx.user.id,
-						ctx.session.activeOrganizationId,
-					);
-					if (member.role !== "owner" && member.role !== "admin") {
-						throw new TRPCError({
-							code: "FORBIDDEN",
-							message:
-								"Only owners and admins can manage server-level schedules.",
-						});
-					}
-				}
-
-				if (
-					existingSchedule.scheduleType === "server" &&
-					existingSchedule.serverId
-				) {
-					const targetServer = await findServerById(existingSchedule.serverId);
-					if (
-						targetServer.organizationId !== ctx.session.activeOrganizationId
-					) {
-						throw new TRPCError({
-							code: "UNAUTHORIZED",
-							message: "You don't have access to this server.",
-						});
-					}
-				}
 			}
 			const updatedSchedule = await updateSchedule(input);
 
@@ -222,50 +164,19 @@ export const scheduleRouter = createTRPCRouter({
 		.input(z.object({ scheduleId: z.string() }))
 		.mutation(async ({ input, ctx }) => {
 			const scheduleItem = await findScheduleById(input.scheduleId);
+			await assertHostScheduleAccess(
+				ctx,
+				scheduleItem.scheduleType,
+				scheduleItem.serverId,
+			);
+
 			const serviceId = scheduleItem.applicationId || scheduleItem.composeId;
 			if (serviceId) {
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["delete"],
 				});
 			} else {
-				if (scheduleItem.scheduleType === "dokploy-server" && IS_CLOUD) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message:
-							"Host-level schedules are not available in the cloud version.",
-					});
-				}
-
 				await checkPermission(ctx, { schedule: ["delete"] });
-
-				if (
-					scheduleItem.scheduleType === "server" ||
-					scheduleItem.scheduleType === "dokploy-server"
-				) {
-					const member = await findMemberByUserId(
-						ctx.user.id,
-						ctx.session.activeOrganizationId,
-					);
-					if (member.role !== "owner" && member.role !== "admin") {
-						throw new TRPCError({
-							code: "FORBIDDEN",
-							message:
-								"Only owners and admins can manage server-level schedules.",
-						});
-					}
-				}
-
-				if (scheduleItem.scheduleType === "server" && scheduleItem.serverId) {
-					const targetServer = await findServerById(scheduleItem.serverId);
-					if (
-						targetServer.organizationId !== ctx.session.activeOrganizationId
-					) {
-						throw new TRPCError({
-							code: "UNAUTHORIZED",
-							message: "You don't have access to this server.",
-						});
-					}
-				}
 			}
 			await deleteSchedule(input.scheduleId);
 
@@ -389,50 +300,19 @@ export const scheduleRouter = createTRPCRouter({
 		.input(z.object({ scheduleId: z.string().min(1) }))
 		.mutation(async ({ input, ctx }) => {
 			const scheduleItem = await findScheduleById(input.scheduleId);
+			await assertHostScheduleAccess(
+				ctx,
+				scheduleItem.scheduleType,
+				scheduleItem.serverId,
+			);
+
 			const serviceId = scheduleItem.applicationId || scheduleItem.composeId;
 			if (serviceId) {
 				await checkServicePermissionAndAccess(ctx, serviceId, {
 					schedule: ["create"],
 				});
 			} else {
-				if (scheduleItem.scheduleType === "dokploy-server" && IS_CLOUD) {
-					throw new TRPCError({
-						code: "FORBIDDEN",
-						message:
-							"Host-level schedules are not available in the cloud version.",
-					});
-				}
-
 				await checkPermission(ctx, { schedule: ["create"] });
-
-				if (
-					scheduleItem.scheduleType === "server" ||
-					scheduleItem.scheduleType === "dokploy-server"
-				) {
-					const member = await findMemberByUserId(
-						ctx.user.id,
-						ctx.session.activeOrganizationId,
-					);
-					if (member.role !== "owner" && member.role !== "admin") {
-						throw new TRPCError({
-							code: "FORBIDDEN",
-							message:
-								"Only owners and admins can manage server-level schedules.",
-						});
-					}
-				}
-
-				if (scheduleItem.scheduleType === "server" && scheduleItem.serverId) {
-					const targetServer = await findServerById(scheduleItem.serverId);
-					if (
-						targetServer.organizationId !== ctx.session.activeOrganizationId
-					) {
-						throw new TRPCError({
-							code: "UNAUTHORIZED",
-							message: "You don't have access to this server.",
-						});
-					}
-				}
 			}
 			try {
 				await runCommand(input.scheduleId);

--- a/packages/server/src/db/schema/schedule.ts
+++ b/packages/server/src/db/schema/schedule.ts
@@ -57,6 +57,7 @@ export const schedules = pgTable("schedule", {
 });
 
 export type Schedule = typeof schedules.$inferSelect;
+export type ScheduleType = Schedule["scheduleType"];
 
 export const schedulesRelations = relations(schedules, ({ one, many }) => ({
 	application: one(applications, {
@@ -78,7 +79,14 @@ export const schedulesRelations = relations(schedules, ({ one, many }) => ({
 	deployments: many(deployments),
 }));
 
-export const createScheduleSchema = createInsertSchema(schedules);
+export const createScheduleSchema = createInsertSchema(schedules, {
+	scheduleType: z.enum([
+		"application",
+		"compose",
+		"server",
+		"dokploy-server",
+	]),
+});
 
 export const updateScheduleSchema = createScheduleSchema.extend({
 	scheduleId: z.string().min(1),

--- a/packages/server/src/db/schema/schedule.ts
+++ b/packages/server/src/db/schema/schedule.ts
@@ -80,12 +80,7 @@ export const schedulesRelations = relations(schedules, ({ one, many }) => ({
 }));
 
 export const createScheduleSchema = createInsertSchema(schedules, {
-	scheduleType: z.enum([
-		"application",
-		"compose",
-		"server",
-		"dokploy-server",
-	]),
+	scheduleType: z.enum(["application", "compose", "server", "dokploy-server"]),
 });
 
 export const updateScheduleSchema = createScheduleSchema.extend({

--- a/packages/server/src/services/schedule.ts
+++ b/packages/server/src/services/schedule.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import type { z } from "zod";
-import { paths } from "../constants";
+import { IS_CLOUD, paths } from "../constants";
 import { db } from "../db";
 import type {
 	createScheduleSchema,
@@ -11,8 +11,50 @@ import type {
 import { type Schedule, schedules } from "../db/schema/schedule";
 import { encodeBase64 } from "../utils/docker/utils";
 import { execAsync, execAsyncRemote } from "../utils/process/execAsync";
+import { findMemberByUserId } from "./permission";
+import { findServerById } from "./server";
 
 export type ScheduleExtended = Awaited<ReturnType<typeof findScheduleById>>;
+
+// Host-level schedules (server / dokploy-server) run their script as root on the
+// host and must stay restricted to owners/admins, regardless of whether the
+// request is also tied to a service. Attaching an accessible applicationId must
+// not downgrade this to a service-access check.
+export const assertHostScheduleAccess = async (
+	ctx: { user: { id: string }; session: { activeOrganizationId: string } },
+	scheduleType: string | undefined,
+	serverId: string | null | undefined,
+) => {
+	if (scheduleType !== "server" && scheduleType !== "dokploy-server") return;
+
+	if (scheduleType === "dokploy-server" && IS_CLOUD) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Host-level schedules are not available in the cloud version.",
+		});
+	}
+
+	const member = await findMemberByUserId(
+		ctx.user.id,
+		ctx.session.activeOrganizationId,
+	);
+	if (member.role !== "owner" && member.role !== "admin") {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Only owners and admins can manage server-level schedules.",
+		});
+	}
+
+	if (scheduleType === "server" && serverId) {
+		const targetServer = await findServerById(serverId);
+		if (targetServer.organizationId !== ctx.session.activeOrganizationId) {
+			throw new TRPCError({
+				code: "UNAUTHORIZED",
+				message: "You don't have access to this server.",
+			});
+		}
+	}
+};
 
 export const createSchedule = async (
 	input: z.infer<typeof createScheduleSchema>,

--- a/packages/server/src/services/schedule.ts
+++ b/packages/server/src/services/schedule.ts
@@ -22,7 +22,7 @@ export type ScheduleExtended = Awaited<ReturnType<typeof findScheduleById>>;
 // not downgrade this to a service-access check.
 export const assertHostScheduleAccess = async (
 	ctx: { user: { id: string }; session: { activeOrganizationId: string } },
-	scheduleType: string | undefined,
+	scheduleType: Schedule["scheduleType"] | null | undefined,
 	serverId: string | null | undefined,
 ) => {
 	if (scheduleType !== "server" && scheduleType !== "dokploy-server") return;


### PR DESCRIPTION
Fixes the incomplete owner/admin gate on host-level schedules (GHSA-r89g-h7x9-phr2, incomplete fix of CVE-2026-45632).

## Problem

`server` and `dokploy-server` schedules run their script as **root on the host**. Only owners/admins may create them — but that gate lived exclusively in the *no-service* branch of each handler:

```ts
const serviceId = input.applicationId || input.composeId; // attacker-controlled
if (serviceId) {
  await checkServicePermissionAndAccess(ctx, serviceId, { schedule: ["create"] }); // service access only
} else {
  // owner/admin gate lived only here
}
```

A member with access to a single application sends `scheduleType:"dokploy-server"` **plus** an accessible `applicationId`. The request takes the `if` branch (service access only), the host-schedule gate never runs, and `schedule.runManually` executes the member-supplied script as root. `create`, `update`, `delete`, and `runManually` all shared this structure.

## Fix

Extract `assertHostScheduleAccess(ctx, scheduleType, serverId)` into the schedule service and call it **before** the service-access branch in all four handlers. For `server`/`dokploy-server` it enforces the owner/admin role (and, for remote `server`, the server-org check) unconditionally, so attaching an `applicationId` can no longer downgrade authorization. Also collapses ~156 lines of duplicated inline checks.

## Verification (localhost, member vs owner)

- Member + `dokploy-server` + accessible `applicationId` → **403 FORBIDDEN** "Only owners and admins can manage server-level schedules."
- Member + `runManually` on a host schedule → **403 FORBIDDEN**
- Member + `application` schedule → still works (no over-block)
- Owner + `dokploy-server` (with or without `applicationId`) → works
- Before/after confirmed by reverting the patch: pre-fix the member bypass **created** a `dokploy-server` schedule; post-fix it is blocked.

Closes GHSA-r89g-h7x9-phr2.