### PR TITLE
fix(schedule): return deployment metadata from runManually and fail early on missing container

### DIFF
--- a/apps/dokploy/components/dashboard/application/schedules/show-schedules.tsx
+++ b/apps/dokploy/components/dashboard/application/schedules/show-schedules.tsx
@@ -58,8 +58,12 @@ export const ShowSchedules = ({ id, scheduleType = "application" }: Props) => {
 	const handleRunManually = async (scheduleId: string) => {
 		setRunningSchedules((prev) => new Set(prev).add(scheduleId));
 		try {
-			await runManually({ scheduleId });
-			toast.success("Schedule run successfully");
+			const result = await runManually({ scheduleId });
+			if (result.status === "error") {
+				toast.error("Schedule run failed, check the deployment logs");
+			} else {
+				toast.success("Schedule run successfully");
+			}
 			await refetchSchedules();
 		} catch {
 			toast.error("Error running schedule");

--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -329,13 +329,17 @@ export const scheduleRouter = createTRPCRouter({
 				await checkPermission(ctx, { schedule: ["create"] });
 			}
 			try {
-				await runCommand(input.scheduleId);
+				const deployment = await runCommand(input.scheduleId);
 				await audit(ctx, {
 					action: "run",
 					resourceType: "schedule",
 					resourceId: input.scheduleId,
 				});
-				return true;
+				return {
+					status: deployment.status,
+					deploymentId: deployment.deploymentId,
+					logPath: deployment.logPath,
+				};
 			} catch (error) {
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",

--- a/packages/server/src/utils/schedules/utils.ts
+++ b/packages/server/src/utils/schedules/utils.ts
@@ -55,25 +55,46 @@ export const runCommand = async (scheduleId: string) => {
 		description: "Schedule",
 	});
 
-	if (scheduleType === "application" || scheduleType === "compose") {
-		let containerId = "";
-		let serverId = "";
-		if (scheduleType === "application" && application) {
-			const container = await getServiceContainer(
-				application.appName,
-				application.serverId,
-			);
-			containerId = container?.Id || "";
-			serverId = application.serverId || "";
-		}
-		if (scheduleType === "compose" && compose) {
-			const container = await getComposeContainer(compose, serviceName || "");
-			containerId = container?.Id || "";
-			serverId = compose.serverId || "";
-		}
+	try {
+		if (scheduleType === "application" || scheduleType === "compose") {
+			let containerId = "";
+			let serverId = "";
+			if (scheduleType === "application" && application) {
+				const container = await getServiceContainer(
+					application.appName,
+					application.serverId,
+				);
+				containerId = container?.Id || "";
+				serverId = application.serverId || "";
+			}
+			if (scheduleType === "compose" && compose) {
+				const container = await getComposeContainer(compose, serviceName || "");
+				containerId = container?.Id || "";
+				serverId = compose.serverId || "";
+			}
 
-		if (serverId) {
-			try {
+			if (!containerId) {
+				const target =
+					scheduleType === "compose"
+						? `service '${serviceName}' of compose '${compose?.name}'`
+						: `application '${application?.appName}'`;
+				const message = `Container not found for ${target}, make sure the service is running`;
+				if (serverId) {
+					await execAsyncRemote(
+						serverId,
+						`echo ${quote([`❌ ${message}`])} >> ${quote([deployment.logPath])}`,
+					);
+				} else {
+					const writeStream = createWriteStream(deployment.logPath, {
+						flags: "a",
+					});
+					writeStream.write(`❌ ${message}\n`);
+					writeStream.end();
+				}
+				throw new Error(message);
+			}
+
+			if (serverId) {
 				await execAsyncRemote(
 					serverId,
 					`
@@ -86,47 +107,44 @@ export const runCommand = async (scheduleId: string) => {
 					echo "✅ Command executed successfully" >> ${quote([deployment.logPath])};
 					`,
 				);
-			} catch (error) {
-				await updateDeploymentStatus(deployment.deploymentId, "error");
-				throw error;
-			}
-		} else {
-			const writeStream = createWriteStream(deployment.logPath, { flags: "a" });
+			} else {
+				const writeStream = createWriteStream(deployment.logPath, {
+					flags: "a",
+				});
 
-			try {
-				if (IS_CLOUD) {
+				try {
+					if (IS_CLOUD) {
+						writeStream.write(
+							"This feature is not available in the cloud version.",
+						);
+						writeStream.end();
+						return { ...deployment, status: "running" as const };
+					}
 					writeStream.write(
-						"This feature is not available in the cloud version.",
+						`docker exec ${containerId} ${shellType} -c ${command}\n`,
+					);
+					await spawnAsync(
+						"docker",
+						["exec", containerId, shellType, "-c", command],
+						(data) => {
+							if (writeStream.writable) {
+								writeStream.write(data);
+							}
+						},
+					);
+
+					writeStream.write("✅ Command executed successfully\n");
+					writeStream.end();
+				} catch (error) {
+					writeStream.write("❌ Command failed\n");
+					writeStream.write(
+						error instanceof Error ? error.message : "Unknown error",
 					);
 					writeStream.end();
-					return;
+					throw error;
 				}
-				writeStream.write(
-					`docker exec ${containerId} ${shellType} -c ${command}\n`,
-				);
-				await spawnAsync(
-					"docker",
-					["exec", containerId, shellType, "-c", command],
-					(data) => {
-						if (writeStream.writable) {
-							writeStream.write(data);
-						}
-					},
-				);
-
-				writeStream.write("✅ Command executed successfully\n");
-			} catch (error) {
-				writeStream.write("❌ Command failed\n");
-				writeStream.write(
-					error instanceof Error ? error.message : "Unknown error",
-				);
-				writeStream.end();
-				await updateDeploymentStatus(deployment.deploymentId, "error");
-				throw error;
 			}
-		}
-	} else if (scheduleType === "dokploy-server") {
-		try {
+		} else if (scheduleType === "dokploy-server") {
 			const writeStream = createWriteStream(deployment.logPath, { flags: "a" });
 			const { SCHEDULES_PATH } = paths();
 			const fullPath = path.join(SCHEDULES_PATH, appName || "");
@@ -151,18 +169,13 @@ export const runCommand = async (scheduleId: string) => {
 					cwd: fullPath,
 				},
 			);
-		} catch (error) {
-			await updateDeploymentStatus(deployment.deploymentId, "error");
-			throw error;
-		}
-	} else if (scheduleType === "server") {
-		try {
+		} else if (scheduleType === "server") {
 			const { SCHEDULES_PATH } = paths(true);
 			const fullPath = path.join(SCHEDULES_PATH, appName || "");
 			const command = `
 				set -e
 				echo "Running script" >> ${deployment.logPath};
-				bash -c ${fullPath}/script.sh 2>&1 | tee -a ${deployment.logPath} || { 
+				bash -c ${fullPath}/script.sh 2>&1 | tee -a ${deployment.logPath} || {
 					echo "❌ Command failed" >> ${deployment.logPath};
 					exit 1;
 				  }
@@ -177,10 +190,11 @@ export const runCommand = async (scheduleId: string) => {
 					});
 				}
 			});
-		} catch (error) {
-			await updateDeploymentStatus(deployment.deploymentId, "error");
-			throw error;
 		}
+		await updateDeploymentStatus(deployment.deploymentId, "done");
+		return { ...deployment, status: "done" as const };
+	} catch {
+		await updateDeploymentStatus(deployment.deploymentId, "error");
+		return { ...deployment, status: "error" as const };
 	}
-	await updateDeploymentStatus(deployment.deploymentId, "done");
 };


### PR DESCRIPTION
Closes #4718

`schedule.runManually` returned a bare 500 for failed runs, so API/MCP clients had no way to locate the created deployment or its logs.

- `runCommand()` no longer throws on execution failures: it marks the deployment as `error` and returns it with the final status. Cron-triggered runs no longer produce unhandled rejections either.
- `schedule.runManually` now returns `{ status, deploymentId, logPath }` for both successful and failed runs — the error details live in the deployment log.
- When the target container is not running, the run fails early and writes `❌ Container not found for ...` to the log, instead of surfacing docker exec's "invalid container name or ID: value is empty".
- The schedules UI shows an error toast pointing to the deployment logs when a manual run fails.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes scheduled-command execution to return deployment metadata and represent command failures through deployment status rather than rejected requests.

- Returns status, deployment ID, and log path from manual schedule runs.
- Adds early missing-container detection and corresponding deployment logging.
- Updates the schedules UI to distinguish error results from successful runs.
- Centralizes schedule deployment finalization across execution types.

<h3>Confidence Score: 4/5</h3>

The host-schedule error logging and cloud early-return status should be corrected before merging because failed or skipped runs can direct users to incomplete logs or be reported as successful.

The new failure-conversion path discards host execution exceptions without reliably recording them, while the cloud-only branch bypasses finalization and returns a running status that the UI treats as success.

**Files Needing Attention:** packages/server/src/utils/schedules/utils.ts; apps/dokploy/components/dashboard/application/schedules/show-schedules.tsx

<sub>Reviews (1): Last reviewed commit: ["fix(schedule): return deployment metadat..."](https://github.com/dokploy/dokploy/commit/cbb3450b9346c40c83b5209c6fdc51f1d89524c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49523761)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->