### PR TITLE
fix(restore): drop USE/CREATE DATABASE statements so mysql/mariadb restores target the selected database

### DIFF
--- a/apps/dokploy/__test__/backups/restore-use-statement.test.ts
+++ b/apps/dokploy/__test__/backups/restore-use-statement.test.ts
@@ -1,0 +1,57 @@
+import { execSync } from "node:child_process";
+import {
+	getRestoreCommand,
+	stripDatabaseSwitchCommand,
+} from "@dokploy/server/utils/restore/utils";
+import { describe, expect, it } from "vitest";
+
+const filter = (input: string) =>
+	execSync(stripDatabaseSwitchCommand, {
+		input,
+		shell: "/bin/bash",
+	}).toString();
+
+describe("restore drops database-switch statements (mysql/mariadb)", () => {
+	const dump = [
+		"-- MariaDB dump",
+		"CREATE DATABASE /*!32312 IF NOT EXISTS*/ `production_db`;",
+		"USE `production_db`;",
+		"use production_db;",
+		"DROP TABLE IF EXISTS `users`;",
+		"CREATE TABLE `users` (`id` int NOT NULL);",
+		"INSERT INTO `users` VALUES (1),(2);",
+		"INSERT INTO `logs` VALUES ('USER: because'),('CREATE DATABASE is a string');",
+	].join("\n");
+
+	it("removes USE and CREATE DATABASE lines but keeps everything else", () => {
+		const result = filter(dump);
+		expect(result).not.toContain("USE `production_db`");
+		expect(result).not.toContain("use production_db");
+		expect(result).not.toContain("CREATE DATABASE /*!32312");
+		expect(result).toContain("DROP TABLE IF EXISTS `users`;");
+		expect(result).toContain("CREATE TABLE `users` (`id` int NOT NULL);");
+		expect(result).toContain("INSERT INTO `users` VALUES (1),(2);");
+		expect(result).toContain(
+			"INSERT INTO `logs` VALUES ('USER: because'),('CREATE DATABASE is a string');",
+		);
+	});
+
+	it("is wired into mysql and mariadb restore pipelines only", () => {
+		const base = {
+			appName: "my-app",
+			restoreType: "database" as const,
+			credentials: {
+				database: "dev_db",
+				databaseUser: "u",
+				databasePassword: "p",
+			},
+			rcloneCommand: "rclone cat ':s3:bucket/file.sql.gz' | gunzip",
+		};
+		for (const type of ["mysql", "mariadb"] as const) {
+			const cmd = getRestoreCommand({ ...base, type });
+			expect(cmd).toContain(`gunzip | ${stripDatabaseSwitchCommand} | docker`);
+		}
+		const pgCmd = getRestoreCommand({ ...base, type: "postgres" });
+		expect(pgCmd).not.toContain(stripDatabaseSwitchCommand);
+	});
+});

--- a/packages/server/src/utils/restore/utils.ts
+++ b/packages/server/src/utils/restore/utils.ts
@@ -79,6 +79,10 @@ const generateRestoreCommand = (
 	}
 };
 
+// Dumps taken with `--databases` carry `USE`/`CREATE DATABASE` statements that
+// would redirect the restore away from the database selected in the dialog.
+export const stripDatabaseSwitchCommand = `grep -viE '^[[:space:]]*(use|create[[:space:]]+database)[[:space:]]'`;
+
 const getMongoSpecificCommand = (
 	rcloneCommand: string,
 	restoreCommand: string,
@@ -125,7 +129,9 @@ export const getRestoreCommand = ({
 	const restoreCommand = generateRestoreCommand(type, credentials);
 	let cmd = `CONTAINER_ID=$(${containerSearch})`;
 
-	if (type !== "mongo") {
+	if (type === "mysql" || type === "mariadb") {
+		cmd += ` && ${rcloneCommand} | ${stripDatabaseSwitchCommand} | ${restoreCommand}`;
+	} else if (type !== "mongo") {
 		cmd += ` && ${rcloneCommand} | ${restoreCommand}`;
 	} else {
 		cmd += ` && ${getMongoSpecificCommand(rcloneCommand, restoreCommand, backupFile || "")}`;


### PR DESCRIPTION
Closes #3436

Dumps taken with `--databases` (or brought from another instance) contain `USE \`source_db\`;` — the restore pipeline piped them verbatim into `mariadb/mysql <target_db>`, so every statement after the `USE` executed against the source database instead of the one selected in the restore dialog. In the reported case this overwrote a production database.

The fix inserts a line filter between `gunzip` and the client for mysql/mariadb restores that drops `USE`/`CREATE DATABASE` statements, so the whole dump applies to the database passed on the command line. String values are safe: `mysqldump`/`mariadb-dump` escape newlines inside values, so data lines can never start with these keywords.

Verified against a real MariaDB 11 container: before the fix, restoring a `--databases` dump into `dev_db` overwrote `production_db` and left `dev_db` empty; after the fix, `production_db` is untouched and `dev_db` receives the data.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents MySQL and MariaDB restores from redirecting writes to a database named inside the dump.
- Adds a case-insensitive line filter that removes `USE` and `CREATE DATABASE` statements from MySQL/MariaDB restore streams.
- Adds tests covering statement removal, preservation of ordinary SQL and string values, and engine-specific pipeline wiring.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable changed-code defects identified.

The filter covers the database-selection statements emitted by the supported MariaDB dump path, remains a harmless pass-through for ordinary SQL, and is limited to MySQL and MariaDB restores.

<sub>Reviews (1): Last reviewed commit: ["fix(restore): drop USE/CREATE DATABASE s..."](https://github.com/dokploy/dokploy/commit/2505c347bc9cbccc071f120a1bb5f4923d434c5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50142475)</sub>

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->