### PR TITLE
fix(ci): push hotfix cherry-picks with PAT to satisfy branch rules

### DIFF
--- a/.github/workflows/hotfix-cherry-pick.yml
+++ b/.github/workflows/hotfix-cherry-pick.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.HOTFIX_PUSH_TOKEN }}
 
       - name: Cherry-pick fix to main
         run: |
@@ -31,4 +32,5 @@ jobs:
           else
             git cherry-pick -x "$SHA"
           fi
+          git commit --amend -m "$(git log -1 --format=%B)" -m "[skip ci]"
           git push origin main


### PR DESCRIPTION
The hotfix cherry-pick workflow fails to push to `main`: the default `GITHUB_TOKEN` is rejected by the branch ruleset (seen with #4972), and the `github-actions` app cannot be added to the ruleset bypass list. 

Fix: push with `HOTFIX_PUSH_TOKEN` (already bypasses the rules) and append `[skip ci]` to the cherry-picked commit so the push does not trigger builds or a release — fixes keep accumulating silently on main until the Hotfix Release workflow is run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR authenticates hotfix cherry-pick pushes with a PAT that can bypass the main branch rules and appends a CI skip marker so builds and releases wait for the manual hotfix release.
- Supplies `HOTFIX_PUSH_TOKEN` to `actions/checkout` so the subsequent push uses that credential.
- Amends each successful cherry-pick with a trailing `[skip ci]` paragraph.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until the PAT-backed workflow is restricted to pull requests targeting main.

The new bypass credential turns an existing branch-agnostic pull-request workflow into a successful protected-main write path for any merged pull request carrying the hotfix label.

**Files Needing Attention:** .github/workflows/hotfix-cherry-pick.yml

<details open><summary><h3>Security Review</h3></summary>

The bypass credential is reachable from merged, hotfix-labeled pull requests targeting any branch because the workflow does not restrict `pull_request_target` to `main`. A non-main merge can therefore be replayed onto protected `main` without main-specific review.

**How this was verified:** The unfiltered trigger and merged-and-labeled gate feed the triggering merge commit directly into a PAT-authenticated push to `main`.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): push hotfix cherry-picks with P..."](https://github.com/dokploy/dokploy/commit/06b67d451991b281be3b87acb9410260f48fd32f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50723746)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->