### PR TITLE
fix: preserve special chars in compose env file generation

### DIFF
--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { getCreateEnvFileCommand } from "@dokploy/server/utils/builders/compose";
+import { afterEach, expect, test } from "vitest";
+
+const appName = `env-file-literals-${process.pid}`;
+const appPath = join(process.cwd(), ".docker", "compose", appName);
+
+afterEach(() => rmSync(appPath, { force: true, recursive: true }));
+
+test("writes special environment values literally", () => {
+	mkdirSync(join(appPath, "code"), { recursive: true });
+
+	const command = getCreateEnvFileCommand({
+		appName,
+		composePath: "docker-compose.yml",
+		env: `PASSWORD=pa$$word
+SPECIAL='!"#$%&/()=?'
+JSON={"nested":{}}
+MAIL_PASSWORD='"abc#de"'`,
+		randomize: false,
+		suffix: "",
+		serverId: null,
+		environment: { project: { env: "" }, env: "" },
+	} as Parameters<typeof getCreateEnvFileCommand>[0]);
+
+	execFileSync("bash", ["-c", command]);
+
+	const output = readFileSync(join(appPath, "code", ".env"), "utf8");
+	expect(output).toContain("PASSWORD=pa$$word");
+	expect(output).toContain('SPECIAL=!"#$%&/()=?');
+	expect(output).toContain('JSON={"nested":{}}');
+	expect(output).toContain('MAIL_PASSWORD="abc#de"');
+});

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -136,7 +136,9 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 	const encodedContent = encodeBase64(envFileContent);
 	return `
 touch ${quote([envFilePath])};
-echo "${encodedContent}" | base64 -d > ${quote([envFilePath])};
+base64 -d > ${quote([envFilePath])} << 'DOKPLOY_EOF'
+${encodedContent}
+DOKPLOY_EOF
 	`;
 };
 


### PR DESCRIPTION
Fixes #4694

## Problem
Special characters like `$$`, `#`, `{`, `}` in env var values were being 
interpreted by the shell when writing the `.env` file, causing `pa$$word` 
to become `paword` inside containers.

## Root cause
`getCreateEnvFileCommand` in `packages/server/src/utils/builders/compose.ts` 
was passing env var content through shell interpolation when writing to disk.

## Fix
Base64-encode the env content in Node before passing it to the shell, then 
decode via a quoted heredoc (`<< 'DOKPLOY_EOF'`). The quoted delimiter 
prevents any shell interpolation of the payload.

## Testing
Added `apps/dokploy/__test__/compose/env-file-literals.test.ts` which runs 
the generated bash command and asserts these values survive intact:
- `pa$$word`
- `!"#$%&/()=?`
- `{"nested":{}}`
- `MAIL_PASSWORD="abc#de"`