### PR TITLE
fix(server): default docker build context to repo root for dockerfile builds

### DIFF
--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -26,11 +26,7 @@ export const getDockerCommand = (application: ApplicationNested) => {
 	try {
 		const image = `${appName}`;
 
-		const defaultContextPath =
-			dockerFilePath.substring(0, dockerFilePath.lastIndexOf("/") + 1) || ".";
-
-		const dockerContextPath =
-			getDockerContextPath(application) || defaultContextPath;
+		const dockerContextPath = getDockerContextPath(application);
 
 		const commandArgs = ["build", "-t", image, "-f", dockerFilePath, "."];
 

--- a/packages/server/src/utils/filesystem/directory.ts
+++ b/packages/server/src/utils/filesystem/directory.ts
@@ -101,37 +101,47 @@ export const removeMonitoringDirectory = async (
 	}
 };
 
+export const getBuildPath = (application: Application) => {
+	const { sourceType, customGitBuildPath } = application;
+
+	if (sourceType === "github") {
+		return application?.buildPath || "";
+	}
+	if (sourceType === "gitlab") {
+		return application?.gitlabBuildPath || "";
+	}
+	if (sourceType === "bitbucket") {
+		return application?.bitbucketBuildPath || "";
+	}
+	if (sourceType === "gitea") {
+		return application?.giteaBuildPath || "";
+	}
+	if (sourceType === "drop") {
+		return application?.dropBuildPath || "";
+	}
+	if (sourceType === "git") {
+		return customGitBuildPath || "";
+	}
+	return "";
+};
+
 export const getBuildAppDirectory = (application: Application) => {
 	const serverId = application.buildServerId || application.serverId;
 	const { APPLICATIONS_PATH } = paths(!!serverId);
-	const { appName, buildType, sourceType, customGitBuildPath, dockerfile } =
-		application;
-	let buildPath = "";
+	const { appName, buildType, dockerfile } = application;
+	const buildPath = getBuildPath(application);
 
-	if (sourceType === "github") {
-		buildPath = application?.buildPath || "";
-	} else if (sourceType === "gitlab") {
-		buildPath = application?.gitlabBuildPath || "";
-	} else if (sourceType === "bitbucket") {
-		buildPath = application?.bitbucketBuildPath || "";
-	} else if (sourceType === "gitea") {
-		buildPath = application?.giteaBuildPath || "";
-	} else if (sourceType === "drop") {
-		buildPath = application?.dropBuildPath || "";
-	} else if (sourceType === "git") {
-		buildPath = customGitBuildPath || "";
-	}
 	if (buildType === "dockerfile") {
 		return path.join(
 			APPLICATIONS_PATH,
 			appName,
 			"code",
-			buildPath ?? "",
+			buildPath,
 			dockerfile || "Dockerfile",
 		);
 	}
 
-	return path.join(APPLICATIONS_PATH, appName, "code", buildPath ?? "");
+	return path.join(APPLICATIONS_PATH, appName, "code", buildPath);
 };
 
 export const getDockerContextPath = (application: Application) => {
@@ -143,6 +153,6 @@ export const getDockerContextPath = (application: Application) => {
 		APPLICATIONS_PATH,
 		appName,
 		"code",
-		dockerContextPath || ".",
+		dockerContextPath || getBuildPath(application) || ".",
 	);
 };

--- a/packages/server/src/utils/filesystem/directory.ts
+++ b/packages/server/src/utils/filesystem/directory.ts
@@ -135,11 +135,14 @@ export const getBuildAppDirectory = (application: Application) => {
 };
 
 export const getDockerContextPath = (application: Application) => {
-	const { APPLICATIONS_PATH } = paths(!!application.serverId);
+	const serverId = application.buildServerId || application.serverId;
+	const { APPLICATIONS_PATH } = paths(!!serverId);
 	const { appName, dockerContextPath } = application;
 
-	if (!dockerContextPath) {
-		return null;
-	}
-	return path.join(APPLICATIONS_PATH, appName, "code", dockerContextPath);
+	return path.join(
+		APPLICATIONS_PATH,
+		appName,
+		"code",
+		dockerContextPath || ".",
+	);
 };


### PR DESCRIPTION
## What is this PR about?

When the **Docker Context Path** field is left empty for a Dockerfile deployment, the build context defaults to the directory containing the Dockerfile instead of the cloned repository root — even though the UI placeholder advertises `(default: .)`. With a Dockerfile in a subfolder (e.g. `docker/Dockerfile`), any `COPY` referencing files outside that subfolder fails with "not found".

There was also an inconsistency: a filled-in context path resolves relative to the repo root (`code/`), while the empty-field fallback resolved relative to the Dockerfile's directory — two different bases.

Changes:
- `getDockerContextPath` now always returns a path, falling back to the repo code root when the field is empty, so the default matches both the UI placeholder and standard `docker build .` convention.
- It now resolves paths using `buildServerId || serverId` (matching `getBuildAppDirectory`), so the context path is also correct when building on a remote build server.
- `getDockerCommand` drops its Dockerfile-directory fallback; the `-f` flag already passes the absolute Dockerfile path, so Dockerfiles in subfolders are still found.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

Verified with `pnpm typecheck` on `packages/server` and the `docker-build-injection` test suite (4/4 passing).

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Dockerfile builds so an empty Docker context resolves to an absolute source-tree path and aligns path selection with remote build-server execution.
- Extracts provider-specific build-path selection into `getBuildPath`.
- Makes `getDockerContextPath` return a concrete path for empty values.
- Removes the Dockerfile-directory fallback from Docker command generation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge within the scope of this follow-up review.

No blocking failure remains among eligible new comments or previously reported findings.

<sub>Reviews (2): Last reviewed commit: ["fix(server): default docker context to b..."](https://github.com/dokploy/dokploy/commit/5c0f379f522a99732f826f750e8cd939b1806d5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49552327)</sub>

**Context used:**

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)
- Knowledge Base — [Server Setup and Packaging](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/server-setup-and-packaging.md)

<!-- /greptile_comment -->