### PR TITLE
fix(ui): expose isStaticSpa toggle for nixpacks + publish directory

### DIFF
--- a/apps/dokploy/components/dashboard/application/build/show.tsx
+++ b/apps/dokploy/components/dashboard/application/build/show.tsx
@@ -88,6 +88,7 @@ const mySchema = z.discriminatedUnion("buildType", [
 	z.object({
 		buildType: z.literal(BuildType.nixpacks),
 		publishDirectory: z.string().optional(),
+		isStaticSpa: z.boolean().default(false),
 	}),
 	z.object({
 		buildType: z.literal(BuildType.railpack),
@@ -138,6 +139,7 @@ const resetData = (data: ApplicationData): AddTemplate => {
 			return {
 				buildType: BuildType.nixpacks,
 				publishDirectory: data.publishDirectory || undefined,
+				isStaticSpa: data.isStaticSpa ?? false,
 			};
 		case BuildType.paketo_buildpacks:
 			return {
@@ -179,6 +181,7 @@ export const ShowBuildChooseForm = ({ applicationId }: Props) => {
 
 	const buildType = form.watch("buildType");
 	const railpackVersion = form.watch("railpackVersion");
+	const publishDirectory = form.watch("publishDirectory");
 	const [isManualRailpackVersion, setIsManualRailpackVersion] = useState(false);
 
 	useEffect(() => {
@@ -224,7 +227,10 @@ export const ShowBuildChooseForm = ({ applicationId }: Props) => {
 					? data.herokuVersion
 					: null,
 			isStaticSpa:
-				data.buildType === BuildType.static ? data.isStaticSpa : null,
+				data.buildType === BuildType.static ||
+				data.buildType === BuildType.nixpacks
+					? data.isStaticSpa
+					: null,
 			railpackVersion:
 				data.buildType === BuildType.railpack
 					? data.railpackVersion || "0.15.4"
@@ -413,6 +419,30 @@ export const ShowBuildChooseForm = ({ applicationId }: Props) => {
 												{...field}
 												value={field.value ?? ""}
 											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						)}
+						{buildType === BuildType.nixpacks && publishDirectory && (
+							<FormField
+								control={form.control}
+								name="isStaticSpa"
+								render={({ field }) => (
+									<FormItem>
+										<FormControl>
+											<div className="flex items-center gap-x-2 p-2">
+												<Checkbox
+													id="checkboxIsStaticSpaNixpacks"
+													value={String(field.value)}
+													checked={field.value}
+													onCheckedChange={field.onChange}
+												/>
+												<FormLabel htmlFor="checkboxIsStaticSpaNixpacks">
+													Single Page Application (SPA)
+												</FormLabel>
+											</div>
 										</FormControl>
 										<FormMessage />
 									</FormItem>


### PR DESCRIPTION
## What

Exposes the **Is Static SPA** toggle in the Build Type form for **Nixpacks + Publish Directory**, and stops the flag from being dropped on save in that mode.

Fixes #4993

## Why

The backend already supports `isStaticSpa` for Nixpacks builds: when a `publishDirectory` is set, `nixpacks.ts` calls `getStaticCommand(application)`, which reads `isStaticSpa` and, when true, generates the nginx config with the SPA fallback `try_files $uri $uri/ /index.html`.

However, the UI form in `apps/dokploy/components/dashboard/application/build/show.tsx` only wired `isStaticSpa` into the `static` variant of the `z.discriminatedUnion`. As a result, for `buildType: nixpacks`:

- the toggle was never rendered, so there was no way to enable the SPA fallback from the UI;
- the field was omitted from the submit payload, so any Build config save in Nixpacks mode reset the value to `null`.

Net user-facing effect: a deep-link hard-refresh / cold-start on a client-side route (`/planning`, `/users/:id`, …) returned a `404` from nginx because `try_files` was absent — the SPA never loaded on first hit. This is a very common setup for monorepos where the `Static` build type can't run the build step.

The Dosu triage on #4993 confirmed the gap and traced it to an integration oversight between #297 (Nixpacks `publishDirectory` support) and #1931 (which added the `isStaticSpa` toggle only for `static`). Railpack does **not** call `getStaticCommand`, so it is intentionally left untouched.

## Changes

Single file, UI-only, no backend change:

- Add `isStaticSpa: z.boolean().default(false)` to the `nixpacks` discriminated-union variant.
- Mirror it in `resetData`'s `nixpacks` case.
- Include `isStaticSpa` in the submit payload for `static` **or** `nixpacks` (else `null`).
- Render the existing SPA checkbox when `buildType === nixpacks && publishDirectory` is set — reusing the exact pattern of the `static` block, with a distinct DOM id (`checkboxIsStaticSpaNixpacks`) to avoid a duplicate id.

## Testing

- `pnpm --filter=dokploy run typecheck` (tsc --noEmit): clean, no diagnostics. The discriminated union now types `isStaticSpa: boolean` for `nixpacks`, and `resetData` stays exhaustive/symmetric with `static`.
- `pnpm exec biome check` on the touched file: clean, no fixes applied.

Honest disclosure per CONTRIBUTING: I verified the change by typecheck + Biome + code review of the schema/reset/render paths, but I did **not** run the full local stack (Docker + Postgres + server:3000) for an interactive browser round-trip. The backend path this restores (`getStaticCommand` → nginx SPA fallback) is already proven working on a real running instance — with `isStaticSpa` forced directly in the DB, the generated nginx serves `index.html` with HTTP 200 on client routes; this PR only reconnects the UI plumbing to that already-working backend path. Happy to add a screencast or a scoped test on `show.tsx` if maintainers prefer.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes the existing SPA setting for Nixpacks applications that specify a publish directory and preserves that setting through build-configuration saves.

- Adds `isStaticSpa` to the Nixpacks form schema and reset data.
- Includes the Nixpacks SPA value in the submitted build configuration.
- Conditionally renders the SPA checkbox when Nixpacks static publishing is active.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The added field is consistently represented in validation, reset state, submission, and rendering, while the checkbox visibility matches the Nixpacks builder condition that activates static publishing.

<sub>Reviews (1): Last reviewed commit: ["fix(ui): expose isStaticSpa toggle for n..."](https://github.com/dokploy/dokploy/commit/94098b2686c809ec8f1bafa8f18aa69a8c268dff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50797846)</sub>

<!-- /greptile_comment -->