### PR TITLE
fix(requests): return the newest access log entries without reading the whole file

### DIFF
--- a/apps/dokploy/__test__/requests/access-log-reader.test.ts
+++ b/apps/dokploy/__test__/requests/access-log-reader.test.ts
@@ -4,18 +4,25 @@ import { join } from "node:path";
 import { readLastLogEntries } from "@dokploy/server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-const makeEntry = (overrides: Record<string, unknown> = {}) =>
-	JSON.stringify({
+const makeEntry = (overrides: Record<string, unknown> = {}) => {
+	const startUTC =
+		(overrides.StartUTC as string) ?? "2024-08-25T04:34:37.306691884Z";
+
+	return JSON.stringify({
 		ClientAddr: "172.19.0.1:56732",
 		DownstreamStatus: 200,
 		RequestHost: "app.traefik.me",
 		RequestMethod: "GET",
 		RequestPath: "/",
 		ServiceName: "my-app-web@docker",
-		StartUTC: "2024-08-25T04:34:37.306691884Z",
-		time: "2024-08-25T04:34:37Z",
+		StartUTC: startUTC,
+		// Traefik writes the entry when the request completes, so `time` is the
+		// completion timestamp. For a fast request it matches the start; tests that
+		// need a slow request override it explicitly.
+		time: startUTC,
 		...overrides,
 	});
+};
 
 const pathsOf = (result: string) =>
 	result
@@ -99,6 +106,30 @@ describe("readLastLogEntries", () => {
 		});
 
 		expect(pathsOf(result)).toEqual(["/cutoff", "/newer"]);
+	});
+
+	it("keeps in-range entries logged after a slower, older request", async () => {
+		// Traefik appends an entry when the request completes, so a slow request can be
+		// logged after faster ones that started later. Cutting off on StartUTC would
+		// stop at /slow and silently drop /fast, which is still in range.
+		const filePath = await writeLog([
+			makeEntry({
+				RequestPath: "/fast",
+				StartUTC: "2024-08-25T02:01:00Z",
+				time: "2024-08-25T02:01:00Z",
+			}),
+			makeEntry({
+				RequestPath: "/slow",
+				StartUTC: "2024-08-25T01:59:00Z",
+				time: "2024-08-25T02:05:00Z",
+			}),
+		]);
+
+		const result = await readLastLogEntries(filePath, {
+			notBefore: new Date("2024-08-25T02:00:00Z"),
+		});
+
+		expect(pathsOf(result)).toEqual(["/fast", "/slow"]);
 	});
 
 	it("reads the last entry when the file has no trailing newline", async () => {

--- a/apps/dokploy/__test__/requests/access-log-reader.test.ts
+++ b/apps/dokploy/__test__/requests/access-log-reader.test.ts
@@ -1,0 +1,159 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readLastLogEntries } from "@dokploy/server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const makeEntry = (overrides: Record<string, unknown> = {}) =>
+	JSON.stringify({
+		ClientAddr: "172.19.0.1:56732",
+		DownstreamStatus: 200,
+		RequestHost: "app.traefik.me",
+		RequestMethod: "GET",
+		RequestPath: "/",
+		ServiceName: "my-app-web@docker",
+		StartUTC: "2024-08-25T04:34:37.306691884Z",
+		time: "2024-08-25T04:34:37Z",
+		...overrides,
+	});
+
+const pathsOf = (result: string) =>
+	result
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line).RequestPath as string);
+
+describe("readLastLogEntries", () => {
+	let directory: string;
+
+	beforeEach(async () => {
+		directory = await mkdtemp(join(tmpdir(), "dokploy-access-log-"));
+	});
+
+	afterEach(async () => {
+		await rm(directory, { recursive: true, force: true });
+	});
+
+	const writeLog = async (lines: string[], trailingNewline = true) => {
+		const filePath = join(directory, "access.log");
+		const suffix = trailingNewline && lines.length > 0 ? "\n" : "";
+		await writeFile(filePath, `${lines.join("\n")}${suffix}`);
+		return filePath;
+	};
+
+	it("returns the newest entries instead of the oldest ones", async () => {
+		const filePath = await writeLog(
+			Array.from({ length: 10 }, (_, index) =>
+				makeEntry({
+					RequestPath: `/page-${index}`,
+					StartUTC: `2024-08-25T0${index}:00:00Z`,
+				}),
+			),
+		);
+
+		const result = await readLastLogEntries(filePath, { limit: 3 });
+
+		expect(pathsOf(result)).toEqual(["/page-7", "/page-8", "/page-9"]);
+	});
+
+	it("returns every entry when the limit exceeds the file", async () => {
+		const filePath = await writeLog([
+			makeEntry({ RequestPath: "/first" }),
+			makeEntry({ RequestPath: "/second" }),
+		]);
+
+		const result = await readLastLogEntries(filePath, { limit: 500 });
+
+		expect(pathsOf(result)).toEqual(["/first", "/second"]);
+	});
+
+	it("handles entries that span chunk boundaries", async () => {
+		// The reader walks the file in 64 KiB chunks; ~4 KiB per entry over 40 entries
+		// forces several chunks and leaves entries straddling the boundaries.
+		const padding = "x".repeat(4096);
+		const filePath = await writeLog(
+			Array.from({ length: 40 }, (_, index) =>
+				makeEntry({
+					RequestPath: `/page-${index}`,
+					request_User_Agent: padding,
+				}),
+			),
+		);
+
+		const paths = pathsOf(await readLastLogEntries(filePath, { limit: 40 }));
+
+		expect(paths).toHaveLength(40);
+		expect(paths[0]).toBe("/page-0");
+		expect(paths[39]).toBe("/page-39");
+	});
+
+	it("stops at the first entry older than notBefore", async () => {
+		const filePath = await writeLog([
+			makeEntry({ RequestPath: "/older", StartUTC: "2024-08-25T01:00:00Z" }),
+			makeEntry({ RequestPath: "/cutoff", StartUTC: "2024-08-25T02:00:00Z" }),
+			makeEntry({ RequestPath: "/newer", StartUTC: "2024-08-25T03:00:00Z" }),
+		]);
+
+		const result = await readLastLogEntries(filePath, {
+			notBefore: new Date("2024-08-25T02:00:00Z"),
+		});
+
+		expect(pathsOf(result)).toEqual(["/cutoff", "/newer"]);
+	});
+
+	it("reads the last entry when the file has no trailing newline", async () => {
+		const filePath = await writeLog(
+			[makeEntry({ RequestPath: "/only" })],
+			false,
+		);
+
+		expect(pathsOf(await readLastLogEntries(filePath))).toEqual(["/only"]);
+	});
+
+	it("skips malformed lines", async () => {
+		const filePath = await writeLog([
+			"not json at all",
+			"{ truncated",
+			makeEntry({ RequestPath: "/valid" }),
+			"",
+		]);
+
+		expect(pathsOf(await readLastLogEntries(filePath))).toEqual(["/valid"]);
+	});
+
+	it("filters out Dokploy dashboard requests", async () => {
+		const filePath = await writeLog([
+			makeEntry({ RequestPath: "/app" }),
+			makeEntry({
+				RequestPath: "/dashboard",
+				ServiceName: "dokploy-service-app@file",
+			}),
+		]);
+
+		expect(pathsOf(await readLastLogEntries(filePath))).toEqual(["/app"]);
+	});
+
+	it("does not count filtered entries against the limit", async () => {
+		const filePath = await writeLog([
+			makeEntry({ RequestPath: "/kept" }),
+			makeEntry({ ServiceName: "dokploy-service-app@file" }),
+			makeEntry({ ServiceName: "dokploy-service-app@file" }),
+		]);
+
+		expect(pathsOf(await readLastLogEntries(filePath, { limit: 1 }))).toEqual([
+			"/kept",
+		]);
+	});
+
+	it("returns an empty string for an empty file", async () => {
+		const filePath = await writeLog([]);
+
+		expect(await readLastLogEntries(filePath)).toBe("");
+	});
+
+	it("returns an empty string when the limit is not positive", async () => {
+		const filePath = await writeLog([makeEntry()]);
+
+		expect(await readLastLogEntries(filePath, { limit: 0 })).toBe("");
+	});
+});

--- a/apps/dokploy/server/api/routers/settings.ts
+++ b/apps/dokploy/server/api/routers/settings.ts
@@ -795,6 +795,7 @@ export const settingsRouter = createTRPCRouter({
 			}
 			const rawConfig = await readMonitoringConfig(
 				!!input.dateRange?.start && !!input.dateRange?.end,
+				input.dateRange,
 			);
 
 			const parsedConfig = parseRawConfig(
@@ -835,6 +836,7 @@ export const settingsRouter = createTRPCRouter({
 			}
 			const rawConfig = await readMonitoringConfig(
 				!!input?.dateRange?.start || !!input?.dateRange?.end,
+				input?.dateRange,
 			);
 			const processedLogs = processLogs(rawConfig as string, input?.dateRange);
 			return processedLogs || [];

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -68,6 +68,7 @@ export {
 	startLogCleanup,
 	stopLogCleanup,
 } from "./utils/access-log/handler";
+export * from "./utils/access-log/reader";
 export * from "./utils/access-log/types";
 export * from "./utils/access-log/utils";
 export * from "./utils/backups/compose";

--- a/packages/server/src/utils/access-log/reader.ts
+++ b/packages/server/src/utils/access-log/reader.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+
+/** Size of each backwards read. */
+const CHUNK_SIZE = 64 * 1024;
+/** Entries returned when the caller does not specify a limit. */
+export const DEFAULT_ENTRY_LIMIT = 500;
+/**
+ * Safety ceiling for date-range queries. The walk normally stops at the start of the
+ * requested range; this only caps how much a very wide range can pull into memory.
+ */
+export const DATE_RANGE_ENTRY_LIMIT = 50_000;
+/** Requests to the Dokploy dashboard itself are never shown on the Requests page. */
+const DOKPLOY_DASHBOARD_SERVICE = "dokploy-service-app@file";
+const NEWLINE = 0x0a;
+
+export interface ReadLastLogEntriesOptions {
+	/** Maximum number of entries to return. Defaults to {@link DEFAULT_ENTRY_LIMIT}. */
+	limit?: number;
+	/** Stop reading as soon as an entry older than this timestamp is reached. */
+	notBefore?: Date;
+}
+
+interface PartialLogEntry {
+	ServiceName?: string;
+	StartUTC?: string;
+}
+
+/**
+ * Reads the most recent entries of a Traefik access log.
+ *
+ * The file is walked backwards in fixed-size chunks and the walk stops as soon as
+ * `limit` entries have been collected or an entry older than `notBefore` is reached.
+ * `access.log` is append-only and chronological, so reading backwards visits entries
+ * newest-first: the first entry older than `notBefore` guarantees every remaining entry
+ * is out of range too, and the rest of the file never has to be touched.
+ *
+ * Memory is bounded by the entries actually returned rather than by the size of the
+ * file, and the event loop is never blocked.
+ *
+ * @returns the matching entries as newline-separated raw JSON lines, in file order
+ * (oldest first), or an empty string when nothing matches.
+ */
+export const readLastLogEntries = async (
+	filePath: string,
+	{ limit = DEFAULT_ENTRY_LIMIT, notBefore }: ReadLastLogEntriesOptions = {},
+): Promise<string> => {
+	if (limit <= 0) {
+		return "";
+	}
+
+	const handle = await fs.promises.open(filePath, "r");
+
+	try {
+		const { size } = await handle.stat();
+
+		const collected: string[] = [];
+		let position = size;
+		let pending = Buffer.alloc(0);
+		let reachedCutoff = false;
+
+		const take = (raw: Buffer) => {
+			const line = raw.toString("utf8").trim();
+			// Same guard as the rest of the access-log helpers: only keep lines that
+			// look like a complete JSON object.
+			if (!line.startsWith("{") || !line.endsWith("}")) {
+				return;
+			}
+
+			let entry: PartialLogEntry;
+			try {
+				entry = JSON.parse(line);
+			} catch {
+				return;
+			}
+
+			if (entry.ServiceName === DOKPLOY_DASHBOARD_SERVICE) {
+				return;
+			}
+
+			if (notBefore) {
+				const startedAt = new Date(entry.StartUTC ?? "").getTime();
+				// An entry without a usable timestamp cannot prove we walked past the
+				// cutoff, so skip it instead of treating it as the boundary.
+				if (Number.isNaN(startedAt)) {
+					return;
+				}
+				if (startedAt < notBefore.getTime()) {
+					reachedCutoff = true;
+					return;
+				}
+			}
+
+			collected.push(line);
+		};
+
+		while (position > 0 && collected.length < limit && !reachedCutoff) {
+			const readSize = Math.min(CHUNK_SIZE, position);
+			position -= readSize;
+
+			const buffer = Buffer.alloc(readSize);
+			const { bytesRead } = await handle.read(buffer, 0, readSize, position);
+			if (bytesRead === 0) {
+				break;
+			}
+
+			const chunk = buffer.subarray(0, bytesRead);
+			const combined = pending.length ? Buffer.concat([chunk, pending]) : chunk;
+
+			// 0x0a never appears inside a multi-byte UTF-8 sequence, so slicing the
+			// buffer on newlines cannot cut a character in half. Scanning from the end
+			// yields the lines newest-first.
+			const lines: Buffer[] = [];
+			let end = combined.length;
+			for (let i = combined.length - 1; i >= 0; i--) {
+				if (combined[i] === NEWLINE) {
+					lines.push(combined.subarray(i + 1, end));
+					end = i;
+				}
+			}
+			// Whatever precedes the earliest newline belongs to a line that continues
+			// into the previous chunk, so carry it over instead of parsing it now.
+			pending = combined.subarray(0, end);
+
+			for (const line of lines) {
+				take(line);
+				if (reachedCutoff || collected.length >= limit) {
+					break;
+				}
+			}
+		}
+
+		// The very first line of the file has no newline before it.
+		if (pending.length > 0 && collected.length < limit && !reachedCutoff) {
+			take(pending);
+		}
+
+		return collected.reverse().join("\n");
+	} finally {
+		await handle.close();
+	}
+};

--- a/packages/server/src/utils/access-log/reader.ts
+++ b/packages/server/src/utils/access-log/reader.ts
@@ -23,16 +23,18 @@ export interface ReadLastLogEntriesOptions {
 interface PartialLogEntry {
 	ServiceName?: string;
 	StartUTC?: string;
+	time?: string;
 }
 
 /**
  * Reads the most recent entries of a Traefik access log.
  *
  * The file is walked backwards in fixed-size chunks and the walk stops as soon as
- * `limit` entries have been collected or an entry older than `notBefore` is reached.
- * `access.log` is append-only and chronological, so reading backwards visits entries
- * newest-first: the first entry older than `notBefore` guarantees every remaining entry
- * is out of range too, and the rest of the file never has to be touched.
+ * `limit` entries have been collected or an entry logged before `notBefore` is reached.
+ * `access.log` is append-only and ordered by the `time` each request finished, so
+ * reading backwards visits entries newest-first and the first entry logged before
+ * `notBefore` guarantees every remaining entry is out of range too — the rest of the
+ * file never has to be touched.
  *
  * Memory is bounded by the entries actually returned rather than by the size of the
  * file, and the event loop is never blocked.
@@ -78,13 +80,20 @@ export const readLastLogEntries = async (
 			}
 
 			if (notBefore) {
-				const startedAt = new Date(entry.StartUTC ?? "").getTime();
+				// Traefik appends an entry when the request *completes*, so the file is
+				// ordered by `time`, not by `StartUTC`: a slow request can be logged
+				// after faster ones that started later. Cutting off on `time` is still
+				// sound because `time >= StartUTC`, so an entry logged before the cutoff
+				// also started before it — and so did everything earlier in the file.
+				// Cutting off on `StartUTC` instead would drop entries that are still in
+				// range but were logged after a slower, older request.
+				const loggedAt = new Date(entry.time ?? entry.StartUTC ?? "").getTime();
 				// An entry without a usable timestamp cannot prove we walked past the
 				// cutoff, so skip it instead of treating it as the boundary.
-				if (Number.isNaN(startedAt)) {
+				if (Number.isNaN(loggedAt)) {
 					return;
 				}
-				if (startedAt < notBefore.getTime()) {
+				if (loggedAt < notBefore.getTime()) {
 					reachedCutoff = true;
 					return;
 				}

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -1,10 +1,14 @@
-import fs, { createReadStream, writeFileSync } from "node:fs";
+import fs, { writeFileSync } from "node:fs";
 import path from "node:path";
-import { createInterface } from "node:readline";
 import { paths } from "@dokploy/server/constants";
 import type { Domain } from "@dokploy/server/services/domain";
 import { quote } from "shell-quote";
 import { parse, stringify } from "yaml";
+import {
+	DATE_RANGE_ENTRY_LIMIT,
+	DEFAULT_ENTRY_LIMIT,
+	readLastLogEntries,
+} from "../access-log/reader";
 import { encodeBase64 } from "../docker/utils";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import type { FileConfig, HttpLoadBalancerService } from "./file-types";
@@ -148,48 +152,27 @@ export const readRemoteConfig = async (serverId: string, appName: string) => {
 	}
 };
 
-export const readMonitoringConfig = async (readAll = false) => {
+export const readMonitoringConfig = async (
+	readAll = false,
+	dateRange?: { start?: string; end?: string },
+) => {
 	const { DYNAMIC_TRAEFIK_PATH } = paths();
 	const configPath = path.join(DYNAMIC_TRAEFIK_PATH, "access.log");
-	if (fs.existsSync(configPath)) {
-		if (!readAll) {
-			// Read first 500 lines using streams
-			let content = "";
-			let validCount = 0;
-
-			const fileStream = createReadStream(configPath, { encoding: "utf8" });
-			const readline = createInterface({
-				input: fileStream,
-				crlfDelay: Number.POSITIVE_INFINITY,
-			});
-
-			for await (const line of readline) {
-				try {
-					const trimmed = line.trim();
-					if (
-						trimmed !== "" &&
-						trimmed.startsWith("{") &&
-						trimmed.endsWith("}")
-					) {
-						const log = JSON.parse(trimmed);
-						// Exclude Dokploy service app and Dashboard requests
-						if (log.ServiceName !== "dokploy-service-app@file") {
-							content += `${line}\n`;
-							validCount++;
-							if (validCount >= 500) {
-								break;
-							}
-						}
-					}
-				} catch {
-					// Ignore invalid JSON
-				}
-			}
-			return content;
-		}
-		return fs.readFileSync(configPath, "utf8");
+	if (!fs.existsSync(configPath)) {
+		return null;
 	}
-	return null;
+
+	// access.log is append-only, so the entries the UI cares about are always at the
+	// end of the file. Reading backwards keeps memory bounded by what is returned
+	// instead of by the size of the log, and never blocks the event loop.
+	//
+	// When a start date is given the walk stops there; the limit is then only a safety
+	// ceiling so that a very wide range still cannot pull an unbounded number of
+	// entries into memory.
+	return readLastLogEntries(configPath, {
+		limit: readAll ? DATE_RANGE_ENTRY_LIMIT : DEFAULT_ENTRY_LIMIT,
+		notBefore: dateRange?.start ? new Date(dateRange.start) : undefined,
+	});
 };
 
 export const readConfigInPath = async (pathFile: string, serverId?: string) => {


### PR DESCRIPTION
## What is this PR about?

`readMonitoringConfig()` read the **first** 500 lines of `access.log`. On an append-only log those are the *oldest* requests, so the Requests page showed stale entries that never advanced until the log was truncated. Selecting a date range took the other branch and read the entire file with a blocking `readFileSync`, which freezes the event loop for every user and throws `ERR_STRING_TOO_LONG` once the log outgrows Node's maximum string length.

This adds `readLastLogEntries()`, which walks the file backwards in 64 KiB chunks and stops as soon as enough entries are collected or an entry older than the requested start date is reached. `access.log` is chronological and append-only, so walking backwards visits entries newest-first and the first out-of-range entry guarantees every remaining one is out of range too. Memory is now bounded by the entries actually returned rather than by the size of the log, and the read never blocks the event loop.

The exported signatures of `parseRawConfig` and `processLogs` are unchanged, so the existing tests keep passing as-is. `readMonitoringConfig` gains an optional `dateRange` argument, which the two `settings` procedures pass through.

### Verification

Seeded a local `access.log` with 2000 entries (2 MB, ~32 chunks), oldest `/req-0000` through newest `/req-1999`:

- The Requests page now lists `/req-1999`, `/req-1998`, `/req-1997` … — before this change it listed `/req-0000` onwards
- `Showing 1 to 10 of 2000 entries`; pagination, sorting and the hostname/status filters behave as before
- A 30-minute date range returns 29 entries in ~5 ms instead of parsing the whole file
- 10 new unit tests cover newest-first ordering, the entry limit, early cut-off on `notBefore`, entries spanning chunk boundaries, files without a trailing newline, malformed lines, and the dashboard-service filter

`vitest run __test__/requests` (17 passing), `tsc --noEmit` on both `apps/dokploy` and `packages/server`, and Biome are all clean.

### Note for reviewers

Date-range reads are now capped by `DATE_RANGE_ENTRY_LIMIT` (50 000 entries) as a safety ceiling. Previously they were unbounded, which is what made large logs fail outright. Happy to change that value, make it configurable, or drop the cap if you would rather keep the previous semantics.

The daily `tail -n 1000` truncation in `access-log/handler.ts` is intentionally left untouched here, since removing it changes retention behaviour and deserves its own discussion.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4990

## Screenshots (if applicable)

_Screenshot of the Requests page after the change is attached below._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes access-log retrieval to scan backward asynchronously and return recent entries without loading the entire file.
- Adds a chunked reverse reader with entry limits and date-range cutoff support.
- Passes date ranges through the settings procedures.
- Adds focused coverage for ordering, filtering, chunk boundaries, malformed input, and out-of-order request completion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix(requests): cut off access log reads ..."](https://github.com/dokploy/dokploy/commit/4b2159c6c14d6db51f4a9e847fa1f97644beba25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50770961)</sub>

**Context used:**

- Knowledge Base — [Monitoring and Live Terminal/Log Streaming](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/monitoring-and-terminal.md)

<!-- /greptile_comment -->