### PR TITLE
fix(requests): guard RequestHost before filtering to avoid crash on malformed logs

### DIFF
--- a/apps/dokploy/__test__/requests/request.test.ts
+++ b/apps/dokploy/__test__/requests/request.test.ts
@@ -55,6 +55,28 @@ describe("processLogs", () => {
 		expect(result.data).toHaveLength(2);
 	});
 
+	it("should not throw when filtering by hostname and an entry has no RequestHost", () => {
+		const entryWithoutRequestHost = sampleLogEntry.replace(
+			/"RequestHost":"[^"]*",/,
+			"",
+		);
+
+		const mixedEntries = `${sampleLogEntry}\n${entryWithoutRequestHost}`;
+
+		expect(() =>
+			parseRawConfig(mixedEntries, undefined, undefined, "traefik.me"),
+		).not.toThrow();
+
+		const result = parseRawConfig(
+			mixedEntries,
+			undefined,
+			undefined,
+			"traefik.me",
+		);
+		expect(result.totalCount).toBe(1);
+		expect(result.data[0]?.RequestHost).toBe("s222-umami-c381af.traefik.me");
+	});
+
 	it("should filter out Dokploy dashboard requests", () => {
 		const dokployDashboardEntry = `{"ClientAddr":"172.71.187.131:9485","ClientHost":"172.71.187.131","ClientPort":"9485","ClientUsername":"-","DownstreamContentSize":14550,"DownstreamStatus":200,"Duration":57681682,"OriginContentSize":14550,"OriginDuration":57612242,"OriginStatus":200,"Overhead":69440,"RequestAddr":"hostinger.dokploy.com","RequestContentSize":0,"RequestCount":20142,"RequestHost":"hostinger.dokploy.com","RequestMethod":"GET","RequestPath":"/_next/data/cb_zzI4Rp9G7Q7djrFKh0/en/dashboard/traefik.json","RequestPort":"-","RequestProtocol":"HTTP/2.0","RequestScheme":"https","RetryAttempts":0,"RouterName":"dokploy-router-app-secure@file","ServiceAddr":"dokploy:3000","ServiceName":"dokploy-service-app@file","ServiceURL":"http://dokploy:3000","StartLocal":"2025-12-10T05:10:41.957755949Z","StartUTC":"2025-12-10T05:10:41.957755949Z","TLSCipher":"TLS_AES_128_GCM_SHA256","TLSVersion":"1.3","entryPointName":"websecure","level":"info","msg":"","time":"2025-12-10T05:10:42Z"}`;
 

--- a/packages/server/src/utils/access-log/utils.ts
+++ b/packages/server/src/utils/access-log/utils.ts
@@ -120,7 +120,7 @@ export function parseRawConfig(
 
 		if (search) {
 			parsedLogs = parsedLogs.filter((log) =>
-				log.RequestHost.toLowerCase().includes(search.toLowerCase()),
+				(log.RequestHost ?? "").toLowerCase().includes(search.toLowerCase()),
 			);
 		}
 


### PR DESCRIPTION
## What is this PR about?

- `parseRawConfig` called `log.RequestHost.toLowerCase()` unguarded when the "Filter by hostname" search was used. Traefik can log entries without `RequestHost` (malformed/probe requests with no Host header), which threw a `TypeError` caught by the outer try/catch and surfaced as a misleading `500 Failed to parse rawConfig` breaking hostname filtering entirely once a single such entry existed in the date range.
- Guard the field with `(log.RequestHost ?? "")` so those entries are treated as non-matching instead of crashing the whole request.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4900 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents hostname filtering from failing when a Traefik access-log entry omits `RequestHost`.
- Uses an empty-string fallback for missing hostnames so malformed entries are treated as non-matches.
- Adds a regression test covering mixed entries with and without `RequestHost`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly addresses the malformed-log failure described.

The nullish fallback preserves existing matching behavior for valid hostnames while excluding entries without RequestHost, and the regression test exercises the corrected mixed-log scenario.

<sub>Reviews (1): Last reviewed commit: ["fix(requests): guard RequestHost before ..."](https://github.com/dokploy/dokploy/commit/314a31dc27d9edb2f2042e18191a169c29dd4792) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50064607)</sub>

<!-- /greptile_comment -->