### PR TITLE
fix(ci): create release tags on the pushed commit instead of default branch

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -164,6 +164,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
+          target_commitish: ${{ github.sha }}
           name: ${{ steps.get_version.outputs.version }}
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
Backport of the dokploy.yml fix from #4980: `softprops/action-gh-release` created tags without `target_commitish`, so GitHub placed them on the default branch (canary) instead of the released commit on main — which is why the v0.29.14 tag pointed to canary. Must be on main because push events run the workflow definition of the pushed branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins newly created release tags to the exact commit that triggered the workflow.
- Passes `github.sha` as `target_commitish` to `softprops/action-gh-release`.
- Keeps release tags aligned with the commit whose package version is being published.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The new target commit matches both the workflow event commit and the checkout used to derive the published version, so the tag and release metadata remain aligned.

<sub>Reviews (1): Last reviewed commit: ["fix(ci): create release tags on the push..."](https://github.com/dokploy/dokploy/commit/85092adc08ed1fc3eefd3bb94a38bf728004235c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50723316)</sub>

<!-- /greptile_comment -->