### PR TITLE
fix(ui): make watch path remove (X) button clickable

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -869,7 +869,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 													<Badge key={index} variant="secondary">
 														{name}
 														<X
-															className="ml-1 size-3 cursor-pointer"
+															className="ml-1 size-3 cursor-pointer pointer-events-auto"
 															onClick={() => {
 																const newMiddlewares = [...(field.value || [])];
 																newMiddlewares.splice(index, 1);

--- a/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-bitbucket-provider.tsx
@@ -448,7 +448,7 @@ export const SaveBitbucketProvider = ({ applicationId }: Props) => {
 											<Badge key={index} variant="secondary">
 												{path}
 												<X
-													className="ml-1 size-3 cursor-pointer"
+													className="ml-1 size-3 cursor-pointer pointer-events-auto"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-git-provider.tsx
@@ -243,7 +243,7 @@ export const SaveGitProvider = ({ applicationId }: Props) => {
 										<Badge key={index} variant="secondary">
 											{path}
 											<X
-												className="ml-1 size-3 cursor-pointer"
+												className="ml-1 size-3 cursor-pointer pointer-events-auto"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitea-provider.tsx
@@ -478,7 +478,7 @@ export const SaveGiteaProvider = ({ applicationId }: Props) => {
 											>
 												{path}
 												<X
-													className="size-3 cursor-pointer hover:text-destructive"
+													className="size-3 cursor-pointer pointer-events-auto hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -488,7 +488,7 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 												>
 													{path}
 													<X
-														className="size-3 cursor-pointer hover:text-destructive"
+														className="size-3 cursor-pointer pointer-events-auto hover:text-destructive"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-gitlab-provider.tsx
@@ -468,7 +468,7 @@ export const SaveGitlabProvider = ({ applicationId }: Props) => {
 											>
 												{path}
 												<X
-													className="size-3 cursor-pointer hover:text-destructive"
+													className="size-3 cursor-pointer pointer-events-auto hover:text-destructive"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
+++ b/apps/dokploy/components/dashboard/application/preview-deployments/show-preview-settings.tsx
@@ -256,7 +256,7 @@ export const ShowPreviewSettings = ({ applicationId }: Props) => {
 														>
 															{label}
 															<X
-																className="size-3 cursor-pointer hover:text-destructive"
+																className="size-3 cursor-pointer pointer-events-auto hover:text-destructive"
 																onClick={() => {
 																	const newLabels = [...(field.value || [])];
 																	newLabels.splice(index, 1);

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-bitbucket-provider-compose.tsx
@@ -452,7 +452,7 @@ export const SaveBitbucketProviderCompose = ({ composeId }: Props) => {
 											<Badge key={index} variant="secondary">
 												{path}
 												<X
-													className="ml-1 size-3 cursor-pointer"
+													className="ml-1 size-3 cursor-pointer pointer-events-auto"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-git-provider-compose.tsx
@@ -252,7 +252,7 @@ export const SaveGitProviderCompose = ({ composeId }: Props) => {
 										<Badge key={index} variant="secondary">
 											{path}
 											<X
-												className="ml-1 size-3 cursor-pointer"
+												className="ml-1 size-3 cursor-pointer pointer-events-auto"
 												onClick={() => {
 													const newPaths = [...(field.value || [])];
 													newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitea-provider-compose.tsx
@@ -443,7 +443,7 @@ export const SaveGiteaProviderCompose = ({ composeId }: Props) => {
 											<Badge key={index} variant="secondary">
 												{path}
 												<X
-													className="ml-1 size-3 cursor-pointer"
+													className="ml-1 size-3 cursor-pointer pointer-events-auto"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -480,7 +480,7 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 												<Badge key={index} variant="secondary">
 													{path}
 													<X
-														className="ml-1 size-3 cursor-pointer"
+														className="ml-1 size-3 cursor-pointer pointer-events-auto"
 														onClick={() => {
 															const newPaths = [...(field.value || [])];
 															newPaths.splice(index, 1);

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-gitlab-provider-compose.tsx
@@ -469,7 +469,7 @@ export const SaveGitlabProviderCompose = ({ composeId }: Props) => {
 											<Badge key={index} variant="secondary">
 												{path}
 												<X
-													className="ml-1 size-3 cursor-pointer"
+													className="ml-1 size-3 cursor-pointer pointer-events-auto"
 													onClick={() => {
 														const newPaths = [...(field.value || [])];
 														newPaths.splice(index, 1);


### PR DESCRIPTION
## Problem

On an application's git provider config, clicking the **X** on a watch path badge does nothing — the path can be added but never removed.

Closes #4780

## Cause

The remove X is a lucide `<X>` rendered as a **direct SVG child of `<Badge>`**. The Badge base class includes `[&>svg]:pointer-events-none` (introduced in the Tailwind v4 / shadcn update, commit `3ca5afd49`). That rule sets `pointer-events: none` on the icon, so the click lands on the Badge instead of the X and the `onClick` (which splices the item out) never runs. The removal logic itself is correct — it just never fires.

## Fix

Add `pointer-events-auto` to each remove X so it stays clickable despite the Badge rule. The same broken pattern exists across all git provider components, so this covers:
- 5 application git providers (git, github, gitlab, gitea, bitbucket)
- 5 compose git providers
- preview-deployment branch filters
- domain middlewares list (`handle-domain.tsx`)

## Verification

Reproduced and verified in the browser: with `pointer-events: none`, `elementFromPoint` over the X returns the Badge (not the SVG) and the badge intercepts the click; after the fix the SVG receives the click and the path badge is removed on click.