### PR TITLE
fix(security): cross-org authorization bypass in server.remove

### DIFF
--- a/apps/dokploy/server/api/routers/server.ts
+++ b/apps/dokploy/server/api/routers/server.ts
@@ -413,6 +413,14 @@ export const serverRouter = createTRPCRouter({
 		.input(apiRemoveServer)
 		.mutation(async ({ input, ctx }) => {
 			try {
+				const currentServer = await findServerById(input.serverId);
+				if (currentServer.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You are not authorized to delete this server",
+					});
+				}
+
 				const activeServers = await haveActiveServices(input.serverId);
 
 				if (activeServers) {
@@ -421,7 +429,6 @@ export const serverRouter = createTRPCRouter({
 						message: "Server has active services, please delete them first",
 					});
 				}
-				const currentServer = await findServerById(input.serverId);
 				await audit(ctx, {
 					action: "delete",
 					resourceType: "server",


### PR DESCRIPTION
Fixes GHSA-3rpx-c3j9-q99x.

## Problem

`server.remove` deleted the server record and its deployment rows using the caller-supplied `serverId` with no check that the server belongs to `ctx.session.activeOrganizationId` — unlike the sibling `server.one` and `server.update`, which do compare. The org check was dropped in `8127dc453` during the migration to `withPermission("server", "delete")`, which only enforces the role within the caller's own org, not ownership of `input.serverId`.

An owner/admin of org A (self-obtainable on open registration) could delete org B's server registration and deployment history by passing org B's `serverId`. `haveActiveServices` also ran before any ownership check, leaking existence/state of cross-org servers.

## Fix

Resolve the server and compare `organizationId` against the active org **before** the active-services guard, matching the `update` handler. Cross-org callers now get `UNAUTHORIZED` with no existence leak. (`redactServerSshKey` was already applied to the response.)

## Verification (localhost, two orgs)

- Owner of org A removing an org B `serverId` → **401 UNAUTHORIZED**, target server row intact.
- Owner removing a server in their own org → **200 OK** (unchanged).

Closes GHSA-3rpx-c3j9-q99x.