### PR TITLE
fix(ci): create release tags on the pushed commit instead of default branch

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -164,6 +164,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
+          target_commitish: ${{ github.sha }}
           name: ${{ steps.get_version.outputs.version }}
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
`softprops/action-gh-release` creates the version tag without `target_commitish`, so the GitHub API places it on the default branch (canary) instead of the commit on main that was actually built. This is why the v0.29.14 tag pointed to a canary commit and its auto-generated notes listed unreleased features. `target_commitish: ${{ github.sha }}` pins the tag to the exact commit the workflow ran on.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins newly created release tags to the exact workflow commit rather than the repository’s default branch.
- Adds `target_commitish: ${{ github.sha }}` to the GitHub release action.
- Keeps release tags aligned with the commit used by the build and release jobs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no blocking or non-blocking issues identified.

The explicitly targeted commit is the same commit used for checkout, version extraction, and image builds, preserving release provenance across supported triggers.

<sub>Reviews (1): Last reviewed commit: ["fix(ci): create release tags on the push..."](https://github.com/dokploy/dokploy/commit/472ebed06c9b804369af51585390cce37ac4c1a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50726392)</sub>

<!-- /greptile_comment -->