### PR TITLE
fix(ci): generate OpenAPI spec from the release commit in sync-version

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -187,6 +187,16 @@ jobs:
         with:
           version: 10.22.0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.4.0
+          cache: pnpm
+
+      - name: Generate OpenAPI specification
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm generate:openapi
+
       - name: Sync version to MCP repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/mcp.git /tmp/mcp-repo
@@ -195,8 +205,8 @@ jobs:
           jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
+          cp ${{ github.workspace }}/openapi.json src/generated/openapi.json
           pnpm install
-          pnpm run fetch-openapi
           pnpm run generate
 
           git config user.name "Dokploy Bot"


### PR DESCRIPTION
Follow-up to #4984. The cli/sdk sync steps copied the repo-root `openapi.json`, which was last committed in March (450 paths vs 546 in the current API), and the mcp step fetched `docs.dokploy.com/openapi.json`, which any canary push can overwrite with unreleased API.

`sync-version` now runs `pnpm generate:openapi` on the release commit checkout and feeds that spec to all three repos, so each package release matches the API of its dokploy tag.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR generates OpenAPI from the checked-out release commit and reuses that artifact while synchronizing the MCP, CLI, and SDK repositories.
- Adds Node setup and release-checkout OpenAPI generation to the sync-version job.
- Replaces MCP's remote specification fetch with the locally generated specification.
- Keeps all downstream package generation aligned with the API represented by the Dokploy release tag.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking supply-chain hardening issue in the newly added release-workflow action reference.

The OpenAPI generation and downstream copy paths are internally consistent, but the new mutable setup-node reference adds avoidable third-party code exposure before the job uses credentials for three repositories.

**Files Needing Attention:** .github/workflows/dokploy.yml

<sub>Reviews (1): Last reviewed commit: ["fix(ci): generate OpenAPI spec from the ..."](https://github.com/dokploy/dokploy/commit/ff9fa7418f98ad0bdc0fdab5da33d82833968585) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50737161)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->