### PR TITLE
fix(certificates): write traefik registration yml into the watched dynamic directory

### DIFF
--- a/apps/dokploy/server/server.ts
+++ b/apps/dokploy/server/server.ts
@@ -10,6 +10,7 @@ import {
 	initializeNetwork,
 	initSchedules,
 	initVolumeBackupsCronJobs,
+	migrateCertificatesToWatchedConfig,
 	sendDokployRestartNotifications,
 	setupDirectories,
 } from "@dokploy/server";
@@ -61,6 +62,7 @@ void app.prepare().then(async () => {
 		if (process.env.NODE_ENV === "production" && !IS_CLOUD) {
 			createDefaultMiddlewares();
 			await initializeNetwork();
+			await migrateCertificatesToWatchedConfig();
 			await initCronJobs();
 			await initSchedules();
 			await initCancelDeployments();

--- a/packages/server/src/services/certificate.ts
+++ b/packages/server/src/services/certificate.ts
@@ -60,13 +60,25 @@ export const createCertificate = async (
 
 export const removeCertificateById = async (certificateId: string) => {
 	const certificate = await findCertificateById(certificateId);
-	const { CERTIFICATES_PATH } = paths(!!certificate.serverId);
+	const { CERTIFICATES_PATH, DYNAMIC_TRAEFIK_PATH } = paths(
+		!!certificate.serverId,
+	);
 	const certDir = path.join(CERTIFICATES_PATH, certificate.certificatePath);
+	const configFile = path.join(
+		DYNAMIC_TRAEFIK_PATH,
+		`${certificate.certificatePath}.yml`,
+	);
 
 	if (certificate.serverId) {
-		await execAsyncRemote(certificate.serverId, `rm -rf ${quote([certDir])}`);
+		await execAsyncRemote(
+			certificate.serverId,
+			`rm -rf ${quote([certDir])}; rm -f ${quote([configFile])}`,
+		);
 	} else {
 		await removeDirectoryIfExistsContent(certDir);
+		if (fs.existsSync(configFile)) {
+			fs.rmSync(configFile);
+		}
 	}
 
 	const result = await db
@@ -84,26 +96,33 @@ export const removeCertificateById = async (certificateId: string) => {
 	return result;
 };
 
+// The traefik file provider does not read subdirectories of `dynamic`, so the
+// registration yml must live at the top level of the watched directory; only
+// the PEM files (referenced by absolute path) stay in the certificates subdir.
 const createCertificateFiles = async (certificate: Certificate) => {
-	const { CERTIFICATES_PATH } = paths(!!certificate.serverId);
+	const { CERTIFICATES_PATH, DYNAMIC_TRAEFIK_PATH } = paths(
+		!!certificate.serverId,
+	);
 	const certDir = path.join(CERTIFICATES_PATH, certificate.certificatePath);
 	const crtPath = path.join(certDir, "chain.crt");
 	const keyPath = path.join(certDir, "privkey.key");
 
-	const chainPath = path.join(certDir, "chain.crt");
-	const keyPathDocker = path.join(certDir, "privkey.key");
 	const traefikConfig = {
 		tls: {
 			certificates: [
 				{
-					certFile: chainPath,
-					keyFile: keyPathDocker,
+					certFile: crtPath,
+					keyFile: keyPath,
 				},
 			],
 		},
 	};
 	const yamlConfig = stringify(traefikConfig);
-	const configFile = path.join(certDir, "certificate.yml");
+	const configFile = path.join(
+		DYNAMIC_TRAEFIK_PATH,
+		`${certificate.certificatePath}.yml`,
+	);
+	const legacyConfigFile = path.join(certDir, "certificate.yml");
 
 	if (certificate.serverId) {
 		const certificateData = encodeBase64(certificate.certificateData);
@@ -113,6 +132,7 @@ const createCertificateFiles = async (certificate: Certificate) => {
 			echo "${certificateData}" | base64 -d > ${quote([crtPath])};
 			echo "${privateKey}" | base64 -d > ${quote([keyPath])};
 			echo "${yamlConfig}" > ${quote([configFile])};
+			rm -f ${quote([legacyConfigFile])};
 		`;
 
 		await execAsyncRemote(certificate.serverId, command);
@@ -125,6 +145,24 @@ const createCertificateFiles = async (certificate: Certificate) => {
 		fs.writeFileSync(keyPath, certificate.privateKey);
 
 		fs.writeFileSync(configFile, yamlConfig);
+
+		if (fs.existsSync(legacyConfigFile)) {
+			fs.rmSync(legacyConfigFile);
+		}
+	}
+};
+
+export const migrateCertificatesToWatchedConfig = async () => {
+	const allCertificates = await db.query.certificates.findMany();
+	for (const certificate of allCertificates) {
+		try {
+			await createCertificateFiles(certificate);
+		} catch (error) {
+			console.error(
+				`Error migrating certificate ${certificate.certificateId}:`,
+				error,
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
Closes #4503
Related: #3762, #4707

Uploaded certificates were written as `dynamic/certificates/<cert-path>/certificate.yml`, but Traefik's file provider does not read subdirectories of the configured `directory` — so the TLS store registration was never loaded and SNI matching never served uploaded certs (Cloudflare Origin CA being the most common casualty).

Changes:
- The registration yml is now written to `dynamic/<cert-path>.yml` (top level, watched). The PEM files stay in `dynamic/certificates/<cert-path>/` since they are referenced by absolute path.
- Deleting a certificate also removes the top-level yml; rewriting removes the legacy nested `certificate.yml`.
- On startup (self-hosted), `migrateCertificatesToWatchedConfig()` rewrites all stored certificates into the new layout, fixing existing installs without user action. Cloud-managed remote servers get migrated the next time the certificate is saved/edited.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR relocates uploaded-certificate registration YAML files into Traefik's watched dynamic directory, removes legacy nested registrations, and adds a startup migration for existing certificates.
- Writes registration files at the dynamic directory's top level while retaining PEM files in certificate subdirectories.
- Removes both layouts when certificates are rewritten or deleted.
- Rewrites stored certificates during self-hosted production startup.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until remote certificate migration can no longer delay background-service startup and remote deletion reliably fails when PEM cleanup fails.

Startup now serially awaits potentially slow SSH operations before initializing scheduled and recovery work, while remote deletion can mask a failed PEM-directory removal and discard the corresponding database record.

**Files Needing Attention:** packages/server/src/services/certificate.ts and apps/dokploy/server/server.ts

<details open><summary><h3>Security Review</h3></summary>

Remote certificate deletion can report success while retaining private-key material if PEM-directory removal fails but the subsequent registration-file removal succeeds.

**How this was verified:** The compound remote command uses `;`, and its caller deletes the database row based on the final command's successful exit status even when the first removal failed.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(certificates): write traefik registr..."](https://github.com/dokploy/dokploy/commit/59cc3801ab84a48b8c9e227cfbc9be09b3054de7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50145947)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->