### PR TITLE
fix(security): command injection in registry.testRegistry / testRegistryById

### DIFF
--- a/apps/dokploy/server/api/routers/registry.ts
+++ b/apps/dokploy/server/api/routers/registry.ts
@@ -5,6 +5,7 @@ import {
 	findRegistryById,
 	IS_CLOUD,
 	removeRegistry,
+	safeDockerLoginCommand,
 	updateRegistry,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
@@ -122,7 +123,11 @@ export const registryRouter = createTRPCRouter({
 				if (input.serverId && input.serverId !== "none") {
 					await execAsyncRemote(
 						input.serverId,
-						`echo ${input.password} | docker ${args.join(" ")}`,
+						safeDockerLoginCommand(
+							input.registryUrl,
+							input.username,
+							input.password,
+						),
 					);
 				} else {
 					await execFileAsync("docker", args, {
@@ -182,7 +187,11 @@ export const registryRouter = createTRPCRouter({
 				if (input.serverId && input.serverId !== "none") {
 					await execAsyncRemote(
 						input.serverId,
-						`echo ${registryData.password} | docker ${args.join(" ")}`,
+						safeDockerLoginCommand(
+							registryData.registryUrl,
+							registryData.username,
+							registryData.password,
+						),
 					);
 				} else {
 					await execFileAsync("docker", args, {


### PR DESCRIPTION
Fixes GHSA-w6r4-f26v-8g36.

## Problem

The remote (`execAsyncRemote`) path of both `registry.testRegistry` and `registry.testRegistryById` built the docker login command by interpolating the password directly into a shell string:

```ts
`echo ${input.password} | docker ${args.join(" ")}`
```

`password` (and `registryUrl`/`username`, which flow into `args`) were only `z.string().min(1)`, so a password like `pw; whoami; #` executed arbitrary commands as root on the target server via SSH. Any user with `registry:read` could trigger it.

## Fix

Reuse `safeDockerLoginCommand` (already used by `createRegistry`/`updateRegistry`), which shell-escapes registry/user/password and feeds the password through `--password-stdin`. The local path already used `execFileAsync` with an argv array + stdin and was safe.

## Verification

- `safeDockerLoginCommand` output: every payload (`; whoami`, `$()`, backtick, `' && rm`) collapses to a single literal `printf %s` argument; legit login command unchanged.
- Runtime: calling `testRegistry` with an injected password did not execute the payload (no marker file created).

Closes GHSA-w6r4-f26v-8g36.