### PR TITLE
feat: add generic rclone backup destinations

### DIFF
--- a/apps/dokploy/components/dashboard/settings/destination/constants.ts
+++ b/apps/dokploy/components/dashboard/settings/destination/constants.ts
@@ -1,7 +1,13 @@
+import { CUSTOM_RCLONE_PROVIDER } from "@dokploy/server/db/validations/destination";
+
 export const S3_PROVIDERS: Array<{
 	key: string;
 	name: string;
 }> = [
+	{
+		key: CUSTOM_RCLONE_PROVIDER,
+		name: "Custom rclone remote (Google Drive, OneDrive, FTP, SFTP, etc.)",
+	},
 	{
 		key: "AWS",
 		name: "Amazon Web Services (AWS) S3",

--- a/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/handle-destinations.tsx
@@ -1,6 +1,7 @@
 import {
 	ADDITIONAL_FLAG_ERROR,
 	ADDITIONAL_FLAG_REGEX,
+	CUSTOM_RCLONE_PROVIDER,
 } from "@dokploy/server/db/validations/destination";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { PenBoxIcon, PlusIcon, Trash2 } from "lucide-react";
@@ -41,26 +42,55 @@ import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 import { S3_PROVIDERS } from "./constants";
 
-const addDestination = z.object({
-	name: z.string().min(1, "Name is required"),
-	provider: z.string().min(1, "Provider is required"),
-	accessKeyId: z.string().min(1, "Access Key Id is required"),
-	secretAccessKey: z.string().min(1, "Secret Access Key is required"),
-	bucket: z.string().min(1, "Bucket is required"),
-	region: z.string(),
-	endpoint: z.string().min(1, "Endpoint is required"),
-	serverId: z.string().optional(),
-	additionalFlags: z
-		.array(
-			z.object({
-				value: z
-					.string()
-					.min(1, "Flag cannot be empty")
-					.regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR),
-			}),
-		)
-		.optional(),
-});
+const addDestination = z
+	.object({
+		name: z.string().min(1, "Name is required"),
+		provider: z.string().min(1, "Provider is required"),
+		accessKeyId: z.string(),
+		secretAccessKey: z.string(),
+		bucket: z.string(),
+		region: z.string(),
+		endpoint: z.string(),
+		serverId: z.string().optional(),
+		additionalFlags: z
+			.array(
+				z.object({
+					value: z
+						.string()
+						.min(1, "Flag cannot be empty")
+						.regex(ADDITIONAL_FLAG_REGEX, ADDITIONAL_FLAG_ERROR),
+				}),
+			)
+			.optional(),
+	})
+	.superRefine((data, ctx) => {
+		if (data.provider === CUSTOM_RCLONE_PROVIDER) {
+			if (!data.endpoint.trim() || !data.endpoint.includes(":")) {
+				ctx.addIssue({
+					code: "custom",
+					path: ["endpoint"],
+					message:
+						"Enter a named remote or connection string, such as gdrive: or :sftp,host=example.com:",
+				});
+			}
+			return;
+		}
+
+		for (const [field, label] of [
+			["accessKeyId", "Access Key Id"],
+			["secretAccessKey", "Secret Access Key"],
+			["bucket", "Bucket"],
+			["endpoint", "Endpoint"],
+		] as const) {
+			if (!data[field].trim()) {
+				ctx.addIssue({
+					code: "custom",
+					path: [field],
+					message: `${label} is required for S3 destinations`,
+				});
+			}
+		}
+	});
 
 type AddDestination = z.infer<typeof addDestination>;
 
@@ -107,6 +137,8 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		},
 		resolver: zodResolver(addDestination),
 	});
+
+	const isCustomRclone = form.watch("provider") === CUSTOM_RCLONE_PROVIDER;
 
 	const { fields, append, remove } = useFieldArray({
 		control: form.control,
@@ -196,7 +228,9 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 		const endpoint = form.getValues("endpoint");
 		const region = form.getValues("region");
 
-		const connectionString = `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
+		const connectionString = isCustomRclone
+			? `${endpoint}${bucket ? `${endpoint.endsWith(":") || endpoint.endsWith("/") ? "" : "/"}${bucket.replace(/^\/+/, "")}` : ""}`
+			: `:s3,provider=${provider},access_key_id=${accessKey},secret_access_key=${secretKey},endpoint=${endpoint}${region ? `,region=${region}` : ""}:${bucket}`;
 
 		await testConnection({
 			provider,
@@ -318,7 +352,11 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => {
 								return (
 									<FormItem>
-										<FormLabel>Access Key Id</FormLabel>
+										<FormLabel>
+											{isCustomRclone
+												? "Access Key Id (unused)"
+												: "Access Key Id"}
+										</FormLabel>
 										<FormControl>
 											<Input placeholder={"xcas41dasde"} {...field} />
 										</FormControl>
@@ -333,7 +371,11 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Secret Access Key</FormLabel>
+										<FormLabel>
+											{isCustomRclone
+												? "Secret Access Key (unused)"
+												: "Secret Access Key"}
+										</FormLabel>
 									</div>
 									<FormControl>
 										<Input placeholder={"asd123asdasw"} {...field} />
@@ -348,7 +390,11 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Bucket</FormLabel>
+										<FormLabel>
+											{isCustomRclone
+												? "Remote Base Path (optional)"
+												: "Bucket"}
+										</FormLabel>
 									</div>
 									<FormControl>
 										<Input placeholder={"dokploy-bucket"} {...field} />
@@ -363,7 +409,9 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							render={({ field }) => (
 								<FormItem>
 									<div className="space-y-0.5">
-										<FormLabel>Region</FormLabel>
+										<FormLabel>
+											{isCustomRclone ? "Region (unused)" : "Region"}
+										</FormLabel>
 									</div>
 									<FormControl>
 										<Input placeholder={"us-east-1"} {...field} />
@@ -377,10 +425,18 @@ export const HandleDestinations = ({ destinationId }: Props) => {
 							name="endpoint"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Endpoint</FormLabel>
+									<FormLabel>
+										{isCustomRclone
+											? "Rclone Remote / Connection String"
+											: "Endpoint"}
+									</FormLabel>
 									<FormControl>
 										<Input
-											placeholder={"https://us.bucket.aws/s3"}
+											placeholder={
+												isCustomRclone
+													? "gdrive: or :sftp,host=example.com:"
+													: "https://us.bucket.aws/s3"
+											}
 											{...field}
 										/>
 									</FormControl>

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -3,6 +3,8 @@ import {
 	execAsync,
 	execAsyncRemote,
 	findDestinationById,
+	getRcloneCredentials,
+	getRcloneDestination,
 	IS_CLOUD,
 	removeDestinationById,
 	updateDestinationById,
@@ -48,36 +50,16 @@ export const destinationRouter = createTRPCRouter({
 	testConnection: withPermission("destination", "create")
 		.input(apiCreateDestination)
 		.mutation(async ({ input }) => {
-			const {
-				secretAccessKey,
-				bucket,
-				region,
-				endpoint,
-				accessKey,
-				provider,
-				additionalFlags,
-			} = input;
 			try {
 				const rcloneFlags = [
-					`--s3-access-key-id=${quote([accessKey])}`,
-					`--s3-secret-access-key=${quote([secretAccessKey])}`,
-					`--s3-region=${quote([region])}`,
-					`--s3-endpoint=${quote([endpoint])}`,
-					"--s3-no-check-bucket",
-					"--s3-force-path-style",
+					...getRcloneCredentials(input),
 					"--retries 1",
 					"--low-level-retries 1",
 					"--timeout 10s",
 					"--contimeout 5s",
 				];
-				if (provider) {
-					rcloneFlags.unshift(`--s3-provider=${quote([provider])}`);
-				}
-				if (additionalFlags?.length) {
-					rcloneFlags.push(...additionalFlags);
-				}
-				const rcloneDestination = `:s3:${bucket}`;
-				const rcloneCommand = `rclone ls ${rcloneFlags.join(" ")} ${quote([rcloneDestination])}`;
+				const rcloneDestination = getRcloneDestination(input);
+				const rcloneCommand = `rclone lsd ${rcloneFlags.join(" ")} ${quote([rcloneDestination])}`;
 
 				if (IS_CLOUD && !input.serverId) {
 					throw new TRPCError({

--- a/packages/server/src/db/schema/destination.ts
+++ b/packages/server/src/db/schema/destination.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import {
 	ADDITIONAL_FLAG_ERROR,
 	ADDITIONAL_FLAG_REGEX,
+	CUSTOM_RCLONE_PROVIDER,
 } from "../validations/destination";
 import { organization } from "./account";
 import { backups } from "./backups";
@@ -54,6 +55,44 @@ const createSchema = createInsertSchema(destinations, {
 		.default([]),
 });
 
+const validateDestination = (
+	data: {
+		provider?: string | null;
+		accessKey?: string;
+		secretAccessKey?: string;
+		bucket?: string;
+		endpoint?: string;
+	},
+	ctx: z.RefinementCtx,
+) => {
+	if (data.provider === CUSTOM_RCLONE_PROVIDER) {
+		if (!data.endpoint?.trim() || !data.endpoint.includes(":")) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["endpoint"],
+				message:
+					"Enter a named rclone remote or connection string, such as gdrive: or :sftp,host=example.com:",
+			});
+		}
+		return;
+	}
+
+	for (const [field, label] of [
+		["accessKey", "Access key"],
+		["secretAccessKey", "Secret access key"],
+		["bucket", "Bucket"],
+		["endpoint", "Endpoint"],
+	] as const) {
+		if (!data[field]?.trim()) {
+			ctx.addIssue({
+				code: "custom",
+				path: [field],
+				message: `${label} is required for S3 destinations`,
+			});
+		}
+	}
+};
+
 export const apiCreateDestination = createSchema
 	.pick({
 		name: true,
@@ -68,7 +107,8 @@ export const apiCreateDestination = createSchema
 	.required()
 	.extend({
 		serverId: z.string().optional(),
-	});
+	})
+	.superRefine(validateDestination);
 
 export const apiFindOneDestination = z.object({
 	destinationId: z.string().min(1),
@@ -95,4 +135,5 @@ export const apiUpdateDestination = createSchema
 	.required()
 	.extend({
 		serverId: z.string().optional(),
-	});
+	})
+	.superRefine(validateDestination);

--- a/packages/server/src/db/validations/destination.ts
+++ b/packages/server/src/db/validations/destination.ts
@@ -1,3 +1,5 @@
+export const CUSTOM_RCLONE_PROVIDER = "RcloneCustom";
+
 export const ADDITIONAL_FLAG_REGEX = /^--[a-zA-Z0-9-]+(=[a-zA-Z0-9._:/@-]+)?$/;
 export const ADDITIONAL_FLAG_ERROR =
 	"Invalid flag format. Must start with -- (e.g. --s3-sign-accept-encoding=false)";

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -12,7 +12,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
 	normalizeS3Path,
 } from "./utils";
 
@@ -35,9 +36,12 @@ export const runComposeBackup = async (
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = getRcloneDestinationArgument(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${rcloneDestination}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/index.ts
+++ b/packages/server/src/utils/backups/index.ts
@@ -6,13 +6,19 @@ import { getAllServers } from "@dokploy/server/services/server";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
 import { eq } from "drizzle-orm";
 import { scheduleJob } from "node-schedule";
+import { quote } from "shell-quote";
 import { db } from "../../db/index";
 import { startLogCleanup } from "../access-log/handler";
 import { cleanupAll } from "../docker/utils";
 import { sendDockerCleanupNotifications } from "../notifications/docker-cleanup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { redactRcloneCredentials } from "./redact";
-import { getS3Credentials, normalizeS3Path, scheduleBackup } from "./utils";
+import {
+	getRcloneCredentials,
+	getRcloneDestination,
+	normalizeS3Path,
+	scheduleBackup,
+} from "./utils";
 
 export const initCronJobs = async () => {
 	console.log("Setting up cron jobs....");
@@ -134,17 +140,20 @@ export const keepLatestNBackups = async (
 
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
+		const rcloneFlags = getRcloneCredentials(destination);
 		const appName = getServiceAppName(backup);
-		const backupFilesPath = `:s3:${destination.bucket}/${appName}/${normalizeS3Path(backup.prefix)}`;
+		const backupFilesPath = getRcloneDestination(
+			destination,
+			`${appName}/${normalizeS3Path(backup.prefix)}`,
+		);
 
 		// --include "*.bson.gz" or "*.sql.gz" or "*.zip" ensures nothing else other than the dokploy backup files are touched by rclone
-		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${backupFilesPath}`;
+		const rcloneList = `rclone lsf ${rcloneFlags.join(" ")} --include "*${backup.databaseType === "web-server" ? ".zip" : ".{sql.gz,bson.gz}"}" ${quote([backupFilesPath])}`;
 		// when we pipe the above command with this one, we only get the list of files we want to delete
 		const sortAndPickUnwantedBackups = `sort -r | tail -n +$((${backup.keepLatestCount}+1)) | xargs -I{}`;
 		// this command deletes the files
-		// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}{}
-		const rcloneDelete = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
+		// to test the deletion before actually deleting we can add --dry-run before ${backupFilesPath}/{}
+		const rcloneDelete = `rclone deletefile ${rcloneFlags.join(" ")} ${quote([`${backupFilesPath}/{}`])}`;
 
 		const rcloneCommand = `${rcloneList} | ${sortAndPickUnwantedBackups} ${rcloneDelete}`;
 

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -12,7 +12,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
 	normalizeS3Path,
 } from "./utils";
 
@@ -34,10 +35,13 @@ export const runLibsqlBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = getRcloneDestinationArgument(
+			destination,
+			bucketDestination,
+		);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${rcloneDestination}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -12,7 +12,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
 	normalizeS3Path,
 } from "./utils";
 
@@ -33,9 +34,12 @@ export const runMariadbBackup = async (
 		description: "MariaDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = getRcloneDestinationArgument(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${rcloneDestination}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -12,7 +12,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
 	normalizeS3Path,
 } from "./utils";
 
@@ -30,9 +31,12 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		description: "MongoDB Backup",
 	});
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = getRcloneDestinationArgument(
+			destination,
+			bucketDestination,
+		);
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${rcloneDestination}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -12,7 +12,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
 	normalizeS3Path,
 } from "./utils";
 
@@ -31,10 +32,13 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	});
 
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = getRcloneDestinationArgument(
+			destination,
+			bucketDestination,
+		);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${rcloneDestination}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -12,7 +12,8 @@ import { execAsync, execAsyncRemote } from "../process/execAsync";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
-	getS3Credentials,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
 	normalizeS3Path,
 } from "./utils";
 
@@ -34,10 +35,13 @@ export const runPostgresBackup = async (
 	const backupFileName = `${getBackupTimestamp()}.sql.gz`;
 	const bucketDestination = `${appName}/${normalizeS3Path(prefix)}${backupFileName}`;
 	try {
-		const rcloneFlags = getS3Credentials(destination);
-		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
+		const rcloneFlags = getRcloneCredentials(destination);
+		const rcloneDestination = getRcloneDestinationArgument(
+			destination,
+			bucketDestination,
+		);
 
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} ${rcloneDestination}`;
 
 		const backupCommand = getBackupCommand(
 			backup,

--- a/packages/server/src/utils/backups/redact.ts
+++ b/packages/server/src/utils/backups/redact.ts
@@ -1,12 +1,29 @@
 /**
- * Redacts S3 credentials from rclone command strings.
+ * Redacts credentials from rclone command strings and connection strings.
  *
- * Used to prevent credential leakage in structured logs and error output.
- * Matches the flag format produced by `getS3Credentials()`:
- *   --s3-access-key-id="VALUE"  and  --s3-secret-access-key="VALUE"
+ * Covers the existing S3 flags, provider-specific password/token flags, and
+ * on-the-fly rclone connection-string parameters such as `pass=` or
+ * `client_secret=`.
  */
 export const redactRcloneCredentials = (command: string): string => {
+	const sensitiveName =
+		"(?:access[_-]?key(?:[_-]?id)?|secret(?:[_-]?access[_-]?key)?|pass(?:word)?|token|access[_-]?token|refresh[_-]?token|client[_-]?secret|private[_-]?key)";
+
 	return command
-		.replace(/(--s3-access-key-id=)"[^"]*"/g, '$1"[REDACTED]"')
-		.replace(/(--s3-secret-access-key=)"[^"]*"/g, '$1"[REDACTED]"');
+		.replace(/(--s3-access-key-id=)(?:"[^"]*"|'[^']*'|\S+)/gi, '$1"[REDACTED]"')
+		.replace(
+			/(--s3-secret-access-key=)(?:"[^"]*"|'[^']*'|\S+)/gi,
+			'$1"[REDACTED]"',
+		)
+		.replace(
+			new RegExp(
+				`(--[a-z0-9-]*${sensitiveName}=)(?:"[^"]*"|'[^']*'|\\S+)`,
+				"gi",
+			),
+			'$1"[REDACTED]"',
+		)
+		.replace(
+			new RegExp(`([,:]${sensitiveName}=)([^,:\\s'"/]+)`, "gi"),
+			"$1[REDACTED]",
+		);
 };

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -1,3 +1,4 @@
+import { CUSTOM_RCLONE_PROVIDER } from "@dokploy/server/db/validations/destination";
 import { logger } from "@dokploy/server/lib/logger";
 import type { BackupSchedule } from "@dokploy/server/services/backup";
 import type { Destination } from "@dokploy/server/services/destination";
@@ -68,7 +69,25 @@ export const normalizeS3Path = (prefix: string) => {
 	return normalizedPrefix ? `${normalizedPrefix}/` : "";
 };
 
-export const getS3Credentials = (destination: Destination) => {
+export const isCustomRcloneDestination = (
+	destination: Pick<Destination, "provider">,
+) => destination.provider === CUSTOM_RCLONE_PROVIDER;
+
+export const getRcloneCredentials = (
+	destination: Pick<
+		Destination,
+		| "provider"
+		| "accessKey"
+		| "secretAccessKey"
+		| "region"
+		| "endpoint"
+		| "additionalFlags"
+	>,
+) => {
+	if (isCustomRcloneDestination(destination)) {
+		return destination.additionalFlags ?? [];
+	}
+
 	const { accessKey, secretAccessKey, region, endpoint, provider } =
 		destination;
 	const rcloneFlags = [
@@ -90,6 +109,44 @@ export const getS3Credentials = (destination: Destination) => {
 
 	return rcloneFlags;
 };
+
+// Backward-compatible alias for downstream imports while the UI and backup
+// code migrate to the provider-neutral name.
+export const getS3Credentials = getRcloneCredentials;
+
+export const getRcloneDestination = (
+	destination: Pick<Destination, "provider" | "bucket" | "endpoint">,
+	path = "",
+) => {
+	const clean = (value: string) => value.trim().replace(/^\/+|\/+$/g, "");
+	const cleanPath = clean(path);
+
+	if (!isCustomRcloneDestination(destination)) {
+		return `:s3:${[clean(destination.bucket), cleanPath]
+			.filter(Boolean)
+			.join("/")}`;
+	}
+
+	const remote = destination.endpoint.trim();
+	if (!remote || !remote.includes(":")) {
+		throw new Error(
+			"Custom rclone destinations require a named remote or connection string (for example, gdrive: or :sftp,host=example.com:)",
+		);
+	}
+
+	const remotePath = [clean(destination.bucket), cleanPath]
+		.filter(Boolean)
+		.join("/");
+	if (!remotePath) return remote;
+
+	const separator = remote.endsWith(":") || remote.endsWith("/") ? "" : "/";
+	return `${remote}${separator}${remotePath}`;
+};
+
+export const getRcloneDestinationArgument = (
+	destination: Pick<Destination, "provider" | "bucket" | "endpoint">,
+	path = "",
+) => quote([getRcloneDestination(destination, path)]);
 
 // User-controlled values (database name, user, password) are passed to the
 // container as environment variables via `docker exec -e VAR=<escaped>` and
@@ -288,24 +345,17 @@ export const getBackupCommand = (
 
 	echo "[$(date)] Container Up: $CONTAINER_ID" >> ${logPath};
 
-	# Run the backup command and capture the exit status
-	BACKUP_OUTPUT=$(${backupCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
-		echo "Error: $BACKUP_OUTPUT" >> ${logPath};
-		exit 1;
-	}
+	echo "[$(date)] Starting backup upload..." >> ${logPath};
 
-	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
-
-	# Run the upload command and capture the exit status
+	# Stream the backup once directly into rclone. The previous implementation
+	# executed the database dump twice: once as a check and once for upload.
 	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
+		echo "[$(date)] ❌ Error: Backup upload failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
 		exit 1;
 	}
 
-	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
+	echo "[$(date)] ✅ Backup upload completed successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -16,7 +16,12 @@ import { findDestinationById } from "@dokploy/server/services/destination";
 import { sendDokployBackupNotifications } from "../notifications/dokploy-backup";
 import { execAsync } from "../process/execAsync";
 import { redactRcloneCredentials } from "./redact";
-import { getBackupTimestamp, getS3Credentials, normalizeS3Path } from "./utils";
+import {
+	getBackupTimestamp,
+	getRcloneCredentials,
+	getRcloneDestinationArgument,
+	normalizeS3Path,
+} from "./utils";
 
 function formatBytes(bytes?: number) {
 	if (bytes === undefined) return "Unknown size";
@@ -41,12 +46,15 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 	let computedBackupSize: number | undefined;
 	try {
 		const destination = await findDestinationById(backup.destinationId);
-		const rcloneFlags = getS3Credentials(destination);
+		const rcloneFlags = getRcloneCredentials(destination);
 		const timestamp = getBackupTimestamp();
 		const { BASE_PATH } = paths();
 		const tempDir = await mkdtemp(join(tmpdir(), "dokploy-backup-"));
 		const backupFileName = `webserver-backup-${timestamp}.zip`;
-		const s3Path = `:s3:${destination.bucket}/${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`;
+		const rclonePath = getRcloneDestinationArgument(
+			destination,
+			`${backup.appName}/${normalizeS3Path(backup.prefix)}${backupFileName}`,
+		);
 
 		try {
 			await execAsync(`mkdir -p ${tempDir}/filesystem`);
@@ -114,10 +122,10 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 				// If stat fails, keep undefined
 			}
 
-			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${zipPath}" "${s3Path}"`;
-			writeStream.write("Running command to upload backup to S3\n");
+			const uploadCommand = `rclone copyto ${rcloneFlags.join(" ")} "${zipPath}" ${rclonePath}`;
+			writeStream.write("Running command to upload backup to destination\n");
 			await execAsync(uploadCommand);
-			writeStream.write("Uploaded backup to S3 ✅\n");
+			writeStream.write("Uploaded backup to destination ✅\n");
 			writeStream.end();
 			await sendDokployBackupNotifications({
 				type: "success",


### PR DESCRIPTION
/claim #416

## Summary

Adds a provider-neutral custom rclone destination while preserving the existing S3 flow.

- adds **Custom rclone remote** to backup destination settings
- accepts a named rclone remote such as `gdrive:` / `onedrive:` or an on-the-fly connection string such as `:sftp,host=example.com,user=alice:`
- supports an optional remote base path
- reuses the same destination builder for connection tests, database backups, compose backups, web-server backups, and retention cleanup
- shell-quotes every generated destination argument and redacts passwords, tokens, secrets, and access keys from logs/errors
- keeps all existing S3 providers and credentials behavior unchanged
- updates backup logs to say “destination” instead of “S3”
- fixes the streaming backup path so database dumps are no longer executed twice before upload

This enables Google Drive, OneDrive, FTP, SFTP, and other rclone-supported backends without adding provider-specific database columns.

## Validation

- `pnpm --filter @dokploy/server typecheck`
- `pnpm --filter dokploy typecheck`
- Biome check on changed files
- `git diff --check`

## Notes

For OAuth-backed remotes such as Google Drive and OneDrive, a named remote already configured on the Dokploy host can be used. For stateless providers such as FTP and SFTP, an rclone connection string can be supplied directly.
