### PR TITLE
fix(application): remove preview deployments when deleting an application

### DIFF
--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -4,6 +4,7 @@ import {
 	deleteAllMiddlewares,
 	findApplicationById,
 	findEnvironmentById,
+	findPreviewDeploymentsByApplicationId,
 	findProjectById,
 	getAccessibleServerIds,
 	getApplicationStats,
@@ -16,6 +17,7 @@ import {
 	removeDeployments,
 	removeDirectoryCode,
 	removeMonitoringDirectory,
+	removePreviewDeployment,
 	removeService,
 	removeTraefikConfig,
 	startService,
@@ -232,6 +234,15 @@ export const applicationRouter = createTRPCRouter({
 					code: "UNAUTHORIZED",
 					message: "You are not authorized to delete this application",
 				});
+			}
+
+			const previewDeploymentsList =
+				await findPreviewDeploymentsByApplicationId(input.applicationId);
+
+			for (const previewDeployment of previewDeploymentsList) {
+				try {
+					await removePreviewDeployment(previewDeployment.previewDeploymentId);
+				} catch (_) {}
 			}
 
 			const result = await db


### PR DESCRIPTION
Fixes #4893

Deleting an application removed the main service, Traefik config and code directory, but never touched its preview deployments. The `preview_deployments` rows were cascade-deleted, while the `preview-{appName}-{hash}` swarm services kept running — and since they have a restart policy, removing their containers with `docker rm` just made swarm recreate them (the "ghost containers" from the issue). Their Traefik configs, code directories and deployment logs were also left behind.

Now `application.delete` fetches the app's preview deployments and calls `removePreviewDeployment()` for each one before deleting the application row (it must run before, since the cascade removes the records it needs). Each removal is wrapped in its own try/catch, consistent with the rest of the cleanup operations, so a failing preview doesn't block the deletion.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends application deletion to remove all associated preview deployments before deleting the application record, preserving the database context required for external cleanup.

- Fetches preview deployments associated with the application.
- Removes each preview deployment using the existing service cleanup routine.
- Keeps cleanup best-effort so one preview failure does not block application deletion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered defect established.

The new cleanup runs before the application deletion cascade, allowing the existing preview-removal service to resolve application context and remove each preview's uniquely named Swarm service, deployment logs, code directory, and Traefik configuration.

<sub>Reviews (1): Last reviewed commit: ["fix(application): remove preview deploym..."](https://github.com/dokploy/dokploy/commit/f6b0700ea544c4e36a4cdc11cfa4f7881ddf0570) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49621834)</sub>

**Context used:**

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)

<!-- /greptile_comment -->