### PR TITLE
fix(ci): hotfix flow — PAT push with skip ci, and release tags on correct commit

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -164,6 +164,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
+          target_commitish: ${{ github.sha }}
           name: ${{ steps.get_version.outputs.version }}
           generate_release_notes: true
           draft: false

--- a/.github/workflows/hotfix-cherry-pick.yml
+++ b/.github/workflows/hotfix-cherry-pick.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.HOTFIX_PUSH_TOKEN }}
 
       - name: Cherry-pick fix to main
         run: |
@@ -31,4 +32,5 @@ jobs:
           else
             git cherry-pick -x "$SHA"
           fi
+          git commit --amend -m "$(git log -1 --format=%B)" -m "[skip ci]"
           git push origin main


### PR DESCRIPTION
Two fixes for the hotfix release flow:

1. **hotfix-cherry-pick.yml**: the ruleset on `main` rejects pushes from the default `GITHUB_TOKEN`, and the `github-actions` app cannot be added to ruleset bypass (GitHub limitation — it is not installable on the org). The workflow now pushes with `HOTFIX_PUSH_TOKEN` (org admin, already bypasses the ruleset) and appends `[skip ci]` to the cherry-picked commit so the push stays silent — no builds or release are triggered until the Hotfix Release button is pressed.

2. **dokploy.yml**: `softprops/action-gh-release` created tags without `target_commitish`, so GitHub placed them on the default branch (canary) instead of the released commit on main. This is why the v0.29.14 tag pointed to canary and its auto release notes listed canary features. Now the tag is created on `github.sha` — the actual commit that was built.

Note: the dokploy.yml fix also needs to reach `main` before the next hotfix release (push events run the workflow definition of the pushed branch) — separate PR to main follows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects the hotfix release path by authenticating protected pushes with the configured PAT, suppressing automatic CI for cherry-picked hotfixes, and explicitly targeting generated release tags at the commit built by the workflow.
- Configures the hotfix cherry-pick checkout and push to use `HOTFIX_PUSH_TOKEN`.
- Appends `[skip ci]` to cherry-picked commits so release work remains manually controlled.
- Pins GitHub release tags and generated notes to `github.sha`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both workflow changes aligned with the described hotfix release behavior.

The release workflow builds and tags the same event SHA, while the cherry-pick workflow uses the configured protected-branch credential and intentionally suppresses automatic CI without exposing the credential to untrusted code.

<sub>Reviews (1): Last reviewed commit: ["fix(ci): push hotfix cherry-picks with P..."](https://github.com/dokploy/dokploy/commit/739e66f09bcdff0c4734e91a223f5ed08fccee41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50723195)</sub>

<!-- /greptile_comment -->