### PR TITLE
fix(domain): allow single-label hostnames without a TLD

### DIFF
--- a/apps/dokploy/__test__/utils/hostname-validation.test.ts
+++ b/apps/dokploy/__test__/utils/hostname-validation.test.ts
@@ -9,6 +9,9 @@ describe("VALID_HOSTNAME_REGEX", () => {
 		"a.b.c.example.co",
 		"xn--80ak6aa92e.com",
 		"123.example.com",
+		"example",
+		"dokploy-server",
+		"localhost",
 	])("accepts valid hostname %s", (host) => {
 		expect(VALID_HOSTNAME_REGEX.test(host)).toBe(true);
 	});
@@ -17,7 +20,6 @@ describe("VALID_HOSTNAME_REGEX", () => {
 		"bbn_client.example.com",
 		"-example.com",
 		"example-.com",
-		"example",
 		"exa mple.com",
 		"example..com",
 		"",

--- a/packages/server/src/utils/hostname-validation.ts
+++ b/packages/server/src/utils/hostname-validation.ts
@@ -1,8 +1,8 @@
 // Valid hostname per RFC 1123: labels of letters, digits and hyphens
-// (no leading/trailing hyphen), separated by dots. Underscores are rejected
+// (no leading/trailing hyphen), optionally separated by dots. Underscores are rejected
 // because Let's Encrypt refuses to issue certificates for them.
 export const VALID_HOSTNAME_REGEX =
-	/^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+	/^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
 
 export const INVALID_HOSTNAME_MESSAGE =
 	"Invalid domain name. Use only letters, numbers, hyphens and dots (e.g. example.com). Underscores are not allowed.";


### PR DESCRIPTION
## What is this PR about?

Regression from #4729: VALID_HOSTNAME_REGEX required at least one dot, rejecting single-label hosts like "dokploy-server", the TLD is optional.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4881 

## Screenshots (if applicable)

<img width="2143" height="380" alt="Screenshot 2026-08-04 at 5 40 51 PM" src="https://github.com/user-attachments/assets/27a586b0-20ae-4f06-bf2e-dc7ba73a0ad4" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores support for valid single-label hostnames by making the dotted-label portion of the hostname regex optional.

- Accepts names such as `dokploy-server`, `localhost`, and `example`.
- Adds regression tests while preserving rejection of malformed labels, underscores, spaces, and empty hostnames.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The quantifier change narrowly permits a hostname without a dot while retaining the existing per-label character, length, and boundary restrictions, and the tests directly cover the intended regression.

<sub>Reviews (1): Last reviewed commit: ["fix(domain): allow single-label hostname..."](https://github.com/dokploy/dokploy/commit/5d231bf3e3ce27dbb337c1fab7628cf03450b6ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50235472)</sub>

<!-- /greptile_comment -->