### PR TITLE
fix(ui): show real status code on error page

### DIFF
--- a/apps/dokploy/pages/_error.tsx
+++ b/apps/dokploy/pages/_error.tsx
@@ -5,12 +5,11 @@ import { buttonVariants } from "@/components/ui/button";
 import { useWhitelabelingPublic } from "@/utils/hooks/use-whitelabeling";
 
 interface Props {
-	statusCode: number;
-	error?: Error;
+	statusCode?: number;
 }
 
-export default function Custom404({ statusCode, error }: Props) {
-	const displayStatusCode = statusCode || 400;
+export default function ErrorPage({ statusCode }: Props) {
+	const displayStatusCode = statusCode || 500;
 	const { config: whitelabeling } = useWhitelabelingPublic();
 	const appName = whitelabeling?.appName || "Dokploy";
 	const logoUrl = whitelabeling?.logoUrl || undefined;
@@ -45,12 +44,6 @@ export default function Custom404({ statusCode, error }: Props) {
 								{errorDescription}
 							</p>
 						)}
-						{error && (
-							<div className="mt-3 text-red-500">
-								<p>{error.message}</p>
-							</div>
-						)}
-
 						<div className="mt-5 flex flex-col justify-center items-center gap-2 sm:flex-row sm:gap-3">
 							<Link
 								href="/dashboard/home"
@@ -101,8 +94,7 @@ export default function Custom404({ statusCode, error }: Props) {
 	);
 }
 
-// @ts-ignore
-Error.getInitialProps = ({ res, err }: NextPageContext) => {
-	const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
-	return { statusCode, error: err };
+ErrorPage.getInitialProps = ({ res, err }: NextPageContext) => {
+	const statusCode = res ? res.statusCode : err ? (err.statusCode ?? 500) : 404;
+	return { statusCode };
 };


### PR DESCRIPTION
The custom `_error` page displayed **400 for every error** — `getInitialProps` was assigned to the global `Error` constructor instead of the page component (hence the `// @ts-ignore`), so `statusCode` was always undefined and fell back to `|| 400`. This is why users report "400" for completely unrelated failures (404s, DB down, disk full — #4849, #3400, #151).

- Attach `getInitialProps` to the component so the real status code renders (404s now show "Sorry, we couldn't find your page").
- Default fallback `400` → `500`.
- Drop the `error.message` render: dead code until now, and with `getInitialProps` working it would leak internal server error details on an unauthenticated page.

Fixes #4849

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the custom Next.js error page so it receives and displays the actual HTTP status while avoiding disclosure of internal error messages.
- Attaches `getInitialProps` to the page component rather than the global `Error` constructor.
- Uses 500 as the fallback for errors without an explicit status and preserves 404 handling when no response or error is available.
- Removes rendering of the server error message from the public page.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The custom error component now receives the status determined from the server response or error context, falls back appropriately, and no longer exposes the underlying error message.

<sub>Reviews (1): Last reviewed commit: ["fix(ui): show real status code on error ..."](https://github.com/dokploy/dokploy/commit/325c2a4180a2a0e0896d9ab92ba062a6e732a67f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49518072)</sub>

<!-- /greptile_comment -->