### PR TITLE
fix(preview-deployments): Filter preview labels before the collaborator check

### DIFF
--- a/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
+++ b/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
@@ -91,6 +91,13 @@ vi.mock("@/server/utils/deploy", () => ({
 	deploy: vi.fn(),
 }));
 
+// These come from the mocked "@dokploy/server" module above, so importing them
+// here gives us the same vi.fn() instances the handler calls.
+import {
+	checkUserRepositoryPermissions,
+	createPreviewDeployment,
+	createSecurityBlockedComment,
+} from "@dokploy/server";
 import handler from "@/pages/api/deploy/github";
 
 const getConditionValue = (
@@ -319,5 +326,132 @@ describe("GitHub app webhook auto-deploy", () => {
 		expect(mocks.queueAdd).not.toHaveBeenCalled();
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith({ message: "No apps to deploy" });
+	});
+});
+
+const createPullRequestRequest = ({
+	action = "opened",
+	labels = [],
+	author = "renovate[bot]",
+}: {
+	action?: string;
+	labels?: Array<{ name: string }>;
+	author?: string;
+} = {}) =>
+	({
+		headers: {
+			"x-hub-signature-256": "sha256=test-signature",
+			"x-github-event": "pull_request",
+		},
+		body: {
+			installation: { id: 12345 },
+			action,
+			pull_request: {
+				id: 987,
+				number: 371,
+				title: "chore(deps): update dependency",
+				html_url: "https://github.com/agentHits/dokploy/pull/371",
+				user: { login: author },
+				labels,
+				head: { ref: "renovate/some-dep", sha: "deadbeef" },
+				base: { ref: "main" },
+			},
+			repository: {
+				name: "dokploy",
+				owner: { login: "agentHits", name: "agentHits" },
+			},
+		},
+	}) as unknown as NextApiRequest;
+
+describe("GitHub app webhook preview deployments (issue #4902)", () => {
+	const previewApp = (overrides: Record<string, unknown> = {}) => ({
+		applicationId: "application-id",
+		name: "preview-app",
+		serverId: null,
+		previewLimit: 0,
+		previewLabels: ["preview"],
+		previewRequireCollaboratorPermissions: true,
+		previewDeployments: [],
+		...overrides,
+	});
+
+	const givenPreviewApp = (overrides: Record<string, unknown> = {}) =>
+		mocks.applicationsFindMany.mockResolvedValue([previewApp(overrides)]);
+
+	const givenAuthorPermission = (permission: {
+		hasWriteAccess: boolean;
+		permission: string | null;
+	}) => vi.mocked(checkUserRepositoryPermissions).mockResolvedValue(permission);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.githubFindFirst.mockResolvedValue({
+			githubId: "github-provider-id",
+			githubInstallationId: 12345,
+			githubWebhookSecret: "webhook-secret",
+		});
+		mocks.verify.mockResolvedValue(true);
+		mocks.queueAdd.mockResolvedValue({ id: "job-id" });
+		vi.mocked(createPreviewDeployment).mockResolvedValue({
+			previewDeploymentId: "preview-deployment-id",
+		} as unknown as Awaited<ReturnType<typeof createPreviewDeployment>>);
+	});
+
+	it("neither checks permissions nor comments when a bot PR fails the label filter", async () => {
+		givenPreviewApp(); // requires the "preview" label
+		const res = createResponse();
+
+		// A renovate PR carries none of the configured preview labels.
+		await handler(
+			createPullRequestRequest({
+				labels: [{ name: "dependencies" }, { name: "renovate" }],
+			}),
+			res,
+		);
+
+		expect(checkUserRepositoryPermissions).not.toHaveBeenCalled();
+		expect(createSecurityBlockedComment).not.toHaveBeenCalled();
+		expect(mocks.queueAdd).not.toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it("posts the security comment when a label-matched PR author lacks write access", async () => {
+		givenPreviewApp();
+		givenAuthorPermission({ hasWriteAccess: false, permission: "none" });
+		const res = createResponse();
+
+		await handler(
+			createPullRequestRequest({ labels: [{ name: "preview" }] }),
+			res,
+		);
+
+		expect(createSecurityBlockedComment).toHaveBeenCalledTimes(1);
+		expect(mocks.queueAdd).not.toHaveBeenCalled();
+	});
+
+	it("queues a preview deployment when the PR matches labels and the author has write access", async () => {
+		givenPreviewApp();
+		givenAuthorPermission({ hasWriteAccess: true, permission: "write" });
+		const res = createResponse();
+
+		await handler(
+			createPullRequestRequest({ labels: [{ name: "preview" }] }),
+			res,
+		);
+
+		expect(createSecurityBlockedComment).not.toHaveBeenCalled();
+		expect(mocks.queueAdd).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationId: "application-id",
+				applicationType: "application-preview",
+				previewDeploymentId: "preview-deployment-id",
+				type: "deploy",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
 	});
 });

--- a/apps/dokploy/__test__/git-provider/preview-deployment-label-order.test.ts
+++ b/apps/dokploy/__test__/git-provider/preview-deployment-label-order.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type PreviewCandidateApp,
+	partitionPreviewApps,
+	pullRequestMatchesPreviewLabels,
+} from "../../utils/preview-deployment";
+
+describe("pullRequestMatchesPreviewLabels", () => {
+	it("matches every PR when the app configures no labels", () => {
+		expect(pullRequestMatchesPreviewLabels(undefined, [{ name: "any" }])).toBe(
+			true,
+		);
+		expect(pullRequestMatchesPreviewLabels(null, [{ name: "any" }])).toBe(true);
+		expect(pullRequestMatchesPreviewLabels([], [{ name: "any" }])).toBe(true);
+	});
+
+	it("matches when the PR carries at least one configured label", () => {
+		expect(
+			pullRequestMatchesPreviewLabels(
+				["preview"],
+				[{ name: "dependencies" }, { name: "preview" }],
+			),
+		).toBe(true);
+	});
+
+	it("does not match when the PR carries none of the configured labels", () => {
+		expect(
+			pullRequestMatchesPreviewLabels(
+				["preview"],
+				[{ name: "dependencies" }, { name: "renovate" }],
+			),
+		).toBe(false);
+	});
+
+	it("does not match when a gate is configured but the PR is unlabeled", () => {
+		expect(pullRequestMatchesPreviewLabels(["preview"], [])).toBe(false);
+		expect(pullRequestMatchesPreviewLabels(["preview"], null)).toBe(false);
+		expect(pullRequestMatchesPreviewLabels(["preview"], undefined)).toBe(false);
+	});
+});
+
+describe("partitionPreviewApps", () => {
+	beforeEach(() => {
+		// Reset spy history, then capture the audit logs the helper emits so we
+		// can assert on them while keeping the test output clean.
+		vi.restoreAllMocks();
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	const pullRequest = {
+		owner: "acme",
+		repository: "web-app",
+		prAuthor: "dependency-bot[bot]",
+		prNumber: 42,
+		action: "opened",
+	};
+
+	const app = (
+		overrides: Partial<PreviewCandidateApp> & { name: string },
+	): PreviewCandidateApp => ({
+		previewLabels: ["preview"],
+		previewRequireCollaboratorPermissions: true,
+		...overrides,
+	});
+
+	const grants = (permission: string) =>
+		vi.fn().mockResolvedValue({ hasWriteAccess: true, permission });
+	const denies = (permission: string | null = "none") =>
+		vi.fn().mockResolvedValue({ hasWriteAccess: false, permission });
+
+	it("skips the permission check for PRs that fail the label filter (issue #4902)", async () => {
+		const resolveAuthorPermission = denies();
+
+		const decision = await partitionPreviewApps({
+			apps: [app({ name: "docs", previewLabels: ["preview"] })],
+			// A renovate PR carries none of the configured labels.
+			pullRequestLabels: [{ name: "dependencies" }, { name: "renovate" }],
+			...pullRequest,
+			resolveAuthorPermission,
+		});
+
+		expect(resolveAuthorPermission).not.toHaveBeenCalled();
+		expect(decision.authorizedApps).toHaveLength(0);
+		// No blocked apps => the handler posts no security comment.
+		expect(decision.blockedAppNames).toEqual([]);
+	});
+
+	it("authorizes a label-matched app when the author has write access", async () => {
+		const decision = await partitionPreviewApps({
+			apps: [app({ name: "docs" })],
+			pullRequestLabels: [{ name: "preview" }],
+			...pullRequest,
+			resolveAuthorPermission: grants("write"),
+		});
+
+		expect(decision.authorizedApps.map((a) => a.name)).toEqual(["docs"]);
+		expect(decision.blockedAppNames).toEqual([]);
+		expect(decision.authorPermission).toBe("write");
+	});
+
+	it("blocks a label-matched app when the author lacks write access", async () => {
+		const decision = await partitionPreviewApps({
+			apps: [app({ name: "docs" })],
+			pullRequestLabels: [{ name: "preview" }],
+			...pullRequest,
+			resolveAuthorPermission: denies("read"),
+		});
+
+		expect(decision.authorizedApps).toHaveLength(0);
+		expect(decision.blockedAppNames).toEqual(["docs"]);
+		expect(decision.authorPermission).toBe("read");
+	});
+
+	it("still enforces permissions for apps without a label gate", async () => {
+		const resolveAuthorPermission = denies();
+
+		const decision = await partitionPreviewApps({
+			apps: [app({ name: "docs", previewLabels: null })],
+			pullRequestLabels: [{ name: "dependencies" }],
+			...pullRequest,
+			resolveAuthorPermission,
+		});
+
+		expect(resolveAuthorPermission).toHaveBeenCalledTimes(1);
+		expect(decision.blockedAppNames).toEqual(["docs"]);
+	});
+
+	it("skips the permission check when it is explicitly disabled", async () => {
+		const resolveAuthorPermission = denies();
+
+		const decision = await partitionPreviewApps({
+			apps: [
+				app({ name: "docs", previewRequireCollaboratorPermissions: false }),
+			],
+			pullRequestLabels: [{ name: "preview" }],
+			...pullRequest,
+			resolveAuthorPermission,
+		});
+
+		expect(resolveAuthorPermission).not.toHaveBeenCalled();
+		expect(decision.authorizedApps.map((a) => a.name)).toEqual(["docs"]);
+	});
+
+	it("fails closed and blocks the app when the permission check throws", async () => {
+		const decision = await partitionPreviewApps({
+			apps: [app({ name: "docs" })],
+			pullRequestLabels: [{ name: "preview" }],
+			...pullRequest,
+			resolveAuthorPermission: vi
+				.fn()
+				.mockRejectedValue(new Error("GitHub API error")),
+		});
+
+		expect(decision.authorizedApps).toHaveLength(0);
+		expect(decision.blockedAppNames).toEqual(["docs"]);
+	});
+
+	it("partitions a mix of apps in a single webhook delivery", async () => {
+		// Only the maintainer's app has write access.
+		const resolveAuthorPermission = vi.fn(async (candidate) =>
+			candidate.name === "authorized"
+				? { hasWriteAccess: true, permission: "admin" }
+				: { hasWriteAccess: false, permission: "none" },
+		);
+
+		const decision = await partitionPreviewApps({
+			apps: [
+				app({ name: "unlabeled", previewLabels: ["preview"] }), // filtered by labels
+				app({ name: "authorized", previewLabels: ["deploy"] }), // write access
+				app({ name: "denied", previewLabels: ["deploy"] }), // no write access
+				app({ name: "no-gate", previewLabels: null }), // always checked
+			],
+			pullRequestLabels: [{ name: "deploy" }],
+			...pullRequest,
+			resolveAuthorPermission,
+		});
+
+		expect(decision.authorizedApps.map((a) => a.name)).toEqual(["authorized"]);
+		expect(decision.blockedAppNames).toEqual(["denied", "no-gate"]);
+		// The label-mismatched app is never permission-checked.
+		expect(
+			resolveAuthorPermission.mock.calls.map(([candidate]) => candidate.name),
+		).not.toContain("unlabeled");
+	});
+
+	describe("logs a traceable reason for every decision", () => {
+		it("logs why a preview is skipped, naming the PR and the label mismatch", async () => {
+			await partitionPreviewApps({
+				apps: [app({ name: "docs", previewLabels: ["preview"] })],
+				pullRequestLabels: [{ name: "dependencies" }],
+				...pullRequest,
+				resolveAuthorPermission: denies(),
+			});
+
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Preview SKIPPED for "docs" — PR #42 (opened) by dependency-bot[bot] on acme/web-app',
+				),
+			);
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					"[dependencies] do not match required [preview]",
+				),
+			);
+		});
+
+		it("logs why a preview is blocked, naming the PR and the permission", async () => {
+			await partitionPreviewApps({
+				apps: [app({ name: "docs" })],
+				pullRequestLabels: [{ name: "preview" }],
+				...pullRequest,
+				resolveAuthorPermission: denies("read"),
+			});
+
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Preview BLOCKED for "docs" — PR #42 (opened) by dependency-bot[bot] on acme/web-app: author lacks write access (permission: read)',
+				),
+			);
+		});
+
+		it("logs why a preview is accepted, naming the PR and the permission", async () => {
+			await partitionPreviewApps({
+				apps: [app({ name: "docs" })],
+				pullRequestLabels: [{ name: "preview" }],
+				...pullRequest,
+				resolveAuthorPermission: grants("admin"),
+			});
+
+			expect(console.log).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Preview ACCEPTED for "docs" — PR #42 (opened) by dependency-bot[bot] on acme/web-app: author has write access (permission: admin)',
+				),
+			);
+		});
+	});
+});

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -17,6 +17,7 @@ import { applications, compose, github } from "@/server/db/schema";
 import type { DeploymentJob } from "@/server/queues/queue-types";
 import { myQueue } from "@/server/queues/queueSetup";
 import { deploy } from "@/server/utils/deploy";
+import { partitionPreviewApps } from "@/utils/preview-deployment";
 import {
 	extractCommitMessage,
 	extractHash,
@@ -378,6 +379,11 @@ export default async function handler(
 			const owner = getGithubRepositoryOwner(githubBody);
 			const prAuthor = githubBody?.pull_request?.user?.login;
 
+			const prNumber = githubBody?.pull_request?.number;
+			const prTitle = githubBody?.pull_request?.title;
+			const prURL = githubBody?.pull_request?.html_url;
+			const prBranch = githubBody?.pull_request?.head?.ref;
+
 			// Validate PR author information is present
 			if (!prAuthor) {
 				console.warn(
@@ -403,87 +409,47 @@ export default async function handler(
 				},
 			});
 
-			// SECURITY: Check collaborator permissions per application setting
-			const secureApps: typeof apps = [];
-			const blockedApps: string[] = [];
-			let userPermission: string | null = null;
-
-			for (const app of apps) {
-				// If the app requires collaborator permissions, verify them
-				if (app.previewRequireCollaboratorPermissions !== false) {
-					try {
+			// Labels are filtered before permissions, so a PR that would be
+			// skipped anyway never triggers a security block (issue #4902).
+			// Every decision is logged with the PR context for traceability.
+			const { authorizedApps, blockedAppNames, authorPermission } =
+				await partitionPreviewApps({
+					apps,
+					pullRequestLabels: githubBody?.pull_request?.labels,
+					owner,
+					repository,
+					prAuthor,
+					prNumber,
+					action,
+					resolveAuthorPermission: async () => {
 						const githubProvider = await findGithubById(githubResult.githubId);
-						const { hasWriteAccess, permission } =
-							await checkUserRepositoryPermissions(
-								githubProvider,
-								owner,
-								repository,
-								prAuthor,
-							);
-
-						userPermission = permission; // Store permission for comment
-
-						if (!hasWriteAccess) {
-							console.warn(
-								`🚨 SECURITY: Blocked preview deployment for ${app.name} from unauthorized user ${prAuthor} on ${owner}/${repository}. Permission: ${permission || "none"}`,
-							);
-							blockedApps.push(app.name);
-							continue;
-						}
-
-						console.log(
-							`✅ SECURITY: Preview deployment authorized for ${app.name} from user ${prAuthor} on ${owner}/${repository}. Permission: ${permission}`,
+						return checkUserRepositoryPermissions(
+							githubProvider,
+							owner,
+							repository,
+							prAuthor,
 						);
-					} catch (error) {
-						console.error(
-							`Error validating PR author permissions for ${app.name}:`,
-							error,
-						);
-						blockedApps.push(app.name);
-						continue; // Skip this app on error
-					}
-				} else {
-					console.warn(
-						`⚠️  SECURITY: Preview deployment for ${app.name} allows deployment from any PR author (security check disabled)`,
-					);
-				}
-				secureApps.push(app);
-			}
-
-			const prBranch = githubBody?.pull_request?.head?.ref;
-
-			const prNumber = githubBody?.pull_request?.number;
-			const prTitle = githubBody?.pull_request?.title;
-			const prURL = githubBody?.pull_request?.html_url;
+					},
+				});
 
 			// Create security notification comment if any apps were blocked
-			if (blockedApps.length > 0) {
+			if (blockedAppNames.length > 0) {
 				await createSecurityBlockedComment({
 					owner,
 					repository,
 					prNumber: Number.parseInt(prNumber),
 					prAuthor,
-					permission: userPermission,
+					permission: authorPermission,
 					githubId: githubResult.githubId,
 				});
 			}
 
-			for (const app of secureApps) {
-				// check for labels
-				if (app?.previewLabels && app?.previewLabels?.length > 0) {
-					let hasLabel = false;
-					const labels = githubBody?.pull_request?.labels;
-					for (const label of labels) {
-						if (app?.previewLabels?.includes(label.name)) {
-							hasLabel = true;
-							break;
-						}
-					}
-					if (!hasLabel) continue;
-				}
-
+			for (const app of authorizedApps) {
 				const previewLimit = app?.previewLimit || 0;
 				if (app?.previewDeployments?.length > previewLimit) {
+					console.log(
+						`⏭️  Preview SKIPPED for "${app.name}" — PR #${prNumber} (${action}): preview limit reached (${app.previewDeployments.length}/${previewLimit})`,
+					);
 					continue;
 				}
 				const previewDeploymentResult =

--- a/apps/dokploy/utils/preview-deployment.ts
+++ b/apps/dokploy/utils/preview-deployment.ts
@@ -1,0 +1,140 @@
+/**
+ * Preview-deployment access control for GitHub pull requests.
+ *
+ * Security ordering (issue #4902): the preview-label filter is itself a valid
+ * gate — only collaborators with write access can add labels to a PR — so it
+ * MUST run before the collaborator-permission check. A PR that does not carry a
+ * configured preview label is not a deployment candidate and is dropped
+ * silently: no GitHub API call, no deployment, and no "Preview Deployment
+ * Blocked" comment. Checking permissions first raised false-positive security
+ * alarms on PRs that were never going to deploy (e.g. dependency-bot PRs).
+ */
+
+export interface PreviewCandidateApp {
+	name: string;
+	previewLabels?: string[] | null;
+	previewRequireCollaboratorPermissions?: boolean | null;
+}
+
+export interface PullRequestLabel {
+	name: string;
+}
+
+export interface CollaboratorPermission {
+	hasWriteAccess: boolean;
+	permission: string | null;
+}
+
+/**
+ * A non-empty label list is a gate: the PR must carry at least one of the
+ * labels. An app with no configured labels deploys a preview for every PR.
+ */
+export const pullRequestMatchesPreviewLabels = (
+	configuredLabels: string[] | null | undefined,
+	pullRequestLabels: PullRequestLabel[] | null | undefined,
+): boolean => {
+	if (!configuredLabels || configuredLabels.length === 0) {
+		return true;
+	}
+	return (pullRequestLabels ?? []).some((label) =>
+		configuredLabels.includes(label.name),
+	);
+};
+
+export interface PreviewAccessDecision<T> {
+	/** Apps cleared to deploy a preview for this PR. */
+	authorizedApps: T[];
+	/** Names of apps blocked because the PR author lacks write access. */
+	blockedAppNames: string[];
+	/** The PR author's resolved permission level, for the security comment. */
+	authorPermission: string | null;
+}
+
+/**
+ * Splits preview-enabled apps into those cleared to deploy and those blocked by
+ * the collaborator-permission check.
+ *
+ * `resolveAuthorPermission` (a GitHub API call) is invoked only for apps whose
+ * labels match the PR, so label-mismatched apps never trigger a permission
+ * check and never appear in `blockedAppNames`. The check fails closed: any
+ * error blocks the app rather than deploying it.
+ *
+ * Every app produces exactly one greppable decision log — ACCEPTED, BLOCKED, or
+ * SKIPPED — carrying the PR context, so an operator can always trace why a
+ * given PR event did or did not deploy a preview.
+ */
+export const partitionPreviewApps = async <T extends PreviewCandidateApp>({
+	apps,
+	pullRequestLabels,
+	owner,
+	repository,
+	prAuthor,
+	prNumber,
+	action,
+	resolveAuthorPermission,
+}: {
+	apps: T[];
+	pullRequestLabels: PullRequestLabel[] | null | undefined;
+	owner: string;
+	repository: string;
+	prAuthor: string;
+	prNumber: number | string;
+	action: string;
+	resolveAuthorPermission: (app: T) => Promise<CollaboratorPermission>;
+}): Promise<PreviewAccessDecision<T>> => {
+	const authorizedApps: T[] = [];
+	const blockedAppNames: string[] = [];
+	let authorPermission: string | null = null;
+
+	// Shared prefix so every decision line is traceable to this PR event.
+	const pr = `PR #${prNumber} (${action}) by ${prAuthor} on ${owner}/${repository}`;
+	const prLabelNames = (pullRequestLabels ?? []).map((label) => label.name);
+
+	for (const app of apps) {
+		// Gate 1 — labels. A mismatch is a routine skip, not a security block.
+		if (
+			!pullRequestMatchesPreviewLabels(app.previewLabels, pullRequestLabels)
+		) {
+			console.log(
+				`⏭️  Preview SKIPPED for "${app.name}" — ${pr}: PR labels [${prLabelNames.join(", ")}] do not match required [${(app.previewLabels ?? []).join(", ")}]`,
+			);
+			continue;
+		}
+
+		// Opt-out defaults to enabled, so `undefined` still enforces the check.
+		if (app.previewRequireCollaboratorPermissions === false) {
+			console.warn(
+				`⚠️  SECURITY: Preview ACCEPTED for "${app.name}" — ${pr}: collaborator permission check disabled (any author allowed)`,
+			);
+			authorizedApps.push(app);
+			continue;
+		}
+
+		// Gate 2 — collaborator permissions (fail closed).
+		try {
+			const { hasWriteAccess, permission } = await resolveAuthorPermission(app);
+			authorPermission = permission;
+
+			if (!hasWriteAccess) {
+				console.warn(
+					`🚨 SECURITY: Preview BLOCKED for "${app.name}" — ${pr}: author lacks write access (permission: ${permission || "none"})`,
+				);
+				blockedAppNames.push(app.name);
+				continue;
+			}
+
+			console.log(
+				`✅ SECURITY: Preview ACCEPTED for "${app.name}" — ${pr}: author has write access (permission: ${permission})`,
+			);
+			authorizedApps.push(app);
+		} catch (error) {
+			console.error(
+				`🚨 SECURITY: Preview BLOCKED for "${app.name}" — ${pr}: permission check failed (blocked fail-closed)`,
+				error,
+			);
+			blockedAppNames.push(app.name);
+		}
+	}
+
+	return { authorizedApps, blockedAppNames, authorPermission };
+};


### PR DESCRIPTION
## What is this PR about?

For GitHub preview deployments the collaborator-permission check ran *before* the preview-label filter. As a result a PR that the label filter would exclude anyway (e.g. a `renovate[bot]` / `dependabot[bot]` PR without the required label) still hit the permission check, was pushed to `blockedApps`, and triggered the alarming `🚨 Preview Deployment Blocked` security comment — even though it was never going to deploy.

The preview label is itself a valid gate: only collaborators with write access can add labels to a PR. Evaluating it first means a PR that does not match the configured `previewLabels` short-circuits with no GitHub API call, no deployment, and no security comment.

Changes:

- Extract the decision logic into `apps/dokploy/utils/preview-deployment.ts` (`pullRequestMatchesPreviewLabels` + `partitionPreviewApps`). The label filter now runs first, so `resolveAuthorPermission` (the GitHub API call) is only invoked for apps whose labels match the PR. The check still fails closed: any error blocks the app rather than deploying it.
- Rework `apps/dokploy/pages/api/deploy/github.ts` to use the helper and drop the now-redundant label check from the deploy loop.
- Improve traceability: every candidate app emits exactly one greppable decision log — `ACCEPTED`, `BLOCKED`, or `SKIPPED` — carrying the PR number, action, author, and reason. The previously-silent label-mismatch `continue` is now logged as a routine skip (deliberately not a `SECURITY` block), and the preview-limit skip is logged too. The `SECURITY` keyword is retained on security-relevant lines so existing log-based alerting keeps matching.

Example decision logs (one per candidate app, per PR event):

    ⏭️  Preview SKIPPED for "web" — PR #42 (opened) by dependency-bot[bot] on acme/web-app: PR labels [dependencies, renovate] do not match required [preview]
    🚨 SECURITY: Preview BLOCKED for "web" — PR #42 (opened) by dependency-bot[bot] on acme/web-app: author lacks write access (permission: none)
    ⚠️  SECURITY: Preview ACCEPTED for "web" — PR #42 (opened) by dependency-bot[bot] on acme/web-app: collaborator permission check disabled (any author allowed)
    ✅ SECURITY: Preview ACCEPTED for "web" — PR #42 (opened) by alice on acme/web-app: author has write access (permission: write)
    ⏭️  Preview SKIPPED for "web" — PR #42 (opened): preview limit reached (3/3)

Tests:

- `apps/dokploy/__test__/git-provider/preview-deployment-label-order.test.ts` (new) unit-tests the label semantics, the label-before-permission ordering, fail-closed behavior, and the traceability log contract.
- `apps/dokploy/__test__/deploy/github-webhook-handler.test.ts` gains three end-to-end `pull_request` cases driving the real handler: a label-mismatched bot PR posts no security comment and does not deploy; a label-matched PR without write access posts the comment; a label-matched PR with write access queues the preview.

---

Built this branch, deployed the image to a real Dokploy instance, and replayed the failing scenario — voraus-renovate[bot] PRs on vorausrobotik/vdoc without the required preview label — across opened / labeled / unlabeled events on two PRs.

Every event now short-circuits at the label filter: no permission check, no deployment, and no 🚨 Preview Deployment Blocked comment. The decision logs confirm it:


```
⏭️  Preview SKIPPED for "preview" — PR #371 (unlabeled) by voraus-renovate[bot] on vorausrobotik/vdoc: PR labels [dependencies] do not match required [preview]
⏭️  Preview SKIPPED for "preview" — PR #371 (labeled)   by voraus-renovate[bot] on vorausrobotik/vdoc: PR labels [dependencies, renovate] do not match required [preview]
⏭️  Preview SKIPPED for "preview" — PR #372 (opened)    by voraus-renovate[bot] on vorausrobotik/vdoc: PR labels [dependencies, renovate] do not match required [preview]
⏭️  Preview SKIPPED for "preview" — PR #372 (labeled)   by voraus-renovate[bot] on vorausrobotik/vdoc: PR labels [dependencies, renovate] do not match required [preview]
```

No security comment was posted on either PR — the false-positive alarm is gone. 

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

Closes #4902

## Screenshots (if applicable)

N/A


---
> [!NOTE]  
> AI assistance: this change was drafted with Claude Code using the `claude-opus-4-8[1m]` model (Opus 4.8, 1M-token context).


