### PR TITLE
fix(ui): make interactive icons inside badges clickable again

### DIFF
--- a/apps/dokploy/components/ui/badge.tsx
+++ b/apps/dokploy/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg:not(.cursor-pointer)]:pointer-events-none [&>svg]:size-3!",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## What is this PR about?

the "x" remove button on middleware badges (domain config) and Watch Path badges (all git provider forms) does nothing when clicked: no request, no error, no confirmation, and the item stays there after reload.

 **Shared cause, not two separate bugs.** ( #4909  and #4886 ) `Badge`'s base class includes `[&>svg]:pointer-events-none`, introduced during the Tailwind v4 / shadcn  migration (#4706). This blanket-disables pointer events on *every* SVG  child of a Badge including icons that are explicitly meant to be interactive.

The remove icon's `onClick` handler is correct and was never the problem.

Since the cause is shared, this single change also fixes the identical bug in:

  - Watch Paths: Application git provider forms: GitHub, GitLab, Gitea,
  Bitbucket, generic Git
  - Watch Paths: Compose git provider forms: GitHub, GitLab, Gitea,
  Bitbucket, generic Git
  - Preview Deployments: trigger labels field

There is an existing PR that fixes this issue [4827](https://github.com/Dokploy/dokploy/pull/4827)

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4909  and #4886 

## Screenshots (if applicable)

