### PR TITLE
fix: run the database dump only once per backup

### DIFF
--- a/apps/dokploy/__test__/utils/backups.test.ts
+++ b/apps/dokploy/__test__/utils/backups.test.ts
@@ -1,4 +1,9 @@
-import { normalizeS3Path } from "@dokploy/server/utils/backups/utils";
+import type { BackupSchedule } from "@dokploy/server/services/backup";
+import {
+	getBackupCommand,
+	getPostgresBackupCommand,
+	normalizeS3Path,
+} from "@dokploy/server/utils/backups/utils";
 import { describe, expect, test } from "vitest";
 
 describe("normalizeS3Path", () => {
@@ -57,5 +62,40 @@ describe("normalizeS3Path", () => {
 		expect(normalizeS3Path("instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("/instance-backups/")).toBe("instance-backups/");
 		expect(normalizeS3Path("instance-backups")).toBe("instance-backups/");
+	});
+});
+
+describe("getBackupCommand", () => {
+	const backup = {
+		backupType: "database",
+		databaseType: "postgres",
+		database: "mydb",
+		postgres: { appName: "my-app", databaseUser: "postgres" },
+	} as unknown as BackupSchedule;
+	const rcloneCommand =
+		'rclone rcat --s3-region=auto ":s3:bucket/my-app/backup.sql.gz"';
+	const buildScript = () =>
+		getBackupCommand(backup, rcloneCommand, "/tmp/backup.log");
+
+	test("should run the database dump exactly once", () => {
+		const script = buildScript();
+		const dumpCommand = getPostgresBackupCommand("mydb", "postgres");
+		expect(script.split(dumpCommand).length - 1).toBe(1);
+	});
+
+	test("should stream the dump directly into rclone", () => {
+		expect(buildScript()).toContain(`| ${rcloneCommand}`);
+	});
+
+	test("should keep dump and upload failures distinguishable", () => {
+		const script = buildScript();
+		expect(script).toContain("Error: Backup failed");
+		expect(script).toContain("Error: Upload to S3 failed");
+	});
+
+	test("should clean up the partial object when a stream fails", () => {
+		expect(buildScript()).toContain(
+			'rclone deletefile --s3-region=auto ":s3:bucket/my-app/backup.sql.gz"',
+		);
 	});
 });

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -265,6 +265,12 @@ export const getBackupCommand = (
 	const containerSearch = getContainerSearchCommand(backup);
 	const backupCommand = generateBackupCommand(backup);
 
+	// A failed stream can leave a truncated object behind in the bucket,
+	// so derive the matching delete command for the failure paths.
+	const rcloneCleanupCommand = rcloneCommand.startsWith("rclone rcat ")
+		? `${rcloneCommand.replace("rclone rcat ", "rclone deletefile ")} >/dev/null 2>&1 || true;`
+		: "";
+
 	logger.info(
 		{
 			containerSearch,
@@ -279,7 +285,7 @@ export const getBackupCommand = (
 	set -eo pipefail;
 	echo "[$(date)] Starting backup process..." >> ${logPath};
 	echo "[$(date)] Executing backup command..." >> ${logPath};
-	CONTAINER_ID=$(${containerSearch})
+	CONTAINER_ID=$(${containerSearch});
 
 	if [ -z "$CONTAINER_ID" ]; then
 		echo "[$(date)] ❌ Error: Container not found" >> ${logPath};
@@ -288,23 +294,34 @@ export const getBackupCommand = (
 
 	echo "[$(date)] Container Up: $CONTAINER_ID" >> ${logPath};
 
-	# Run the backup command and capture the exit status
-	BACKUP_OUTPUT=$(${backupCommand} 2>&1 >/dev/null) || {
+	echo "[$(date)] Streaming backup to S3..." >> ${logPath};
+
+	# Run the dump once and stream it directly into rclone. The dump exit
+	# code and stderr are captured through temp files so a dump failure and
+	# an upload failure remain distinguishable in the logs.
+	DUMP_STATUS_FILE=$(mktemp);
+	DUMP_ERROR_FILE=$(mktemp);
+	trap 'rm -f "$DUMP_STATUS_FILE" "$DUMP_ERROR_FILE"' EXIT;
+
+	UPLOAD_FAILED=0;
+	UPLOAD_OUTPUT=$({ ${backupCommand} 2> "$DUMP_ERROR_FILE"; echo $? > "$DUMP_STATUS_FILE"; } | ${rcloneCommand} 2>&1 >/dev/null) || UPLOAD_FAILED=1;
+	DUMP_STATUS=$(cat "$DUMP_STATUS_FILE");
+
+	if [ "$DUMP_STATUS" != "0" ]; then
 		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
-		echo "Error: $BACKUP_OUTPUT" >> ${logPath};
+		echo "Error: $(cat "$DUMP_ERROR_FILE")" >> ${logPath};
+		${rcloneCleanupCommand}
 		exit 1;
-	}
+	fi
 
-	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
-
-	# Run the upload command and capture the exit status
-	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
+	if [ "$UPLOAD_FAILED" != "0" ]; then
 		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
+		${rcloneCleanupCommand}
 		exit 1;
-	}
+	fi
 
+	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
 	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;


### PR DESCRIPTION
## Problem

`getBackupCommand` interpolates the generated dump command into the backup script twice: once as a validation run discarded to `/dev/null`, then a second time piped into `rclone rcat` for the actual upload. Every backup therefore dumps the database **twice**:

- Doubles backup runtime and database load. Real-world measurement: an 11 GB Postgres database takes ~24 minutes instead of ~12, with `pg_dump` pinning one core at 100% the whole time.
- Affects all database types (postgres, mysql, mariadb, mongo, libsql) and compose backups, since they all go through `getBackupCommand`.
- The dump that gets "validated" is not the dump that gets uploaded, so the validation says nothing about the file actually stored in S3.

## Fix

Run the dump once and stream it directly into rclone. The point of the old validation run — distinguishing "Backup failed" from "Upload to S3 failed" in the deployment log — is preserved: the dump's exit code and stderr are captured through temp files inside the combined pipeline, so the failure paths stay separate:

- dump fails → logs `❌ Error: Backup failed` plus the dump's stderr, exits 1
- rclone fails → logs `❌ Error: Upload to S3 failed` plus rclone's stderr, exits 1
- if both fail, the dump failure takes precedence

Additionally, a failed streamed run can leave a truncated object behind in the bucket (already possible today whenever the second dump or the connection failed mid-stream — the truncated object then counted against the `keepLatestNBackups` retention window). Both failure paths now delete the partial object via a `rclone deletefile` command derived from the rcat command, so failed runs no longer pollute the bucket or evict good backups from retention.

## Notes regarding #4235

The double dump is mentioned there as a secondary finding — this PR removes it.

Regarding the reported missing semicolon after `CONTAINER_ID=$(...)`: on current `canary` the generated script contains real newlines, so this does not parse as a syntax error (the error output in the issue shows the script collapsed to a single line, which looks like a display artifact of the error message). I still added the `;` for consistency with the rest of the script and as defense in depth. Worth noting for triage: the container filter in the issue's error output shows an empty app name (`com.docker.swarm.service.name=`), so the reporter's actual failure is most likely "container not found" due to an empty `appName`, not a parse error.

## Testing

- Added unit tests in `apps/dokploy/__test__/utils/backups.test.ts` asserting that the dump command appears exactly once in the generated script, that it is piped directly into the rclone command, that both error messages remain present, and that the cleanup command is derived correctly. All 13 tests in the file pass (`pnpm server:build` + `vitest run`).
- Verified the new bash logic with a harness exercising all four paths (success, dump failure, upload failure, both failing): the dump runs exactly once, the correct error message and stderr are logged per side, the partial-object cleanup runs on both failure paths, and the temp files are removed via the `EXIT` trap in every case.
- `biome check` passes on both changed files.
- Not run: an end-to-end backup against a live Docker/S3 setup — the change is confined to the generated script, whose semantics are covered by the harness above.

Related to #4235