### PR TITLE
fix(ui): organization menu clipped when sidebar is collapsed

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -648,7 +648,7 @@ function SidebarLogo() {
 								</SidebarMenuButton>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent
-								className="rounded-lg max-h-[min(70vh,28rem)] flex flex-col"
+								className="w-64 rounded-lg max-h-[min(70vh,28rem)] flex flex-col"
 								align="start"
 								side={isMobile ? "bottom" : "right"}
 								sideOffset={4}


### PR DESCRIPTION
## Problem

When the sidebar is collapsed to icon mode, the organization switcher's dropdown menu renders too narrow (~128px), cutting off the organization name and cramming the action buttons against the edge.

Closes #4840

## Cause

The org switcher's `DropdownMenuContent` had no explicit width, so it inherited `w-(--radix-dropdown-menu-trigger-width)` from the base primitive. In icon mode the trigger shrinks to ~40px, dropping the menu to the `min-w-32` (128px) floor.

## Fix

Set an explicit `w-64` on the org switcher's `DropdownMenuContent`, matching the pattern already used by the notification dropdown in the same file. The menu now sizes to its content regardless of the collapsed trigger width.

## Before / After

Verified in the browser with the sidebar collapsed:

| | Menu width | Org name | Text clipped |
|---|---|---|---|
| Before | 128px | 16px (hidden) | yes |
| After | 256px | fully visible | no |