### PR TITLE
Fix/allow compose chaining

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -140,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
+      npm_version: ${{ steps.get_version.outputs.npm_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,6 +152,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./apps/dokploy/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "npm_version=${VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Fetch install.sh
         run: |
@@ -181,15 +183,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.22.0
+
       - name: Sync version to MCP repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/mcp.git /tmp/mcp-repo
           cd /tmp/mcp-repo
 
-          jq --arg v "${{ needs.generate-release.outputs.version }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
-          npm install -g pnpm
           pnpm install
           pnpm run fetch-openapi
           pnpm run generate
@@ -197,55 +202,53 @@ jobs:
           git config user.name "Dokploy Bot"
           git config user.email "bot@dokploy.com"
           git add -A
-          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.version }}" \
+          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.npm_version }}" \
             -m "Source: ${{ github.repository }}@${{ github.sha }}" \
             --allow-empty
           git push
 
-          echo "✅ MCP repo synced to version ${{ needs.generate-release.outputs.version }}"
+          echo "✅ MCP repo synced to version ${{ needs.generate-release.outputs.npm_version }}"
 
       - name: Sync version to CLI repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/cli.git /tmp/cli-repo
           cd /tmp/cli-repo
 
-          jq --arg v "${{ needs.generate-release.outputs.version }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
           cp ${{ github.workspace }}/openapi.json ./openapi.json
-          npm install -g pnpm
           pnpm install
           pnpm run generate
 
           git config user.name "Dokploy Bot"
           git config user.email "bot@dokploy.com"
           git add -A
-          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.version }}" \
+          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.npm_version }}" \
             -m "Source: ${{ github.repository }}@${{ github.sha }}" \
             --allow-empty
           git push
 
-          echo "✅ CLI repo synced to version ${{ needs.generate-release.outputs.version }}"
+          echo "✅ CLI repo synced to version ${{ needs.generate-release.outputs.npm_version }}"
 
       - name: Sync version to SDK repository
         run: |
           git clone https://x-access-token:${{ secrets.DOCS_SYNC_TOKEN }}@github.com/dokploy/sdk.git /tmp/sdk-repo
           cd /tmp/sdk-repo
 
-          jq --arg v "${{ needs.generate-release.outputs.version }}" '.version = $v' package.json > package.json.tmp
+          jq --arg v "${{ needs.generate-release.outputs.npm_version }}" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
 
           cp ${{ github.workspace }}/openapi.json ./openapi.json
-          npm install -g pnpm
           pnpm install
           pnpm run generate
 
           git config user.name "Dokploy Bot"
           git config user.email "bot@dokploy.com"
           git add -A
-          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.version }}" \
+          git commit -m "chore: bump version to ${{ needs.generate-release.outputs.npm_version }}" \
             -m "Source: ${{ github.repository }}@${{ github.sha }}" \
             --allow-empty
           git push
 
-          echo "✅ SDK repo synced to version ${{ needs.generate-release.outputs.version }}"
+          echo "✅ SDK repo synced to version ${{ needs.generate-release.outputs.npm_version }}"

--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -164,6 +164,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
+          target_commitish: ${{ github.sha }}
           name: ${{ steps.get_version.outputs.version }}
           generate_release_notes: true
           draft: false

--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { getCreateEnvFileCommand } from "@dokploy/server/utils/builders/compose";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Regression coverage for https://github.com/Dokploy/dokploy/issues/4694 —
+// values must survive Docker Compose's own `.env` parsing, not just base64 decode.
+const appName = `env-file-literals-${process.pid}`;
+const projectPath = join(process.cwd(), ".docker", "compose", appName);
+const codePath = join(projectPath, "code");
+
+afterEach(() => {
+	try {
+		execFileSync("docker", ["compose", "down", "--remove-orphans"], {
+			cwd: codePath,
+			stdio: "ignore",
+		});
+	} catch {
+		// Project may not have been created (e.g. an earlier assertion failed).
+	}
+	rmSync(projectPath, { force: true, recursive: true });
+});
+
+const cases: Record<string, string> = {
+	PASSWORD: "pa$$word",
+	SPECIAL: '!"#$%&/()=?',
+	NESTED_JSON: '{"nested":{"a":1}}',
+	MAIL_PASSWORD: "abc#de",
+	TRAILING_BACKSLASH: "trailing\\",
+	QUOTE_INSIDE: 'she said "hi"',
+	APOSTROPHE: "it's a test",
+	UNICODE: "héllo wörld 日本語 🚀",
+	MULTILINE_PEM: "-----BEGIN KEY-----\nabc123\n-----END KEY-----",
+};
+
+// How each value must be typed in the UI so the (unchanged) dotenv input
+// parser resolves it to the raw string in `cases` above.
+const inputEncoding: Record<string, string> = {
+	PASSWORD: "pa$$word",
+	SPECIAL: `'!"#$%&/()=?'`,
+	NESTED_JSON: '{"nested":{"a":1}}',
+	MAIL_PASSWORD: `"abc#de"`,
+	TRAILING_BACKSLASH: "trailing\\",
+	QUOTE_INSIDE: 'she said "hi"',
+	APOSTROPHE: "it's a test",
+	UNICODE: "héllo wörld 日本語 🚀",
+	MULTILINE_PEM: '"-----BEGIN KEY-----\nabc123\n-----END KEY-----"',
+};
+
+describe("getCreateEnvFileCommand", () => {
+	it("writes special environment values that Docker Compose reads back literally", () => {
+		mkdirSync(codePath, { recursive: true });
+
+		const serviceEnv = Object.entries(inputEncoding)
+			.map(([key, value]) => `${key}=${value}`)
+			.join("\n");
+
+		const command = getCreateEnvFileCommand({
+			appName,
+			composePath: "docker-compose.yml",
+			env: serviceEnv,
+			randomize: false,
+			suffix: "",
+			serverId: null,
+			environment: { project: { env: "" }, env: "" },
+		} as Parameters<typeof getCreateEnvFileCommand>[0]);
+
+		execFileSync("bash", ["-c", command]);
+
+		const composeFile = `services:\n  test:\n    image: busybox\n    environment:\n${Object.keys(
+			cases,
+		)
+			.map((key) => `      - ${key}=\${${key}}`)
+			.join("\n")}\n`;
+		writeFileSync(join(codePath, "docker-compose.yml"), composeFile);
+
+		const dumpScript = `for k in ${Object.keys(cases).join(" ")}; do printf '%s\\0' "$k"; eval "printf '%s\\0' \\"\\$$k\\""; done`;
+
+		const out = execFileSync(
+			"docker",
+			["compose", "run", "--rm", "-T", "test", "sh", "-c", dumpScript],
+			{ cwd: codePath, encoding: "utf8" },
+		);
+
+		const parts = out.split("\0");
+		const actual: Record<string, string> = {};
+		for (let i = 0; i < parts.length - 1; i += 2) {
+			actual[parts[i] as string] = parts[i + 1] as string;
+		}
+
+		for (const [key, value] of Object.entries(cases)) {
+			expect(actual[key], key).toBe(value);
+		}
+	}, 60000);
+});

--- a/apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts
+++ b/apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { createEnvFileCommand } from "@dokploy/server/utils/builders/utils";
+import { parse } from "dotenv";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Unlike compose's .env, this one is read by the app's own build tooling
+// (generic dotenv, e.g. Next.js/Vite) — must stay unquoted, not Compose-escaped.
+const appName = `env-file-literals-dockerfile-${process.pid}`;
+const projectPath = join(process.cwd(), ".docker", "compose", appName);
+const codePath = join(projectPath, "code");
+const dockerFilePath = join(codePath, "Dockerfile");
+
+afterEach(() => rmSync(projectPath, { force: true, recursive: true }));
+
+const cases: Record<string, string> = {
+	PASSWORD: "pa$$word",
+	NESTED_JSON: '{"nested":{"a":1}}',
+	QUOTE_INSIDE: 'she said "hi"',
+	BACKSLASH: "back\\slash",
+	UNICODE: "héllo wörld 日本語 🚀",
+};
+
+describe("createEnvFileCommand", () => {
+	it("writes special environment values that a generic dotenv parser reads back literally", () => {
+		mkdirSync(codePath, { recursive: true });
+
+		const serviceEnv = Object.entries(cases)
+			.map(([key, value]) => `${key}=${value}`)
+			.join("\n");
+
+		const command = createEnvFileCommand(dockerFilePath, serviceEnv, "", "");
+		execFileSync("bash", ["-c", command]);
+
+		const written = readFileSync(join(codePath, ".env"), "utf8");
+		const parsed = parse(written);
+
+		for (const [key, value] of Object.entries(cases)) {
+			expect(parsed[key], key).toBe(value);
+		}
+	});
+});

--- a/apps/dokploy/__test__/utils/hostname-validation.test.ts
+++ b/apps/dokploy/__test__/utils/hostname-validation.test.ts
@@ -9,6 +9,9 @@ describe("VALID_HOSTNAME_REGEX", () => {
 		"a.b.c.example.co",
 		"xn--80ak6aa92e.com",
 		"123.example.com",
+		"example",
+		"dokploy-server",
+		"localhost",
 	])("accepts valid hostname %s", (host) => {
 		expect(VALID_HOSTNAME_REGEX.test(host)).toBe(true);
 	});
@@ -17,7 +20,6 @@ describe("VALID_HOSTNAME_REGEX", () => {
 		"bbn_client.example.com",
 		"-example.com",
 		"example-.com",
-		"example",
 		"exa mple.com",
 		"example..com",
 		"",

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -70,22 +70,39 @@ Compose Type: ${composeType} ✅`;
 // Shell control characters that must never appear in a user-provided compose
 // command: they would let it break out of the `docker ${command}` invocation
 // into arbitrary host commands. A normal docker compose CLI line never needs them.
-const UNSAFE_COMPOSE_COMMAND = /[;&|`$(){}<>\n\\]/;
+// Removed '&' from the blocklist to allow '&&' chaining
+const UNSAFE_COMPOSE_COMMAND = /[;|`$(){}<>\n\\]/;
 
 const sanitizeCommand = (command: string) => {
-	const sanitizedCommand = command.trim();
+    const sanitizedCommand = command.trim();
 
-	if (UNSAFE_COMPOSE_COMMAND.test(sanitizedCommand)) {
-		throw new Error(
-			"Invalid characters in compose command: shell control characters are not allowed",
-		);
-	}
+    if (UNSAFE_COMPOSE_COMMAND.test(sanitizedCommand)) {
+        throw new Error(
+            "Invalid characters in compose command: shell control characters are not allowed",
+        );
+    }
 
-	const parts = sanitizedCommand.split(/\s+/);
+    if (sanitizedCommand.includes("&")) {
+        // Block single '&' (e.g., backgrounding tasks) or malformed chains like '&&&'
+        if (/(?<!&)&(?!&)/.test(sanitizedCommand) || sanitizedCommand.includes("&&&")) {
+            throw new Error("Single '&' is not allowed. Use '&&' for chaining.");
+        }
 
-	const restCommand = parts.map((arg) => arg.replace(/^"(.*)"$/, "$1"));
+        // Split by '&&' and check that every chained command (skipping the first one) is safe
+        const chains = sanitizedCommand.split("&&").map((cmd) => cmd.trim());
+        const isSafeChain = chains.slice(1).every((cmd) => 
+            cmd.startsWith("docker compose ") || cmd.startsWith("docker-compose ")
+        );
 
-	return restCommand.join(" ");
+        if (!isSafeChain) {
+            throw new Error("Chained commands must strictly start with 'docker compose '");
+        }
+    }
+
+    const parts = sanitizedCommand.split(/\s+/);
+    const restCommand = parts.map((arg) => arg.replace(/^"(.*)"$/, "$1"));
+
+    return restCommand.join(" ");
 };
 
 export const createCommand = (compose: ComposeNested) => {

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -7,7 +7,7 @@ import { writeDomainsToCompose } from "../docker/domain";
 import {
 	encodeBase64,
 	getEnvironmentVariablesObject,
-	prepareEnvironmentVariables,
+	prepareEnvironmentVariablesForFile,
 } from "../docker/utils";
 
 export type ComposeNested = InferResultType<
@@ -127,7 +127,7 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 		envContent += `\nCOMPOSE_PREFIX=${compose.suffix}`;
 	}
 
-	const envFileContent = prepareEnvironmentVariables(
+	const envFileContent = prepareEnvironmentVariablesForFile(
 		envContent,
 		compose.environment.project.env,
 		compose.environment.env,

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -465,6 +465,27 @@ export const prepareEnvironmentVariablesForShell = (
 	return envVars.map((env) => quote([env]));
 };
 
+export const prepareEnvironmentVariablesForFile = (
+	serviceEnv: string | null,
+	projectEnv?: string | null,
+	environmentEnv?: string | null,
+): string[] => {
+	const envVars = prepareEnvironmentVariables(
+		serviceEnv,
+		projectEnv,
+		environmentEnv,
+	);
+
+	return envVars.map((pair) => {
+		const [key, value] = parseEnvironmentKeyValuePair(pair);
+		const escapedValue = value
+			.replace(/\\/g, "\\\\")
+			.replace(/"/g, '\\"')
+			.replace(/\$/g, "\\$");
+		return `${key}="${escapedValue}"`;
+	});
+};
+
 export const parseEnvironmentKeyValuePair = (
 	pair: string,
 ): [string, string] => {

--- a/packages/server/src/utils/hostname-validation.ts
+++ b/packages/server/src/utils/hostname-validation.ts
@@ -1,8 +1,8 @@
 // Valid hostname per RFC 1123: labels of letters, digits and hyphens
-// (no leading/trailing hyphen), separated by dots. Underscores are rejected
+// (no leading/trailing hyphen), optionally separated by dots. Underscores are rejected
 // because Let's Encrypt refuses to issue certificates for them.
 export const VALID_HOSTNAME_REGEX =
-	/^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+	/^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
 
 export const INVALID_HOSTNAME_MESSAGE =
 	"Invalid domain name. Use only letters, numbers, hyphens and dots (e.g. example.com). Underscores are not allowed.";


### PR DESCRIPTION
## What is this PR about?

This PR updates the `sanitizeCommand` logic to safely allow `&&` chaining in custom compose deployment commands. Currently, the strict blocklist on `&` prevents users from executing standard multi-step deployments (such as `compose pull && docker compose down && docker compose up -d --build`). This is critical for stacks that require full teardowns to clear in-memory caches (e.g., Redis) or sync volume mounts during image updates. The updated logic blocks single `&` (backgrounding) and strictly enforces that any chained command must securely start with `docker compose ` or `docker-compose `, maintaining security while unblocking legitimate DevOps workflows.

## Checklist

Before submitting this PR, please make sure that:

* [x] You created a dedicated branch based on the `canary` branch.
* [x] You have read the suggestions in the CONTRIBUTING.md file [https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request](https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request)
* [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4992 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR permits guarded `&&` chaining in custom Compose commands, adds Compose-specific environment-file escaping and regression coverage, broadens hostname validation, and adjusts release synchronization.

- Allows chained Docker Compose deployment commands while continuing to reject other shell metacharacters
- Serializes Compose `.env` values with quoting and escaping and adds Docker-backed literal-value tests
- Accepts single-label hostnames such as `localhost`
- Normalizes synchronized package versions and installs pnpm through its GitHub Action

<h3>Confidence Score: 4/5</h3>

The hostname change should be fixed before merging because it allows users to configure public HTTPS domains for which certificate issuance cannot succeed; the release action pinning issue is non-blocking hardening.

Single-label names now pass the shared domain validation and can reach Traefik's Let's Encrypt resolver despite not being eligible public certificate names, while the added release action also relies on a mutable upstream tag.

**Files Needing Attention:** packages/server/src/utils/hostname-validation.ts, .github/workflows/dokploy.yml

<details open><summary><h3>Security Review</h3></summary>

The newly introduced `pnpm/action-setup` step uses a mutable major-version tag; pinning it to a full commit SHA would harden the credential-bearing release workflow.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow docker compose command chaini..."](https://github.com/dokploy/dokploy/commit/f24b78abb14627100f5262f7feba0231e8f3d373) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50809609)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Compose Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/compose-deployment.md)
- Knowledge Base — [Server Setup and Packaging](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/server-setup-and-packaging.md)

<!-- /greptile_comment -->