### PR TITLE
fix(ui): keep dropdown menus open on window blur

### DIFF
--- a/apps/dokploy/components/ui/dropdown-menu.tsx
+++ b/apps/dokploy/components/ui/dropdown-menu.tsx
@@ -1,21 +1,37 @@
 import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
-import type * as React from "react";
+import * as React from "react";
 import { markNestedPopupClosed } from "@/components/ui/nested-popup-context";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({
+	open,
+	defaultOpen,
 	onOpenChange,
 	...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+	const [uncontrolledOpen, setUncontrolledOpen] = React.useState(
+		defaultOpen ?? false,
+	);
+	const isControlled = open !== undefined;
+	const isOpen = isControlled ? open : uncontrolledOpen;
+
 	return (
 		<DropdownMenuPrimitive.Root
 			data-slot="dropdown-menu"
-			onOpenChange={(open) => {
-				if (!open) {
+			open={isOpen}
+			onOpenChange={(nextOpen) => {
+				// Radix closes menus on window blur, unmounting any dialog rendered inside
+				if (!nextOpen && !document.hasFocus()) {
+					return;
+				}
+				if (!isControlled) {
+					setUncontrolledOpen(nextOpen);
+				}
+				if (!nextOpen) {
 					markNestedPopupClosed();
 				}
-				onOpenChange?.(open);
+				onOpenChange?.(nextOpen);
 			}}
 			{...props}
 		/>


### PR DESCRIPTION
Fixes #4907
Fixes #4851

Radix Menu (`@radix-ui/react-menu` 2.1.x) closes any open dropdown menu when the window fires `blur`. The create-service dialogs (`AddDatabase`, `AddApplication`, `AddCompose`, etc.) are rendered inside `DropdownMenuContent`, so switching to another window/app closed the menu, unmounted the dialog, and wiped everything the user had typed. It was not related to `refetchOnWindowFocus` — the close happens instantly on blur, before any refetch.

The `DropdownMenu` wrapper now controls the open state and ignores the close request when `document.hasFocus()` is `false` (only true for window-blur closes; Escape, outside click and item selection all happen with the document focused). This covers every dropdown-hosted dialog in the app at once.

Verified in the running app: reproduced the close on `window` blur before the change; after it, the dialog stays open with the form state intact, and normal dismissal (Escape, outside click) still works.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps dropdown-hosted dialogs and their form state mounted when the browser window loses focus.

- Makes the dropdown root’s open state explicitly controllable.
- Ignores Radix close requests while the document is unfocused.
- Preserves normal close handling and nested-popup coordination for focused interactions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The wrapper preserves controlled and uncontrolled open-state behavior while suppressing only close requests received when the document lacks focus; focused dismissal paths continue to update state, notify callers, and mark nested popups closed.

<sub>Reviews (1): Last reviewed commit: ["fix(ui): keep dropdown menus open on win..."](https://github.com/dokploy/dokploy/commit/081cf3fb80093390b2c0aab2ed2a57961b72e55d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49510764)</sub>

**Context used:**

- Knowledge Base — [UI Overlay Primitives (dialog, sheet, popover, dropdown-menu, alert-dialog)](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/ui-component-primitives.md)

<!-- /greptile_comment -->