### PR TITLE
fix(ui): widen restore backup dialog to match other backup dialogs

### DIFF
--- a/apps/dokploy/components/dashboard/database/backups/restore-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/restore-backup.tsx
@@ -316,7 +316,7 @@ export const RestoreBackup = ({
 					Restore Backup
 				</Button>
 			</DialogTrigger>
-			<DialogContent className="sm:max-w-lg">
+			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle className="flex items-center">
 						<RotateCcw className="mr-2 size-4" />


### PR DESCRIPTION
Closes #3986

The restore dialog used `sm:max-w-lg` (512px) while the create/update backup dialogs use `sm:max-w-2xl`, so the file listing overflowed horizontally. Aligned it to `sm:max-w-2xl`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR widens the restore-backup dialog to match the create and update backup dialogs.
- Replaces `sm:max-w-lg` with `sm:max-w-2xl`.
- Provides more horizontal space for backup file listings.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only increases the restore dialog’s responsive maximum width and does not alter backup behavior, state, or data flow.

<sub>Reviews (1): Last reviewed commit: ["fix(ui): widen restore backup dialog to ..."](https://github.com/dokploy/dokploy/commit/5ae289cae3c668defe2b8d4f2a73b2ee63cf127c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50146939)</sub>

<!-- /greptile_comment -->