### PR TITLE
fix: warn on postgres image change when the implied data directory mismatches the mounted volume

### DIFF
--- a/apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx
+++ b/apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx
@@ -109,16 +109,21 @@ export const ShowCustomCommand = ({ id, type }: Props) => {
 
 	const mountPathWarning = (() => {
 		if (type !== "postgres" || !dockerImage) return null;
-		const mounts = (data as any)?.mounts ?? [];
-		const dataMount = mounts.find(
-			(mount: { type: string; mountPath: string }) =>
+		const mounts = data && "mounts" in data ? data.mounts : [];
+		const dataMounts = mounts.filter(
+			(mount) =>
 				mount.type === "volume" &&
 				POSTGRES_DATA_PATH_REGEX.test(mount.mountPath),
 		);
-		if (!dataMount) return null;
+		if (dataMounts.length === 0) return null;
 		const expectedPath = getPostgresMountPath(dockerImage);
-		if (expectedPath === dataMount.mountPath) return null;
-		return { expectedPath, currentPath: dataMount.mountPath };
+		if (dataMounts.some((mount) => mount.mountPath === expectedPath)) {
+			return null;
+		}
+		return {
+			expectedPath,
+			currentPath: dataMounts.map((mount) => mount.mountPath).join(", "),
+		};
 	})();
 
 	const onSubmit = async (formData: AddDockerImage) => {

--- a/apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx
+++ b/apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -17,6 +18,19 @@ import {
 import { Input } from "@/components/ui/input";
 import { api } from "@/utils/api";
 import type { ServiceType } from "../../application/advanced/show-resources";
+
+const getPostgresMountPath = (dockerImage: string): string => {
+	const versionMatch = dockerImage.match(/postgres:(\d+)/);
+	if (versionMatch?.[1]) {
+		const version = Number.parseInt(versionMatch[1], 10);
+		if (version >= 18) {
+			return `/var/lib/postgresql/${version}/docker`;
+		}
+	}
+	return "/var/lib/postgresql/data";
+};
+
+const POSTGRES_DATA_PATH_REGEX = /^\/var\/lib\/postgresql(\/|$)/;
 
 const addDockerImage = z.object({
 	dockerImage: z.string().min(1, "Docker image is required"),
@@ -91,6 +105,22 @@ export const ShowCustomCommand = ({ id, type }: Props) => {
 		}
 	}, [data, form]);
 
+	const dockerImage = form.watch("dockerImage");
+
+	const mountPathWarning = (() => {
+		if (type !== "postgres" || !dockerImage) return null;
+		const mounts = (data as any)?.mounts ?? [];
+		const dataMount = mounts.find(
+			(mount: { type: string; mountPath: string }) =>
+				mount.type === "volume" &&
+				POSTGRES_DATA_PATH_REGEX.test(mount.mountPath),
+		);
+		if (!dataMount) return null;
+		const expectedPath = getPostgresMountPath(dockerImage);
+		if (expectedPath === dataMount.mountPath) return null;
+		return { expectedPath, currentPath: dataMount.mountPath };
+	})();
+
 	const onSubmit = async (formData: AddDockerImage) => {
 		await mutateAsync({
 			mongoId: id || "",
@@ -139,6 +169,18 @@ export const ShowCustomCommand = ({ id, type }: Props) => {
 											</FormItem>
 										)}
 									/>
+									{mountPathWarning && (
+										<AlertBlock type="warning">
+											This image expects its data directory under{" "}
+											<code>{mountPathWarning.expectedPath}</code>, but the
+											volume of this database is mounted at{" "}
+											<code>{mountPathWarning.currentPath}</code>. Changing the
+											image does not migrate existing data — Postgres may
+											crash-loop or start with an empty database. Adjust the
+											volume mount path in the Volumes section or keep a
+											compatible image before saving.
+										</AlertBlock>
+									)}
 								</div>
 								<FormField
 									control={form.control}


### PR DESCRIPTION
## Problem

The Postgres data-directory mount path is derived from the docker image **once at creation** (`getMountPath`) and persisted as a mount. Changing the image later never reconciles it, so a service can silently become internally inconsistent:

- `postgres:18` → switch to `ghcr.io/railwayapp-templates/postgres-ssl:18`: the volume stays at `/var/lib/postgresql/18/docker` but the image enforces `/var/lib/postgresql/data` → crash loop before Postgres starts.
- `postgres:16` → switch to `postgres:18`: the volume stays at `/var/lib/postgresql/data` but PG18's PGDATA is `/var/lib/postgresql/18/docker`, outside the mounted volume → starts with an empty cluster (looks like data loss).

Creation-time selection is fine (#3048); the gap is image changes on existing services.

## Change

In the database Advanced settings, when editing the Docker Image of a **postgres** service, compare the data path implied by the typed image against the service's persisted volume mount (only mounts under `/var/lib/postgresql`). On mismatch, show a warning explaining that changing the image does not migrate data and pointing to the Volumes section, before the user saves.

No behavior change for compatible images, other database types, or custom mount layouts outside `/var/lib/postgresql`.

Closes #4717

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an Advanced-settings warning when a Postgres image’s implied data directory differs from persisted volume paths.
- Derives the expected Postgres data path from the entered image and major version.
- Compares that path with Postgres-subtree volume mounts.
- Displays guidance before saving an incompatible image change.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because an unrelated matching volume can still suppress the data-directory mismatch warning.

The warning gathers every volume beneath `/var/lib/postgresql` and suppresses itself if any one matches the image-implied path, so it does not resolve the previously reported ambiguity about which mount contains the existing database.

**Files Needing Attention:** apps/dokploy/components/dashboard/postgres/advanced/show-custom-command.tsx

<sub>Reviews (2): Last reviewed commit: ["fix: improve mount path warning for Post..."](https://github.com/dokploy/dokploy/commit/c0694eb5b2e32280c2b4709a800b273042941c0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51094897)</sub>

**Context used:**

- Knowledge Base — [Managed Databases](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/managed-databases.md)

<!-- /greptile_comment -->