### PR TITLE
feat: auto-validate DNS when Domains page loads

### DIFF
--- a/apps/dokploy/__test__/services/domain-validation.test.ts
+++ b/apps/dokploy/__test__/services/domain-validation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+	didServerIpChange,
+	getHostsToAutoValidate,
+	isCurrentValidation,
+} from "@/components/dashboard/application/domains/validation";
+
+describe("domain auto-validation", () => {
+	it("only schedules enabled, unvalidated hosts", () => {
+		const hosts = getHostsToAutoValidate(
+			[
+				{ host: "already.example.com", enabled: true },
+				{ host: "disabled.example.com", enabled: false },
+				{ host: "new.example.com", enabled: true },
+			],
+			new Set(["already.example.com"]),
+		);
+
+		expect(hosts).toEqual(["new.example.com"]);
+	});
+
+	it("rejects results from a previous service scope", () => {
+		expect(
+			isCurrentValidation({
+				currentScopeRequestId: 2,
+				currentHostRequestId: 1,
+				hostRequestId: 1,
+				scopeRequestId: 1,
+			}),
+		).toBe(false);
+	});
+
+	it("rejects an older request for the same host", () => {
+		expect(
+			isCurrentValidation({
+				currentScopeRequestId: 1,
+				currentHostRequestId: 2,
+				hostRequestId: 1,
+				scopeRequestId: 1,
+			}),
+		).toBe(false);
+	});
+
+	it("detects expected server IP changes", () => {
+		expect(didServerIpChange("203.0.113.10", "203.0.113.11")).toBe(true);
+		expect(didServerIpChange("203.0.113.10", "203.0.113.10")).toBe(false);
+	});
+});

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -220,13 +220,11 @@ export const ShowDomains = ({ id, type }: Props) => {
 	}
 
 	const handleValidateDomain = useCallback(
-		async (host: string, serverIpOverride?: string) => {
+		async (host: string) => {
 			const serviceRequestId = validationRequestIdRef.current;
 			const hostRequestId =
 				(hostValidationRequestIdsRef.current.get(host) ?? 0) + 1;
 			hostValidationRequestIdsRef.current.set(host, hostRequestId);
-
-			const serverIp = serverIpOverride ?? resolveServerIp() ?? "";
 
 			const isCurrentRequest = () =>
 				isCurrentValidation({
@@ -248,7 +246,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 			try {
 				const result = await validateDomain({
 					domain: host,
-					serverIp,
+					serverId: application?.serverId ?? undefined,
 				});
 
 				if (!isCurrentRequest()) {
@@ -282,7 +280,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 				}));
 			}
 		},
-		[validateDomain, resolveServerIp],
+		[validateDomain, application?.serverId],
 	);
 
 	useEffect(() => {
@@ -341,7 +339,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 				if (!host) {
 					continue;
 				}
-				await handleValidateDomain(host, serverIp);
+				await handleValidateDomain(host);
 			}
 		};
 

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -322,6 +322,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 		data,
 		isIpFetched,
 		isApplicationFetched,
+		application,
 		application?.serverId,
 		application?.server?.ipAddress,
 		resolveServerIp,

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -66,6 +66,11 @@ import { DnsHelperModal } from "./dns-helper-modal";
 import { AddDomain } from "./handle-domain";
 import { HandleForwardAuth } from "./handle-forward-auth";
 import { COMPOSE_REDEPLOY_TOAST, ComposeRedeployAlert } from "./redeploy-hint";
+import {
+	didServerIpChange,
+	getHostsToAutoValidate,
+	isCurrentValidation,
+} from "./validation";
 
 export type ValidationState = {
 	isLoading: boolean;
@@ -112,6 +117,9 @@ export const ShowDomains = ({ id, type }: Props) => {
 	const validationRequestIdRef = useRef(0);
 	const hostValidationRequestIdsRef = useRef<Map<string, number>>(new Map());
 	const lastAutoValidatedServerIpRef = useRef<string | undefined>(undefined);
+	const activeValidationScopeRef = useRef(`${type}:${id}`);
+	const lastObservedServerIpRef = useRef<string | undefined>(undefined);
+	const validationScope = `${type}:${id}`;
 	const [viewMode, setViewMode] = useState<"grid" | "table">(() => {
 		if (typeof window !== "undefined") {
 			return (
@@ -194,6 +202,22 @@ export const ShowDomains = ({ id, type }: Props) => {
 
 		return ip?.toString() || undefined;
 	}, [application?.server?.ipAddress, application?.serverId, ip]);
+	const resolvedServerIp = resolveServerIp();
+
+	if (activeValidationScopeRef.current !== validationScope) {
+		activeValidationScopeRef.current = validationScope;
+		validationRequestIdRef.current += 1;
+		autoValidatedHostsRef.current = new Set();
+		hostValidationRequestIdsRef.current = new Map();
+		lastAutoValidatedServerIpRef.current = undefined;
+	}
+
+	if (didServerIpChange(lastObservedServerIpRef.current, resolvedServerIp)) {
+		lastObservedServerIpRef.current = resolvedServerIp;
+		validationRequestIdRef.current += 1;
+		hostValidationRequestIdsRef.current = new Map();
+		autoValidatedHostsRef.current = new Set();
+	}
 
 	const handleValidateDomain = useCallback(
 		async (host: string, serverIpOverride?: string) => {
@@ -202,13 +226,15 @@ export const ShowDomains = ({ id, type }: Props) => {
 				(hostValidationRequestIdsRef.current.get(host) ?? 0) + 1;
 			hostValidationRequestIdsRef.current.set(host, hostRequestId);
 
-			const serverIp =
-				serverIpOverride ??
-				(application?.server?.ipAddress?.toString() || ip?.toString() || "");
+			const serverIp = serverIpOverride ?? resolveServerIp() ?? "";
 
 			const isCurrentRequest = () =>
-				validationRequestIdRef.current === serviceRequestId &&
-				hostValidationRequestIdsRef.current.get(host) === hostRequestId;
+				isCurrentValidation({
+					currentScopeRequestId: validationRequestIdRef.current,
+					currentHostRequestId: hostValidationRequestIdsRef.current.get(host),
+					hostRequestId,
+					scopeRequestId: serviceRequestId,
+				});
 
 			if (!isCurrentRequest()) {
 				return;
@@ -256,16 +282,19 @@ export const ShowDomains = ({ id, type }: Props) => {
 				}));
 			}
 		},
-		[validateDomain, application?.server?.ipAddress, ip],
+		[validateDomain, resolveServerIp],
 	);
 
 	useEffect(() => {
-		validationRequestIdRef.current += 1;
-		autoValidatedHostsRef.current = new Set();
-		hostValidationRequestIdsRef.current = new Map();
-		lastAutoValidatedServerIpRef.current = undefined;
 		setValidationStates({});
-	}, [id]);
+
+		return () => {
+			validationRequestIdRef.current += 1;
+			autoValidatedHostsRef.current = new Set();
+			hostValidationRequestIdsRef.current = new Map();
+			lastAutoValidatedServerIpRef.current = undefined;
+		};
+	}, [validationScope]);
 
 	useEffect(() => {
 		if (!data?.length || !isApplicationFetched || !application) {
@@ -280,7 +309,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 			return;
 		}
 
-		const serverIp = resolveServerIp();
+		const serverIp = resolvedServerIp;
 		if (!serverIp) {
 			return;
 		}
@@ -290,16 +319,13 @@ export const ShowDomains = ({ id, type }: Props) => {
 			autoValidatedHostsRef.current = new Set();
 		}
 
-		const hostsToValidate = data
-			.map((item) => item.host)
-			.filter((host) => {
-				if (autoValidatedHostsRef.current.has(host)) {
-					return false;
-				}
-
-				autoValidatedHostsRef.current.add(host);
-				return true;
-			});
+		const hostsToValidate = getHostsToAutoValidate(
+			data,
+			autoValidatedHostsRef.current,
+		);
+		hostsToValidate.forEach((host) => {
+			autoValidatedHostsRef.current.add(host);
+		});
 
 		if (hostsToValidate.length === 0) {
 			return;
@@ -332,7 +358,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 		application,
 		application?.serverId,
 		application?.server?.ipAddress,
-		resolveServerIp,
+		resolvedServerIp,
 		handleValidateDomain,
 	]);
 

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -25,7 +25,7 @@ import {
 	XCircle,
 } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { DialogAction } from "@/components/shared/dialog-action";
 import { Badge } from "@/components/ui/badge";
@@ -87,7 +87,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const canCreateDomain = permissions?.domain.create ?? false;
 	const canDeleteDomain = permissions?.domain.delete ?? false;
-	const { data: application } =
+	const { data: application, isFetched: isApplicationFetched } =
 		type === "application"
 			? api.application.one.useQuery(
 					{
@@ -108,6 +108,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 	const [validationStates, setValidationStates] = useState<ValidationStates>(
 		{},
 	);
+	const autoValidatedHostsRef = useRef<Set<string>>(new Set());
 	const [viewMode, setViewMode] = useState<"grid" | "table">(() => {
 		if (typeof window !== "undefined") {
 			return (
@@ -121,7 +122,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
 	const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 	const [rowSelection, setRowSelection] = useState({});
-	const { data: ip } = api.settings.getIp.useQuery();
+	const { data: ip, isFetched: isIpFetched } = api.settings.getIp.useQuery();
 
 	const {
 		data,
@@ -182,41 +183,65 @@ export const ShowDomains = ({ id, type }: Props) => {
 		}
 	};
 
-	const handleValidateDomain = async (host: string) => {
-		setValidationStates((prev) => ({
-			...prev,
-			[host]: { isLoading: true },
-		}));
-
-		try {
-			const result = await validateDomain({
-				domain: host,
-				serverId: application?.serverId ?? undefined,
-			});
-
+	const handleValidateDomain = useCallback(
+		async (host: string) => {
 			setValidationStates((prev) => ({
 				...prev,
-				[host]: {
-					isLoading: false,
-					isValid: result.isValid,
-					error: result.error,
-					resolvedIp: result.resolvedIp,
-					cdnProvider: result.cdnProvider,
-					message: result.error && result.isValid ? result.error : undefined,
-				},
+				[host]: { isLoading: true },
 			}));
-		} catch (err) {
-			const error = err as Error;
-			setValidationStates((prev) => ({
-				...prev,
-				[host]: {
-					isLoading: false,
-					isValid: false,
-					error: error.message || "Failed to validate domain",
-				},
-			}));
+
+			try {
+				const result = await validateDomain({
+					domain: host,
+					serverIp:
+						application?.server?.ipAddress?.toString() || ip?.toString() || "",
+				});
+
+				setValidationStates((prev) => ({
+					...prev,
+					[host]: {
+						isLoading: false,
+						isValid: result.isValid,
+						error: result.error,
+						resolvedIp: result.resolvedIp,
+						cdnProvider: result.cdnProvider,
+						message: result.error && result.isValid ? result.error : undefined,
+					},
+				}));
+			} catch (err) {
+				const error = err as Error;
+				setValidationStates((prev) => ({
+					...prev,
+					[host]: {
+						isLoading: false,
+						isValid: false,
+						error: error.message || "Failed to validate domain",
+					},
+				}));
+			}
+		},
+		[validateDomain, application?.server?.ipAddress, ip],
+	);
+
+	useEffect(() => {
+		autoValidatedHostsRef.current = new Set();
+		setValidationStates({});
+	}, [id]);
+
+	useEffect(() => {
+		if (!data?.length || !isIpFetched || !isApplicationFetched) {
+			return;
 		}
-	};
+
+		for (const item of data) {
+			if (autoValidatedHostsRef.current.has(item.host)) {
+				continue;
+			}
+
+			autoValidatedHostsRef.current.add(item.host);
+			void handleValidateDomain(item.host);
+		}
+	}, [data, isIpFetched, isApplicationFetched, handleValidateDomain]);
 
 	const columns = createColumns({
 		id,

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -109,6 +109,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 		{},
 	);
 	const autoValidatedHostsRef = useRef<Set<string>>(new Set());
+	const validationRequestIdRef = useRef(0);
 	const [viewMode, setViewMode] = useState<"grid" | "table">(() => {
 		if (typeof window !== "undefined") {
 			return (
@@ -183,8 +184,26 @@ export const ShowDomains = ({ id, type }: Props) => {
 		}
 	};
 
+	const resolveServerIp = useCallback(() => {
+		const remoteIp = application?.server?.ipAddress?.toString();
+		if (application?.serverId) {
+			return remoteIp || undefined;
+		}
+
+		return ip?.toString() || undefined;
+	}, [application?.server?.ipAddress, application?.serverId, ip]);
+
 	const handleValidateDomain = useCallback(
-		async (host: string) => {
+		async (host: string, serverIpOverride?: string) => {
+			const requestId = validationRequestIdRef.current;
+			const serverIp =
+				serverIpOverride ??
+				(application?.server?.ipAddress?.toString() || ip?.toString() || "");
+
+			if (validationRequestIdRef.current !== requestId) {
+				return;
+			}
+
 			setValidationStates((prev) => ({
 				...prev,
 				[host]: { isLoading: true },
@@ -193,9 +212,12 @@ export const ShowDomains = ({ id, type }: Props) => {
 			try {
 				const result = await validateDomain({
 					domain: host,
-					serverIp:
-						application?.server?.ipAddress?.toString() || ip?.toString() || "",
+					serverIp,
 				});
+
+				if (validationRequestIdRef.current !== requestId) {
+					return;
+				}
 
 				setValidationStates((prev) => ({
 					...prev,
@@ -209,6 +231,10 @@ export const ShowDomains = ({ id, type }: Props) => {
 					},
 				}));
 			} catch (err) {
+				if (validationRequestIdRef.current !== requestId) {
+					return;
+				}
+
 				const error = err as Error;
 				setValidationStates((prev) => ({
 					...prev,
@@ -224,24 +250,73 @@ export const ShowDomains = ({ id, type }: Props) => {
 	);
 
 	useEffect(() => {
+		validationRequestIdRef.current += 1;
 		autoValidatedHostsRef.current = new Set();
 		setValidationStates({});
 	}, [id]);
 
 	useEffect(() => {
-		if (!data?.length || !isIpFetched || !isApplicationFetched) {
+		if (!data?.length || !isApplicationFetched) {
 			return;
 		}
 
-		for (const item of data) {
-			if (autoValidatedHostsRef.current.has(item.host)) {
-				continue;
+		if (application?.serverId) {
+			if (!application.server?.ipAddress) {
+				return;
 			}
-
-			autoValidatedHostsRef.current.add(item.host);
-			void handleValidateDomain(item.host);
+		} else if (!isIpFetched) {
+			return;
 		}
-	}, [data, isIpFetched, isApplicationFetched, handleValidateDomain]);
+
+		const serverIp = resolveServerIp();
+		if (!serverIp) {
+			return;
+		}
+
+		const hostsToValidate = data
+			.map((item) => item.host)
+			.filter((host) => {
+				if (autoValidatedHostsRef.current.has(host)) {
+					return false;
+				}
+
+				autoValidatedHostsRef.current.add(host);
+				return true;
+			});
+
+		if (hostsToValidate.length === 0) {
+			return;
+		}
+
+		const maxConcurrent = 5;
+		let nextIndex = 0;
+
+		const runNext = async () => {
+			while (nextIndex < hostsToValidate.length) {
+				const host = hostsToValidate[nextIndex];
+				nextIndex += 1;
+				if (!host) {
+					continue;
+				}
+				await handleValidateDomain(host, serverIp);
+			}
+		};
+
+		void Promise.all(
+			Array.from(
+				{ length: Math.min(maxConcurrent, hostsToValidate.length) },
+				() => runNext(),
+			),
+		);
+	}, [
+		data,
+		isIpFetched,
+		isApplicationFetched,
+		application?.serverId,
+		application?.server?.ipAddress,
+		resolveServerIp,
+		handleValidateDomain,
+	]);
 
 	const columns = createColumns({
 		id,

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -110,6 +110,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 	);
 	const autoValidatedHostsRef = useRef<Set<string>>(new Set());
 	const validationRequestIdRef = useRef(0);
+	const hostValidationRequestIdsRef = useRef<Map<string, number>>(new Map());
 	const [viewMode, setViewMode] = useState<"grid" | "table">(() => {
 		if (typeof window !== "undefined") {
 			return (
@@ -195,12 +196,20 @@ export const ShowDomains = ({ id, type }: Props) => {
 
 	const handleValidateDomain = useCallback(
 		async (host: string, serverIpOverride?: string) => {
-			const requestId = validationRequestIdRef.current;
+			const serviceRequestId = validationRequestIdRef.current;
+			const hostRequestId =
+				(hostValidationRequestIdsRef.current.get(host) ?? 0) + 1;
+			hostValidationRequestIdsRef.current.set(host, hostRequestId);
+
 			const serverIp =
 				serverIpOverride ??
 				(application?.server?.ipAddress?.toString() || ip?.toString() || "");
 
-			if (validationRequestIdRef.current !== requestId) {
+			const isCurrentRequest = () =>
+				validationRequestIdRef.current === serviceRequestId &&
+				hostValidationRequestIdsRef.current.get(host) === hostRequestId;
+
+			if (!isCurrentRequest()) {
 				return;
 			}
 
@@ -215,7 +224,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 					serverIp,
 				});
 
-				if (validationRequestIdRef.current !== requestId) {
+				if (!isCurrentRequest()) {
 					return;
 				}
 
@@ -231,7 +240,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 					},
 				}));
 			} catch (err) {
-				if (validationRequestIdRef.current !== requestId) {
+				if (!isCurrentRequest()) {
 					return;
 				}
 
@@ -252,6 +261,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 	useEffect(() => {
 		validationRequestIdRef.current += 1;
 		autoValidatedHostsRef.current = new Set();
+		hostValidationRequestIdsRef.current = new Map();
 		setValidationStates({});
 	}, [id]);
 

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -266,11 +266,11 @@ export const ShowDomains = ({ id, type }: Props) => {
 	}, [id]);
 
 	useEffect(() => {
-		if (!data?.length || !isApplicationFetched) {
+		if (!data?.length || !isApplicationFetched || !application) {
 			return;
 		}
 
-		if (application?.serverId) {
+		if (application.serverId) {
 			if (!application.server?.ipAddress) {
 				return;
 			}

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -111,6 +111,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 	const autoValidatedHostsRef = useRef<Set<string>>(new Set());
 	const validationRequestIdRef = useRef(0);
 	const hostValidationRequestIdsRef = useRef<Map<string, number>>(new Map());
+	const lastAutoValidatedServerIpRef = useRef<string | undefined>(undefined);
 	const [viewMode, setViewMode] = useState<"grid" | "table">(() => {
 		if (typeof window !== "undefined") {
 			return (
@@ -262,6 +263,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 		validationRequestIdRef.current += 1;
 		autoValidatedHostsRef.current = new Set();
 		hostValidationRequestIdsRef.current = new Map();
+		lastAutoValidatedServerIpRef.current = undefined;
 		setValidationStates({});
 	}, [id]);
 
@@ -281,6 +283,11 @@ export const ShowDomains = ({ id, type }: Props) => {
 		const serverIp = resolveServerIp();
 		if (!serverIp) {
 			return;
+		}
+
+		if (lastAutoValidatedServerIpRef.current !== serverIp) {
+			lastAutoValidatedServerIpRef.current = serverIp;
+			autoValidatedHostsRef.current = new Set();
 		}
 
 		const hostsToValidate = data

--- a/apps/dokploy/components/dashboard/application/domains/validation.ts
+++ b/apps/dokploy/components/dashboard/application/domains/validation.ts
@@ -1,0 +1,33 @@
+export type AutoValidationDomain = {
+	host: string;
+	enabled?: boolean;
+};
+
+export const getHostsToAutoValidate = (
+	domains: readonly AutoValidationDomain[],
+	validatedHosts: ReadonlySet<string>,
+) =>
+	domains
+		.filter(
+			(domain) => domain.enabled !== false && !validatedHosts.has(domain.host),
+		)
+		.map((domain) => domain.host);
+
+export const isCurrentValidation = ({
+	currentScopeRequestId,
+	currentHostRequestId,
+	hostRequestId,
+	scopeRequestId,
+}: {
+	currentScopeRequestId: number;
+	currentHostRequestId: number | undefined;
+	hostRequestId: number;
+	scopeRequestId: number;
+}) =>
+	currentScopeRequestId === scopeRequestId &&
+	currentHostRequestId === hostRequestId;
+
+export const didServerIpChange = (
+	previousServerIp: string | undefined,
+	serverIp: string | undefined,
+) => previousServerIp !== serverIp;


### PR DESCRIPTION
## Summary
- Automatically validate DNS for each domain when the Domains page loads (application/compose)
- Wait until domains and IP context are fetched so validation uses the correct server IP
- Keep the existing Validate DNS badge for manual re-checks
- Closes #5000

## Test plan
- [ ] Open an application/compose Domains tab with at least one domain
- [ ] Confirm each domain shows "Checking DNS..." then Valid/error without clicking
- [ ] Click the DNS badge again and confirm manual re-validation still works
- [ ] Switch to another service Domains tab and confirm validation runs for its domains
- [ ] Add a new domain and confirm it auto-validates after creation/refetch

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR automatically validates domain DNS after the relevant domain and server-IP context loads while preserving manual validation.
- Discards validation results from prior services and superseded per-host requests.
- Revalidates domains when the expected server IP changes.
- Limits automatic validation to five concurrent requests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (7): Last reviewed commit: ["fix: re-run auto DNS validation when exp..."](https://github.com/dokploy/dokploy/commit/121496672ae161be073ccdb6d6e82ec4e4de27d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51044770)</sub>

**Context used:**

- Knowledge Base — [Git Providers and Domains](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/git-providers-and-domains.md)

<!-- /greptile_comment -->