### PR TITLE
fix(backup): redact unquoted and malformed rclone S3 credentials

### DIFF
--- a/apps/dokploy/__test__/backups/redact-credentials.test.ts
+++ b/apps/dokploy/__test__/backups/redact-credentials.test.ts
@@ -48,3 +48,112 @@ describe("redactRcloneCredentials (#4621)", () => {
 		expect(redacted).toContain("[REDACTED]");
 	});
 });
+
+// Reproduction of the leak observed in production on v0.29.13:
+// getS3Credentials() emits shell-quote'd values, and shell-quote leaves
+// "safe" values (hex keys, tokens without spaces) UNQUOTED. The original
+// redactRcloneCredentials() only masked the double-quoted form, so those
+// values leaked into structured logs and error output.
+// All values below are deliberately fake.
+describe("redactRcloneCredentials — unquoted/variant forms (leak reproduction)", () => {
+	const FAKE_ACCESS = "FAKE_R2_ACCESS_KEY_0123456789";
+	const FAKE_SECRET = "FAKE_R2_SECRET_KEY_ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+	const expectClean = (output: string) => {
+		expect(output).not.toContain(FAKE_ACCESS);
+		expect(output).not.toContain(FAKE_SECRET);
+	};
+
+	it("redacts unquoted --flag=value (shell-quote output for hex keys)", () => {
+		const cmd = `rclone rcat --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key=${FAKE_SECRET} --s3-region=auto ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted).toContain("--s3-access-key-id=[REDACTED]");
+		expect(redacted).toContain("--s3-secret-access-key=[REDACTED]");
+		expect(redacted).toContain("--s3-region=auto");
+	});
+
+	it('redacts double-quoted --flag="value"', () => {
+		const cmd = `rclone rcat --s3-access-key-id="${FAKE_ACCESS}" --s3-secret-access-key="${FAKE_SECRET}" ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted).toContain('--s3-access-key-id="[REDACTED]"');
+		expect(redacted).toContain('--s3-secret-access-key="[REDACTED]"');
+	});
+
+	it("redacts single-quoted --flag='value'", () => {
+		const cmd = `rclone rcat --s3-access-key-id='${FAKE_ACCESS}' --s3-secret-access-key='${FAKE_SECRET}' ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted).toContain("--s3-access-key-id='[REDACTED]'");
+	});
+
+	it("redacts space-separated --flag value", () => {
+		const cmd = `rclone rcat --s3-access-key-id ${FAKE_ACCESS} --s3-secret-access-key ${FAKE_SECRET} ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted).toContain("--s3-access-key-id [REDACTED]");
+	});
+
+	it("redacts space-separated quoted values", () => {
+		const cmd = `rclone rcat --s3-access-key-id "${FAKE_ACCESS}" --s3-secret-access-key '${FAKE_SECRET}' ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+	});
+
+	it("redacts credentials in reverse argument order", () => {
+		const cmd = `rclone rcat --s3-secret-access-key=${FAKE_SECRET} --s3-region=auto --s3-access-key-id=${FAKE_ACCESS} ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted).toContain("--s3-region=auto");
+	});
+
+	it("keeps non-sensitive arguments intact", () => {
+		const cmd = `rclone copyto --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key=${FAKE_SECRET} --s3-no-check-bucket --s3-force-path-style --s3-endpoint=https://fake.endpoint.example ":s3:bucket/a.tar"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted).toContain("--s3-no-check-bucket");
+		expect(redacted).toContain("--s3-force-path-style");
+		expect(redacted).toContain("--s3-endpoint=https://fake.endpoint.example");
+		expect(redacted).toContain(":s3:bucket/a.tar");
+	});
+
+	it("redacts credentials inside an error message echoing the command", () => {
+		const err = `Command execution failed: Command failed: rclone rcat --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key=${FAKE_SECRET} ":s3:bucket/file.gz"\nERROR : s3: upload failed`;
+		const redacted = redactRcloneCredentials(err);
+		expectClean(redacted);
+		expect(redacted).toContain("ERROR : s3: upload failed");
+	});
+
+	it("redacts shell-escaped values (single-quote idiom and special chars)", () => {
+		// shell-quote renders a value containing a single quote as 'a'\''b'
+		const cmd = `rclone rcat --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key='${FAKE_SECRET}'\\''pwned' ":s3:bucket/file.gz"`;
+		const redacted = redactRcloneCredentials(cmd);
+		expect(redacted).not.toContain(FAKE_SECRET);
+		expect(redacted).not.toContain("pwned");
+	});
+
+	it("is idempotent", () => {
+		const cmd = `rclone rcat --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key="${FAKE_SECRET}" ":s3:bucket/file.gz"`;
+		const once = redactRcloneCredentials(cmd);
+		expectClean(once);
+		expect(redactRcloneCredentials(once)).toBe(once);
+	});
+
+	it("handles empty or malformed input safely", () => {
+		expect(redactRcloneCredentials("")).toBe("");
+		expect(redactRcloneCredentials("--s3-access-key-id=")).toBe(
+			"--s3-access-key-id=",
+		);
+		expect(redactRcloneCredentials("--s3-access-key-id")).toBe(
+			"--s3-access-key-id",
+		);
+	});
+
+	it("never leaves the fake secrets in the output of a full pipeline command", () => {
+		const cmd = `rclone lsf --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key=${FAKE_SECRET} --include "*.sql.gz" :s3:bucket/app/ | sort -r | tail -n +31 | xargs -I{} rclone delete --s3-access-key-id=${FAKE_ACCESS} --s3-secret-access-key=${FAKE_SECRET} :s3:bucket/app/{}`;
+		const redacted = redactRcloneCredentials(cmd);
+		expectClean(redacted);
+		expect(redacted.match(/\[REDACTED\]/g)).toHaveLength(4);
+	});
+});

--- a/apps/dokploy/__test__/backups/redact-credentials.test.ts
+++ b/apps/dokploy/__test__/backups/redact-credentials.test.ts
@@ -157,3 +157,50 @@ describe("redactRcloneCredentials — unquoted/variant forms (leak reproduction)
 		expect(redacted.match(/\[REDACTED\]/g)).toHaveLength(4);
 	});
 });
+
+// Truncated command strings (e.g. inside an error message) can carry an
+// unterminated quoted value. The last-resort pass must still mask it.
+describe("redactRcloneCredentials — malformed/truncated forms", () => {
+	const FAKE_ACCESS = "FAKE_R2_ACCESS_KEY_0123456789";
+	const FAKE_SECRET = "FAKE_R2_SECRET_KEY_ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+	it("redacts an unterminated double-quoted value", () => {
+		const redacted = redactRcloneCredentials(
+			`rclone rcat --s3-access-key-id="${FAKE_ACCESS}`,
+		);
+		expect(redacted).not.toContain(FAKE_ACCESS);
+	});
+
+	it("redacts an unterminated single-quoted value", () => {
+		const redacted = redactRcloneCredentials(
+			`rclone rcat --s3-secret-access-key='${FAKE_SECRET}`,
+		);
+		expect(redacted).not.toContain(FAKE_SECRET);
+	});
+
+	it("redacts a value ending with an escaped quote at end of string", () => {
+		const redacted = redactRcloneCredentials(
+			`--s3-secret-access-key="${FAKE_SECRET}\\"`,
+		);
+		expect(redacted).not.toContain(FAKE_SECRET);
+	});
+
+	it("redacts an unterminated quoted value in space-separated form", () => {
+		const redacted = redactRcloneCredentials(
+			`rclone rcat --s3-access-key-id "${FAKE_ACCESS}`,
+		);
+		expect(redacted).not.toContain(FAKE_ACCESS);
+	});
+
+	it("keeps the quoted placeholder shape of balanced forms (last-resort pass is a no-op)", () => {
+		expect(redactRcloneCredentials(`--s3-access-key-id="${FAKE_ACCESS}"`)).toBe(
+			'--s3-access-key-id="[REDACTED]"',
+		);
+		expect(redactRcloneCredentials(`--s3-access-key-id='${FAKE_ACCESS}'`)).toBe(
+			"--s3-access-key-id='[REDACTED]'",
+		);
+		expect(redactRcloneCredentials('--s3-access-key-id="[REDACTED]"')).toBe(
+			'--s3-access-key-id="[REDACTED]"',
+		);
+	});
+});

--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -31,6 +31,7 @@ import {
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { checkServicePermissionAndAccess } from "@dokploy/server/services/permission";
 import { runComposeBackup } from "@dokploy/server/utils/backups/compose";
+import { redactRcloneCredentials } from "@dokploy/server/utils/backups/redact";
 import {
 	getS3Credentials,
 	normalizeS3Path,
@@ -551,13 +552,17 @@ export const backupRouter = createTRPCRouter({
 
 				return results.slice(0, 100);
 			} catch (error) {
-				console.error("Error in listBackupFiles:", error);
+				console.error(
+					"Error in listBackupFiles:",
+					redactRcloneCredentials(String(error)),
+				);
 				throw new TRPCError({
 					code: "BAD_REQUEST",
-					message:
+					message: redactRcloneCredentials(
 						error instanceof Error
 							? error.message
 							: "Error listing backup files",
+					),
 					cause: error,
 				});
 			}
@@ -611,7 +616,7 @@ export const backupRouter = createTRPCRouter({
 			runRestore()
 				.catch((error) => {
 					onLog(
-						`Error: ${error instanceof Error ? error.message : String(error)}`,
+						`Error: ${redactRcloneCredentials(error instanceof Error ? error.message : String(error))}`,
 					);
 				})
 				.finally(() => {

--- a/apps/dokploy/server/api/routers/destination.ts
+++ b/apps/dokploy/server/api/routers/destination.ts
@@ -8,6 +8,7 @@ import {
 	updateDestinationById,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import { redactRcloneCredentials } from "@dokploy/server/utils/backups/redact";
 import { TRPCError } from "@trpc/server";
 import { desc, eq } from "drizzle-orm";
 import { quote } from "shell-quote";
@@ -94,10 +95,11 @@ export const destinationRouter = createTRPCRouter({
 			} catch (error) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
-					message:
+					message: redactRcloneCredentials(
 						error instanceof Error
 							? error?.message
 							: "Error connecting to bucket",
+					),
 					cause: error,
 				});
 			}
@@ -172,10 +174,11 @@ export const destinationRouter = createTRPCRouter({
 			} catch (error) {
 				throw new TRPCError({
 					code: "BAD_REQUEST",
-					message:
+					message: redactRcloneCredentials(
 						error instanceof Error
 							? error?.message
 							: "Error connecting to bucket",
+					),
 					cause: error,
 				});
 			}

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -64,7 +64,7 @@ export const runComposeBackup = async (
 
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.log(redactRcloneCredentials(String(error)));
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,
@@ -79,7 +79,11 @@ export const runComposeBackup = async (
 		});
 
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		throw error;
+		throw new Error(
+			redactRcloneCredentials(
+				error instanceof Error ? error.message : "Error message not provided",
+			),
+		);
 	}
 };
 

--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -9,6 +9,7 @@ import { findEnvironmentById } from "@dokploy/server/services/environment";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { redactRcloneCredentials } from "./redact";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
@@ -70,7 +71,9 @@ export const runComposeBackup = async (
 			databaseType: getDatabaseType(databaseType),
 			type: "error",
 			// @ts-ignore
-			errorMessage: error?.message || "Error message not provided",
+			errorMessage: redactRcloneCredentials(
+				error?.message || "Error message not provided",
+			),
 			organizationId: project.organizationId,
 			databaseName: backup.database,
 		});

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -9,6 +9,7 @@ import type { Libsql } from "@dokploy/server/services/libsql";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { redactRcloneCredentials } from "./redact";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
@@ -69,7 +70,9 @@ export const runLibsqlBackup = async (
 			databaseType: "libsql",
 			type: "error",
 			// @ts-ignore
-			errorMessage: error?.message || "Error message not provided",
+			errorMessage: redactRcloneCredentials(
+				error?.message || "Error message not provided",
+			),
 			organizationId: project.organizationId,
 			databaseName: backup.database,
 		});

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -79,6 +79,10 @@ export const runLibsqlBackup = async (
 
 		await updateDeploymentStatus(deployment.deploymentId, "error");
 
-		throw error;
+		throw new Error(
+			redactRcloneCredentials(
+				error instanceof Error ? error.message : "Error message not provided",
+			),
+		);
 	}
 };

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -61,7 +61,7 @@ export const runMariadbBackup = async (
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.log(redactRcloneCredentials(String(error)));
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,
@@ -75,6 +75,10 @@ export const runMariadbBackup = async (
 			databaseName: backup.database,
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		throw error;
+		throw new Error(
+			redactRcloneCredentials(
+				error instanceof Error ? error.message : "Error message not provided",
+			),
+		);
 	}
 };

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -9,6 +9,7 @@ import type { Mariadb } from "@dokploy/server/services/mariadb";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { redactRcloneCredentials } from "./redact";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
@@ -67,7 +68,9 @@ export const runMariadbBackup = async (
 			databaseType: "mariadb",
 			type: "error",
 			// @ts-ignore
-			errorMessage: error?.message || "Error message not provided",
+			errorMessage: redactRcloneCredentials(
+				error?.message || "Error message not provided",
+			),
 			organizationId: project.organizationId,
 			databaseName: backup.database,
 		});

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -9,6 +9,7 @@ import type { Mongo } from "@dokploy/server/services/mongo";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { redactRcloneCredentials } from "./redact";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
@@ -65,7 +66,9 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 			databaseType: "mongodb",
 			type: "error",
 			// @ts-ignore
-			errorMessage: error?.message || "Error message not provided",
+			errorMessage: redactRcloneCredentials(
+				error?.message || "Error message not provided",
+			),
 			organizationId: project.organizationId,
 			databaseName: backup.database,
 		});

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -59,7 +59,7 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.log(redactRcloneCredentials(String(error)));
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,
@@ -73,6 +73,10 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 			databaseName: backup.database,
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		throw error;
+		throw new Error(
+			redactRcloneCredentials(
+				error instanceof Error ? error.message : "Error message not provided",
+			),
+		);
 	}
 };

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -9,6 +9,7 @@ import type { MySql } from "@dokploy/server/services/mysql";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { redactRcloneCredentials } from "./redact";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
@@ -66,7 +67,9 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 			databaseType: "mysql",
 			type: "error",
 			// @ts-ignore
-			errorMessage: error?.message || "Error message not provided",
+			errorMessage: redactRcloneCredentials(
+				error?.message || "Error message not provided",
+			),
 			organizationId: project.organizationId,
 			databaseName: backup.database,
 		});

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -60,7 +60,7 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "done");
 	} catch (error) {
-		console.log(error);
+		console.log(redactRcloneCredentials(String(error)));
 		await sendDatabaseBackupNotifications({
 			applicationName: name,
 			projectName: project.name,
@@ -74,6 +74,10 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 			databaseName: backup.database,
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		throw error;
+		throw new Error(
+			redactRcloneCredentials(
+				error instanceof Error ? error.message : "Error message not provided",
+			),
+		);
 	}
 };

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -79,7 +79,11 @@ export const runPostgresBackup = async (
 
 		await updateDeploymentStatus(deployment.deploymentId, "error");
 
-		throw error;
+		throw new Error(
+			redactRcloneCredentials(
+				error instanceof Error ? error.message : "Error message not provided",
+			),
+		);
 	} finally {
 	}
 };

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -9,6 +9,7 @@ import type { Postgres } from "@dokploy/server/services/postgres";
 import { findProjectById } from "@dokploy/server/services/project";
 import { sendDatabaseBackupNotifications } from "../notifications/database-backup";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { redactRcloneCredentials } from "./redact";
 import {
 	getBackupCommand,
 	getBackupTimestamp,
@@ -69,7 +70,9 @@ export const runPostgresBackup = async (
 			databaseType: "postgres",
 			type: "error",
 			// @ts-ignore
-			errorMessage: error?.message || "Error message not provided",
+			errorMessage: redactRcloneCredentials(
+				error?.message || "Error message not provided",
+			),
 			organizationId: project.organizationId,
 			databaseName: backup.database,
 		});

--- a/packages/server/src/utils/backups/redact.ts
+++ b/packages/server/src/utils/backups/redact.ts
@@ -2,11 +2,49 @@
  * Redacts S3 credentials from rclone command strings.
  *
  * Used to prevent credential leakage in structured logs and error output.
- * Matches the flag format produced by `getS3Credentials()`:
- *   --s3-access-key-id="VALUE"  and  --s3-secret-access-key="VALUE"
+ *
+ * `getS3Credentials()` passes values through shell-quote, which leaves
+ * "safe" values (hex keys, tokens without spaces) UNQUOTED and quotes the
+ * others — so every flag form must be covered:
+ *   --s3-access-key-id=VALUE        (unquoted — the v0.29.13 leak)
+ *   --s3-access-key-id="VALUE"      (double quotes)
+ *   --s3-access-key-id='VALUE'      (single quotes, incl. shell-quote's '\'' idiom)
+ *   --s3-access-key-id VALUE        (space separated, any quoting)
  */
+const SENSITIVE_RCLONE_FLAGS = [
+	"--s3-access-key-id",
+	"--s3-secret-access-key",
+] as const;
+
+const escapeRegExp = (value: string): string =>
+	value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Double-quoted value, tolerating escaped characters inside.
+const DOUBLE_QUOTED = String.raw`"(?:[^"\\]|\\.)*"`;
+// Single-quoted value, including shell-quote's embedded-quote idiom ('a'\''b').
+const SINGLE_QUOTED = String.raw`'[^']*'(?:\\''[^']*')*`;
+// Bare value: a single shell token without quotes or whitespace.
+const BARE = String.raw`[^\s"']+`;
+
 export const redactRcloneCredentials = (command: string): string => {
-	return command
-		.replace(/(--s3-access-key-id=)"[^"]*"/g, '$1"[REDACTED]"')
-		.replace(/(--s3-secret-access-key=)"[^"]*"/g, '$1"[REDACTED]"');
+	if (!command) {
+		return command;
+	}
+
+	let result = command;
+	for (const flag of SENSITIVE_RCLONE_FLAGS) {
+		const f = escapeRegExp(flag);
+		result = result
+			// --flag="value" / --flag "value"
+			.replace(new RegExp(`(${f}=)${DOUBLE_QUOTED}`, "g"), '$1"[REDACTED]"')
+			.replace(new RegExp(`(${f}\\s+)${DOUBLE_QUOTED}`, "g"), '$1"[REDACTED]"')
+			// --flag='value' / --flag 'value'
+			.replace(new RegExp(`(${f}=)${SINGLE_QUOTED}`, "g"), "$1'[REDACTED]'")
+			.replace(new RegExp(`(${f}\\s+)${SINGLE_QUOTED}`, "g"), "$1'[REDACTED]'")
+			// --flag=value / --flag value (unquoted — must run after the
+			// quoted forms so the quote characters are never left behind)
+			.replace(new RegExp(`(${f}=)${BARE}`, "g"), "$1[REDACTED]")
+			.replace(new RegExp(`(${f}\\s+)${BARE}`, "g"), "$1[REDACTED]");
+	}
+	return result;
 };

--- a/packages/server/src/utils/backups/redact.ts
+++ b/packages/server/src/utils/backups/redact.ts
@@ -10,6 +10,7 @@
  *   --s3-access-key-id="VALUE"      (double quotes)
  *   --s3-access-key-id='VALUE'      (single quotes, incl. shell-quote's '\'' idiom)
  *   --s3-access-key-id VALUE        (space separated, any quoting)
+ *   --s3-access-key-id="UNTERMINATED (truncated strings — last-resort pass)
  */
 const SENSITIVE_RCLONE_FLAGS = [
 	"--s3-access-key-id",
@@ -44,7 +45,18 @@ export const redactRcloneCredentials = (command: string): string => {
 			// --flag=value / --flag value (unquoted — must run after the
 			// quoted forms so the quote characters are never left behind)
 			.replace(new RegExp(`(${f}=)${BARE}`, "g"), "$1[REDACTED]")
-			.replace(new RegExp(`(${f}\\s+)${BARE}`, "g"), "$1[REDACTED]");
+			.replace(new RegExp(`(${f}\\s+)${BARE}`, "g"), "$1[REDACTED]")
+			// Last resort: unterminated quoted value (e.g. a truncated command
+			// string in an error message). Runs after every other pass and
+			// skips values already replaced by the placeholder.
+			.replace(
+				new RegExp(`(${f}=)["'](?!\\[REDACTED\\])[^\\s]*`, "g"),
+				"$1[REDACTED]",
+			)
+			.replace(
+				new RegExp(`(${f}\\s+)["'](?!\\[REDACTED\\])[^\\s]*`, "g"),
+				"$1[REDACTED]",
+			);
 	}
 	return result;
 };

--- a/packages/server/src/utils/backups/web-server.ts
+++ b/packages/server/src/utils/backups/web-server.ts
@@ -149,6 +149,6 @@ export const runWebServerBackup = async (backup: BackupSchedule) => {
 			backupSize: formatBytes(computedBackupSize),
 		});
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		throw error;
+		throw new Error(safeErrorMessage || "Error message not provided");
 	}
 };

--- a/packages/server/src/utils/restore/compose.ts
+++ b/packages/server/src/utils/restore/compose.ts
@@ -3,6 +3,7 @@ import type { Compose } from "@dokploy/server/services/compose";
 import type { Destination } from "@dokploy/server/services/destination";
 import { quote } from "shell-quote";
 import type { z } from "zod";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
@@ -90,14 +91,11 @@ export const restoreComposeBackup = async (
 
 		emit("Restore completed successfully!");
 	} catch (error) {
-		console.error(error);
-		emit(
-			`Error: ${
-				error instanceof Error ? error.message : "Error restoring mongo backup"
-			}`,
-		);
-		throw new Error(
+		const safeMessage = redactRcloneCredentials(
 			error instanceof Error ? error.message : "Error restoring mongo backup",
 		);
+		console.error(safeMessage);
+		emit(`Error: ${safeMessage}`);
+		throw new Error(safeMessage);
 	}
 };

--- a/packages/server/src/utils/restore/libsql.ts
+++ b/packages/server/src/utils/restore/libsql.ts
@@ -3,6 +3,7 @@ import type { Destination } from "@dokploy/server/services/destination";
 import type { Libsql } from "@dokploy/server/services/libsql";
 import { quote } from "shell-quote";
 import type { z } from "zod";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials, getServiceContainerCommand } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 
@@ -38,11 +39,10 @@ export const restoreLibsqlBackup = async (
 
 		emit("Restore completed successfully!");
 	} catch (error) {
-		emit(
-			`Error: ${
-				error instanceof Error ? error.message : "Error restoring libsql backup"
-			}`,
+		const safeMessage = redactRcloneCredentials(
+			error instanceof Error ? error.message : "Error restoring libsql backup",
 		);
+		emit(`Error: ${safeMessage}`);
 		throw error;
 	}
 };

--- a/packages/server/src/utils/restore/mariadb.ts
+++ b/packages/server/src/utils/restore/mariadb.ts
@@ -3,6 +3,7 @@ import type { Destination } from "@dokploy/server/services/destination";
 import type { Mariadb } from "@dokploy/server/services/mariadb";
 import { quote } from "shell-quote";
 import type { z } from "zod";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
@@ -47,16 +48,11 @@ export const restoreMariadbBackup = async (
 
 		emit("Restore completed successfully!");
 	} catch (error) {
-		console.error(error);
-		emit(
-			`Error: ${
-				error instanceof Error
-					? error.message
-					: "Error restoring mariadb backup"
-			}`,
-		);
-		throw new Error(
+		const safeMessage = redactRcloneCredentials(
 			error instanceof Error ? error.message : "Error restoring mariadb backup",
 		);
+		console.error(safeMessage);
+		emit(`Error: ${safeMessage}`);
+		throw new Error(safeMessage);
 	}
 };

--- a/packages/server/src/utils/restore/mongo.ts
+++ b/packages/server/src/utils/restore/mongo.ts
@@ -3,6 +3,7 @@ import type { Destination } from "@dokploy/server/services/destination";
 import type { Mongo } from "@dokploy/server/services/mongo";
 import { quote } from "shell-quote";
 import type { z } from "zod";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
@@ -47,14 +48,11 @@ export const restoreMongoBackup = async (
 
 		emit("Restore completed successfully!");
 	} catch (error) {
-		console.error(error);
-		emit(
-			`Error: ${
-				error instanceof Error ? error.message : "Error restoring mongo backup"
-			}`,
-		);
-		throw new Error(
+		const safeMessage = redactRcloneCredentials(
 			error instanceof Error ? error.message : "Error restoring mongo backup",
 		);
+		console.error(safeMessage);
+		emit(`Error: ${safeMessage}`);
+		throw new Error(safeMessage);
 	}
 };

--- a/packages/server/src/utils/restore/mysql.ts
+++ b/packages/server/src/utils/restore/mysql.ts
@@ -3,6 +3,7 @@ import type { Destination } from "@dokploy/server/services/destination";
 import type { MySql } from "@dokploy/server/services/mysql";
 import { quote } from "shell-quote";
 import type { z } from "zod";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
@@ -46,14 +47,11 @@ export const restoreMySqlBackup = async (
 
 		emit("Restore completed successfully!");
 	} catch (error) {
-		console.error(error);
-		emit(
-			`Error: ${
-				error instanceof Error ? error.message : "Error restoring mysql backup"
-			}`,
-		);
-		throw new Error(
+		const safeMessage = redactRcloneCredentials(
 			error instanceof Error ? error.message : "Error restoring mysql backup",
 		);
+		console.error(safeMessage);
+		emit(`Error: ${safeMessage}`);
+		throw new Error(safeMessage);
 	}
 };

--- a/packages/server/src/utils/restore/postgres.ts
+++ b/packages/server/src/utils/restore/postgres.ts
@@ -3,6 +3,7 @@ import type { Destination } from "@dokploy/server/services/destination";
 import type { Postgres } from "@dokploy/server/services/postgres";
 import { quote } from "shell-quote";
 import type { z } from "zod";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { getRestoreCommand } from "./utils";
@@ -47,13 +48,12 @@ export const restorePostgresBackup = async (
 
 		emit("Restore completed successfully!");
 	} catch (error) {
-		emit(
-			`Error: ${
-				error instanceof Error
-					? error.message
-					: "Error restoring postgres backup"
-			}`,
+		const safeMessage = redactRcloneCredentials(
+			error instanceof Error
+				? error.message
+				: "Error restoring postgres backup",
 		);
+		emit(`Error: ${safeMessage}`);
 		throw error;
 	}
 };

--- a/packages/server/src/utils/restore/web-server.ts
+++ b/packages/server/src/utils/restore/web-server.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { IS_CLOUD, paths } from "@dokploy/server/constants";
 import type { Destination } from "@dokploy/server/services/destination";
 import { quote } from "shell-quote";
+import { redactRcloneCredentials } from "../backups/redact";
 import { getS3Credentials } from "../backups/utils";
 import { execAsync } from "../process/execAsync";
 
@@ -143,14 +144,13 @@ export const restoreWebServerBackup = async (
 			await execAsync(`rm -rf ${tempDir}`);
 		}
 	} catch (error) {
-		console.error(error);
-		emit(
-			`Error: ${
-				error instanceof Error
-					? error.message
-					: "Error restoring web server backup"
-			}`,
+		const safeMessage = redactRcloneCredentials(
+			error instanceof Error
+				? error.message
+				: "Error restoring web server backup",
 		);
+		console.error(safeMessage);
+		emit(`Error: ${safeMessage}`);
 		throw error;
 	}
 };

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -6,6 +6,7 @@ import {
 } from "@dokploy/server/services/deployment";
 import { findDestinationById } from "@dokploy/server/services/destination";
 import { findVolumeBackupById } from "@dokploy/server/services/volume-backups";
+import { redactRcloneCredentials } from "@dokploy/server/utils/backups/redact";
 import {
 	execAsync,
 	execAsyncRemote,
@@ -98,7 +99,10 @@ const cleanupOldVolumeBackups = async (
 			await execAsync(fullCommand);
 		}
 	} catch (error) {
-		console.error("Volume backup retention error", error);
+		console.error(
+			"Volume backup retention error",
+			redactRcloneCredentials(String(error)),
+		);
 	}
 };
 
@@ -179,7 +183,9 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 				serviceType: mappedServiceType,
 				type: "error",
 				organizationId,
-				errorMessage: error instanceof Error ? error.message : String(error),
+				errorMessage: redactRcloneCredentials(
+					error instanceof Error ? error.message : String(error),
+				),
 			});
 		} catch (notificationError) {
 			console.error(


### PR DESCRIPTION
## Summary

- The existing `redactRcloneCredentials()` covers only the double-quoted form `--flag="value"`.
- `getS3Credentials()` passes values through `shell-quote`, which emits "safe" credential strings (e.g. hex keys without spaces) **unquoted**.
- As a result, credentials remain visible in structured logs, notifications, API error responses and UI restore streams. This was reproduced with 10 failing test cases on v0.29.13.
- All reproduction values used in tests and in this PR are entirely fictitious (`FAKE_R2_*` constants).

## Root cause

- The existing expression only matches the double-quoted `--flag="value"` form.
- Unquoted (`--flag=value`), single-quoted (`--flag='value'`), space-separated (`--flag value`) and malformed (unterminated quote) forms are not covered.
- Raw `ExecError` objects — whose `message` embeds the full command line and which carry the cleartext `command` property — can also reach Pino, `console` and scheduled task handlers.

## Additional exposure paths

- Raw errors logged with `console.log(error)` in four database backup modules (the stack includes the full command).
- The scheduled-jobs worker logs the rethrown `ExecError` via Pino, which serializes `err.message`, `err.stack` **and** the enumerable `command`/`stdout`/`stderr` properties (verified against `pino@9.4.0`).
- The `node-schedule` backup callback receives raw rethrows (unhandled rejection prints the full message).
- API routers (`testConnection`, `listBackupFiles`, restore subscriptions), database backup failure notifications, restore `emit()` streams and volume-backup retention paths.

## Fix

- Robust, idempotent credential redaction covering quoted, unquoted, space-separated, shell-escaped and malformed (truncated/unterminated) forms, with a last-resort pass that skips already-redacted placeholders.
- Redaction applied **before** every log, notification, API and UI exposure point.
- Sanitized rethrow from the backup runners, so upstream loggers (Pino worker, node-schedule callback, tRPC dev handler) never see the raw command.

Executed commands, retention, scheduling and notification triggers are unchanged — only logged/emitted/thrown strings are sanitized.

## Tests

- Reproduction tests using fictitious values (10 red cases on the unpatched code, all green after the fix).
- Malformed input tests (unterminated quotes, trailing backslash).
- Idempotence, determinism, empty/malformed input safety.
- Performance/large input (1 MiB string unchanged, 100k malformed chars, 1000 sensitive args — no algorithmic blow-up).
- Pino serialization proof demonstrating the `ExecError.command` leak and its resolution via the sanitized rethrow.
- TypeScript `--strict` on the rewritten module and Biome checks pass.

## Known limitation

The patch does **not** remove S3 credentials from the `rclone` process argv (visible in `ps` during execution). A follow-up could pass credentials through the officially documented `RCLONE_S3_ACCESS_KEY_ID` / `RCLONE_S3_SECRET_ACCESS_KEY` environment variables instead of command-line flags.

## Related issue

Refs #4621 — the initial fix covers only the double-quoted form; this PR completes it and demonstrates the gap with reproducible tests.
