### PR TITLE
fix(security): missing authorization on GitHub App setup callback (unauth cross-org write)

### DIFF
--- a/apps/dokploy/pages/api/providers/github/setup.ts
+++ b/apps/dokploy/pages/api/providers/github/setup.ts
@@ -23,9 +23,6 @@ export default async function handler(
 		return res.status(400).json({ error: "Missing code parameter" });
 	}
 
-	// This callback performs privileged writes (persisting App secrets, re-pointing
-	// installations) but sits outside tRPC, so it must authenticate and authorize
-	// on its own. The write target is derived from the session, never from `state`.
 	const { user, session } = await validateRequest(req);
 	if (!user || !session?.activeOrganizationId) {
 		return res.status(401).json({ error: "Unauthorized" });
@@ -36,8 +33,6 @@ export default async function handler(
 	};
 
 	const [action] = state?.split(":") ?? [];
-	// gh_init creates a provider, gh_setup re-points an existing one; both require
-	// the gitProviders permission (the same guard the tRPC github router uses).
 	if (!(await hasPermission(ctx, { gitProviders: ["create"] }))) {
 		return res.status(403).json({ error: "Forbidden" });
 	}

--- a/apps/dokploy/pages/api/providers/github/setup.ts
+++ b/apps/dokploy/pages/api/providers/github/setup.ts
@@ -1,5 +1,6 @@
-import { createGithub } from "@dokploy/server";
+import { createGithub, validateRequest } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import { hasPermission } from "@dokploy/server/services/permission";
 import { eq } from "drizzle-orm";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Octokit } from "octokit";
@@ -21,18 +22,27 @@ export default async function handler(
 	if (!code) {
 		return res.status(400).json({ error: "Missing code parameter" });
 	}
-	const [action, ...rest] = state?.split(":");
-	// For gh_init: rest[0] = organizationId, rest[1] = userId
-	// For gh_setup: rest[0] = githubProviderId
+
+	// This callback performs privileged writes (persisting App secrets, re-pointing
+	// installations) but sits outside tRPC, so it must authenticate and authorize
+	// on its own. The write target is derived from the session, never from `state`.
+	const { user, session } = await validateRequest(req);
+	if (!user || !session?.activeOrganizationId) {
+		return res.status(401).json({ error: "Unauthorized" });
+	}
+	const ctx = {
+		user: { id: user.id },
+		session: { activeOrganizationId: session.activeOrganizationId },
+	};
+
+	const [action] = state?.split(":") ?? [];
+	// gh_init creates a provider, gh_setup re-points an existing one; both require
+	// the gitProviders permission (the same guard the tRPC github router uses).
+	if (!(await hasPermission(ctx, { gitProviders: ["create"] }))) {
+		return res.status(403).json({ error: "Forbidden" });
+	}
 
 	if (action === "gh_init") {
-		const organizationId = rest[0];
-		const userId = rest[1] || (req.query.userId as string);
-
-		if (!userId) {
-			return res.status(400).json({ error: "Missing userId parameter" });
-		}
-
 		const octokit = new Octokit({});
 		const { data } = await octokit.request(
 			"POST /app-manifests/{code}/conversions",
@@ -51,16 +61,32 @@ export default async function handler(
 				githubWebhookSecret: data.webhook_secret,
 				githubPrivateKey: data.pem,
 			},
-			organizationId as string,
-			userId,
+			session.activeOrganizationId,
+			user.id,
 		);
 	} else if (action === "gh_setup") {
+		const githubId = state?.split(":")[1];
+		if (!githubId) {
+			return res.status(400).json({ error: "Missing github provider id" });
+		}
+
+		const provider = await db.query.github.findFirst({
+			where: eq(github.githubId, githubId),
+			with: { gitProvider: true },
+		});
+		if (
+			!provider ||
+			provider.gitProvider.organizationId !== session.activeOrganizationId
+		) {
+			return res.status(404).json({ error: "Github provider not found" });
+		}
+
 		await db
 			.update(github)
 			.set({
 				githubInstallationId: installation_id,
 			})
-			.where(eq(github.githubId, rest[0] as string))
+			.where(eq(github.githubId, githubId))
 			.returning();
 	}
 


### PR DESCRIPTION
Fixes the unauthenticated / cross-org write on the GitHub App setup callback (GHSA-g9pp-xcf2-ph7x; also the closed duplicate GHSA-5w3m-g58x-6452).

## Problem

`GET /api/providers/github/setup` sits outside tRPC and did **no authentication and no authorization**. It parsed the write target straight from the attacker-controlled `state`:

- `gh_init:<organizationId>:<userId>` → `createGithub()` inserts a `git_provider` + `github` row (holding the App `client_secret`, `webhook_secret`, PEM key) using those IDs.
- `gh_setup:<githubId>` → `UPDATE github SET githubInstallationId=… WHERE githubId=<githubId>` with no ownership check.

So an unauthenticated attacker (or a member with **no** `gitProviders` permission) could plant a provider carrying their own App secrets into any org, or re-point an existing provider's installation — a cross-tenant write / IDOR, and a plausible deployment-hijack path.

## Fix (per the advisory remediation)

- **Authenticate**: `validateRequest(req)`; reject with 401 when there is no session.
- **Authorize**: require the `gitProviders` permission — the same guard the tRPC github router uses (`withPermission("gitProviders", ...)`).
- **Derive the target from the session**, not from `state`: `gh_init` now creates the provider under `session.activeOrganizationId` / `user.id`.
- **Ownership check on `gh_setup`**: look up the `github` row and confirm its `gitProvider.organizationId` matches the caller's org before updating (404 otherwise).

The legitimate flow is a same-origin browser redirect back from GitHub, so the session cookie is present and unaffected.

## Verification (localhost)

- Unauthenticated `gh_init` / `gh_setup` → **401** (was 500/307, i.e. it reached the write).
- Member without `gitProviders` permission → **403** (matches the gated tRPC `github.update`, also 401/403).
- Member with `gitProviders` permission → passes the gate (reaches the GitHub code exchange), same as the gated path.
- `gh_setup` with a `githubId` from another org → **404**, no update.

Closes GHSA-g9pp-xcf2-ph7x.