### PR TITLE
feat(api): allow owners and admins to create an API key for another member

### DIFF
--- a/apps/dokploy/__test__/api/api-key-name.test.ts
+++ b/apps/dokploy/__test__/api/api-key-name.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { API_KEY_NAME_MAX_LENGTH, apiKeyNameSchema } from "@/lib/api-keys";
+import {
+	API_KEY_NAME_MAX_LENGTH,
+	apiKeyNameSchema,
+	canCreateApiKeyForAnotherUser,
+} from "@/lib/api-keys";
 
 describe("apiKeyNameSchema", () => {
 	it("rejects an empty name", () => {
@@ -22,5 +26,22 @@ describe("apiKeyNameSchema", () => {
 				`Name must be at most ${API_KEY_NAME_MAX_LENGTH} characters`,
 			);
 		}
+	});
+});
+
+describe("canCreateApiKeyForAnotherUser", () => {
+	it("allows owners and admins", () => {
+		expect(canCreateApiKeyForAnotherUser("owner")).toBe(true);
+		expect(canCreateApiKeyForAnotherUser("admin")).toBe(true);
+	});
+
+	it("refuses a plain member, who may still mint for themselves", () => {
+		expect(canCreateApiKeyForAnotherUser("member")).toBe(false);
+	});
+
+	it("refuses an absent role instead of defaulting to allowed", () => {
+		expect(canCreateApiKeyForAnotherUser(undefined)).toBe(false);
+		expect(canCreateApiKeyForAnotherUser(null)).toBe(false);
+		expect(canCreateApiKeyForAnotherUser("")).toBe(false);
 	});
 });

--- a/apps/dokploy/lib/api-keys.ts
+++ b/apps/dokploy/lib/api-keys.ts
@@ -21,3 +21,15 @@ export const apiKeyNameSchema = z
 		API_KEY_NAME_MAX_LENGTH,
 		`Name must be at most ${API_KEY_NAME_MAX_LENGTH} characters`,
 	);
+
+/**
+ * Whether an organization role may create an API key on behalf of another
+ * member. Owners and admins may; everyone else may only mint for themselves.
+ *
+ * A key minted this way carries the TARGET user's permissions, so this is the
+ * one place that decision lives, kept pure so it can be unit tested.
+ */
+export const canCreateApiKeyForAnotherUser = (
+	role?: string | null,
+): boolean => role === "owner" || role === "admin";
+

--- a/apps/dokploy/server/api/routers/user.ts
+++ b/apps/dokploy/server/api/routers/user.ts
@@ -35,7 +35,10 @@ import { TRPCError } from "@trpc/server";
 import * as bcrypt from "bcrypt";
 import { and, asc, eq, gt, ne } from "drizzle-orm";
 import { z } from "zod";
-import { apiKeyNameSchema } from "@/lib/api-keys";
+import {
+	apiKeyNameSchema,
+	canCreateApiKeyForAnotherUser,
+} from "@/lib/api-keys";
 import { audit } from "@/server/api/utils/audit";
 import {
 	adminProcedure,
@@ -49,6 +52,12 @@ const apiCreateApiKey = z.object({
 	name: apiKeyNameSchema,
 	prefix: z.string().optional(),
 	expiresIn: z.number().optional(),
+	/**
+	 * Mint the key for another member of the organization instead of the
+	 * caller. Restricted to organization owners and admins; the target must be
+	 * a member of the same organization. Omit it to mint for yourself.
+	 */
+	userId: z.string().optional(),
 	metadata: z.object({
 		organizationId: z.string(),
 	}),
@@ -553,12 +562,49 @@ export const userRouter = createTRPCRouter({
 				}
 			}
 
-			const apiKey = await createApiKey(ctx.user.id, input);
+			const targetUserId = input.userId ?? ctx.user.id;
+
+			if (targetUserId !== ctx.user.id) {
+				if (!canCreateApiKeyForAnotherUser(ctx.user.role)) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message:
+							"Only organization owners and admins can create an API key for another user",
+					});
+				}
+
+				if (!input.metadata?.organizationId) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							"metadata.organizationId is required when creating an API key for another user",
+					});
+				}
+
+				const targetMember = await db.query.member.findFirst({
+					where: and(
+						eq(member.organizationId, input.metadata.organizationId),
+						eq(member.userId, targetUserId),
+					),
+				});
+
+				if (!targetMember) {
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "The target user is not a member of this organization",
+					});
+				}
+			}
+
+			const apiKey = await createApiKey(targetUserId, input);
 			await audit(ctx, {
 				action: "create",
 				resourceType: "user",
 				resourceId: apiKey.id,
-				resourceName: input.name,
+				resourceName:
+					targetUserId === ctx.user.id
+						? input.name
+						: `${input.name} (on behalf of ${targetUserId})`,
 			});
 			return apiKey;
 		}),


### PR DESCRIPTION
## Problem

`user.createApiKey` can only ever mint a key for the calling session's user: the service function already forwards a `userId` to better-auth, but the tRPC route hardcodes `ctx.user.id`.

That leaves automation with no way to bootstrap a per-user key. Anything that provisions users (SSO/SCIM-style onboarding, an internal developer platform handing each engineer their own credential) has to fall back to sharing a single admin key across everyone, which loses per-user attribution and per-user revocation, the two properties API keys exist for.

## Change

`createApiKey` accepts an optional `userId`.

Minting for someone else is gated:

- the caller must be an organization **owner** or **admin**
- `metadata.organizationId` is required in that case
- the target user must be a member of that organization

Omitting `userId` keeps the existing behaviour byte for byte, so this is backwards compatible and the UI is unchanged. The audit entry records when a key was created on behalf of another user.

## Security

A key minted this way carries the **target** user's permissions, not the caller's, so the authorization decision is deliberately kept in one pure place (`canCreateApiKeyForAnotherUser` in `lib/api-keys.ts`, next to the existing api-key name validation) rather than inlined. It refuses an absent or empty role instead of defaulting to allowed, and it is case-sensitive.

## Tests

Unit tests for the guard added alongside the existing `apiKeyNameSchema` tests in `__test__/api/api-key-name.test.ts` (owner/admin allowed, member refused, absent/empty role refused).

Note: I could not run the full suite locally without a complete monorepo install, so CI is the check for the rest.

## Backwards compatibility

No migration, no schema change, no UI change. Existing callers that omit `userId` are unaffected.