### PR TITLE
fix(domains): don't render CDN info message as an error in DNS tooltip

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/columns.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/columns.tsx
@@ -209,7 +209,9 @@ export const createColumns = ({
 									</Badge>
 								</TooltipTrigger>
 								<TooltipContent className="max-w-xs">
-									{validationState?.error ? (
+									{validationState?.isValid && validationState?.message ? (
+										<p>{validationState.message}</p>
+									) : validationState?.error ? (
 										<div className="flex flex-col gap-1">
 											<p className="font-medium text-red-500">Error:</p>
 											<p>{validationState.error}</p>

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -626,7 +626,10 @@ export const ShowDomains = ({ id, type }: Props) => {
 																</Badge>
 															</TooltipTrigger>
 															<TooltipContent className="max-w-xs">
-																{validationState?.error ? (
+																{validationState?.isValid &&
+																validationState?.message ? (
+																	<p>{validationState.message}</p>
+																) : validationState?.error ? (
 																	<div className="flex flex-col gap-1">
 																		<p className="font-medium text-red-500">
 																			Error:


### PR DESCRIPTION
## What is this PR about?

`validateDomain` treats a CDN-fronted domain as valid, but reuses the `error` field to carry the provider's informational warning:

```ts
// packages/server/src/services/domain.ts
if (cdnProvider) {
    return { isValid: true, resolvedIp, cdnProvider: cdnProvider.displayName, error: cdnProvider.warningMessage };
}
```

`show-domains.tsx` already untangles this when storing state (`message: result.error && result.isValid ? result.error : undefined`), and the badge reads `message` to render the green "Behind Cloudflare" label correctly. The **tooltip**, however, branched on `error` alone — so the informational text was displayed under a red **Error:** heading, as reported in #4910.

This checks the valid + `message` case first, mirroring the distinction the badge already makes.

Note that the same tooltip is duplicated in two places, so both are fixed:
- `columns.tsx` — the domains table view
- `show-domains.tsx` — the card view, which is the one in the issue screenshot ("Behind Cloudflare")

Fixing only the table view would leave the reported repro unchanged.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.


Repro for anyone verifying: `detectCDNProvider` matches the *resolved* IP against CDN ranges, so any Cloudflare-fronted domain (e.g. `discord.com`) added as an application domain will hit the CDN branch — you don't need to own a domain on Cloudflare.

## Issues related (if applicable)

closes #4910

## Screenshots (if applicable)
<img width="862" height="450" alt="image (5)" src="https://github.com/user-attachments/assets/ee6b53a4-63cc-47ce-8349-953795a385cc" />
<img width="768" height="386" alt="Screenshot-224" src="https://github.com/user-attachments/assets/2a1f1b2e-cba1-4c97-a344-904ba3253e08" />


