### PR TITLE
fix: avoid postgres 100-argument limit in schedule, volume backup and port queries

### DIFF
--- a/apps/schedules/src/utils.ts
+++ b/apps/schedules/src/utils.ts
@@ -180,6 +180,9 @@ export const initializeJobs = async () => {
 		where: eq(schedules.enabled, true),
 		with: {
 			application: {
+				columns: {
+					applicationId: true,
+				},
 				with: {
 					server: true,
 				},
@@ -227,6 +230,9 @@ export const initializeJobs = async () => {
 		where: eq(volumeBackups.enabled, true),
 		with: {
 			application: {
+				columns: {
+					applicationId: true,
+				},
 				with: {
 					server: true,
 				},

--- a/packages/server/src/services/port.ts
+++ b/packages/server/src/services/port.ts
@@ -30,12 +30,8 @@ export const finPortById = async (portId: string) => {
 		where: eq(ports.portId, portId),
 		with: {
 			application: {
-				with: {
-					environment: {
-						with: {
-							project: true,
-						},
-					},
+				columns: {
+					applicationId: true,
 				},
 			},
 		},

--- a/packages/server/src/services/schedule.ts
+++ b/packages/server/src/services/schedule.ts
@@ -81,6 +81,11 @@ export const findScheduleById = async (scheduleId: string) => {
 		where: eq(schedules.scheduleId, scheduleId),
 		with: {
 			application: {
+				columns: {
+					applicationId: true,
+					appName: true,
+					serverId: true,
+				},
 				with: {
 					environment: {
 						with: {

--- a/packages/server/src/services/volume-backups.ts
+++ b/packages/server/src/services/volume-backups.ts
@@ -13,6 +13,11 @@ export const findVolumeBackupById = async (volumeBackupId: string) => {
 		where: eq(volumeBackups.volumeBackupId, volumeBackupId),
 		with: {
 			application: {
+				columns: {
+					applicationId: true,
+					appName: true,
+					serverId: true,
+				},
 				with: {
 					environment: {
 						with: {


### PR DESCRIPTION
Closes #4926

Migration 0175 took the `application` table to 101 columns, so any Drizzle relational query that hydrates the full table now exceeds Postgres' `FUNC_MAX_ARGS = 100` limit in `json_build_array()` and fails with error 54023. This broke `finPortById`, `findScheduleById` and `findVolumeBackupById` — schedules and volume backups silently stopped running, and ports could not be read or edited.

Same fix as #4257 and #4924: narrow each nested `application` selection to the columns its consumers actually read (`applicationId`, `appName`, `serverId`), keeping the `environment → project` nesting where the org-id resolution needs it.

Also fixes two call sites not listed in the issue: both `initializeJobs` queries in `apps/schedules/src/utils.ts` hydrate `application → server` (102 arguments), so the cloud worker would fail to initialize schedules and volume backups on startup.

Verified against a local dev database: all five fixed queries execute correctly, while the previous shape still reproduces the 54023 failure.