### PR TITLE
fix(backups): dump the database once instead of twice

### DIFF
--- a/apps/dokploy/__test__/backups/backup-command.test.ts
+++ b/apps/dokploy/__test__/backups/backup-command.test.ts
@@ -1,0 +1,184 @@
+import { execSync } from "node:child_process";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BackupSchedule } from "@dokploy/server/services/backup";
+import { getBackupCommand } from "@dokploy/server/utils/backups/utils";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+// The script produced by getBackupCommand is run for real, with `docker` and
+// `rclone` replaced by stubs on PATH. The docker stub counts how many times the
+// dump is executed — the regression this suite guards against is dumping twice.
+let dir: string;
+let binDir: string;
+let logPath: string;
+let counterPath: string;
+let uploadPath: string;
+let cleanupMarkPath: string;
+
+const write = (path: string, contents: string) => {
+	writeFileSync(path, contents);
+	chmodSync(path, 0o755);
+};
+
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), "dokploy-backup-cmd-"));
+	binDir = join(dir, "bin");
+	mkdirSync(binDir);
+	logPath = join(dir, "backup.log");
+	counterPath = join(dir, "dump-runs");
+	uploadPath = join(dir, "uploaded.gz");
+	cleanupMarkPath = join(dir, "cleanup-ran");
+
+	// `docker ps` resolves the container id; anything else is the dump itself.
+	write(
+		join(binDir, "docker"),
+		`#!/bin/bash
+if [ "$1" = "ps" ]; then echo "container123"; exit 0; fi
+echo run >> "${counterPath}"
+printf 'DUMP-PAYLOAD'
+if [ -n "$DUMP_FAILS" ]; then echo "pg_dump: server closed the connection" >&2; exit 1; fi
+exit 0
+`,
+	);
+
+	write(
+		join(dir, "rclone-ok"),
+		`#!/bin/bash
+cat > "${uploadPath}"
+`,
+	);
+
+	write(
+		join(dir, "rclone-fail"),
+		`#!/bin/bash
+echo "rclone: failed to create file system" >&2
+exit 1
+`,
+	);
+
+	write(
+		join(dir, "rclone-cleanup"),
+		`#!/bin/bash
+rm -f "${uploadPath}"
+touch "${cleanupMarkPath}"
+`,
+	);
+});
+
+afterAll(() => {
+	if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+	for (const path of [logPath, counterPath, uploadPath, cleanupMarkPath]) {
+		if (existsSync(path)) rmSync(path);
+	}
+});
+
+const backup = {
+	backupId: "backup-id",
+	backupType: "database",
+	databaseType: "postgres",
+	database: "testdb",
+	postgres: {
+		appName: "test-postgres-app",
+		databaseUser: "testuser",
+	},
+} as unknown as BackupSchedule;
+
+// Runs the generated script; returns the exit code (0 on success).
+const run = (rclone: string, opts: { dumpFails?: boolean } = {}) => {
+	const command = getBackupCommand(
+		backup,
+		join(dir, rclone),
+		logPath,
+		join(dir, "rclone-cleanup"),
+	);
+
+	try {
+		execSync(command, {
+			shell: "/bin/bash",
+			stdio: "ignore",
+			env: {
+				...process.env,
+				PATH: `${binDir}:${process.env.PATH}`,
+				...(opts.dumpFails ? { DUMP_FAILS: "1" } : {}),
+			},
+		});
+		return 0;
+	} catch (error) {
+		// @ts-ignore - execSync errors carry the exit status
+		return (error?.status as number) ?? 1;
+	}
+};
+
+const dumpRuns = () =>
+	existsSync(counterPath)
+		? readFileSync(counterPath, "utf8").trim().split("\n").length
+		: 0;
+
+const log = () => (existsSync(logPath) ? readFileSync(logPath, "utf8") : "");
+
+describe("getBackupCommand", () => {
+	it("dumps the database exactly once and uploads that stream", () => {
+		expect(run("rclone-ok")).toBe(0);
+
+		expect(dumpRuns()).toBe(1);
+		expect(readFileSync(uploadPath, "utf8")).toBe("DUMP-PAYLOAD");
+		expect(log()).toContain("✅ backup completed successfully");
+		expect(log()).toContain("✅ Upload to S3 completed successfully");
+		expect(log()).toContain("Backup done ✅");
+	});
+
+	it("reports a failed dump, still dumping only once", () => {
+		expect(run("rclone-ok", { dumpFails: true })).not.toBe(0);
+
+		expect(dumpRuns()).toBe(1);
+		expect(log()).toContain("❌ Error: Backup failed");
+		expect(log()).toContain("server closed the connection");
+		expect(log()).not.toContain("✅ backup completed successfully");
+	});
+
+	it("removes the partially uploaded object when the dump fails", () => {
+		expect(run("rclone-ok", { dumpFails: true })).not.toBe(0);
+
+		expect(existsSync(cleanupMarkPath)).toBe(true);
+		expect(existsSync(uploadPath)).toBe(false);
+	});
+
+	it("blames the upload, not the dump, when rclone fails", () => {
+		expect(run("rclone-fail")).not.toBe(0);
+
+		expect(log()).toContain("❌ Error: Upload to S3 failed");
+		expect(log()).not.toContain("❌ Error: Backup failed");
+	});
+
+	it("aborts when the container cannot be found", () => {
+		write(join(binDir, "docker"), "#!/bin/bash\nexit 0\n");
+		try {
+			expect(run("rclone-ok")).not.toBe(0);
+			expect(dumpRuns()).toBe(0);
+			expect(log()).toContain("❌ Error: Container not found");
+		} finally {
+			write(
+				join(binDir, "docker"),
+				`#!/bin/bash
+if [ "$1" = "ps" ]; then echo "container123"; exit 0; fi
+echo run >> "${counterPath}"
+printf 'DUMP-PAYLOAD'
+if [ -n "$DUMP_FAILS" ]; then echo "pg_dump: server closed the connection" >&2; exit 1; fi
+exit 0
+`,
+			);
+		}
+	});
+});

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -38,11 +38,13 @@ export const runComposeBackup = async (
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCleanupCommand = `rclone delete ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rcloneCleanupCommand,
 		);
 		if (compose.serverId) {
 			await execAsyncRemote(compose.serverId, backupCommand);

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -38,11 +38,13 @@ export const runLibsqlBackup = async (
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCleanupCommand = `rclone delete ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rcloneCleanupCommand,
 		);
 		if (libsql.serverId) {
 			await execAsyncRemote(libsql.serverId, backupCommand);

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -36,11 +36,13 @@ export const runMariadbBackup = async (
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCleanupCommand = `rclone delete ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rcloneCleanupCommand,
 		);
 		if (mariadb.serverId) {
 			await execAsyncRemote(mariadb.serverId, backupCommand);

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -33,11 +33,13 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCleanupCommand = `rclone delete ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rcloneCleanupCommand,
 		);
 
 		if (mongo.serverId) {

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -35,11 +35,13 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCleanupCommand = `rclone delete ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rcloneCleanupCommand,
 		);
 
 		if (mysql.serverId) {

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -38,11 +38,13 @@ export const runPostgresBackup = async (
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
 
 		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCleanupCommand = `rclone delete ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 		const backupCommand = getBackupCommand(
 			backup,
 			rcloneCommand,
 			deployment.logPath,
+			rcloneCleanupCommand,
 		);
 		if (postgres.serverId) {
 			await execAsyncRemote(postgres.serverId, backupCommand);

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -261,6 +261,10 @@ export const getBackupCommand = (
 	backup: BackupSchedule,
 	rcloneCommand: string,
 	logPath: string,
+	// Optional. Removes the object that `rcloneCommand` created when the dump
+	// fails halfway through: the stream is uploaded as it is produced, so a dump
+	// that dies mid-way leaves a truncated file behind.
+	cleanupCommand?: string,
 ) => {
 	const containerSearch = getContainerSearchCommand(backup);
 	const backupCommand = generateBackupCommand(backup);
@@ -288,23 +292,41 @@ export const getBackupCommand = (
 
 	echo "[$(date)] Container Up: $CONTAINER_ID" >> ${logPath};
 
-	# Run the backup command and capture the exit status
-	BACKUP_OUTPUT=$(${backupCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
-		echo "Error: $BACKUP_OUTPUT" >> ${logPath};
+	# Dump straight into rclone: the database is read and compressed ONCE and the
+	# stream is uploaded as it is produced. Each side keeps its own stderr file so
+	# the log can still tell a failed dump apart from a failed upload — note that
+	# PIPESTATUS only survives if the pipeline is not wrapped in $(...).
+	DUMP_STDERR=$(mktemp);
+	UPLOAD_STDERR=$(mktemp);
+	set +e;
+	${backupCommand} 2>"$DUMP_STDERR" | ${rcloneCommand} >/dev/null 2>"$UPLOAD_STDERR";
+	BACKUP_STATUS=("\${PIPESTATUS[@]}");
+	set -e;
+
+	# rclone is checked first: when the upload dies early the dump is killed by
+	# SIGPIPE, so a non-zero dump status is a consequence and not the cause.
+	if [ "\${BACKUP_STATUS[1]}" -ne 0 ]; then
+		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
+		echo "Error: $(cat "$UPLOAD_STDERR")" >> ${logPath};
+		rm -f "$DUMP_STDERR" "$UPLOAD_STDERR";
 		exit 1;
-	}
+	fi
+
+	if [ "\${BACKUP_STATUS[0]}" -ne 0 ]; then
+		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
+		echo "Error: $(cat "$DUMP_STDERR")" >> ${logPath};${
+			cleanupCommand
+				? `
+		${cleanupCommand} >/dev/null 2>&1 || true;`
+				: ""
+		}
+		rm -f "$DUMP_STDERR" "$UPLOAD_STDERR";
+		exit 1;
+	fi
+
+	rm -f "$DUMP_STDERR" "$UPLOAD_STDERR";
 
 	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
-
-	# Run the upload command and capture the exit status
-	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
-		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
-		exit 1;
-	}
-
 	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;


### PR DESCRIPTION
Closes #4915

## Problem

`getBackupCommand` interpolates `${backupCommand}` twice: once with its stdout thrown away, purely to check that the dump works, and once more piped into `rclone`. Every database backup — postgres, mysql, mariadb, mongo, libsql and compose — therefore reads and compresses the entire database **two times**.

On a 9.4 GB Postgres this is what the log looks like today:

```
[Mon Jul 27 00:00:04 UTC 2026] Executing backup command...
[Mon Jul 27 00:09:17 UTC 2026] ✅ backup completed successfully      ← 9m13s, discarded
[Mon Jul 27 00:09:17 UTC 2026] Starting upload to S3...
[Mon Jul 27 00:16:35 UTC 2026] ✅ Upload to S3 completed successfully ← 7m18s, dumped again
```

16m31s instead of ~8m. It also doubles the CPU burned by single-threaded `gzip`/`pg_dump -Fc` on the same box that serves traffic, and — the part that actually hurts — it doubles the window in which `pg_dump` holds `ACCESS SHARE` on every table and keeps a snapshot open, which is the window where a concurrent migration's `ALTER TABLE` blocks and autovacuum is held back.

## What changed

The dump is piped straight into rclone, so the database is read once and the stream is uploaded as it is produced.

Three details worth reviewing:

1. **Error attribution is preserved.** Each side of the pipe writes to its own stderr file, and `PIPESTATUS` tells which side failed, so the log keeps distinguishing `❌ Error: Backup failed` from `❌ Error: Upload to S3 failed`. (`PIPESTATUS` only survives if the pipeline is *not* wrapped in `$(...)` — hence the temp files rather than a command substitution.) As a side effect the dump's stderr now actually reaches the log on the upload path; previously `2>&1 >/dev/null` bound to the rclone side only.
2. **rclone is checked first.** If the upload dies early, the dump is killed by `SIGPIPE`, so a non-zero dump status is a consequence, not the cause.
3. **Partial objects are cleaned up.** With streaming, a dump that dies halfway leaves a truncated object in the bucket, so each runner now passes an `rclone delete` command that removes it when the dump fails. (Worth noting the discarded first run never really prevented this: the second dump could fail just as well and leave the same truncated file.)

The script still relies on bash, exactly as before (`set -o pipefail` is already bash-only).

**One behavioural change to be aware of:** the `Starting upload to S3...` log line is gone, since there is no longer a separate upload phase — the two `✅` lines are now emitted together at the end. I checked that nothing in the codebase parses those strings.

## Testing

Added `apps/dokploy/__test__/backups/backup-command.test.ts`, which runs the generated script for real with `docker`/`rclone` stubs on `PATH` (same approach as the existing `db-backup-restore-injection.test.ts`) and asserts:

- the dump runs **exactly once** and the uploaded bytes are the dump's output;
- a failing dump is reported as `Backup failed`, still dumping only once;
- a failing dump removes the partially uploaded object;
- a failing rclone is reported as `Upload to S3 failed`, not as a dump failure;
- a missing container still aborts before dumping.

```
✓ __test__/backups/backup-command.test.ts (5 tests) 139ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Full suite, before and after, on the same machine (the failures are pre-existing and environmental — they need a database and a swarm manager, neither of which exists in my sandbox):

| | test files | tests |
|---|---|---|
| `canary` | 42 failed / 29 passed | 4 failed / 267 passed / 1 skipped |
| this branch | 42 failed / 30 passed | 4 failed / 272 passed / 1 skipped |

`biome check` clean on the touched files, `tsc --noEmit` clean in `packages/server`.

Happy to drop the cleanup-command part into a separate PR if you would rather keep this one to the single-dump change.
