### PR TITLE
fix(ui): persist trigger type selection in GitHub provider forms

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/save-github-provider.tsx
@@ -438,8 +438,12 @@ export const SaveGithubProvider = ({ applicationId }: Props) => {
 										</TooltipProvider>
 									</div>
 									<Select
-										onValueChange={field.onChange}
-										defaultValue={field.value}
+										onValueChange={(value) => {
+											if (!value) {
+												return;
+											}
+											field.onChange(value);
+										}}
 										value={field.value}
 									>
 										<FormControl>

--- a/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/save-github-provider-compose.tsx
@@ -432,8 +432,12 @@ export const SaveGithubProviderCompose = ({ composeId }: Props) => {
 										</TooltipProvider>
 									</div>
 									<Select
-										onValueChange={field.onChange}
-										defaultValue={field.value}
+										onValueChange={(value) => {
+											if (!value) {
+												return;
+											}
+											field.onChange(value);
+										}}
 										value={field.value}
 									>
 										<FormControl>


### PR DESCRIPTION
## What is this PR about?

Fix: "On Tag" trigger selection is not persisted. The bug is in the form state not in the schema, not in the mutation.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4888 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the GitHub trigger-type selectors controlled by form state in both application and Compose provider forms.
- Replaces `defaultValue` with `value` so persisted trigger selections appear after form reset.
- Ignores empty selection values before updating the form field.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix(ui): persist trigger type selection ..."](https://github.com/dokploy/dokploy/commit/15bc4b5dc5053bb6dd0638ca59f9d6576c06206a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48455556)</sub>

<!-- /greptile_comment -->