### PR TITLE
fix: preserve special characters in Compose-generated .env values

### DIFF
--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getCreateEnvFileCommand } from "@dokploy/server/utils/builders/compose";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Regression coverage for https://github.com/Dokploy/dokploy/issues/4694 —
+// values must survive Docker Compose's own `.env` parsing, not just base64 decode.
+const appName = `env-file-literals-${process.pid}`;
+const projectPath = join(process.cwd(), ".docker", "compose", appName);
+const codePath = join(projectPath, "code");
+
+afterEach(() => {
+	try {
+		execFileSync("docker", ["compose", "down", "--remove-orphans"], {
+			cwd: codePath,
+			stdio: "ignore",
+		});
+	} catch {
+		// Project may not have been created (e.g. an earlier assertion failed).
+	}
+	rmSync(projectPath, { force: true, recursive: true });
+});
+
+const cases: Record<string, string> = {
+	PASSWORD: "pa$$word",
+	SPECIAL: '!"#$%&/()=?',
+	NESTED_JSON: '{"nested":{"a":1}}',
+	MAIL_PASSWORD: "abc#de",
+	TRAILING_BACKSLASH: "trailing\\",
+	QUOTE_INSIDE: 'she said "hi"',
+	APOSTROPHE: "it's a test",
+	UNICODE: "héllo wörld 日本語 🚀",
+	MULTILINE_PEM: "-----BEGIN KEY-----\nabc123\n-----END KEY-----",
+};
+
+// How each value must be typed in the UI so the (unchanged) dotenv input
+// parser resolves it to the raw string in `cases` above.
+const inputEncoding: Record<string, string> = {
+	PASSWORD: "pa$$word",
+	SPECIAL: `'!"#$%&/()=?'`,
+	NESTED_JSON: '{"nested":{"a":1}}',
+	MAIL_PASSWORD: `"abc#de"`,
+	TRAILING_BACKSLASH: "trailing\\",
+	QUOTE_INSIDE: 'she said "hi"',
+	APOSTROPHE: "it's a test",
+	UNICODE: "héllo wörld 日本語 🚀",
+	MULTILINE_PEM: '"-----BEGIN KEY-----\nabc123\n-----END KEY-----"',
+};
+
+describe("getCreateEnvFileCommand", () => {
+	it("writes special environment values that Docker Compose reads back literally", () => {
+		mkdirSync(codePath, { recursive: true });
+
+		const serviceEnv = Object.entries(inputEncoding)
+			.map(([key, value]) => `${key}=${value}`)
+			.join("\n");
+
+		const command = getCreateEnvFileCommand({
+			appName,
+			composePath: "docker-compose.yml",
+			env: serviceEnv,
+			randomize: false,
+			suffix: "",
+			serverId: null,
+			environment: { project: { env: "" }, env: "" },
+		} as Parameters<typeof getCreateEnvFileCommand>[0]);
+
+		execFileSync("bash", ["-c", command]);
+
+		const composeFile = `services:\n  test:\n    image: busybox\n    environment:\n${Object.keys(
+			cases,
+		)
+			.map((key) => `      - ${key}=\${${key}}`)
+			.join("\n")}\n`;
+		writeFileSync(join(codePath, "docker-compose.yml"), composeFile);
+
+		const dumpScript = `for k in ${Object.keys(cases).join(" ")}; do printf '%s\\0' "$k"; eval "printf '%s\\0' \\"\\$$k\\""; done`;
+
+		const out = execFileSync(
+			"docker",
+			["compose", "run", "--rm", "-T", "test", "sh", "-c", dumpScript],
+			{ cwd: codePath, encoding: "utf8" },
+		);
+
+		const parts = out.split("\0");
+		const actual: Record<string, string> = {};
+		for (let i = 0; i < parts.length - 1; i += 2) {
+			actual[parts[i] as string] = parts[i + 1] as string;
+		}
+
+		for (const [key, value] of Object.entries(cases)) {
+			expect(actual[key], key).toBe(value);
+		}
+	}, 60000);
+});

--- a/apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts
+++ b/apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { createEnvFileCommand } from "@dokploy/server/utils/builders/utils";
+import { parse } from "dotenv";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Unlike compose's .env, this one is read by the app's own build tooling
+// (generic dotenv, e.g. Next.js/Vite) — must stay unquoted, not Compose-escaped.
+const appName = `env-file-literals-dockerfile-${process.pid}`;
+const projectPath = join(process.cwd(), ".docker", "compose", appName);
+const codePath = join(projectPath, "code");
+const dockerFilePath = join(codePath, "Dockerfile");
+
+afterEach(() => rmSync(projectPath, { force: true, recursive: true }));
+
+const cases: Record<string, string> = {
+	PASSWORD: "pa$$word",
+	NESTED_JSON: '{"nested":{"a":1}}',
+	QUOTE_INSIDE: 'she said "hi"',
+	BACKSLASH: "back\\slash",
+	UNICODE: "héllo wörld 日本語 🚀",
+};
+
+describe("createEnvFileCommand", () => {
+	it("writes special environment values that a generic dotenv parser reads back literally", () => {
+		mkdirSync(codePath, { recursive: true });
+
+		const serviceEnv = Object.entries(cases)
+			.map(([key, value]) => `${key}=${value}`)
+			.join("\n");
+
+		const command = createEnvFileCommand(dockerFilePath, serviceEnv, "", "");
+		execFileSync("bash", ["-c", command]);
+
+		const written = readFileSync(join(codePath, ".env"), "utf8");
+		const parsed = parse(written);
+
+		for (const [key, value] of Object.entries(cases)) {
+			expect(parsed[key], key).toBe(value);
+		}
+	});
+});

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -7,7 +7,7 @@ import { writeDomainsToCompose } from "../docker/domain";
 import {
 	encodeBase64,
 	getEnvironmentVariablesObject,
-	prepareEnvironmentVariables,
+	prepareEnvironmentVariablesForFile,
 } from "../docker/utils";
 
 export type ComposeNested = InferResultType<
@@ -127,7 +127,7 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 		envContent += `\nCOMPOSE_PREFIX=${compose.suffix}`;
 	}
 
-	const envFileContent = prepareEnvironmentVariables(
+	const envFileContent = prepareEnvironmentVariablesForFile(
 		envContent,
 		compose.environment.project.env,
 		compose.environment.env,

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -465,6 +465,27 @@ export const prepareEnvironmentVariablesForShell = (
 	return envVars.map((env) => quote([env]));
 };
 
+export const prepareEnvironmentVariablesForFile = (
+	serviceEnv: string | null,
+	projectEnv?: string | null,
+	environmentEnv?: string | null,
+): string[] => {
+	const envVars = prepareEnvironmentVariables(
+		serviceEnv,
+		projectEnv,
+		environmentEnv,
+	);
+
+	return envVars.map((pair) => {
+		const [key, value] = parseEnvironmentKeyValuePair(pair);
+		const escapedValue = value
+			.replace(/\\/g, "\\\\")
+			.replace(/"/g, '\\"')
+			.replace(/\$/g, "\\$");
+		return `${key}="${escapedValue}"`;
+	});
+};
+
 export const parseEnvironmentKeyValuePair = (
 	pair: string,
 ): [string, string] => {


### PR DESCRIPTION
## What is this PR about?

## Problem
Values containing `$`, `#`, quotes, or backslashes were getting corrupted when Dokploy wrote them to the `.env` file that Docker Compose reads for  variable interpolation. Example: `PASSWORD=pa$$word` in the UI became `pa$word` inside the container, because Docker Compose interpolates `$` in  unquoted `.env` values (`$$` collapses to `$`).

## Root cause
`getCreateEnvFileCommand` in `packages/server/src/utils/builders/compose.ts` wrote every resolved `KEY=value` pair unquoted into the `.env` file. Docker Compose's own `.env` parser then applied its normal interpolation rules to that unquoted content.

## Fix
Added `prepareEnvironmentVariablesForFile` (`packages/server/src/utils/docker/utils.ts`),  which wraps each value in double quotes and escapes `\`, `"`, and `$`. Used only in `compose.ts`, the one `.env` file Compose actually parses.

`builders/utils.ts` (`createEnvFileCommand`, used by the Dockerfile builder's  `createEnvFile` option) intentionally keeps the original unquoted output, that `.env` lands in the Docker build context for the app's own build  tooling (Next.js/Vite/etc. via a generic `dotenv` parser), which doesn't  interpolate `$` and would corrupt Compose-style escaping instead.

 ## Testing
Verified against real `docker compose`/`dotenv`. Two new regression tests:
  - `apps/dokploy/__test__/compose/env-file-literals.test.ts`
  - `apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts`

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4694 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes Compose-generated `.env` serialization so resolved values containing Docker Compose-sensitive characters survive interpolation unchanged.

- Adds a dedicated serializer that double-quotes values and escapes backslashes, quotes, and dollar signs.
- Uses the serializer only for Compose-generated `.env` files while retaining the existing Dockerfile build-context behavior.
- Adds regression coverage for Docker Compose and generic dotenv consumers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed Compose serialization covered against the relevant special-character cases.

The serializer resolves values through the existing environment pipeline, applies the escaping required by double-quoted Compose `.env` values, and leaves the distinct Dockerfile and stack serialization paths unchanged.

<sub>Reviews (1): Last reviewed commit: ["fix: escape env values written to the Co..."](https://github.com/dokploy/dokploy/commit/ff39cb51e6b1af7a645be0fea9717ffeb4382d93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49866336)</sub>

**Context used:**

- Knowledge Base — [Compose Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/compose-deployment.md)
- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)

<!-- /greptile_comment -->