### PR TITLE
fix(backup): attach reconnecting restore subscriptions to the in-flight job instead of re-running the restore

### DIFF
--- a/apps/dokploy/server/api/routers/backup.ts
+++ b/apps/dokploy/server/api/routers/backup.ts
@@ -79,6 +79,15 @@ interface RcloneFile {
 	};
 }
 
+interface RestoreJob {
+	logs: string[];
+	done: boolean;
+}
+
+// The websocket client re-subscribes on reconnect; attaching to the in-flight
+// job instead of starting a new restore prevents concurrent duplicate runs.
+const activeRestores = new Map<string, RestoreJob>();
+
 export const backupRouter = createTRPCRouter({
 	create: protectedProcedure
 		.input(apiCreateBackup)
@@ -580,46 +589,70 @@ export const backupRouter = createTRPCRouter({
 				});
 			}
 			const destination = await findDestinationById(input.destinationId);
-			const queue: string[] = [];
-			let done = false;
-			const onLog = (log: string) => queue.push(log);
-			const runRestore = async () => {
-				if (input.backupType === "database") {
-					if (input.databaseType === "postgres") {
-						const postgres = await findPostgresById(input.databaseId);
-						await restorePostgresBackup(postgres, destination, input, onLog);
-					} else if (input.databaseType === "mysql") {
-						const mysql = await findMySqlById(input.databaseId);
-						await restoreMySqlBackup(mysql, destination, input, onLog);
-					} else if (input.databaseType === "mariadb") {
-						const mariadb = await findMariadbById(input.databaseId);
-						await restoreMariadbBackup(mariadb, destination, input, onLog);
-					} else if (input.databaseType === "mongo") {
-						const mongo = await findMongoById(input.databaseId);
-						await restoreMongoBackup(mongo, destination, input, onLog);
-					} else if (input.databaseType === "libsql") {
-						const libsql = await findLibsqlById(input.databaseId);
-						await restoreLibsqlBackup(libsql, destination, input, onLog);
-					} else if (input.databaseType === "web-server") {
-						await restoreWebServerBackup(destination, input.backupFile, onLog);
+			const jobKey = [
+				input.backupType,
+				input.databaseId,
+				input.databaseType,
+				input.databaseName,
+				input.backupFile,
+				input.destinationId,
+			].join("|");
+
+			let job = activeRestores.get(jobKey);
+			if (!job) {
+				const newJob: RestoreJob = { logs: [], done: false };
+				activeRestores.set(jobKey, newJob);
+				job = newJob;
+				const onLog = (log: string) => newJob.logs.push(log);
+				const runRestore = async () => {
+					if (input.backupType === "database") {
+						if (input.databaseType === "postgres") {
+							const postgres = await findPostgresById(input.databaseId);
+							await restorePostgresBackup(postgres, destination, input, onLog);
+						} else if (input.databaseType === "mysql") {
+							const mysql = await findMySqlById(input.databaseId);
+							await restoreMySqlBackup(mysql, destination, input, onLog);
+						} else if (input.databaseType === "mariadb") {
+							const mariadb = await findMariadbById(input.databaseId);
+							await restoreMariadbBackup(mariadb, destination, input, onLog);
+						} else if (input.databaseType === "mongo") {
+							const mongo = await findMongoById(input.databaseId);
+							await restoreMongoBackup(mongo, destination, input, onLog);
+						} else if (input.databaseType === "libsql") {
+							const libsql = await findLibsqlById(input.databaseId);
+							await restoreLibsqlBackup(libsql, destination, input, onLog);
+						} else if (input.databaseType === "web-server") {
+							await restoreWebServerBackup(
+								destination,
+								input.backupFile,
+								onLog,
+							);
+						}
+					} else if (input.backupType === "compose") {
+						const compose = await findComposeById(input.databaseId);
+						await restoreComposeBackup(compose, destination, input, onLog);
 					}
-				} else if (input.backupType === "compose") {
-					const compose = await findComposeById(input.databaseId);
-					await restoreComposeBackup(compose, destination, input, onLog);
-				}
-			};
-			runRestore()
-				.catch((error) => {
-					onLog(
-						`Error: ${error instanceof Error ? error.message : String(error)}`,
-					);
-				})
-				.finally(() => {
-					done = true;
-				});
-			while (!done || queue.length > 0) {
-				if (queue.length > 0) {
-					yield queue.shift()!;
+				};
+				runRestore()
+					.catch((error) => {
+						onLog(
+							`Error: ${error instanceof Error ? error.message : String(error)}`,
+						);
+					})
+					.finally(() => {
+						newJob.done = true;
+						setTimeout(() => {
+							if (activeRestores.get(jobKey) === newJob) {
+								activeRestores.delete(jobKey);
+							}
+						}, 5000);
+					});
+			}
+
+			let cursor = 0;
+			while (!job.done || cursor < job.logs.length) {
+				if (cursor < job.logs.length) {
+					yield job.logs[cursor++]!;
 				} else {
 					await new Promise((r) => setTimeout(r, 50));
 				}


### PR DESCRIPTION
Closes #3388

`restoreBackupWithLogs` starts the restore inside the subscription handler, and the websocket client (`createWSClient` with `retryDelayMs: 3000`) re-subscribes automatically whenever the connection drops. For large backups the socket sits idle for minutes (proxies like Cloudflare cut idle connections), so every reconnect re-invoked the handler and launched another full `pg_restore`/`mariadb` run — the concurrent duplicate restores reported in the issue.

Restores are now tracked in an in-flight job map keyed by backup type, service, database name, backup file and destination. The first subscription starts the restore; any re-subscription with the same key attaches to the running job and replays its log buffer instead of starting a new process. Jobs are evicted 5s after completion so a genuine re-run later starts fresh.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents reconnecting WebSocket subscriptions from launching duplicate database restores by retaining in-flight jobs and replaying their logs.
- Adds a process-local restore-job map.
- Keys jobs by restore target and backup details.
- Retains completed jobs for five seconds before eviction.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking key-serialization edge case that can conflate distinct restore requests containing pipe characters.

The reconnect deduplication works in the supported single-process server architecture, but the unescaped delimiter-based key is ambiguous for two unrestricted input fields.

**Files Needing Attention:** apps/dokploy/server/api/routers/backup.ts

<sub>Reviews (1): Last reviewed commit: ["fix(backup): attach reconnecting restore..."](https://github.com/dokploy/dokploy/commit/bd800af14015ff1b8c6e160a0c0377cad53cb877) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50143260)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->