### PR TITLE
fix(ci): pin pnpm and strip v prefix in sync-version job

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -140,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
+      npm_version: ${{ steps.get_version.outputs.npm_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,6 +152,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./apps/dokploy/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "npm_version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Fetch install.sh
         run: |
@@ -181,15 +183,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.22.0
+
       - name: Sync version to MCP repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/mcp.git /tmp/mcp-repo
           cd /tmp/mcp-repo
 
-          jq --arg v "${{ needs.generate-release.outputs.version }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
-          npm install -g pnpm
           pnpm install
           pnpm run fetch-openapi
           pnpm run generate
@@ -197,55 +202,53 @@ jobs:
           git config user.name "Dokploy Bot"
           git config user.email "bot@dokploy.com"
           git add -A
-          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.version }}" \
+          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.npm_version }}" \
             -m "Source: ${{ github.repository }}@${{ github.sha }}" \
             --allow-empty
           git push
 
-          echo "✅ MCP repo synced to version ${{ needs.generate-release.outputs.version }}"
+          echo "✅ MCP repo synced to version ${{ needs.generate-release.outputs.npm_version }}"
 
       - name: Sync version to CLI repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/cli.git /tmp/cli-repo
           cd /tmp/cli-repo
 
-          jq --arg v "${{ needs.generate-release.outputs.version }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
           cp ${{ github.workspace }}/openapi.json ./openapi.json
-          npm install -g pnpm
           pnpm install
           pnpm run generate
 
           git config user.name "Dokploy Bot"
           git config user.email "bot@dokploy.com"
           git add -A
-          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.version }}" \
+          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.npm_version }}" \
             -m "Source: ${{ github.repository }}@${{ github.sha }}" \
             --allow-empty
           git push
 
-          echo "✅ CLI repo synced to version ${{ needs.generate-release.outputs.version }}"
+          echo "✅ CLI repo synced to version ${{ needs.generate-release.outputs.npm_version }}"
 
       - name: Sync version to SDK repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/sdk.git /tmp/sdk-repo
           cd /tmp/sdk-repo
 
-          jq --arg v "${{ needs.generate-release.outputs.version }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
           cp ${{ github.workspace }}/openapi.json ./openapi.json
-          npm install -g pnpm
           pnpm install
           pnpm run generate
 
           git config user.name "Dokploy Bot"
           git config user.email "bot@dokploy.com"
           git add -A
-          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.version }}" \
+          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.npm_version }}" \
             -m "Source: ${{ github.repository }}@${{ github.sha }}" \
             --allow-empty
           git push
 
-          echo "✅ SDK repo synced to version ${{ needs.generate-release.outputs.version }}"
+          echo "✅ SDK repo synced to version ${{ needs.generate-release.outputs.npm_version }}"


### PR DESCRIPTION
The `sync-version` job has failed on every release since v0.29.5, so mcp/cli/sdk never got version bumps and nothing was published to npm since May (sdk/cli stuck at 0.29.4, mcp at 0.29.3).

Two causes:
- `npm install -g pnpm` installs latest (pnpm 11), which turns the esbuild ignored-build-scripts warning into a fatal `ERR_PNPM_IGNORED_BUILDS` (exit 1) on the MCP step, killing the job before the CLI/SDK steps run. Replaced with `pnpm/action-setup@v4` pinned to 10.22.0, matching the repo's `packageManager`.
- Since v0.29.5 the dokploy `package.json` version carries a `v` prefix (`v0.29.14`), which the job copied verbatim into the npm packages' `package.json` — invalid npm semver, and their publish workflows would produce `vv*` tags. New `npm_version` output strips the prefix; the dokploy release tag keeps its current format.

Verified locally: pnpm 11 reproduces the exact CI failure on the mcp repo; with pnpm 10.22.0 the full MCP step (install + fetch-openapi + generate) passes clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs downstream package synchronization by installing the repository-aligned pnpm version and separating the v-prefixed Dokploy release version from the bare npm package version.
- Adds an `npm_version` job output that strips the leading `v` for MCP, CLI, and SDK package metadata.
- Replaces repeated global pnpm installation with `pnpm/action-setup` configured for pnpm 10.22.0.
- Updates downstream commit messages and status output to use the normalized npm version.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking supply-chain hardening opportunity in the newly added action reference.

The version normalization and pnpm setup align with the current release format and repository package-manager version; the remaining concern is that the new third-party action can change without a reviewed workflow update because it is not pinned to an immutable commit.

**Files Needing Attention:** .github/workflows/dokploy.yml

<details open><summary><h3>Security Review</h3></summary>

The new package-manager setup action uses a mutable third-party action tag. Pinning it to the corresponding full commit SHA would harden the release job against upstream tag replacement.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin pnpm and strip v prefix in ..."](https://github.com/dokploy/dokploy/commit/b6190ff3142fef95990334b26d6e98f1a42276d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50735280)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->