### PR TITLE
fix(preview-deployment): refetch github provider before authenticating

### DIFF
--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -17,7 +17,7 @@ import { manageDomain } from "../utils/traefik/domain";
 import { findApplicationById } from "./application";
 import { removeDeploymentsByPreviewDeploymentId } from "./deployment";
 import { createDomain } from "./domain";
-import { type Github, getIssueComment } from "./github";
+import { findGithubById, getIssueComment } from "./github";
 import { getWebServerSettings } from "./web-server-settings";
 
 export type PreviewDeployment = typeof previewDeployments.$inferSelect;
@@ -142,7 +142,17 @@ export const createPreviewDeployment = async (
 		org?.ownerId || "",
 	);
 
-	const octokit = authGithub(application?.github as Github);
+	if (!application.githubId) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Github Account not configured correctly",
+		});
+	}
+
+	// `findApplicationById` redacts `githubPrivateKey` from the `github`
+	// relation, so the provider must be refetched to authenticate.
+	const githubProvider = await findGithubById(application.githubId);
+	const octokit = authGithub(githubProvider);
 
 	const runningComment = getIssueComment(
 		application.name,


### PR DESCRIPTION
`findApplicationById` redacts `githubPrivateKey` from the `github` relation, but `createPreviewDeployment` passed that redacted object straight to `authGithub`. Since `haveGithubRequirements` requires the private key, it always returned false and `authGithub` threw `TRPCError NOT_FOUND: "Github Account not configured correctly"`.

That throw is uncaught in `pages/api/deploy/github.ts`, so every `pull_request` webhook returned a bare 500 and no preview deployment was ever created.

Resolve the provider through `findGithubById(application.githubId)` instead, matching how every other call site obtains credentials. This keeps the redaction introduced for `findApplicationById` intact.

Fixes #4898

## What is this PR about?

Please describe in a short paragraph what this PR is about.

## Checklist

Before submitting this PR, please make sure that:

- [ ] You created a dedicated branch based on the `canary` branch.
- [ ] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #123

## Screenshots (if applicable)

