### PR TITLE
fix(ui): scope deployment delete loading

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -63,6 +63,9 @@ export const ShowDeployments = ({
 	const [activeLog, setActiveLog] = useState<
 		RouterOutputs["deployment"]["all"][number] | null
 	>(null);
+	const [removingDeploymentId, setRemovingDeploymentId] = useState<
+		string | null
+	>(null);
 	const { data: deployments, isPending: isLoadingDeployments } =
 		api.deployment.allByType.useQuery(
 			{
@@ -408,6 +411,7 @@ export const ShowDeployments = ({
 													description="Are you sure you want to delete this deployment? This action cannot be undone."
 													type="default"
 													onClick={async () => {
+														setRemovingDeploymentId(deployment.deploymentId);
 														try {
 															await removeDeployment({
 																deploymentId: deployment.deploymentId,
@@ -415,13 +419,18 @@ export const ShowDeployments = ({
 															toast.success("Deployment deleted successfully");
 														} catch (error) {
 															toast.error("Error deleting deployment");
+														} finally {
+															setRemovingDeploymentId(null);
 														}
 													}}
 												>
 													<Button
 														variant="destructive"
 														size="sm"
-														isLoading={isRemovingDeployment}
+														isLoading={
+															isRemovingDeployment &&
+															removingDeploymentId === deployment.deploymentId
+														}
 													>
 														Delete
 														<Trash2 className="size-4" />

--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -63,9 +63,9 @@ export const ShowDeployments = ({
 	const [activeLog, setActiveLog] = useState<
 		RouterOutputs["deployment"]["all"][number] | null
 	>(null);
-	const [removingDeploymentId, setRemovingDeploymentId] = useState<
-		string | null
-	>(null);
+	const [removingDeploymentIds, setRemovingDeploymentIds] = useState<
+		Set<string>
+	>(new Set());
 	const { data: deployments, isPending: isLoadingDeployments } =
 		api.deployment.allByType.useQuery(
 			{
@@ -84,7 +84,7 @@ export const ShowDeployments = ({
 		api.rollback.rollback.useMutation();
 	const { mutateAsync: killProcess, isPending: isKillingProcess } =
 		api.deployment.killProcess.useMutation();
-	const { mutateAsync: removeDeployment, isPending: isRemovingDeployment } =
+	const { mutateAsync: removeDeployment } =
 		api.deployment.removeDeployment.useMutation();
 
 	// Cancel deployment mutations
@@ -411,7 +411,11 @@ export const ShowDeployments = ({
 													description="Are you sure you want to delete this deployment? This action cannot be undone."
 													type="default"
 													onClick={async () => {
-														setRemovingDeploymentId(deployment.deploymentId);
+														setRemovingDeploymentIds((deploymentIds) => {
+															const nextDeploymentIds = new Set(deploymentIds);
+															nextDeploymentIds.add(deployment.deploymentId);
+															return nextDeploymentIds;
+														});
 														try {
 															await removeDeployment({
 																deploymentId: deployment.deploymentId,
@@ -420,17 +424,24 @@ export const ShowDeployments = ({
 														} catch (error) {
 															toast.error("Error deleting deployment");
 														} finally {
-															setRemovingDeploymentId(null);
+															setRemovingDeploymentIds((deploymentIds) => {
+																const nextDeploymentIds = new Set(
+																	deploymentIds,
+																);
+																nextDeploymentIds.delete(
+																	deployment.deploymentId,
+																);
+																return nextDeploymentIds;
+															});
 														}
 													}}
 												>
 													<Button
 														variant="destructive"
 														size="sm"
-														isLoading={
-															isRemovingDeployment &&
-															removingDeploymentId === deployment.deploymentId
-														}
+														isLoading={removingDeploymentIds.has(
+															deployment.deploymentId,
+														)}
 													>
 														Delete
 														<Trash2 className="size-4" />


### PR DESCRIPTION
## What is this PR about?

This PR scopes deployment deletion loading states to the deployments being removed. Previously, the mutation's shared pending state was passed to every delete button, causing all rows to show a spinner. A set of in-flight deployment IDs now lets concurrent deletions independently add and clear their own loading state.

https://github.com/user-attachments/assets/bd41593f-11a9-428c-b5dd-6d4130fdad43


## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [ ] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Testing

- `pnpm --filter=dokploy typecheck`
- `pnpm exec biome check apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx`
- `git diff --check`

## Issues related (if applicable)

Closes #4945

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The deletion loading state now tracks deployments independently.
- Stores all deployment IDs with active deletion requests in a Set.
- Adds an ID when deletion starts and removes only that ID when it settles.
- Shows the loading state exclusively on the corresponding deployment’s Delete button.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; each deletion now removes only its own deployment ID from the loading-state Set, so one request settling cannot clear another deployment’s pending indicator.

<sub>Reviews (2): Last reviewed commit: ["fix(ui): track concurrent deployment del..."](https://github.com/dokploy/dokploy/commit/6e792704239f6da2059249b78ca60f0f1ac05bb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49251481)</sub>

<!-- /greptile_comment -->