### PR TITLE
fix(2fa): show correct error message for invalid TOTP code

### DIFF
--- a/apps/dokploy/components/dashboard/settings/profile/enable-2fa.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/enable-2fa.tsx
@@ -100,7 +100,7 @@ export const Enable2FA = () => {
 			});
 
 			if (result.error) {
-				if (result.error.code === "INVALID_TWO_FACTOR_AUTHENTICATION") {
+				if (result.error.code === "INVALID_CODE") {
 					toast.error("Invalid verification code");
 					return;
 				}


### PR DESCRIPTION
## Problem

When enabling 2FA, entering an incorrect TOTP code shows a confusing "Error verifying 2FA code / Unknown error" toast instead of a clear "Invalid verification code" message. The user has no idea they simply mistyped the code.

Related to #4866 (see note below).

## Cause

`enable-2fa.tsx` checks for the error code `INVALID_TWO_FACTOR_AUTHENTICATION`, but that code does not exist in better-auth 1.6.23 — the two-factor plugin now returns `INVALID_CODE` for a wrong TOTP. So the specific branch never matches and execution falls through to the generic catch.

## Fix

Check for `INVALID_CODE` (the current better-auth error code) so the actionable "Invalid verification code" message is shown.

## Verification

Reproduced and verified in the browser (enable 2FA → enter a wrong 6-digit code):

| | Toast shown |
|---|---|
| Before | "Error verifying 2FA code / Unknown error" |
| After | "Invalid verification code" |

## Note on #4866

Issue #4866 ("2FA cannot be enabled") reports a separate, intermittent problem where `twoFactorEnabled` stays `false` after a successful verify. That appears to be a session-rotation race in the verify flow (better-auth [#6077](https://github.com/better-auth/better-auth/issues/6077)) and is **not** addressed by this PR — this only fixes the misleading error message. Details posted on the issue.