### PR TITLE
fix(server): security audit JSON parse error on duplicate sshd_config directives

### DIFF
--- a/packages/server/src/setup/server-audit.ts
+++ b/packages/server/src/setup/server-audit.ts
@@ -6,7 +6,7 @@ const validateUfw = () => `
   if command -v ufw >/dev/null 2>&1; then
     isInstalled=true
     isActive=$(sudo ufw status | grep -q "Status: active" && echo true || echo false)
-    defaultIncoming=$(sudo ufw status verbose | grep "Default:" | grep "incoming" | awk '{print $2}')
+    defaultIncoming=$(sudo ufw status verbose | grep "Default:" | grep "incoming" | awk '{print $2}' | head -n1 | tr -d '\\r')
     echo "{\\"installed\\": $isInstalled, \\"active\\": $isActive, \\"defaultIncoming\\": \\"$defaultIncoming\\"}"
   else
     echo "{\\"installed\\": false, \\"active\\": false, \\"defaultIncoming\\": \\"unknown\\"}"
@@ -27,7 +27,7 @@ const validateSsh = () => `
     
     # Check for key authentication
     # SSH key auth is enabled by default unless explicitly disabled
-    pubkey_line=$(sudo grep -i "^PubkeyAuthentication" "$sshd_config" 2>/dev/null | grep -v "#")
+    pubkey_line=$(sudo grep -i "^PubkeyAuthentication" "$sshd_config" 2>/dev/null | grep -v "#" | head -n1)
     if [ -z "$pubkey_line" ] || echo "$pubkey_line" | grep -q -i "yes"; then
       keyAuth=true
     else
@@ -36,21 +36,21 @@ const validateSsh = () => `
     
     # Get the exact PermitRootLogin value from config
     # This preserves values like "prohibit-password" without normalization
-    permitRootLogin=$(sudo grep -i "^PermitRootLogin" "$sshd_config" 2>/dev/null | grep -v "#" | awk '{print $2}')
+    permitRootLogin=$(sudo grep -i "^PermitRootLogin" "$sshd_config" 2>/dev/null | grep -v "#" | awk '{print $2}' | head -n1 | tr -d '\\r')
     if [ -z "$permitRootLogin" ]; then
       # Default is prohibit-password in newer versions
       permitRootLogin="prohibit-password"
     fi
     
     # Get the exact PasswordAuthentication value from config
-    passwordAuth=$(sudo grep -i "^PasswordAuthentication" "$sshd_config" 2>/dev/null | grep -v "#" | awk '{print $2}')
+    passwordAuth=$(sudo grep -i "^PasswordAuthentication" "$sshd_config" 2>/dev/null | grep -v "#" | awk '{print $2}' | head -n1 | tr -d '\\r')
     if [ -z "$passwordAuth" ]; then
       # Default is yes
       passwordAuth="yes"
     fi
     
     # Get the exact UsePAM value from config
-    usePam=$(sudo grep -i "^UsePAM" "$sshd_config" 2>/dev/null | grep -v "#" | awk '{print $2}')
+    usePam=$(sudo grep -i "^UsePAM" "$sshd_config" 2>/dev/null | grep -v "#" | awk '{print $2}' | head -n1 | tr -d '\\r')
     if [ -z "$usePam" ]; then
       # Default is yes in most distros
       usePam="yes"


### PR DESCRIPTION
## What is this PR about?

The Security tab for remote servers fails with a red banner — `Failed to parse output: Bad control character in string literal in JSON at position 148 (line 1 column 149)` — whenever the remote `/etc/ssh/sshd_config` contains **more than one active line for the same directive** (e.g. a global `PermitRootLogin` plus one added by a provisioning/hardening script or a `Match` block). All values in the tab then fall back to defaults, which also explains the "false negatives" reported in #2478.

**Root cause:** `serverAudit()` builds JSON on the remote host by interpolating raw `grep | awk` output into string literals:

```bash
permitRootLogin=$(sudo grep -i "^PermitRootLogin" "$sshd_config" | grep -v "#" | awk '{print $2}')
```

With two matching lines this yields `prohibit-password\nyes`. Command substitution strips only *trailing* newlines, so the interior newline lands inside a JSON string literal and `JSON.parse` rejects it.

**Fix:** append `| head -n1 | tr -d '\r'` to the value captures (`permitRootLogin`, `passwordAuth`, `usePam`, ufw `defaultIncoming`) and `| head -n1` to the `pubkey_line` check. `head -n1` mirrors sshd's own first-match-wins semantics, so the reported value is the one actually in effect; `tr -d '\r'` guards against CRLF-edited config files causing the same parse error.

### How this was tested

**1. Local instance against a real affected server.** Ran a local dev instance (canary + this patch), added a remote Ubuntu server whose `sshd_config` has two active `PermitRootLogin` lines (line 42 `prohibit-password`, line 132 `yes`), and opened the Security tab — see before/after screenshots below.

**2. Byte-for-byte reproduction of the generated script.** Extracted the exact bash that `serverAudit()` generates from the TypeScript source, ran it against a replica of that sshd_config, and fed the output to `JSON.parse` exactly as `server-audit.ts` does.

Before (byte-for-byte the reported error):

```
{"ufw": {...}, "ssh": {..., "permitRootLogin": "prohibit-password
yes", ...}
SyntaxError: Bad control character in string literal in JSON at position 148 (line 1 column 149)
```

After:

```
{"ufw": {"installed": true, "active": false, "defaultIncoming": ""}, "ssh": {"enabled": true, "keyAuth": true, "permitRootLogin": "prohibit-password", "passwordAuth": "yes", "usePam": "yes"}, "fail2ban": {"installed": false, ...}}
PARSE OK
```

`permitRootLogin` correctly reports `prohibit-password` — the first match, which is the value sshd actually applies.

### What this intentionally does not cover

The audit reads only the main `sshd_config`, not files pulled in via `Include /etc/ssh/sshd_config.d/*.conf` (mentioned in a comment on #2478, e.g. cloud-init's `50-cloud-init.conf` setting `PasswordAuthentication yes`). Resolving effective values (e.g. via `sudo sshd -T`) would be a good follow-up, but is a separate accuracy concern — this PR is scoped to the parse failure that breaks the tab entirely.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

Fixes the JSON parse error and the resulting default/false values reported in #2478 (the `sshd_config.d` include handling from that issue is noted above as a follow-up).

## Screenshots (if applicable)

Before — parse error banner, every field showing false defaults:

![Security tab before the fix](https://raw.githubusercontent.com/automaze-me/dokploy/pr-4889-assets/security-check-before-fix.png)

After (same server) — real state rendered: UFW detected, SSH enabled, key auth on:

![Security tab after the fix](https://raw.githubusercontent.com/automaze-me/dokploy/pr-4889-assets/security-check-after-fix.png)
