### PR TITLE
fix: pin Traefik routing to the isolated network on isolated deployments

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -220,6 +220,17 @@ export const addDomainToCompose = async (
 						labels.unshift("traefik.swarm.network=dokploy-network");
 					}
 				}
+			} else {
+				const isolatedNetwork = compose.suffix || compose.appName;
+				if (compose.composeType === "docker-compose") {
+					if (!labels.includes(`traefik.docker.network=${isolatedNetwork}`)) {
+						labels.unshift(`traefik.docker.network=${isolatedNetwork}`);
+					}
+				} else {
+					if (!labels.includes(`traefik.swarm.network=${isolatedNetwork}`)) {
+						labels.unshift(`traefik.swarm.network=${isolatedNetwork}`);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

When **Isolated Deployment** is enabled, Dokploy intentionally skips the `traefik.docker.network` label on domain-linked services. If the container is attached to more than one network (e.g. the isolated network plus an internal network declared in the compose file), Traefik picks the backend IP **arbitrarily** among the container's networks, and re-picks on every provider config rebuild (any docker event on the host).

When it picks the internal network — where Traefik is not connected — the domain becomes unreachable until the next re-roll. This exactly matches the reported behavior: one successful request after redeploy, then dead, and seemingly random interference between deployments (any deploy/restart on the host triggers a re-pick for every ambiguous service).

Verified live: with two services sharing an `internal` network and isolation enabled, Traefik's `/api/http/services` flipped between the isolated network IP (working) and the internal network IP (dead) across consecutive config rebuilds.

## Fix

Emit the network hint label in isolated mode too, pointing at the isolated network (`suffix || appName`) — the same network `dokploy-traefik` is connected to during deploy:

- `traefik.docker.network=<isolated network>` for `docker-compose`
- `traefik.swarm.network=<isolated network>` for `stack`

After the fix, the selected backend IP stays pinned to the isolated network across rebuilds (verified over repeated provider refreshes, all requests 200).

Closes #4899
Closes #4040 (author confirmed it was an isolated deployment; manually adding the network label fixed it)

Related (same multi-network ambiguity class, not closed by this PR): #3945, #3313

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins Traefik routing for isolated Compose deployments to the deployment's isolated network.

- Adds `traefik.docker.network` for Docker Compose services.
- Adds `traefik.swarm.network` for Docker Swarm stacks.
- Derives the isolated network hint from the configured suffix or application name.

<h3>Confidence Score: 4/5</h3>

The mapping-form label path must be handled before merging because it bypasses the new isolated-network pin and leaves affected domains intermittently unreachable.

The new pinning logic only runs for array-form labels, while the supported mapping form skips all generated labels and therefore retains ambiguous Traefik network selection.

**Files Needing Attention:** packages/server/src/utils/docker/domain.ts

<sub>Reviews (1): Last reviewed commit: ["fix: pin traefik routing to the isolated..."](https://github.com/dokploy/dokploy/commit/a8c35f750113581fe8a604bb488fca6bb07bfcfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51090393)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Traefik Networking](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/traefik-networking.md)

<!-- /greptile_comment -->