### PR TITLE
feat: add project filter to free monitoring dashboard

### DIFF
--- a/apps/dokploy/__test__/monitoring/project-stats.test.ts
+++ b/apps/dokploy/__test__/monitoring/project-stats.test.ts
@@ -1,0 +1,78 @@
+import {
+	aggregateProjectContainerStats,
+	findBestMatchingService,
+	getContainerServiceMatchScore,
+	type ProjectServiceRef,
+	parseDockerSizeToBytes,
+} from "@dokploy/server/monitoring/project-stats";
+import { describe, expect, it } from "vitest";
+
+const application = (
+	overrides: Partial<ProjectServiceRef> = {},
+): ProjectServiceRef => ({
+	id: "application-1",
+	name: "Web",
+	appName: "web-app",
+	type: "application",
+	serverId: "server-1",
+	...overrides,
+});
+
+describe("project monitoring stats", () => {
+	it("parses Docker sizes and rejects invalid values", () => {
+		expect(parseDockerSizeToBytes("1.5GiB")).toBe(1.5 * 1024 ** 3);
+		expect(parseDockerSizeToBytes("--")).toBe(0);
+		expect(parseDockerSizeToBytes("not-a-size")).toBe(0);
+	});
+
+	it("matches containers to the most specific service on the same server", () => {
+		const broad = application({ id: "broad", appName: "web" });
+		const specific = application({ id: "specific", appName: "web-app" });
+
+		expect(getContainerServiceMatchScore("web-app_api_1", "web-app")).toBe(
+			"web-app".length,
+		);
+		expect(
+			findBestMatchingService("web-app_api_1", [broad, specific], "server-1")
+				?.id,
+		).toBe("specific");
+		expect(
+			findBestMatchingService("web-app_api_1", [specific], "server-2"),
+		).toBeUndefined();
+	});
+
+	it("aggregates only containers owned by allowed services", () => {
+		const services = [application()];
+		const result = aggregateProjectContainerStats(services, [
+			{
+				BlockIO: "1MB / 2MB",
+				CPUPerc: "12.5%",
+				Container: "container-1",
+				ID: "container-1",
+				MemPerc: "10%",
+				MemUsage: "128MiB / 1GiB",
+				Name: "web-app_api_1",
+				NetIO: "3MB / 4MB",
+				serverId: "server-1",
+			},
+			{
+				BlockIO: "10MB / 10MB",
+				CPUPerc: "90%",
+				Container: "other",
+				ID: "other",
+				MemPerc: "90%",
+				MemUsage: "900MiB / 1GiB",
+				Name: "unrelated_service_1",
+				NetIO: "10MB / 10MB",
+				serverId: "server-1",
+			},
+		]);
+
+		expect(result.aggregated.cpu.value).toBe("12.50%");
+		expect(result.services[0]).toMatchObject({
+			containerCount: 1,
+			cpuPerc: 12.5,
+			memUsed: "128.00MiB",
+		});
+	});
+});

--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -1,8 +1,26 @@
 import { formatMb } from "@dokploy/server/monitoring/units";
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
+import { FolderKanban } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { api } from "@/utils/api";
 import { DockerBlockChart } from "./docker-block-chart";
 import { DockerCpuChart } from "./docker-cpu-chart";
@@ -10,6 +28,8 @@ import { DockerDiskChart } from "./docker-disk-chart";
 import { DockerDiskUsageChart } from "./docker-disk-usage-chart";
 import { DockerMemoryChart } from "./docker-memory-chart";
 import { DockerNetworkChart } from "./docker-network-chart";
+
+const ALL_SERVER = "all";
 
 const defaultData = {
 	cpu: {
@@ -54,8 +74,8 @@ export interface DockerStats {
 	};
 	memory: {
 		value: {
-			used: number;
-			total: number;
+			used: number | string;
+			total: number | string;
 		};
 		time: string;
 	};
@@ -117,39 +137,61 @@ export const convertMemoryToBytes = (
 	}
 };
 
+const resetAccumulativeData = (): DockerStatsJSON => ({
+	cpu: [],
+	memory: [],
+	block: [],
+	network: [],
+	disk: [],
+});
+
 export const ContainerFreeMonitoring = ({
 	appName,
 	appType = "application",
 }: Props) => {
+	const isServerView = appName === "dokploy";
+	const [selectedProjectId, setSelectedProjectId] = useState(ALL_SERVER);
+	const isProjectView = isServerView && selectedProjectId !== ALL_SERVER;
+
+	const { data: projects } = api.project.all.useQuery(undefined, {
+		enabled: isServerView,
+	});
+
 	const { data } = api.application.readAppMonitoring.useQuery(
 		{ appName },
 		{
 			refetchOnWindowFocus: false,
+			enabled: !isProjectView,
 		},
 	);
-	const [accumulativeData, setAccumulativeData] = useState<DockerStatsJSON>({
-		cpu: [],
-		memory: [],
-		block: [],
-		network: [],
-		disk: [],
-	});
+
+	const { data: projectStats } = api.project.resourceStats.useQuery(
+		{ projectId: selectedProjectId },
+		{
+			enabled: isProjectView,
+			refetchInterval: 2000,
+			refetchOnWindowFocus: false,
+		},
+	);
+
+	const [accumulativeData, setAccumulativeData] = useState<DockerStatsJSON>(
+		resetAccumulativeData,
+	);
 	const [currentData, setCurrentData] = useState<DockerStats>(defaultData);
+	const lastProjectSampleRef = useRef<string>("");
+
+	const selectedProjectName =
+		projects?.find((project) => project.projectId === selectedProjectId)
+			?.name ?? projectStats?.projectName;
 
 	useEffect(() => {
 		setCurrentData(defaultData);
-
-		setAccumulativeData({
-			cpu: [],
-			memory: [],
-			block: [],
-			network: [],
-			disk: [],
-		});
-	}, [appName]);
+		setAccumulativeData(resetAccumulativeData());
+		lastProjectSampleRef.current = "";
+	}, [appName, selectedProjectId]);
 
 	useEffect(() => {
-		if (!data) return;
+		if (isProjectView || !data) return;
 
 		setCurrentData({
 			cpu: data.cpu[data.cpu.length - 1] ?? currentData.cpu,
@@ -165,10 +207,37 @@ export const ContainerFreeMonitoring = ({
 			memory: data?.memory || [],
 			network: data?.network || [],
 		});
-	}, [data]);
+	}, [data, isProjectView]);
 
 	useEffect(() => {
-		if (!appName) return;
+		if (!isProjectView || !projectStats?.aggregated) return;
+
+		const sampleTime = projectStats.aggregated.cpu.time;
+		if (lastProjectSampleRef.current === sampleTime) return;
+		lastProjectSampleRef.current = sampleTime;
+
+		const nextData: DockerStats = {
+			cpu: projectStats.aggregated.cpu,
+			memory: projectStats.aggregated.memory,
+			block: projectStats.aggregated.block,
+			network: projectStats.aggregated.network,
+			disk: defaultData.disk,
+		};
+
+		setCurrentData(nextData);
+
+		const MAX_DATA_POINTS = 300;
+		setAccumulativeData((prevData) => ({
+			cpu: [...prevData.cpu, nextData.cpu].slice(-MAX_DATA_POINTS),
+			memory: [...prevData.memory, nextData.memory].slice(-MAX_DATA_POINTS),
+			block: [...prevData.block, nextData.block].slice(-MAX_DATA_POINTS),
+			network: [...prevData.network, nextData.network].slice(-MAX_DATA_POINTS),
+			disk: prevData.disk,
+		}));
+	}, [projectStats, isProjectView]);
+
+	useEffect(() => {
+		if (isProjectView) return;
 
 		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 		const wsUrl = `${protocol}//${window.location.host}/listen-docker-stats-monitoring?appName=${appName}&appType=${appType}`;
@@ -178,7 +247,7 @@ export const ContainerFreeMonitoring = ({
 			const value = JSON.parse(e.data);
 			if (!value) return;
 
-			const data = {
+			const nextData = {
 				cpu: value.data.cpu ?? currentData.cpu,
 				memory: value.data.memory ?? currentData.memory,
 				block: value.data.block ?? currentData.block,
@@ -186,36 +255,74 @@ export const ContainerFreeMonitoring = ({
 				network: value.data.network ?? currentData.network,
 			};
 
-			setCurrentData(data);
+			setCurrentData(nextData);
 
 			const MAX_DATA_POINTS = 300;
 			setAccumulativeData((prevData) => ({
-				cpu: [...prevData.cpu, data.cpu].slice(-MAX_DATA_POINTS),
-				memory: [...prevData.memory, data.memory].slice(-MAX_DATA_POINTS),
-				block: [...prevData.block, data.block].slice(-MAX_DATA_POINTS),
-				network: [...prevData.network, data.network].slice(-MAX_DATA_POINTS),
-				disk: [...prevData.disk, data.disk].slice(-MAX_DATA_POINTS),
+				cpu: [...prevData.cpu, nextData.cpu].slice(-MAX_DATA_POINTS),
+				memory: [...prevData.memory, nextData.memory].slice(-MAX_DATA_POINTS),
+				block: [...prevData.block, nextData.block].slice(-MAX_DATA_POINTS),
+				network: [...prevData.network, nextData.network].slice(
+					-MAX_DATA_POINTS,
+				),
+				disk: [...prevData.disk, nextData.disk].slice(-MAX_DATA_POINTS),
 			}));
 		};
 
 		ws.onclose = (e) => {
-			if (e.reason) {
-				toast.error(e.reason);
-			}
+			console.log(e.reason);
 		};
 
 		return () => ws.close();
-	}, [appName]);
+	}, [appName, appType, isProjectView]);
+
+	const memoryUsedLabel = String(currentData.memory.value.used ?? "0");
+	const memoryTotalLabel = String(currentData.memory.value.total ?? "0");
+	const memoryProgress =
+		(convertMemoryToBytes(memoryUsedLabel) /
+			(convertMemoryToBytes(memoryTotalLabel) || 1)) *
+		100;
 
 	return (
 		<div className="rounded-xl bg-background flex flex-col gap-4">
-			<header className="flex items-center justify-between">
+			<header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
 				<div className="space-y-1">
 					<h1 className="text-2xl font-semibold tracking-tight">Monitoring</h1>
 					<p className="text-sm text-muted-foreground">
-						Watch the usage of your server in the current app
+						{isProjectView
+							? `Resource usage for ${selectedProjectName || "selected project"}`
+							: "Watch the usage of your server in the current app"}
 					</p>
 				</div>
+				{isServerView && (
+					<div className="w-full sm:w-[260px]">
+						<Select
+							value={selectedProjectId}
+							onValueChange={setSelectedProjectId}
+						>
+							<SelectTrigger>
+								<div className="flex items-center gap-2 truncate">
+									<FolderKanban className="size-4 shrink-0 text-muted-foreground" />
+									<SelectValue placeholder="Filter by project" />
+								</div>
+							</SelectTrigger>
+							<SelectContent>
+								<SelectGroup>
+									<SelectLabel>Scope</SelectLabel>
+									<SelectItem value={ALL_SERVER}>All Server</SelectItem>
+									{projects?.map((project) => (
+										<SelectItem
+											key={project.projectId}
+											value={project.projectId}
+										>
+											{project.name}
+										</SelectItem>
+									))}
+								</SelectGroup>
+							</SelectContent>
+						</Select>
+					</div>
+				)}
 			</header>
 
 			<div className="grid gap-6 lg:grid-cols-2">
@@ -229,9 +336,11 @@ export const ContainerFreeMonitoring = ({
 								Used: {String(currentData.cpu.value ?? "0%")}
 							</span>
 							<Progress
-								value={Number.parseInt(
-									String(currentData.cpu.value ?? "0%").replace("%", ""),
-									10,
+								value={Math.min(
+									Number.parseFloat(
+										String(currentData.cpu.value ?? "0%").replace("%", ""),
+									) || 0,
+									100,
 								)}
 								className="w-full"
 							/>
@@ -246,30 +355,19 @@ export const ContainerFreeMonitoring = ({
 					<CardContent>
 						<div className="flex flex-col gap-2 w-full">
 							<span className="text-sm text-muted-foreground">
-								{`Used:  ${currentData.memory.value.used} / Limit: ${currentData.memory.value.total} `}
+								{`Used:  ${memoryUsedLabel} / Limit: ${memoryTotalLabel} `}
 							</span>
-							<Progress
-								value={
-									// @ts-ignore
-									(convertMemoryToBytes(currentData.memory.value.used) /
-										// @ts-ignore
-										convertMemoryToBytes(currentData.memory.value.total)) *
-									100
-								}
-								className="w-full"
-							/>
+							<Progress value={memoryProgress} className="w-full" />
 							<DockerMemoryChart
 								accumulativeData={accumulativeData.memory}
 								memoryLimitGB={
-									// @ts-ignore
-									convertMemoryToBytes(currentData.memory.value.total) /
-									1024 ** 3
+									convertMemoryToBytes(memoryTotalLabel) / 1024 ** 3
 								}
 							/>
 						</div>
 					</CardContent>
 				</Card>
-				{appName === "dokploy" && (
+				{!isProjectView && appName === "dokploy" && (
 					<Card className="bg-background">
 						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 							<CardTitle className="text-sm font-medium">Disk Space</CardTitle>
@@ -291,7 +389,7 @@ export const ContainerFreeMonitoring = ({
 						</CardContent>
 					</Card>
 				)}
-				{appName === "dokploy" && (
+				{!isProjectView && appName === "dokploy" && (
 					<Card className="bg-background">
 						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 							<CardTitle className="text-sm font-medium">
@@ -331,6 +429,64 @@ export const ContainerFreeMonitoring = ({
 					</CardContent>
 				</Card>
 			</div>
+
+			{isProjectView && (
+				<Card className="bg-background">
+					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+						<div className="space-y-1">
+							<CardTitle className="text-sm font-medium">
+								Services breakdown
+							</CardTitle>
+							<p className="text-xs text-muted-foreground">
+								Live CPU and memory usage by service in this project
+							</p>
+						</div>
+					</CardHeader>
+					<CardContent>
+						{!projectStats?.services?.length ? (
+							<p className="text-sm text-muted-foreground py-6 text-center">
+								No services found in this project.
+							</p>
+						) : (
+							<div className="rounded-md border">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Service</TableHead>
+											<TableHead>Type</TableHead>
+											<TableHead>Containers</TableHead>
+											<TableHead>CPU</TableHead>
+											<TableHead>Memory</TableHead>
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{projectStats.services.map((service) => (
+											<TableRow key={service.id}>
+												<TableCell className="font-medium">
+													{service.name}
+												</TableCell>
+												<TableCell>
+													<Badge variant="outline" className="capitalize">
+														{service.type}
+													</Badge>
+												</TableCell>
+												<TableCell>{service.containerCount}</TableCell>
+												<TableCell>{service.cpuPerc.toFixed(2)}%</TableCell>
+												<TableCell>
+													{service.memUsed}
+													{service.containerCount > 0
+														? ` / ${service.memLimit}`
+														: ""}
+												</TableCell>
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</div>
+						)}
+					</CardContent>
+				</Card>
+			)}
 		</div>
 	);
 };

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -677,11 +677,10 @@ export const projectRouter = createTRPCRouter({
 				ctx.user.role === "owner" || ctx.user.role === "admin";
 
 			if (!isPrivileged) {
-				const { accessedProjects, accessedServices } =
-					await findMemberByUserId(
-						ctx.user.id,
-						ctx.session.activeOrganizationId,
-					);
+				const { accessedProjects, accessedServices } = await findMemberByUserId(
+					ctx.user.id,
+					ctx.session.activeOrganizationId,
+				);
 
 				if (!accessedProjects.includes(input.projectId)) {
 					throw new TRPCError({

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -27,6 +27,7 @@ import {
 	findProjectById,
 	findRedisById,
 	findUserById,
+	getProjectResourceStats,
 	IS_CLOUD,
 	updateProjectById,
 } from "@dokploy/server";
@@ -653,6 +654,49 @@ export const projectRouter = createTRPCRouter({
 			status,
 		};
 	}),
+
+	resourceStats: withPermission("monitoring", "read")
+		.input(apiFindOneProject)
+		.query(async ({ input, ctx }) => {
+			if (IS_CLOUD) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "Functionality not available in cloud version",
+				});
+			}
+
+			const project = await findProjectById(input.projectId);
+			if (project.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "UNAUTHORIZED",
+					message: "You don't have access to this project",
+				});
+			}
+
+			const isPrivileged =
+				ctx.user.role === "owner" || ctx.user.role === "admin";
+
+			if (!isPrivileged) {
+				const { accessedProjects, accessedServices } =
+					await findMemberByUserId(
+						ctx.user.id,
+						ctx.session.activeOrganizationId,
+					);
+
+				if (!accessedProjects.includes(input.projectId)) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You don't have access to this project",
+					});
+				}
+
+				return await getProjectResourceStats(input.projectId, {
+					accessedServices,
+				});
+			}
+
+			return await getProjectResourceStats(input.projectId);
+		}),
 
 	search: protectedProcedure
 		.input(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ export * from "./db/validations/domain";
 export * from "./db/validations/index";
 export * from "./lib/auth";
 export * from "./lib/logger";
+export * from "./monitoring/project-stats";
 export * from "./monitoring/utils";
 export * from "./services/admin";
 export * from "./services/application";

--- a/packages/server/src/monitoring/project-stats.ts
+++ b/packages/server/src/monitoring/project-stats.ts
@@ -17,6 +17,7 @@ export interface ProjectServiceRef {
 	name: string;
 	appName: string;
 	type: ProjectServiceType;
+	serverId: string | null;
 }
 
 export interface ProjectServiceStats extends ProjectServiceRef {
@@ -52,6 +53,10 @@ export interface ProjectResourceStats {
 	};
 	services: ProjectServiceStats[];
 }
+
+type ContainerWithServer = Container & {
+	serverId: string | null;
+};
 
 const UNIT_TO_BYTES: Record<string, number> = {
 	b: 1,
@@ -118,6 +123,15 @@ const parseMemUsage = (
 	};
 };
 
+const pushService = (
+	services: ProjectServiceRef[],
+	service: ProjectServiceRef,
+	allow: (id: string) => boolean,
+) => {
+	if (!allow(service.id)) return;
+	services.push(service);
+};
+
 export const collectProjectServices = (
 	project: Awaited<ReturnType<typeof findProjectById>>,
 	accessedServices?: string[],
@@ -129,105 +143,169 @@ export const collectProjectServices = (
 
 	for (const environment of project.environments) {
 		for (const item of environment.applications) {
-			if (!allow(item.applicationId)) continue;
-			services.push({
-				id: item.applicationId,
-				name: item.name,
-				appName: item.appName,
-				type: "application",
-			});
+			pushService(
+				services,
+				{
+					id: item.applicationId,
+					name: item.name,
+					appName: item.appName,
+					type: "application",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.compose) {
-			if (!allow(item.composeId)) continue;
-			services.push({
-				id: item.composeId,
-				name: item.name,
-				appName: item.appName,
-				type: "compose",
-			});
+			pushService(
+				services,
+				{
+					id: item.composeId,
+					name: item.name,
+					appName: item.appName,
+					type: "compose",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.mariadb) {
-			if (!allow(item.mariadbId)) continue;
-			services.push({
-				id: item.mariadbId,
-				name: item.name,
-				appName: item.appName,
-				type: "mariadb",
-			});
+			pushService(
+				services,
+				{
+					id: item.mariadbId,
+					name: item.name,
+					appName: item.appName,
+					type: "mariadb",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.postgres) {
-			if (!allow(item.postgresId)) continue;
-			services.push({
-				id: item.postgresId,
-				name: item.name,
-				appName: item.appName,
-				type: "postgres",
-			});
+			pushService(
+				services,
+				{
+					id: item.postgresId,
+					name: item.name,
+					appName: item.appName,
+					type: "postgres",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.mysql) {
-			if (!allow(item.mysqlId)) continue;
-			services.push({
-				id: item.mysqlId,
-				name: item.name,
-				appName: item.appName,
-				type: "mysql",
-			});
+			pushService(
+				services,
+				{
+					id: item.mysqlId,
+					name: item.name,
+					appName: item.appName,
+					type: "mysql",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.mongo) {
-			if (!allow(item.mongoId)) continue;
-			services.push({
-				id: item.mongoId,
-				name: item.name,
-				appName: item.appName,
-				type: "mongo",
-			});
+			pushService(
+				services,
+				{
+					id: item.mongoId,
+					name: item.name,
+					appName: item.appName,
+					type: "mongo",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.redis) {
-			if (!allow(item.redisId)) continue;
-			services.push({
-				id: item.redisId,
-				name: item.name,
-				appName: item.appName,
-				type: "redis",
-			});
+			pushService(
+				services,
+				{
+					id: item.redisId,
+					name: item.name,
+					appName: item.appName,
+					type: "redis",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 		for (const item of environment.libsql) {
-			if (!allow(item.libsqlId)) continue;
-			services.push({
-				id: item.libsqlId,
-				name: item.name,
-				appName: item.appName,
-				type: "libsql",
-			});
+			pushService(
+				services,
+				{
+					id: item.libsqlId,
+					name: item.name,
+					appName: item.appName,
+					type: "libsql",
+					serverId: item.serverId ?? null,
+				},
+				allow,
+			);
 		}
 	}
 
 	return services;
 };
 
-const containerMatchesService = (
+/**
+ * Score how specifically a container belongs to a service.
+ * Longer appName matches win so `myapp-api` is not attributed to `myapp`.
+ * Hyphen prefixes are intentionally excluded because Dokploy app names themselves
+ * commonly contain hyphens (`myapp-api`), which would create false ownership.
+ * Returns -1 when there is no valid ownership match.
+ */
+export const getContainerServiceMatchScore = (
 	containerName: string,
-	service: ProjectServiceRef,
-): boolean => {
+	appName: string,
+): number => {
 	const name = containerName.toLowerCase();
-	const appName = service.appName.toLowerCase();
-	if (!appName) return false;
+	const normalizedAppName = appName.toLowerCase();
+	if (!normalizedAppName || !name) return -1;
 
-	// Swarm service / task names and compose project prefixes include appName
-	return (
-		name === appName ||
-		name.startsWith(`${appName}.`) ||
-		name.startsWith(`${appName}_`) ||
-		name.startsWith(`${appName}-`) ||
-		name.includes(`/${appName}`) ||
-		name.includes(`_${appName}_`) ||
-		name.includes(`.${appName}.`)
-	);
+	if (name === normalizedAppName) {
+		return normalizedAppName.length * 1000;
+	}
+
+	// Swarm task names: appName.1.hash
+	if (name.startsWith(`${normalizedAppName}.`)) {
+		return normalizedAppName.length;
+	}
+
+	// Compose project containers: appName_service_1
+	if (name.startsWith(`${normalizedAppName}_`)) {
+		return normalizedAppName.length;
+	}
+
+	return -1;
+};
+
+export const findBestMatchingService = <T extends ProjectServiceRef>(
+	containerName: string,
+	services: T[],
+	serverId: string | null,
+): T | undefined => {
+	let best: T | undefined;
+	let bestScore = -1;
+
+	for (const service of services) {
+		if ((service.serverId ?? null) !== serverId) continue;
+		const score = getContainerServiceMatchScore(containerName, service.appName);
+		if (score > bestScore) {
+			bestScore = score;
+			best = service;
+		}
+	}
+
+	return best;
 };
 
 export const aggregateProjectContainerStats = (
 	services: ProjectServiceRef[],
-	containers: Container[],
+	containers: ContainerWithServer[],
 	now = new Date().toISOString(),
 ): Pick<ProjectResourceStats, "aggregated" | "services"> => {
 	const serviceStats: ProjectServiceStats[] = services.map((service) => ({
@@ -253,8 +331,10 @@ export const aggregateProjectContainerStats = (
 	let totalNetOut = 0;
 
 	for (const container of containers) {
-		const matched = serviceStats.find((service) =>
-			containerMatchesService(container.Name || "", service),
+		const matched = findBestMatchingService(
+			container.Name || "",
+			serviceStats,
+			container.serverId,
 		);
 		if (!matched) continue;
 
@@ -327,13 +407,34 @@ export const aggregateProjectContainerStats = (
 	};
 };
 
+const collectContainersForServers = async (
+	serverIds: Array<string | null>,
+): Promise<ContainerWithServer[]> => {
+	if (serverIds.length === 0) return [];
+
+	const batches = await Promise.all(
+		serverIds.map(async (serverId) => {
+			const stats = (await getAllContainerStats(
+				serverId ?? undefined,
+			)) as Container[];
+			return stats.map((stat) => ({
+				...stat,
+				serverId,
+			}));
+		}),
+	);
+
+	return batches.flat();
+};
+
 export const getProjectResourceStats = async (
 	projectId: string,
 	options?: { accessedServices?: string[] },
 ): Promise<ProjectResourceStats> => {
 	const project = await findProjectById(projectId);
 	const services = collectProjectServices(project, options?.accessedServices);
-	const containers = (await getAllContainerStats()) as Container[];
+	const serverIds = [...new Set(services.map((service) => service.serverId))];
+	const containers = await collectContainersForServers(serverIds);
 	const { aggregated, services: serviceStats } = aggregateProjectContainerStats(
 		services,
 		containers,

--- a/packages/server/src/monitoring/project-stats.ts
+++ b/packages/server/src/monitoring/project-stats.ts
@@ -1,0 +1,348 @@
+import { getAllContainerStats } from "../services/docker";
+import { findProjectById } from "../services/project";
+import type { Container } from "./utils";
+
+export type ProjectServiceType =
+	| "application"
+	| "compose"
+	| "mariadb"
+	| "postgres"
+	| "mysql"
+	| "mongo"
+	| "redis"
+	| "libsql";
+
+export interface ProjectServiceRef {
+	id: string;
+	name: string;
+	appName: string;
+	type: ProjectServiceType;
+}
+
+export interface ProjectServiceStats extends ProjectServiceRef {
+	cpuPerc: number;
+	memUsed: string;
+	memLimit: string;
+	memUsedBytes: number;
+	memLimitBytes: number;
+	containerCount: number;
+	blockReadMb: number;
+	blockWriteMb: number;
+	netInputMb: number;
+	netOutputMb: number;
+}
+
+export interface ProjectResourceStats {
+	projectId: string;
+	projectName: string;
+	aggregated: {
+		cpu: { value: string; time: string };
+		memory: {
+			value: { used: string; total: string };
+			time: string;
+		};
+		block: {
+			value: { readMb: number; writeMb: number };
+			time: string;
+		};
+		network: {
+			value: { inputMb: number; outputMb: number };
+			time: string;
+		};
+	};
+	services: ProjectServiceStats[];
+}
+
+const UNIT_TO_BYTES: Record<string, number> = {
+	b: 1,
+	kb: 1000,
+	mb: 1000 ** 2,
+	gb: 1000 ** 3,
+	tb: 1000 ** 4,
+	kib: 1024,
+	mib: 1024 ** 2,
+	gib: 1024 ** 3,
+	tib: 1024 ** 4,
+};
+
+export const parseDockerSizeToBytes = (value: string | undefined): number => {
+	if (!value || typeof value !== "string") return 0;
+	const trimmed = value.trim();
+	if (!trimmed || trimmed === "--") return 0;
+
+	const match = trimmed.match(/^([\d.]+)\s*([a-zA-Z]+)$/);
+	if (!match) {
+		const asNumber = Number.parseFloat(trimmed);
+		return Number.isFinite(asNumber) ? asNumber : 0;
+	}
+
+	const amount = Number.parseFloat(match[1] || "0");
+	const unit = (match[2] || "").toLowerCase();
+	const multiplier = UNIT_TO_BYTES[unit] ?? 1;
+	return Number.isFinite(amount) ? amount * multiplier : 0;
+};
+
+export const formatBytesAsDockerSize = (bytes: number): string => {
+	if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
+	if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(2)}GiB`;
+	if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(2)}MiB`;
+	if (bytes >= 1024) return `${(bytes / 1024).toFixed(2)}KiB`;
+	return `${Math.round(bytes)}B`;
+};
+
+const parseCpuPercent = (value: string | undefined): number => {
+	if (!value) return 0;
+	const parsed = Number.parseFloat(String(value).replace("%", ""));
+	return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const parseIoPairToMb = (
+	value: string | undefined,
+): { left: number; right: number } => {
+	if (!value) return { left: 0, right: 0 };
+	const [leftRaw, rightRaw] = value.split("/").map((part) => part.trim());
+	return {
+		left: parseDockerSizeToBytes(leftRaw) / (1000 * 1000),
+		right: parseDockerSizeToBytes(rightRaw) / (1000 * 1000),
+	};
+};
+
+const parseMemUsage = (
+	value: string | undefined,
+): { usedBytes: number; limitBytes: number } => {
+	if (!value) return { usedBytes: 0, limitBytes: 0 };
+	const [usedRaw, limitRaw] = value.split("/").map((part) => part.trim());
+	return {
+		usedBytes: parseDockerSizeToBytes(usedRaw),
+		limitBytes: parseDockerSizeToBytes(limitRaw),
+	};
+};
+
+export const collectProjectServices = (
+	project: Awaited<ReturnType<typeof findProjectById>>,
+	accessedServices?: string[],
+): ProjectServiceRef[] => {
+	const allow = (id: string) =>
+		!accessedServices || accessedServices.includes(id);
+
+	const services: ProjectServiceRef[] = [];
+
+	for (const environment of project.environments) {
+		for (const item of environment.applications) {
+			if (!allow(item.applicationId)) continue;
+			services.push({
+				id: item.applicationId,
+				name: item.name,
+				appName: item.appName,
+				type: "application",
+			});
+		}
+		for (const item of environment.compose) {
+			if (!allow(item.composeId)) continue;
+			services.push({
+				id: item.composeId,
+				name: item.name,
+				appName: item.appName,
+				type: "compose",
+			});
+		}
+		for (const item of environment.mariadb) {
+			if (!allow(item.mariadbId)) continue;
+			services.push({
+				id: item.mariadbId,
+				name: item.name,
+				appName: item.appName,
+				type: "mariadb",
+			});
+		}
+		for (const item of environment.postgres) {
+			if (!allow(item.postgresId)) continue;
+			services.push({
+				id: item.postgresId,
+				name: item.name,
+				appName: item.appName,
+				type: "postgres",
+			});
+		}
+		for (const item of environment.mysql) {
+			if (!allow(item.mysqlId)) continue;
+			services.push({
+				id: item.mysqlId,
+				name: item.name,
+				appName: item.appName,
+				type: "mysql",
+			});
+		}
+		for (const item of environment.mongo) {
+			if (!allow(item.mongoId)) continue;
+			services.push({
+				id: item.mongoId,
+				name: item.name,
+				appName: item.appName,
+				type: "mongo",
+			});
+		}
+		for (const item of environment.redis) {
+			if (!allow(item.redisId)) continue;
+			services.push({
+				id: item.redisId,
+				name: item.name,
+				appName: item.appName,
+				type: "redis",
+			});
+		}
+		for (const item of environment.libsql) {
+			if (!allow(item.libsqlId)) continue;
+			services.push({
+				id: item.libsqlId,
+				name: item.name,
+				appName: item.appName,
+				type: "libsql",
+			});
+		}
+	}
+
+	return services;
+};
+
+const containerMatchesService = (
+	containerName: string,
+	service: ProjectServiceRef,
+): boolean => {
+	const name = containerName.toLowerCase();
+	const appName = service.appName.toLowerCase();
+	if (!appName) return false;
+
+	// Swarm service / task names and compose project prefixes include appName
+	return (
+		name === appName ||
+		name.startsWith(`${appName}.`) ||
+		name.startsWith(`${appName}_`) ||
+		name.startsWith(`${appName}-`) ||
+		name.includes(`/${appName}`) ||
+		name.includes(`_${appName}_`) ||
+		name.includes(`.${appName}.`)
+	);
+};
+
+export const aggregateProjectContainerStats = (
+	services: ProjectServiceRef[],
+	containers: Container[],
+	now = new Date().toISOString(),
+): Pick<ProjectResourceStats, "aggregated" | "services"> => {
+	const serviceStats: ProjectServiceStats[] = services.map((service) => ({
+		...service,
+		cpuPerc: 0,
+		memUsed: "0B",
+		memLimit: "0B",
+		memUsedBytes: 0,
+		memLimitBytes: 0,
+		containerCount: 0,
+		blockReadMb: 0,
+		blockWriteMb: 0,
+		netInputMb: 0,
+		netOutputMb: 0,
+	}));
+
+	let totalCpu = 0;
+	let totalMemUsed = 0;
+	let maxMemLimit = 0;
+	let totalBlockRead = 0;
+	let totalBlockWrite = 0;
+	let totalNetIn = 0;
+	let totalNetOut = 0;
+
+	for (const container of containers) {
+		const matched = serviceStats.find((service) =>
+			containerMatchesService(container.Name || "", service),
+		);
+		if (!matched) continue;
+
+		const cpu = parseCpuPercent(container.CPUPerc);
+		const memory = parseMemUsage(container.MemUsage);
+		const block = parseIoPairToMb(container.BlockIO);
+		const network = parseIoPairToMb(container.NetIO);
+
+		matched.cpuPerc += cpu;
+		matched.memUsedBytes += memory.usedBytes;
+		matched.memLimitBytes = Math.max(matched.memLimitBytes, memory.limitBytes);
+		matched.containerCount += 1;
+		matched.blockReadMb += block.left;
+		matched.blockWriteMb += block.right;
+		matched.netInputMb += network.left;
+		matched.netOutputMb += network.right;
+
+		totalCpu += cpu;
+		totalMemUsed += memory.usedBytes;
+		maxMemLimit = Math.max(maxMemLimit, memory.limitBytes);
+		totalBlockRead += block.left;
+		totalBlockWrite += block.right;
+		totalNetIn += network.left;
+		totalNetOut += network.right;
+	}
+
+	for (const service of serviceStats) {
+		service.memUsed = formatBytesAsDockerSize(service.memUsedBytes);
+		service.memLimit = formatBytesAsDockerSize(service.memLimitBytes);
+		service.cpuPerc = Number(service.cpuPerc.toFixed(2));
+		service.blockReadMb = Number(service.blockReadMb.toFixed(2));
+		service.blockWriteMb = Number(service.blockWriteMb.toFixed(2));
+		service.netInputMb = Number(service.netInputMb.toFixed(2));
+		service.netOutputMb = Number(service.netOutputMb.toFixed(2));
+	}
+
+	serviceStats.sort(
+		(a, b) => b.cpuPerc - a.cpuPerc || b.memUsedBytes - a.memUsedBytes,
+	);
+
+	return {
+		aggregated: {
+			cpu: {
+				value: `${totalCpu.toFixed(2)}%`,
+				time: now,
+			},
+			memory: {
+				value: {
+					used: formatBytesAsDockerSize(totalMemUsed),
+					total: formatBytesAsDockerSize(maxMemLimit),
+				},
+				time: now,
+			},
+			block: {
+				value: {
+					readMb: Number(totalBlockRead.toFixed(2)),
+					writeMb: Number(totalBlockWrite.toFixed(2)),
+				},
+				time: now,
+			},
+			network: {
+				value: {
+					inputMb: Number(totalNetIn.toFixed(2)),
+					outputMb: Number(totalNetOut.toFixed(2)),
+				},
+				time: now,
+			},
+		},
+		services: serviceStats,
+	};
+};
+
+export const getProjectResourceStats = async (
+	projectId: string,
+	options?: { accessedServices?: string[] },
+): Promise<ProjectResourceStats> => {
+	const project = await findProjectById(projectId);
+	const services = collectProjectServices(project, options?.accessedServices);
+	const containers = (await getAllContainerStats()) as Container[];
+	const { aggregated, services: serviceStats } = aggregateProjectContainerStats(
+		services,
+		containers,
+	);
+
+	return {
+		projectId: project.projectId,
+		projectName: project.name,
+		aggregated,
+		services: serviceStats,
+	};
+};


### PR DESCRIPTION
## Summary
- Adds a project filter dropdown on the free Monitoring page (default: **All Server**)
- When a project is selected, shows live aggregated CPU / memory / block / network usage for that project's running containers
- Includes a per-service breakdown table; host-only Disk / Docker Disk cards are hidden in project view
- New `project.resourceStats` tRPC endpoint (`monitoring:read`) with org/member access checks

## Test plan
- [ ] Open `/dashboard/monitoring` and confirm All Server view still shows host CPU/memory/disk charts
- [ ] Use the project dropdown and select a project with running services
- [ ] Confirm aggregated metrics update and services breakdown lists services with container counts
- [ ] Confirm Disk Space / Docker Disk Usage cards are hidden in project view
- [ ] Select an empty project and confirm zeroed metrics / empty or zero-container services
- [ ] Confirm unauthenticated/unauthorized access to `project.resourceStats` is rejected
- [ ] Confirm services breakdown does not show a loading spinner while polling

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds project-scoped monitoring to the free dashboard, including aggregated live metrics and a per-service breakdown.
- Adds a project selector and switches between host and project monitoring views.
- Adds an authorized `project.resourceStats` endpoint.
- Collects container statistics per local or remote server and attributes them to project services.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (3): Last reviewed commit: ["fix: tighten project monitoring containe..."](https://github.com/dokploy/dokploy/commit/ec7f958b44f614deca400fbfceb05cb0ac06bc9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51090041)</sub>

**Context used:**

- Knowledge Base — [Monitoring and Live Terminal/Log Streaming](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/monitoring-and-terminal.md)

<!-- /greptile_comment -->