### PR TITLE
feat(ci): add hotfix cherry-pick and release workflows

### DIFF
--- a/.github/workflows/hotfix-cherry-pick.yml
+++ b/.github/workflows/hotfix-cherry-pick.yml
@@ -1,0 +1,34 @@
+name: Hotfix Cherry-Pick
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+concurrency:
+  group: hotfix-to-main
+  cancel-in-progress: false
+
+jobs:
+  cherry-pick:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'hotfix')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Cherry-pick fix to main
+        run: |
+          git config user.name "Dokploy Bot"
+          git config user.email "bot@dokploy.com"
+          SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          if [ "$(git rev-list --parents -n1 "$SHA" | wc -w)" -gt 2 ]; then
+            git cherry-pick -x -m 1 "$SHA"
+          else
+            git cherry-pick -x "$SHA"
+          fi
+          git push origin main

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -1,0 +1,28 @@
+name: Hotfix Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: hotfix-to-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.HOTFIX_PUSH_TOKEN }}
+
+      - name: Bump patch version and push
+        run: |
+          git config user.name "Dokploy Bot"
+          git config user.email "bot@dokploy.com"
+          CURRENT=$(node -p "require('./apps/dokploy/package.json').version")
+          NEW=$(echo "$CURRENT" | awk -F. -v OFS=. '{$NF++; print}')
+          sed -i "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW\"/" apps/dokploy/package.json
+          git commit -am "chore: release ${NEW}"
+          git push origin main


### PR DESCRIPTION
Adds a hotfix flow so urgent bug fixes can ship as patch releases without waiting for the next big canary → main merge.

## How it works

- **`hotfix-cherry-pick.yml`** — when a PR labeled `hotfix` is merged into canary, the bot cherry-picks it onto `main` and pushes with the default `GITHUB_TOKEN`, which intentionally does **not** trigger other workflows. Fixes accumulate silently on main. A `concurrency` group queues concurrent cherry-picks so they don't race.
- **`hotfix-release.yml`** — manual `workflow_dispatch` button: bumps the patch version in `apps/dokploy/package.json` (preserving the `v` prefix) and pushes with `HOTFIX_PUSH_TOKEN` (PAT), which **does** trigger the existing `dokploy.yml` build + release. One click = one release with all accumulated fixes.

## Rules

- Hotfixes must be code-only — never Drizzle migrations (out-of-order migrations get silently skipped by the migrator on stable instances). A migration in a cherry-pick will conflict on `_journal.json` and fail loudly.
- Big releases are unchanged: manual bump + canary → main merge.

Requires the `hotfix` label and the `HOTFIX_PUSH_TOKEN` repo secret (already configured).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two GitHub Actions workflows for accumulating hotfix commits on main and manually releasing them with a patch-version bump.
- Cherry-picks merged, labeled PRs onto main under a shared concurrency group.
- Uses a PAT-backed version-bump push to trigger the existing main release pipeline.
- The cherry-pick eligibility and content checks do not fully enforce the described hotfix boundary.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until hotfix promotion is restricted to canary-targeted, migration-free PRs.

The new write-capable workflow accepts merged labeled PRs from any base branch and cherry-picks complete commits without excluding migrations, allowing both the intended branch boundary and migration-ordering invariant to be bypassed.

**Files Needing Attention:** .github/workflows/hotfix-cherry-pick.yml; .github/workflows/hotfix-release.yml

<details open><summary><h3>Security Review</h3></summary>

The cherry-pick workflow can promote a labeled PR merged into a branch other than canary because it does not validate the PR base branch. Both privileged workflows also use a mutable checkout action tag.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): add hotfix cherry-pick and rel..."](https://github.com/dokploy/dokploy/commit/2f8af90da4c319dabf0358577bafb929ddcb52ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50713189)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->