### PR TITLE
fix(ui): prevent collapsed avatar clipping

### DIFF
--- a/apps/dokploy/components/ui/sidebar.tsx
+++ b/apps/dokploy/components/ui/sidebar.tsx
@@ -464,7 +464,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-	"peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+	"peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
 	{
 		variants: {
 			variant: {
@@ -473,8 +473,8 @@ const sidebarMenuButtonVariants = cva(
 					"bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
 			},
 			size: {
-				default: "h-8 text-sm",
-				sm: "h-7 text-xs",
+				default: "h-8 text-sm group-data-[collapsible=icon]:p-2!",
+				sm: "h-7 text-xs group-data-[collapsible=icon]:p-2!",
 				lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
 			},
 		},


### PR DESCRIPTION
## What is this PR about?

Prevents the account avatar from being clipped when the sidebar is collapsed. Collapsed padding is now assigned by button size, so default and small icon buttons keep their padding while the large account button reliably uses zero padding around its 32px avatar.

## Checklist

- [x] Created a dedicated branch based on the latest `canary` branch.
- [x] Read the pull request guidance in `CONTRIBUTING.md`.
- [ ] Tested in a running local Dokploy instance. Manual visual verification is still required because no configured development instance is available in this workspace.

## Verification

- `biome check apps/dokploy/components/ui/sidebar.tsx` (passes; reports one pre-existing `noDocumentCookie` warning at line 82)
- `git diff --check`

## Issues related

Closes #4946

## Screenshots
<img width="66" height="312" alt="Screenshot 2026-07-29 at 8 24 44 PM" src="https://github.com/user-attachments/assets/7c180b2a-ed26-4c38-8c8f-f920c09f690c" />

Before state is described in #4946. No after screenshot is available without a configured local Dokploy instance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts collapsed sidebar button padding according to button size.
- Preserves 8px collapsed padding for default and small buttons.
- Removes collapsed padding from large buttons so the 32px account avatar fits within its 32px container.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the size-specific padding behavior matching all current sidebar button callers.

All current callers use default, small, or large size variants; default and small preserve their previous collapsed padding while the large account button intentionally removes padding to fit its avatar.

<sub>Reviews (1): Last reviewed commit: ["fix(ui): prevent collapsed avatar clippi..."](https://github.com/dokploy/dokploy/commit/9999f0a18e0209f44ec23ff75b3e23ea3633b6dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49251484)</sub>

<!-- /greptile_comment -->