### PR TITLE
style: add backup recommendation before rebuilding database

### DIFF
--- a/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
+++ b/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
@@ -69,6 +69,13 @@ export const RebuildDatabase = ({ id, type }: Props) => {
 							This action will completely reset your database to its initial
 							state. All data, tables, and configurations will be removed.
 						</p>
+						<p className="text-sm text-amber-600 dark:text-amber-400 flex items-center gap-1.5">
+							<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+							<span>
+								<strong>Recommended:</strong>{" "}
+								Create a backup before rebuilding to avoid permanent data loss.
+							</span>
+						</p>
 					</div>
 					<AlertDialog>
 						<AlertDialogTrigger asChild>
@@ -98,6 +105,13 @@ export const RebuildDatabase = ({ id, type }: Props) => {
 										</ul>
 										<p className="font-medium text-destructive mt-4">
 											This action cannot be undone.
+										</p>
+										<p className="text-sm text-amber-600 dark:text-amber-400 flex items-center gap-1.5 mt-2">
+											<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+											<span>
+												<strong>Tip:</strong>{" "}
+												Go to the Backups tab to create a backup before rebuilding.
+											</span>
 										</p>
 									</div>
 								</AlertDialogDescription>

--- a/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
+++ b/apps/dokploy/components/dashboard/shared/rebuild-database.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle, DatabaseIcon } from "lucide-react";
+import { useRouter } from "next/router";
 import { toast } from "sonner";
 import {
 	AlertDialog,
@@ -21,7 +22,18 @@ interface Props {
 }
 
 export const RebuildDatabase = ({ id, type }: Props) => {
+	const router = useRouter();
 	const utils = api.useUtils();
+
+	const goToBackups = () => {
+		const projectId = router.query.projectId as string;
+		const environmentId = router.query.environmentId as string;
+		router.push(
+			`/dashboard/project/${projectId}/environment/${environmentId}/services/${type}/${id}?tab=backups`,
+			undefined,
+			{ shallow: true },
+		);
+	};
 
 	const mutationMap = {
 		libsql: () => api.libsql.rebuild.useMutation(),
@@ -73,7 +85,13 @@ export const RebuildDatabase = ({ id, type }: Props) => {
 							<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
 							<span>
 								<strong>Recommended:</strong>{" "}
-								Create a backup before rebuilding to avoid permanent data loss.
+								<span
+									onClick={goToBackups}
+									className="underline underline-offset-2 hover:text-amber-500 cursor-pointer"
+								>
+									Create a backup
+								</span>{" "}
+								before rebuilding to avoid permanent data loss.
 							</span>
 						</p>
 					</div>
@@ -110,7 +128,13 @@ export const RebuildDatabase = ({ id, type }: Props) => {
 											<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
 											<span>
 												<strong>Tip:</strong>{" "}
-												Go to the Backups tab to create a backup before rebuilding.
+												<span
+													onClick={goToBackups}
+													className="underline underline-offset-2 hover:text-amber-500 cursor-pointer"
+												>
+													Go to the Backups tab
+												</span>{" "}
+												to create a backup before rebuilding.
 											</span>
 										</p>
 									</div>

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -9,7 +9,7 @@ import type {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-environment";
@@ -59,6 +59,12 @@ const Libsql = (
 	const router = useRouter();
 	const { projectId, environmentId } = router.query;
 	const [tab, setSab] = useState<TabState>(activeTab);
+	useEffect(() => {
+		const tabFromUrl = router.query.tab as TabState;
+		if (tabFromUrl && tabFromUrl !== tab) {
+			setSab(tabFromUrl);
+		}
+	}, [router.query.tab]);
 	const { data } = api.libsql.one.useQuery({ libsqlId });
 	const { data: auth } = api.user.get.useQuery();
 

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -9,7 +9,7 @@ import type {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-environment";
@@ -60,6 +60,12 @@ const Mariadb = (
 	const router = useRouter();
 	const { projectId, environmentId } = router.query;
 	const [tab, setSab] = useState<TabState>(activeTab);
+	useEffect(() => {
+		const tabFromUrl = router.query.tab as TabState;
+		if (tabFromUrl && tabFromUrl !== tab) {
+			setSab(tabFromUrl);
+		}
+	}, [router.query.tab]);
 	const { data } = api.mariadb.one.useQuery({ mariadbId });
 	const { data: auth } = api.user.get.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -9,7 +9,7 @@ import type {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-environment";
@@ -59,6 +59,12 @@ const Mongo = (
 	const router = useRouter();
 	const { projectId, environmentId } = router.query;
 	const [tab, setSab] = useState<TabState>(activeTab);
+	useEffect(() => {
+		const tabFromUrl = router.query.tab as TabState;
+		if (tabFromUrl && tabFromUrl !== tab) {
+			setSab(tabFromUrl);
+		}
+	}, [router.query.tab]);
 	const { data } = api.mongo.one.useQuery({ mongoId });
 
 	const { data: auth } = api.user.get.useQuery();

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -9,7 +9,7 @@ import type {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-environment";
@@ -59,6 +59,12 @@ const MySql = (
 	const router = useRouter();
 	const { projectId, environmentId } = router.query;
 	const [tab, setSab] = useState<TabState>(activeTab);
+	useEffect(() => {
+		const tabFromUrl = router.query.tab as TabState;
+		if (tabFromUrl && tabFromUrl !== tab) {
+			setSab(tabFromUrl);
+		}
+	}, [router.query.tab]);
 	const { data } = api.mysql.one.useQuery({ mysqlId });
 	const { data: auth } = api.user.get.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -9,7 +9,7 @@ import type {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-environment";
@@ -59,6 +59,12 @@ const Postgresql = (
 	const router = useRouter();
 	const { projectId, environmentId } = router.query;
 	const [tab, setSab] = useState<TabState>(activeTab);
+	useEffect(() => {
+		const tabFromUrl = router.query.tab as TabState;
+		if (tabFromUrl && tabFromUrl !== tab) {
+			setSab(tabFromUrl);
+		}
+	}, [router.query.tab]);
 	const { data } = api.postgres.one.useQuery({ postgresId });
 	const { data: auth } = api.user.get.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -9,7 +9,7 @@ import type {
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import superjson from "superjson";
 import { ShowEnvironment } from "@/components/dashboard/application/environment/show-environment";
@@ -58,6 +58,12 @@ const Redis = (
 	const router = useRouter();
 	const { projectId, environmentId } = router.query;
 	const [tab, setSab] = useState<TabState>(activeTab);
+	useEffect(() => {
+		const tabFromUrl = router.query.tab as TabState;
+		if (tabFromUrl && tabFromUrl !== tab) {
+			setSab(tabFromUrl);
+		}
+	}, [router.query.tab]);
 	const { data } = api.redis.one.useQuery({ redisId });
 
 	const { data: auth } = api.user.get.useQuery();


### PR DESCRIPTION
## feat: add backup recommendation with one-click navigation before rebuilding database

### Problem

When users click **"Rebuild Database"** in the Danger Zone, the dialog warns about data loss but never suggests creating a backup first — nor provides a way to navigate there directly. This puts user data at unnecessary risk, especially since Dokploy already has a backup system in place.

### Solution

Added backup reminder text in two places, both with **clickable links** that navigate directly to the Backups tab:

1. **Card body** — below the destructive warning description:

   > ⚠️ **Recommended:** **Create a backup** before rebuilding to avoid permanent data loss.

2. **Confirmation dialog** — after "This action cannot be undone":

   > ⚠️ **Tip:** **Go to the Backups tab** to create a backup before rebuilding.

### Changes

| File | Change |
|---|---|
| `apps/dokploy/components/dashboard/shared/rebuild-database.tsx` | Added two amber-colored alert paragraphs with `AlertTriangle` icon and `onClick` handlers that navigate to `?tab=backups` via `router.push` with `shallow: true` |
| `apps/dokploy/pages/.../services/postgres/[postgresId].tsx` | Added `useEffect` to sync tab state from `router.query.tab` |
| `apps/dokploy/pages/.../services/mongo/[mongoId].tsx` | Same |
| `apps/dokploy/pages/.../services/mysql/[mysqlId].tsx` | Same |
| `apps/dokploy/pages/.../services/mariadb/[mariadbId].tsx` | Same |
| `apps/dokploy/pages/.../services/libsql/[libsqlId].tsx` | Same |
| `apps/dokploy/pages/.../services/redis/[redisId].tsx` | Same |

### How it works

The clickable text uses `router.push(url, undefined, { shallow: true })` — matching the project's existing tab-switching convention. A `useEffect` in each database page syncs the local `tab` state with the URL's `?tab=` parameter, so clicking the link properly switches to the **Backups** tab without a full page reload.

### Screenshots
<img width="1472" height="438" alt="Screenshot 2026-07-22 at 07 41 24" src="https://github.com/user-attachments/assets/a2ee578d-fd17-4445-90df-e285edcda01c" />

<img width="606" height="402" alt="Screenshot 2026-07-22 at 07 40 24" src="https://github.com/user-attachments/assets/bd181a1d-e5bf-4d83-90e6-e0bfa27b4c60" />


### Testing

- `pnpm typecheck` — passes clean for `apps/dokploy`
- Verified the clickable text navigates to the Backups tab
- No logic changes to the rebuild mutation itself — purely UI additions