### PR TITLE
feat: turn home into a comprehensive org dashboard

### DIFF
--- a/apps/dokploy/__test__/dashboard/home-logic.test.ts
+++ b/apps/dokploy/__test__/dashboard/home-logic.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getDeploymentWindowBounds } from "../../../../packages/server/src/services/deployment-window";
+import { getScopedServerServiceCount } from "../../components/dashboard/home/home-logic";
+
+describe("home dashboard service scoping", () => {
+	it("does not fall back to an unscoped server total", () => {
+		expect(getScopedServerServiceCount("server-a", { "server-a": 3 })).toBe(3);
+		expect(getScopedServerServiceCount("server-a", {})).toBe(0);
+		expect(getScopedServerServiceCount("server-b", { "server-a": 3 })).toBe(0);
+	});
+});
+
+describe("home dashboard deployment windows", () => {
+	it("uses a half-open previous window at the seven-day boundary", () => {
+		const nowMs = Date.UTC(2026, 7, 11, 12);
+		const { last7dStart, prev7dStart } = getDeploymentWindowBounds(nowMs);
+
+		expect(last7dStart.getTime()).toBe(nowMs - 7 * 24 * 60 * 60 * 1000);
+		expect(prev7dStart.getTime()).toBe(nowMs - 14 * 24 * 60 * 60 * 1000);
+
+		const isInWindow = (
+			createdAtMs: number,
+			sinceMs: number,
+			untilMs?: number,
+		) =>
+			createdAtMs >= sinceMs &&
+			(untilMs === undefined || createdAtMs < untilMs);
+
+		expect(isInWindow(last7dStart.getTime(), last7dStart.getTime())).toBe(true);
+		expect(
+			isInWindow(
+				last7dStart.getTime(),
+				prev7dStart.getTime(),
+				last7dStart.getTime(),
+			),
+		).toBe(false);
+		expect(
+			isInWindow(
+				prev7dStart.getTime(),
+				prev7dStart.getTime(),
+				last7dStart.getTime(),
+			),
+		).toBe(true);
+	});
+});

--- a/apps/dokploy/components/dashboard/home/home-logic.ts
+++ b/apps/dokploy/components/dashboard/home/home-logic.ts
@@ -1,0 +1,6 @@
+export function getScopedServerServiceCount(
+	serverId: string,
+	servicesByServerId: Readonly<Record<string, number>>,
+) {
+	return servicesByServerId[serverId] ?? 0;
+}

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -280,12 +280,25 @@ function deployDelta(last7d: number, prev7d: number) {
 }
 
 export const ShowHome = () => {
-	const { data: auth, isLoading: authLoading } = api.user.get.useQuery();
-	const { data: homeStats, isLoading: statsLoading } =
-		api.project.homeStats.useQuery();
-	const { data: permissions, isLoading: permissionsLoading } =
-		api.user.getPermissions.useQuery();
 	const { data: isCloud } = api.settings.isCloud.useQuery();
+	const { data: activeOrganization, isLoading: orgLoading } =
+		api.organization.active.useQuery();
+	const hasOrg = !!activeOrganization;
+
+	const { data: auth, isLoading: authLoading } = api.user.get.useQuery(
+		undefined,
+		{
+			enabled: hasOrg,
+		},
+	);
+	const { data: homeStats, isLoading: statsLoading } =
+		api.project.homeStats.useQuery(undefined, {
+			enabled: hasOrg,
+		});
+	const { data: permissions, isLoading: permissionsLoading } =
+		api.user.getPermissions.useQuery(undefined, {
+			enabled: hasOrg,
+		});
 
 	const canReadDeployments = !!permissions?.deployment.read;
 	const canReadServers = !!permissions?.server.read;
@@ -295,32 +308,34 @@ export const ShowHome = () => {
 
 	const { data: deploySummary, isLoading: deployLoading } =
 		api.deployment.homeSummary.useQuery(undefined, {
-			enabled: canReadDeployments,
+			enabled: hasOrg && canReadDeployments,
 			refetchInterval: 10000,
 		});
 
 	const { data: servers, isLoading: serversLoading } = api.server.all.useQuery(
 		undefined,
 		{
-			enabled: canReadServers,
+			enabled: hasOrg && canReadServers,
 		},
 	);
 
 	const { data: queue, isLoading: queueLoading } =
 		api.deployment.queueList.useQuery(undefined, {
-			enabled: canReadDeployments,
+			enabled: hasOrg && canReadDeployments,
 			refetchInterval: 10000,
 		});
 
 	const { data: dokployVersion } = api.settings.getDokployVersion.useQuery();
 	const { data: infraHealth, isLoading: healthLoading } =
 		api.settings.checkInfrastructureHealth.useQuery(undefined, {
-			enabled: !!isAdmin && isCloud === false,
+			enabled: hasOrg && !!isAdmin && isCloud === false,
 			retry: false,
 		});
 
 	const firstName = auth?.user?.firstName?.trim();
-	const loadingStats = statsLoading || authLoading || permissionsLoading;
+	const loadingStats =
+		orgLoading ||
+		(hasOrg && (statsLoading || authLoading || permissionsLoading));
 
 	const totals = homeStats ?? {
 		projects: 0,
@@ -361,6 +376,24 @@ export const ShowHome = () => {
 		erroredServices.length + (canReadDeployments ? failedDeploys.length : 0);
 	const showAttention = !loadingStats && attentionCount > 0;
 	const showServerSummary = !isCloud || canReadServers;
+
+	if (!orgLoading && !hasOrg) {
+		return (
+			<div className="w-full">
+				<Card className="h-full bg-sidebar p-2.5 rounded-xl min-h-[85vh]">
+					<div className="rounded-xl bg-background shadow-md p-6 flex flex-col items-center justify-center gap-3 min-h-[70vh] text-center">
+						<Server className="size-8 text-muted-foreground opacity-40" />
+						<h1 className="text-xl font-semibold tracking-tight">
+							No organization selected
+						</h1>
+						<p className="text-sm text-muted-foreground max-w-md">
+							Select or create an organization to view your dashboard overview.
+						</p>
+					</div>
+				</Card>
+			</div>
+		);
+	}
 
 	return (
 		<div className="w-full">

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -1,39 +1,81 @@
+import type { inferRouterOutputs } from "@trpc/server";
 import { formatDistanceToNow } from "date-fns";
-import { ArrowRight, Rocket, Server } from "lucide-react";
+import {
+	Activity,
+	AlertTriangle,
+	ArrowRight,
+	Boxes,
+	CheckCircle2,
+	Folder,
+	HardDrive,
+	Loader2,
+	type LucideIcon,
+	Monitor,
+	Rocket,
+	Server,
+	XCircle,
+} from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { AppRouter } from "@/server/api/root";
 import { api } from "@/utils/api";
 
-type DeploymentStatus = "idle" | "running" | "done" | "error";
+type HomeStats = inferRouterOutputs<AppRouter>["project"]["homeStats"];
+type HomeSummary = inferRouterOutputs<AppRouter>["deployment"]["homeSummary"];
+type DeploymentRow = HomeSummary["recent"][number];
+type ErroredService = HomeStats["erroredServices"][number];
 
-const statusDotClass: Record<string, string> = {
-	done: "bg-emerald-500",
-	running: "bg-amber-500",
-	error: "bg-red-500",
-	idle: "bg-muted-foreground/40",
+const statusVariants: Record<
+	string,
+	| "default"
+	| "secondary"
+	| "destructive"
+	| "outline"
+	| "yellow"
+	| "green"
+	| "red"
+> = {
+	running: "yellow",
+	done: "green",
+	error: "red",
+	cancelled: "outline",
+	idle: "secondary",
 };
 
-function getServiceInfo(d: any) {
+const serviceTypePath: Record<ErroredService["type"], string> = {
+	application: "application",
+	compose: "compose",
+	libsql: "libsql",
+	mariadb: "mariadb",
+	mongo: "mongo",
+	mysql: "mysql",
+	postgres: "postgres",
+	redis: "redis",
+};
+
+function getServiceInfo(d: DeploymentRow) {
 	const app = d.application;
 	const comp = d.compose;
 	const serverName: string =
 		d.server?.name ?? app?.server?.name ?? comp?.server?.name ?? "Dokploy";
 	if (app?.environment?.project && app.environment) {
 		return {
-			name: app.name as string,
-			environment: app.environment.name as string,
-			projectName: app.environment.project.name as string,
+			name: app.name,
+			environment: app.environment.name,
+			projectName: app.environment.project.name,
 			serverName,
 			href: `/dashboard/project/${app.environment.project.projectId}/environment/${app.environment.environmentId}/services/application/${app.applicationId}`,
 		};
 	}
 	if (comp?.environment?.project && comp.environment) {
 		return {
-			name: comp.name as string,
-			environment: comp.environment.name as string,
-			projectName: comp.environment.project.name as string,
+			name: comp.name,
+			environment: comp.environment.name,
+			projectName: comp.environment.project.name,
 			serverName,
 			href: `/dashboard/project/${comp.environment.project.projectId}/environment/${comp.environment.environmentId}/services/compose/${comp.composeId}`,
 		};
@@ -41,14 +83,20 @@ function getServiceInfo(d: any) {
 	return null;
 }
 
+function erroredServiceHref(service: ErroredService) {
+	return `/dashboard/project/${service.projectId}/environment/${service.environmentId}/services/${serviceTypePath[service.type]}/${service.id}`;
+}
+
 function StatCard({
 	label,
 	value,
 	delta,
+	loading,
 }: {
 	label: string;
 	value: string;
 	delta?: string;
+	loading?: boolean;
 }) {
 	return (
 		<div className="rounded-xl border bg-background p-5 min-h-[140px] flex flex-col justify-between">
@@ -56,9 +104,17 @@ function StatCard({
 				{label}
 			</span>
 			<div className="flex flex-col gap-1">
-				<span className="text-3xl font-semibold tracking-tight">{value}</span>
-				{delta && (
-					<span className="text-xs text-muted-foreground">{delta}</span>
+				{loading ? (
+					<Skeleton className="h-9 w-16" />
+				) : (
+					<span className="text-3xl font-semibold tracking-tight">{value}</span>
+				)}
+				{loading ? (
+					<Skeleton className="h-3 w-28" />
+				) : (
+					delta && (
+						<span className="text-xs text-muted-foreground">{delta}</span>
+					)
 				)}
 			</div>
 		</div>
@@ -68,45 +124,203 @@ function StatCard({
 function StatusListCard({
 	label,
 	items,
+	loading,
 }: {
 	label: string;
 	items: { dotClass: string; label: string; count: number }[];
+	loading?: boolean;
 }) {
 	return (
 		<div className="rounded-xl border bg-background p-5 min-h-[140px] flex flex-col gap-3">
 			<span className="text-xs uppercase tracking-wider text-muted-foreground">
 				{label}
 			</span>
-			<ul className="flex flex-col gap-1.5">
-				{items.map((item) => (
-					<li key={item.label} className="flex items-center gap-2.5 text-sm">
-						<span
-							className={`size-2 rounded-full shrink-0 ${item.dotClass}`}
-							aria-hidden
-						/>
-						<span className="font-semibold tabular-nums w-8">{item.count}</span>
-						<span className="text-muted-foreground">{item.label}</span>
-					</li>
-				))}
-			</ul>
+			{loading ? (
+				<div className="flex flex-col gap-2">
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-3/4" />
+				</div>
+			) : (
+				<ul className="flex flex-col gap-1.5">
+					{items.map((item) => (
+						<li key={item.label} className="flex items-center gap-2.5 text-sm">
+							<span
+								className={`size-2 rounded-full shrink-0 ${item.dotClass}`}
+								aria-hidden
+							/>
+							<span className="font-semibold tabular-nums w-8">
+								{item.count}
+							</span>
+							<span className="text-muted-foreground">{item.label}</span>
+						</li>
+					))}
+				</ul>
+			)}
 		</div>
 	);
 }
 
+function SectionHeader({
+	icon: Icon,
+	title,
+	href,
+	linkLabel = "view all →",
+}: {
+	icon: LucideIcon;
+	title: string;
+	href?: string;
+	linkLabel?: string;
+}) {
+	return (
+		<div className="flex items-center justify-between px-5 py-4 border-b">
+			<div className="flex items-center gap-2">
+				<Icon className="size-4 text-muted-foreground" />
+				<h2 className="text-sm font-semibold">{title}</h2>
+			</div>
+			{href && (
+				<Link
+					href={href}
+					className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+				>
+					{linkLabel}
+				</Link>
+			)}
+		</div>
+	);
+}
+
+function EmptyBlock({
+	icon: Icon,
+	message,
+	compact,
+}: {
+	icon: LucideIcon;
+	message: string;
+	compact?: boolean;
+}) {
+	return (
+		<div
+			className={`flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground p-10 ${compact ? "min-h-[160px]" : "min-h-[280px]"}`}
+		>
+			<Icon className="size-8 opacity-40" />
+			<span>{message}</span>
+		</div>
+	);
+}
+
+function DeploymentList({
+	items,
+	emptyMessage,
+}: {
+	items: DeploymentRow[];
+	emptyMessage: string;
+}) {
+	const rows = items
+		.map((d) => ({ d, info: getServiceInfo(d) }))
+		.filter(
+			(
+				row,
+			): row is {
+				d: DeploymentRow;
+				info: NonNullable<ReturnType<typeof getServiceInfo>>;
+			} => !!row.info,
+		);
+
+	if (rows.length === 0) {
+		return <EmptyBlock icon={Rocket} message={emptyMessage} compact />;
+	}
+
+	return (
+		<ul className="divide-y">
+			{rows.map(({ d, info }) => {
+				const status = d.status ?? "idle";
+				return (
+					<li key={d.deploymentId}>
+						<Link
+							href={info.href}
+							className="flex items-center gap-4 px-5 py-3.5 hover:bg-muted/40 transition-colors"
+						>
+							<div className="flex flex-col min-w-0 flex-1">
+								<span className="text-sm truncate">{info.name}</span>
+								<span className="text-xs text-muted-foreground truncate">
+									{info.projectName} · {info.environment}
+								</span>
+							</div>
+							<span className="text-xs text-muted-foreground w-32 hidden lg:flex items-center justify-end gap-1.5 truncate">
+								<Server className="size-3 shrink-0" />
+								<span className="truncate">{info.serverName}</span>
+							</span>
+							<Badge
+								variant={statusVariants[status] ?? "secondary"}
+								className="capitalize shrink-0"
+							>
+								{status}
+							</Badge>
+							<span className="text-xs text-muted-foreground w-24 text-right hidden md:inline shrink-0">
+								{formatDistanceToNow(new Date(d.createdAt), {
+									addSuffix: true,
+								})}
+							</span>
+						</Link>
+					</li>
+				);
+			})}
+		</ul>
+	);
+}
+
+function deployDelta(last7d: number, prev7d: number) {
+	if (prev7d > 0) {
+		const pct = Math.round(((last7d - prev7d) / prev7d) * 100);
+		return `${pct >= 0 ? "+" : ""}${pct}% vs prev 7d`;
+	}
+	if (last7d > 0) return "no prior data";
+	return "no activity yet";
+}
+
 export const ShowHome = () => {
-	const { data: auth } = api.user.get.useQuery();
-	const { data: homeStats } = api.project.homeStats.useQuery();
-	const { data: permissions } = api.user.getPermissions.useQuery();
+	const { data: auth, isLoading: authLoading } = api.user.get.useQuery();
+	const { data: homeStats, isLoading: statsLoading } =
+		api.project.homeStats.useQuery();
+	const { data: permissions, isLoading: permissionsLoading } =
+		api.user.getPermissions.useQuery();
+	const { data: isCloud } = api.settings.isCloud.useQuery();
+
 	const canReadDeployments = !!permissions?.deployment.read;
-	const { data: deployments } = api.deployment.allCentralized.useQuery(
-		undefined,
-		{
+	const canReadServers = !!permissions?.server.read;
+	const canReadDocker = !!permissions?.docker.read;
+	const canReadMonitoring = !!permissions?.monitoring.read;
+	const isAdmin = auth?.role === "owner" || auth?.role === "admin";
+
+	const { data: deploySummary, isLoading: deployLoading } =
+		api.deployment.homeSummary.useQuery(undefined, {
 			enabled: canReadDeployments,
 			refetchInterval: 10000,
+		});
+
+	const { data: servers, isLoading: serversLoading } = api.server.all.useQuery(
+		undefined,
+		{
+			enabled: canReadServers,
 		},
 	);
 
+	const { data: queue, isLoading: queueLoading } =
+		api.deployment.queueList.useQuery(undefined, {
+			enabled: canReadDeployments,
+			refetchInterval: 10000,
+		});
+
+	const { data: dokployVersion } = api.settings.getDokployVersion.useQuery();
+	const { data: infraHealth, isLoading: healthLoading } =
+		api.settings.checkInfrastructureHealth.useQuery(undefined, {
+			enabled: !!isAdmin && isCloud === false,
+			retry: false,
+		});
+
 	const firstName = auth?.user?.firstName?.trim();
+	const loadingStats = statsLoading || authLoading || permissionsLoading;
 
 	const totals = homeStats ?? {
 		projects: 0,
@@ -122,59 +336,61 @@ export const ShowHome = () => {
 		idle: 0,
 	};
 
-	const recentDeployments = useMemo(() => {
-		if (!deployments) return [];
-		return [...deployments]
-			.sort(
-				(a, b) =>
-					new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-			)
-			.slice(0, 10);
-	}, [deployments]);
+	const deployStats = deploySummary?.stats;
+	const failedDeploys = deploySummary?.failed ?? [];
+	const recentDeployments = deploySummary?.recent ?? [];
+	const erroredServices = homeStats?.erroredServices ?? [];
+	const recentProjects = homeStats?.recentProjects ?? [];
+	const dokployHostServices = homeStats?.dokployHostServices ?? 0;
+	const servicesByServerId = homeStats?.servicesByServerId ?? {};
 
-	const deployStats = useMemo(() => {
-		const now = Date.now();
-		const weekMs = 7 * 24 * 60 * 60 * 1000;
-		const lastStart = now - weekMs;
-		const prevStart = now - 2 * weekMs;
-
-		const last: NonNullable<typeof deployments> = [];
-		const prev: NonNullable<typeof deployments> = [];
-		for (const d of deployments ?? []) {
-			const t = new Date(d.createdAt).getTime();
-			if (t >= lastStart) last.push(d);
-			else if (t >= prevStart) prev.push(d);
+	const serverSummary = useMemo(() => {
+		if (!servers) return { total: 0, active: 0, inactive: 0, services: 0 };
+		let active = 0;
+		let inactive = 0;
+		let services = 0;
+		for (const s of servers) {
+			if (s.serverStatus === "inactive") inactive++;
+			else active++;
+			services += servicesByServerId[s.serverId] ?? s.totalSum ?? 0;
 		}
+		return { total: servers.length, active, inactive, services };
+	}, [servers, servicesByServerId]);
 
-		const lastCount = last.length;
-		const prevCount = prev.length;
-		let delta: string | undefined;
-		if (prevCount > 0) {
-			const pct = Math.round(((lastCount - prevCount) / prevCount) * 100);
-			delta = `${pct >= 0 ? "+" : ""}${pct}% vs prev 7d`;
-		} else if (lastCount > 0) {
-			delta = "no prior data";
-		} else {
-			delta = "no activity yet";
-		}
-
-		return { value: String(lastCount), delta };
-	}, [deployments]);
+	const attentionCount =
+		erroredServices.length + (canReadDeployments ? failedDeploys.length : 0);
+	const showAttention = !loadingStats && attentionCount > 0;
+	const showServerSummary = !isCloud || canReadServers;
 
 	return (
 		<div className="w-full">
 			<Card className="h-full bg-sidebar p-2.5 rounded-xl min-h-[85vh]">
 				<div className="rounded-xl bg-background shadow-md p-6 flex flex-col gap-6 h-full">
-					<div className="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
-						<h1 className="text-3xl font-semibold tracking-tight">
-							{firstName ? `Welcome back, ${firstName}` : "Welcome back"}
-						</h1>
-						<Button asChild variant="secondary" className="w-fit">
-							<Link href="/dashboard/projects">
-								Go to projects
-								<ArrowRight className="size-4" />
-							</Link>
-						</Button>
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+						<div className="flex flex-col gap-1">
+							<h1 className="text-3xl font-semibold tracking-tight">
+								{firstName ? `Welcome back, ${firstName}` : "Welcome back"}
+							</h1>
+							<p className="text-sm text-muted-foreground">
+								Overview of your projects, services, and deployments
+							</p>
+						</div>
+						<div className="flex flex-wrap gap-2">
+							{canReadDeployments && (
+								<Button asChild variant="outline" className="w-fit">
+									<Link href="/dashboard/deployments">
+										Deployments
+										<Rocket className="size-4" />
+									</Link>
+								</Button>
+							)}
+							<Button asChild variant="secondary" className="w-fit">
+								<Link href="/dashboard/projects">
+									Go to projects
+									<ArrowRight className="size-4" />
+								</Link>
+							</Button>
+						</div>
 					</div>
 
 					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -182,19 +398,32 @@ export const ShowHome = () => {
 							label="Projects"
 							value={String(totals.projects)}
 							delta={`${totals.environments} ${totals.environments === 1 ? "environment" : "environments"}`}
+							loading={loadingStats}
 						/>
 						<StatCard
 							label="Services"
 							value={String(totals.services)}
 							delta={`${totals.applications} apps · ${totals.compose} compose · ${totals.databases} db`}
+							loading={loadingStats}
 						/>
 						<StatCard
 							label="Deploys / 7d"
-							value={deployStats.value}
-							delta={deployStats.delta}
+							value={
+								canReadDeployments ? String(deployStats?.last7d ?? 0) : "—"
+							}
+							delta={
+								canReadDeployments
+									? deployDelta(
+											deployStats?.last7d ?? 0,
+											deployStats?.prev7d ?? 0,
+										)
+									: "no deployment access"
+							}
+							loading={loadingStats || (canReadDeployments && deployLoading)}
 						/>
 						<StatusListCard
 							label="Status"
+							loading={loadingStats}
 							items={[
 								{
 									dotClass: "bg-emerald-500",
@@ -215,75 +444,452 @@ export const ShowHome = () => {
 						/>
 					</div>
 
-					<div className="rounded-xl border bg-background">
-						<div className="flex items-center justify-between px-5 py-4 border-b">
-							<div className="flex items-center gap-2">
-								<Rocket className="size-4 text-muted-foreground" />
-								<h2 className="text-sm font-semibold">Recent deployments</h2>
+					{showAttention && (
+						<div className="rounded-xl border border-destructive/20 bg-destructive/5">
+							<div className="flex items-center gap-2 px-5 py-4 border-b border-destructive/15">
+								<AlertTriangle className="size-4 text-destructive" />
+								<h2 className="text-sm font-semibold">Needs attention</h2>
+								{canReadDeployments && (deployStats?.failed7d ?? 0) > 0 && (
+									<Badge variant="red" className="ml-1">
+										{deployStats?.failed7d} failed / 7d
+									</Badge>
+								)}
 							</div>
-							{canReadDeployments && (
-								<Link
-									href="/dashboard/overview?tab=deployments"
-									className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-								>
-									view all →
-								</Link>
+							<div className="grid grid-cols-1 lg:grid-cols-2 divide-y lg:divide-y-0 lg:divide-x divide-destructive/15">
+								{erroredServices.length > 0 && (
+									<div
+										className={
+											failedDeploys.length === 0 ? "lg:col-span-2" : ""
+										}
+									>
+										<div className="px-5 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+											Errored services
+										</div>
+										<ul className="divide-y divide-destructive/10">
+											{erroredServices.map((service) => (
+												<li key={`${service.type}-${service.id}`}>
+													<Link
+														href={erroredServiceHref(service)}
+														className="flex items-center gap-3 px-5 py-3 hover:bg-destructive/10 transition-colors"
+													>
+														<Badge
+															variant="red"
+															className="capitalize shrink-0"
+														>
+															{service.type}
+														</Badge>
+														<div className="flex flex-col min-w-0 flex-1">
+															<span className="text-sm truncate">
+																{service.name}
+															</span>
+															<span className="text-xs text-muted-foreground truncate">
+																{service.projectName} ·{" "}
+																{service.environmentName}
+															</span>
+														</div>
+														<ArrowRight className="size-3.5 text-muted-foreground shrink-0" />
+													</Link>
+												</li>
+											))}
+										</ul>
+									</div>
+								)}
+								{canReadDeployments && failedDeploys.length > 0 && (
+									<div
+										className={
+											erroredServices.length === 0 ? "lg:col-span-2" : ""
+										}
+									>
+										<div className="px-5 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+											Failed deployments
+										</div>
+										<DeploymentList
+											items={failedDeploys}
+											emptyMessage="No failed deployments."
+										/>
+									</div>
+								)}
+							</div>
+						</div>
+					)}
+
+					{showServerSummary && (
+						<div className="rounded-xl border bg-background">
+							<SectionHeader
+								icon={HardDrive}
+								title="Server summary"
+								href={
+									canReadServers
+										? "/dashboard/settings/servers"
+										: !isCloud
+											? "/dashboard/settings/server"
+											: undefined
+								}
+								linkLabel={canReadServers ? "manage servers →" : "web server →"}
+							/>
+							{(statsLoading || (canReadServers && serversLoading)) && (
+								<div className="flex items-center justify-center gap-2 min-h-[140px] text-sm text-muted-foreground">
+									<Loader2 className="size-4 animate-spin" />
+									Loading servers…
+								</div>
+							)}
+							{!statsLoading && !(canReadServers && serversLoading) && (
+								<div className="flex flex-col gap-4 p-4">
+									<div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+										<div className="rounded-lg border p-3 flex flex-col gap-1">
+											<span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+												Hosts
+											</span>
+											<span className="text-2xl font-semibold tabular-nums">
+												{(isCloud ? 0 : 1) + serverSummary.total}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{isCloud
+													? "remote only"
+													: `${serverSummary.total} remote`}
+											</span>
+										</div>
+										<div className="rounded-lg border p-3 flex flex-col gap-1">
+											<span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+												On Dokploy
+											</span>
+											<span className="text-2xl font-semibold tabular-nums">
+												{isCloud ? "—" : dokployHostServices}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{isCloud ? "cloud host" : "local services"}
+											</span>
+										</div>
+										<div className="rounded-lg border p-3 flex flex-col gap-1">
+											<span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+												On remotes
+											</span>
+											<span className="text-2xl font-semibold tabular-nums">
+												{serverSummary.services}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{serverSummary.active} active
+												{serverSummary.inactive > 0
+													? ` · ${serverSummary.inactive} inactive`
+													: ""}
+											</span>
+										</div>
+										<div className="rounded-lg border p-3 flex flex-col gap-1">
+											<span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+												Version
+											</span>
+											<span className="text-2xl font-semibold tabular-nums truncate">
+												{dokployVersion ?? "—"}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												Dokploy
+											</span>
+										</div>
+									</div>
+
+									{!isCloud && isAdmin && (
+										<div className="flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2.5">
+											<span className="text-xs font-medium text-muted-foreground mr-1">
+												Infrastructure
+											</span>
+											{healthLoading ? (
+												<span className="text-xs text-muted-foreground flex items-center gap-1.5">
+													<Loader2 className="size-3 animate-spin" />
+													Checking…
+												</span>
+											) : infraHealth ? (
+												(
+													[
+														["Postgres", infraHealth.postgres],
+														["Redis", infraHealth.redis],
+														["Traefik", infraHealth.traefik],
+													] as const
+												).map(([name, service]) => (
+													<span
+														key={name}
+														className="inline-flex items-center gap-1.5 text-xs"
+													>
+														{service.status === "healthy" ? (
+															<CheckCircle2 className="size-3.5 text-emerald-500" />
+														) : (
+															<XCircle className="size-3.5 text-destructive" />
+														)}
+														{name}
+													</span>
+												))
+											) : (
+												<span className="text-xs text-muted-foreground">
+													Unavailable
+												</span>
+											)}
+										</div>
+									)}
+
+									<ul className="divide-y rounded-lg border">
+										{!isCloud && (
+											<li>
+												<Link
+													href={
+														canReadMonitoring
+															? "/dashboard/monitoring"
+															: "/dashboard/settings/server"
+													}
+													className="flex items-center gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+												>
+													<span className="flex size-8 items-center justify-center rounded-md bg-muted shrink-0">
+														<Server className="size-4 text-muted-foreground" />
+													</span>
+													<div className="flex flex-col min-w-0 flex-1">
+														<span className="text-sm font-medium truncate">
+															Dokploy host
+														</span>
+														<span className="text-xs text-muted-foreground truncate">
+															Local web server
+														</span>
+													</div>
+													<span className="text-xs text-muted-foreground tabular-nums hidden sm:inline">
+														{dokployHostServices}{" "}
+														{dokployHostServices === 1 ? "service" : "services"}
+													</span>
+													<Badge variant="green" className="shrink-0">
+														local
+													</Badge>
+													<ArrowRight className="size-3.5 text-muted-foreground shrink-0" />
+												</Link>
+											</li>
+										)}
+										{canReadServers &&
+											servers?.map((server) => {
+												const serviceCount =
+													servicesByServerId[server.serverId] ??
+													server.totalSum ??
+													0;
+												const inactive = server.serverStatus === "inactive";
+												return (
+													<li key={server.serverId}>
+														<Link
+															href="/dashboard/settings/servers"
+															className="flex items-center gap-3 px-4 py-3 hover:bg-muted/40 transition-colors"
+														>
+															<span className="flex size-8 items-center justify-center rounded-md bg-muted shrink-0">
+																<Server className="size-4 text-muted-foreground" />
+															</span>
+															<div className="flex flex-col min-w-0 flex-1">
+																<span className="text-sm font-medium truncate">
+																	{server.name}
+																</span>
+																<span className="text-xs text-muted-foreground truncate">
+																	{server.ipAddress || "Remote server"}
+																	{server.serverType === "build"
+																		? " · build"
+																		: ""}
+																</span>
+															</div>
+															<span className="text-xs text-muted-foreground tabular-nums hidden sm:inline">
+																{serviceCount}{" "}
+																{serviceCount === 1 ? "service" : "services"}
+															</span>
+															<Badge
+																variant={inactive ? "red" : "green"}
+																className="capitalize shrink-0"
+															>
+																{server.serverStatus ?? "active"}
+															</Badge>
+															<ArrowRight className="size-3.5 text-muted-foreground shrink-0" />
+														</Link>
+													</li>
+												);
+											})}
+										{canReadServers && serverSummary.total === 0 && (
+											<li className="px-4 py-3 text-sm text-muted-foreground">
+												No remote servers yet.{" "}
+												<Link
+													href="/dashboard/settings/servers"
+													className="text-foreground underline-offset-4 hover:underline"
+												>
+													Add a server
+												</Link>{" "}
+												to deploy remotely.
+											</li>
+										)}
+									</ul>
+								</div>
 							)}
 						</div>
-						{!canReadDeployments ? (
-							<div className="min-h-[400px] flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground p-10">
-								<Rocket className="size-8 opacity-40" />
-								<span>You do not have permission to view deployments.</span>
+					)}
+
+					<div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+						<div className="rounded-xl border bg-background xl:col-span-2">
+							<SectionHeader
+								icon={Rocket}
+								title="Recent deployments"
+								href={canReadDeployments ? "/dashboard/deployments" : undefined}
+							/>
+							{canReadDeployments && (deployStats?.running ?? 0) > 0 && (
+								<div className="px-5 py-2 border-b bg-muted/30">
+									<Badge variant="yellow">
+										{deployStats?.running} currently deploying
+									</Badge>
+								</div>
+							)}
+							{permissionsLoading || (canReadDeployments && deployLoading) ? (
+								<div className="flex items-center justify-center gap-2 min-h-[280px] text-sm text-muted-foreground">
+									<Loader2 className="size-4 animate-spin" />
+									Loading deployments…
+								</div>
+							) : !canReadDeployments ? (
+								<EmptyBlock
+									icon={Rocket}
+									message="You do not have permission to view deployments."
+								/>
+							) : (
+								<DeploymentList
+									items={recentDeployments}
+									emptyMessage="No deployments yet."
+								/>
+							)}
+						</div>
+
+						<div className="flex flex-col gap-4">
+							{canReadDeployments && (
+								<div className="rounded-xl border bg-background">
+									<SectionHeader
+										icon={Activity}
+										title="Deploy queue"
+										href="/dashboard/deployments"
+										linkLabel="open queue →"
+									/>
+									{queueLoading ? (
+										<div className="flex items-center justify-center gap-2 min-h-[120px] text-sm text-muted-foreground">
+											<Loader2 className="size-4 animate-spin" />
+										</div>
+									) : (
+										<div className="px-5 py-5 flex flex-col gap-2">
+											<span className="text-3xl font-semibold tracking-tight tabular-nums">
+												{queue?.length ?? 0}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{(queue?.length ?? 0) === 1
+													? "job in queue"
+													: "jobs in queue"}
+											</span>
+										</div>
+									)}
+								</div>
+							)}
+
+							{!isCloud && canReadMonitoring && (
+								<div className="rounded-xl border bg-background flex-1">
+									<SectionHeader
+										icon={Monitor}
+										title="Monitoring"
+										href="/dashboard/monitoring"
+										linkLabel="open →"
+									/>
+									<div className="px-5 py-4 flex flex-col gap-3">
+										<p className="text-sm text-muted-foreground">
+											Host and container CPU, memory, and disk metrics.
+										</p>
+										<div className="flex flex-wrap gap-2">
+											<Badge variant="blank">
+												{dokployHostServices} on host
+											</Badge>
+											{serverSummary.total > 0 && (
+												<Badge variant="blank">
+													{serverSummary.total} remotes
+												</Badge>
+											)}
+										</div>
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+
+					<div className="rounded-xl border bg-background">
+						<SectionHeader
+							icon={Folder}
+							title="Recent projects"
+							href="/dashboard/projects"
+						/>
+						{statsLoading ? (
+							<div className="flex items-center justify-center gap-2 min-h-[160px] text-sm text-muted-foreground">
+								<Loader2 className="size-4 animate-spin" />
+								Loading projects…
 							</div>
-						) : recentDeployments.length === 0 ? (
-							<div className="min-h-[400px] flex flex-col items-center justify-center gap-3 text-center text-sm text-muted-foreground p-10">
-								<Rocket className="size-8 opacity-40" />
-								<span>No deployments yet.</span>
-							</div>
+						) : recentProjects.length === 0 ? (
+							<EmptyBlock
+								icon={Folder}
+								message="No projects yet. Create one to get started."
+								compact
+							/>
 						) : (
-							<ul className="divide-y">
-								{recentDeployments.map((d) => {
-									const info = getServiceInfo(d);
-									if (!info) return null;
-									const status = (d.status ?? "idle") as DeploymentStatus;
+							<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+								{recentProjects.map((project) => {
+									const href = project.defaultEnvironmentId
+										? `/dashboard/project/${project.projectId}/environment/${project.defaultEnvironmentId}`
+										: `/dashboard/project/${project.projectId}`;
 									return (
-										<li key={d.deploymentId}>
-											<Link
-												href={info.href}
-												className="flex items-center gap-4 px-5 py-4 hover:bg-muted/40 transition-colors"
-											>
-												<span
-													className={`size-2 rounded-full shrink-0 ${statusDotClass[status] ?? statusDotClass.idle}`}
-													aria-hidden
-												/>
-												<div className="flex flex-col min-w-0 flex-1">
-													<span className="text-sm truncate">{info.name}</span>
-													<span className="text-xs text-muted-foreground truncate">
-														{info.projectName} · {info.environment}
-													</span>
-												</div>
-												<span className="text-xs text-muted-foreground w-36 hidden lg:flex items-center justify-end gap-1.5 truncate">
-													<Server className="size-3 shrink-0" />
-													<span className="truncate">{info.serverName}</span>
+										<Link
+											key={project.projectId}
+											href={href}
+											className="rounded-xl border p-4 hover:bg-muted/40 transition-colors flex flex-col gap-3 min-h-[120px]"
+										>
+											<div className="flex items-start justify-between gap-2">
+												<span className="text-sm font-medium truncate">
+													{project.name}
 												</span>
-												<span className="text-xs text-muted-foreground w-20 text-right hidden sm:inline">
-													{status}
+												<Boxes className="size-4 text-muted-foreground shrink-0" />
+											</div>
+											{project.description && (
+												<p className="text-xs text-muted-foreground line-clamp-2">
+													{project.description}
+												</p>
+											)}
+											<div className="mt-auto flex items-center justify-between text-xs text-muted-foreground">
+												<span>
+													{project.services}{" "}
+													{project.services === 1 ? "service" : "services"}
 												</span>
-												<span className="text-xs text-muted-foreground w-24 text-right hidden md:inline">
-													{formatDistanceToNow(new Date(d.createdAt), {
+												<span>
+													{formatDistanceToNow(new Date(project.createdAt), {
 														addSuffix: true,
 													})}
 												</span>
-												<span className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-													logs →
-												</span>
-											</Link>
-										</li>
+											</div>
+										</Link>
 									);
 								})}
-							</ul>
+							</div>
 						)}
 					</div>
+
+					{(canReadDocker ||
+						canReadServers ||
+						(!isCloud && canReadMonitoring)) && (
+						<div className="flex flex-wrap gap-2">
+							{!isCloud && canReadMonitoring && (
+								<Button asChild variant="outline" size="sm">
+									<Link href="/dashboard/monitoring">Monitoring</Link>
+								</Button>
+							)}
+							{canReadServers && (
+								<Button asChild variant="outline" size="sm">
+									<Link href="/dashboard/settings/servers">Servers</Link>
+								</Button>
+							)}
+							{canReadDocker && (
+								<Button asChild variant="outline" size="sm">
+									<Link href="/dashboard/docker">Docker</Link>
+								</Button>
+							)}
+							{canReadDeployments && (
+								<Button asChild variant="outline" size="sm">
+									<Link href="/dashboard/deployments">All deployments</Link>
+								</Button>
+							)}
+						</div>
+					)}
 				</div>
 			</Card>
 		</div>

--- a/apps/dokploy/components/dashboard/home/show-home.tsx
+++ b/apps/dokploy/components/dashboard/home/show-home.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
+import { getScopedServerServiceCount } from "@/components/dashboard/home/home-logic";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -367,7 +368,7 @@ export const ShowHome = () => {
 		for (const s of servers) {
 			if (s.serverStatus === "inactive") inactive++;
 			else active++;
-			services += servicesByServerId[s.serverId] ?? s.totalSum ?? 0;
+			services += getScopedServerServiceCount(s.serverId, servicesByServerId);
 		}
 		return { total: servers.length, active, inactive, services };
 	}, [servers, servicesByServerId]);
@@ -634,7 +635,6 @@ export const ShowHome = () => {
 												(
 													[
 														["Postgres", infraHealth.postgres],
-														["Redis", infraHealth.redis],
 														["Traefik", infraHealth.traefik],
 													] as const
 												).map(([name, service]) => (
@@ -693,10 +693,10 @@ export const ShowHome = () => {
 										)}
 										{canReadServers &&
 											servers?.map((server) => {
-												const serviceCount =
-													servicesByServerId[server.serverId] ??
-													server.totalSum ??
-													0;
+												const serviceCount = getScopedServerServiceCount(
+													server.serverId,
+													servicesByServerId,
+												);
 												const inactive = server.serverStatus === "inactive";
 												return (
 													<li key={server.serverId}>

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -80,7 +80,7 @@ export const UserNav = () => {
 					<DropdownMenuItem
 						className="cursor-pointer"
 						onClick={() => {
-							router.push("/dashboard/home");
+							router.push("/dashboard/projects");
 						}}
 					>
 						Projects

--- a/apps/dokploy/pages/dashboard/home.tsx
+++ b/apps/dokploy/pages/dashboard/home.tsx
@@ -1,4 +1,5 @@
 import { validateRequest } from "@dokploy/server/lib/auth";
+import { hasPermission } from "@dokploy/server/services/permission";
 import { createServerSideHelpers } from "@trpc/react-query/server";
 import type { GetServerSidePropsContext } from "next";
 import type { ReactElement } from "react";
@@ -42,8 +43,26 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 		transformer: superjson,
 	});
 
-	await helpers.settings.isCloud.prefetch();
-	await helpers.user.get.prefetch();
+	const permissionCtx = {
+		user: { id: user.id },
+		session: { activeOrganizationId: session?.activeOrganizationId || "" },
+	};
+
+	const [canReadDeployments, canReadServers] = await Promise.all([
+		hasPermission(permissionCtx, { deployment: ["read"] }),
+		hasPermission(permissionCtx, { server: ["read"] }),
+	]);
+
+	await Promise.all([
+		helpers.settings.isCloud.prefetch(),
+		helpers.user.get.prefetch(),
+		helpers.user.getPermissions.prefetch(),
+		helpers.project.homeStats.prefetch(),
+		canReadDeployments
+			? helpers.deployment.homeSummary.prefetch()
+			: Promise.resolve(),
+		canReadServers ? helpers.server.all.prefetch() : Promise.resolve(),
+	]);
 
 	return {
 		props: {

--- a/apps/dokploy/pages/dashboard/home.tsx
+++ b/apps/dokploy/pages/dashboard/home.tsx
@@ -48,6 +48,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 	const prefetchTasks: Promise<unknown>[] = [
 		helpers.settings.isCloud.prefetch(),
 		helpers.user.get.prefetch(),
+		helpers.organization.active.prefetch(),
 	];
 
 	// Org-scoped queries require an active membership; skipping them avoids

--- a/apps/dokploy/pages/dashboard/home.tsx
+++ b/apps/dokploy/pages/dashboard/home.tsx
@@ -43,26 +43,40 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 		transformer: superjson,
 	});
 
-	const permissionCtx = {
-		user: { id: user.id },
-		session: { activeOrganizationId: session?.activeOrganizationId || "" },
-	};
+	const activeOrganizationId = session?.activeOrganizationId;
 
-	const [canReadDeployments, canReadServers] = await Promise.all([
-		hasPermission(permissionCtx, { deployment: ["read"] }),
-		hasPermission(permissionCtx, { server: ["read"] }),
-	]);
-
-	await Promise.all([
+	const prefetchTasks: Promise<unknown>[] = [
 		helpers.settings.isCloud.prefetch(),
 		helpers.user.get.prefetch(),
-		helpers.user.getPermissions.prefetch(),
-		helpers.project.homeStats.prefetch(),
-		canReadDeployments
-			? helpers.deployment.homeSummary.prefetch()
-			: Promise.resolve(),
-		canReadServers ? helpers.server.all.prefetch() : Promise.resolve(),
-	]);
+	];
+
+	// Org-scoped queries require an active membership; skipping them avoids
+	// UNAUTHORIZED during SSR when the user has no organization selected.
+	if (activeOrganizationId) {
+		const permissionCtx = {
+			user: { id: user.id },
+			session: { activeOrganizationId },
+		};
+
+		const [canReadDeployments, canReadServers] = await Promise.all([
+			hasPermission(permissionCtx, { deployment: ["read"] }),
+			hasPermission(permissionCtx, { server: ["read"] }),
+		]);
+
+		prefetchTasks.push(
+			helpers.user.getPermissions.prefetch(),
+			helpers.project.homeStats.prefetch(),
+		);
+
+		if (canReadDeployments) {
+			prefetchTasks.push(helpers.deployment.homeSummary.prefetch());
+		}
+		if (canReadServers) {
+			prefetchTasks.push(helpers.server.all.prefetch());
+		}
+	}
+
+	await Promise.all(prefetchTasks);
 
 	return {
 		props: {

--- a/apps/dokploy/server/api/routers/deployment.ts
+++ b/apps/dokploy/server/api/routers/deployment.ts
@@ -1,4 +1,5 @@
 import {
+	countDeploymentsCentralized,
 	execAsync,
 	execAsyncRemote,
 	findAllDeploymentsByApplicationId,
@@ -64,8 +65,16 @@ export const deploymentRouter = createTRPCRouter({
 			}
 			return await findAllDeploymentsByServerId(input.serverId);
 		}),
-	allCentralized: withPermission("deployment", "read").query(
-		async ({ ctx }) => {
+	allCentralized: withPermission("deployment", "read")
+		.input(
+			z
+				.object({
+					limit: z.number().min(1).max(500).optional(),
+					status: z.enum(["running", "done", "error", "cancelled"]).optional(),
+				})
+				.optional(),
+		)
+		.query(async ({ ctx, input }) => {
 			const orgId = ctx.session.activeOrganizationId;
 			const accessedServices =
 				ctx.user.role !== "owner" && ctx.user.role !== "admin"
@@ -74,9 +83,59 @@ export const deploymentRouter = createTRPCRouter({
 			if (accessedServices !== null && accessedServices.length === 0) {
 				return [];
 			}
-			return findAllDeploymentsCentralized(orgId, accessedServices);
-		},
-	),
+			return findAllDeploymentsCentralized(orgId, accessedServices, {
+				limit: input?.limit,
+				status: input?.status,
+			});
+		}),
+
+	homeSummary: withPermission("deployment", "read").query(async ({ ctx }) => {
+		const orgId = ctx.session.activeOrganizationId;
+		const accessedServices =
+			ctx.user.role !== "owner" && ctx.user.role !== "admin"
+				? (await findMemberByUserId(ctx.user.id, orgId)).accessedServices
+				: null;
+
+		const now = Date.now();
+		const weekMs = 7 * 24 * 60 * 60 * 1000;
+		const last7dStart = new Date(now - weekMs);
+		const prev7dStart = new Date(now - 2 * weekMs);
+
+		const [recent, failed, last7d, prev7d, failed7d, runningCount] =
+			await Promise.all([
+				findAllDeploymentsCentralized(orgId, accessedServices, { limit: 10 }),
+				findAllDeploymentsCentralized(orgId, accessedServices, {
+					limit: 5,
+					status: "error",
+					since: last7dStart,
+				}),
+				countDeploymentsCentralized(orgId, accessedServices, {
+					since: last7dStart,
+				}),
+				countDeploymentsCentralized(orgId, accessedServices, {
+					since: prev7dStart,
+					until: last7dStart,
+				}),
+				countDeploymentsCentralized(orgId, accessedServices, {
+					status: "error",
+					since: last7dStart,
+				}),
+				countDeploymentsCentralized(orgId, accessedServices, {
+					status: "running",
+				}),
+			]);
+
+		return {
+			recent,
+			failed,
+			stats: {
+				last7d,
+				prev7d,
+				failed7d,
+				running: runningCount,
+			},
+		};
+	}),
 
 	queueList: withPermission("deployment", "read").query(async ({ ctx }) => {
 		const orgId = ctx.session.activeOrganizationId;

--- a/apps/dokploy/server/api/routers/deployment.ts
+++ b/apps/dokploy/server/api/routers/deployment.ts
@@ -8,6 +8,7 @@ import {
 	findAllDeploymentsCentralized,
 	findDeploymentById,
 	findScheduleById,
+	getDeploymentWindowBounds,
 	IS_CLOUD,
 	removeDeployment,
 	resolveServicePath,
@@ -96,10 +97,7 @@ export const deploymentRouter = createTRPCRouter({
 				? (await findMemberByUserId(ctx.user.id, orgId)).accessedServices
 				: null;
 
-		const now = Date.now();
-		const weekMs = 7 * 24 * 60 * 60 * 1000;
-		const last7dStart = new Date(now - weekMs);
-		const prev7dStart = new Date(now - 2 * weekMs);
+		const { last7dStart, prev7dStart } = getDeploymentWindowBounds(Date.now());
 
 		const [recent, failed, last7d, prev7d, failed7d, runningCount] =
 			await Promise.all([

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -519,6 +519,44 @@ export const projectRouter = createTRPCRouter({
 		let accessedEnvironments: string[] = [];
 		let accessedServices: string[] = [];
 
+		const empty = {
+			projects: 0,
+			environments: 0,
+			applications: 0,
+			compose: 0,
+			databases: 0,
+			services: 0,
+			status: { running: 0, error: 0, idle: 0 },
+			dokployHostServices: 0,
+			servicesByServerId: {} as Record<string, number>,
+			recentProjects: [] as {
+				projectId: string;
+				name: string;
+				description: string | null;
+				createdAt: string;
+				environments: number;
+				services: number;
+				defaultEnvironmentId: string | null;
+			}[],
+			erroredServices: [] as {
+				id: string;
+				name: string;
+				type:
+					| "application"
+					| "compose"
+					| "libsql"
+					| "mariadb"
+					| "mongo"
+					| "mysql"
+					| "postgres"
+					| "redis";
+				projectId: string;
+				projectName: string;
+				environmentId: string;
+				environmentName: string;
+			}[],
+		};
+
 		if (!isPrivileged) {
 			const member = await findMemberByUserId(
 				ctx.user.id,
@@ -529,15 +567,7 @@ export const projectRouter = createTRPCRouter({
 			accessedServices = member.accessedServices;
 
 			if (accessedProjects.length === 0) {
-				return {
-					projects: 0,
-					environments: 0,
-					applications: 0,
-					compose: 0,
-					databases: 0,
-					services: 0,
-					status: { running: 0, error: 0, idle: 0 },
-				};
+				return empty;
 			}
 		}
 
@@ -565,43 +595,89 @@ export const projectRouter = createTRPCRouter({
 
 		const rows = await db.query.projects.findMany({
 			where: projectIdFilter,
-			columns: { projectId: true },
+			orderBy: desc(projects.createdAt),
+			columns: {
+				projectId: true,
+				name: true,
+				description: true,
+				createdAt: true,
+			},
 			with: {
 				environments: {
 					where: environmentFilter,
-					columns: { environmentId: true },
+					columns: { environmentId: true, name: true },
 					with: {
 						applications: {
 							where: applyFilter(applications.applicationId),
-							columns: { applicationStatus: true },
+							columns: {
+								applicationId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 						compose: {
 							where: applyFilter(compose.composeId),
-							columns: { composeStatus: true },
+							columns: {
+								composeId: true,
+								name: true,
+								composeStatus: true,
+								serverId: true,
+							},
 						},
 						libsql: {
 							where: applyFilter(libsql.libsqlId),
-							columns: { applicationStatus: true },
+							columns: {
+								libsqlId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 						mariadb: {
 							where: applyFilter(mariadb.mariadbId),
-							columns: { applicationStatus: true },
+							columns: {
+								mariadbId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 						mongo: {
 							where: applyFilter(mongo.mongoId),
-							columns: { applicationStatus: true },
+							columns: {
+								mongoId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 						mysql: {
 							where: applyFilter(mysql.mysqlId),
-							columns: { applicationStatus: true },
+							columns: {
+								mysqlId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 						postgres: {
 							where: applyFilter(postgres.postgresId),
-							columns: { applicationStatus: true },
+							columns: {
+								postgresId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 						redis: {
 							where: applyFilter(redis.redisId),
-							columns: { applicationStatus: true },
+							columns: {
+								redisId: true,
+								name: true,
+								applicationStatus: true,
+								serverId: true,
+							},
 						},
 					},
 				},
@@ -612,34 +688,191 @@ export const projectRouter = createTRPCRouter({
 		let composeCount = 0;
 		let databasesCount = 0;
 		let environmentsCount = 0;
+		let dokployHostServices = 0;
+		const servicesByServerId: Record<string, number> = {};
 		const status = { running: 0, error: 0, idle: 0 };
+		const erroredServices: (typeof empty)["erroredServices"] = [];
+
 		const bump = (s?: string | null) => {
 			if (s === "done") status.running++;
 			else if (s === "error") status.error++;
 			else status.idle++;
 		};
 
+		const bumpServer = (serverId?: string | null) => {
+			if (!serverId) {
+				dokployHostServices++;
+				return;
+			}
+			servicesByServerId[serverId] = (servicesByServerId[serverId] ?? 0) + 1;
+		};
+
+		const pushError = (
+			service: {
+				id: string;
+				name: string;
+				type: (typeof empty)["erroredServices"][number]["type"];
+				status?: string | null;
+			},
+			project: { projectId: string; name: string },
+			env: { environmentId: string; name: string },
+		) => {
+			if (service.status !== "error") return;
+			if (erroredServices.length >= 8) return;
+			erroredServices.push({
+				id: service.id,
+				name: service.name,
+				type: service.type,
+				projectId: project.projectId,
+				projectName: project.name,
+				environmentId: env.environmentId,
+				environmentName: env.name,
+			});
+		};
+
+		const recentProjects: (typeof empty)["recentProjects"] = [];
+
 		for (const project of rows) {
+			let projectServices = 0;
 			for (const env of project.environments) {
 				environmentsCount++;
 				applicationsCount += env.applications.length;
 				composeCount += env.compose.length;
-				databasesCount +=
+				const dbCount =
 					env.libsql.length +
 					env.mariadb.length +
 					env.mongo.length +
 					env.mysql.length +
 					env.postgres.length +
 					env.redis.length;
+				databasesCount += dbCount;
+				projectServices +=
+					env.applications.length + env.compose.length + dbCount;
 
-				for (const a of env.applications) bump(a.applicationStatus);
-				for (const c of env.compose) bump(c.composeStatus);
-				for (const s of env.libsql) bump(s.applicationStatus);
-				for (const s of env.mariadb) bump(s.applicationStatus);
-				for (const s of env.mongo) bump(s.applicationStatus);
-				for (const s of env.mysql) bump(s.applicationStatus);
-				for (const s of env.postgres) bump(s.applicationStatus);
-				for (const s of env.redis) bump(s.applicationStatus);
+				for (const a of env.applications) {
+					bump(a.applicationStatus);
+					bumpServer(a.serverId);
+					pushError(
+						{
+							id: a.applicationId,
+							name: a.name,
+							type: "application",
+							status: a.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const c of env.compose) {
+					bump(c.composeStatus);
+					bumpServer(c.serverId);
+					pushError(
+						{
+							id: c.composeId,
+							name: c.name,
+							type: "compose",
+							status: c.composeStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const s of env.libsql) {
+					bump(s.applicationStatus);
+					bumpServer(s.serverId);
+					pushError(
+						{
+							id: s.libsqlId,
+							name: s.name,
+							type: "libsql",
+							status: s.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const s of env.mariadb) {
+					bump(s.applicationStatus);
+					bumpServer(s.serverId);
+					pushError(
+						{
+							id: s.mariadbId,
+							name: s.name,
+							type: "mariadb",
+							status: s.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const s of env.mongo) {
+					bump(s.applicationStatus);
+					bumpServer(s.serverId);
+					pushError(
+						{
+							id: s.mongoId,
+							name: s.name,
+							type: "mongo",
+							status: s.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const s of env.mysql) {
+					bump(s.applicationStatus);
+					bumpServer(s.serverId);
+					pushError(
+						{
+							id: s.mysqlId,
+							name: s.name,
+							type: "mysql",
+							status: s.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const s of env.postgres) {
+					bump(s.applicationStatus);
+					bumpServer(s.serverId);
+					pushError(
+						{
+							id: s.postgresId,
+							name: s.name,
+							type: "postgres",
+							status: s.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+				for (const s of env.redis) {
+					bump(s.applicationStatus);
+					bumpServer(s.serverId);
+					pushError(
+						{
+							id: s.redisId,
+							name: s.name,
+							type: "redis",
+							status: s.applicationStatus,
+						},
+						project,
+						env,
+					);
+				}
+			}
+
+			if (recentProjects.length < 6) {
+				recentProjects.push({
+					projectId: project.projectId,
+					name: project.name,
+					description: project.description,
+					createdAt: project.createdAt,
+					environments: project.environments.length,
+					services: projectServices,
+					defaultEnvironmentId: project.environments[0]?.environmentId ?? null,
+				});
 			}
 		}
 
@@ -651,6 +884,10 @@ export const projectRouter = createTRPCRouter({
 			databases: databasesCount,
 			services: applicationsCount + composeCount + databasesCount,
 			status,
+			dokployHostServices,
+			servicesByServerId,
+			recentProjects,
+			erroredServices,
 		};
 	}),
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -15,6 +15,7 @@ export * from "./services/certificate";
 export * from "./services/cluster";
 export * from "./services/compose";
 export * from "./services/deployment";
+export * from "./services/deployment-window";
 export * from "./services/destination";
 export * from "./services/dns-provider";
 export * from "./services/docker";

--- a/packages/server/src/services/deployment-window.ts
+++ b/packages/server/src/services/deployment-window.ts
@@ -1,0 +1,10 @@
+export const DEPLOYMENT_REPORT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function getDeploymentWindowBounds(nowMs: number) {
+	const last7dStart = new Date(nowMs - DEPLOYMENT_REPORT_WINDOW_MS);
+
+	return {
+		last7dStart,
+		prev7dStart: new Date(nowMs - 2 * DEPLOYMENT_REPORT_WINDOW_MS),
+	};
+}

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -23,7 +23,17 @@ import {
 } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { format } from "date-fns";
-import { and, desc, eq, inArray, or, sql } from "drizzle-orm";
+import {
+	and,
+	desc,
+	eq,
+	gte,
+	inArray,
+	lt,
+	or,
+	type SQL,
+	sql,
+} from "drizzle-orm";
 import type { z } from "zod";
 import {
 	type Application,
@@ -903,16 +913,19 @@ async function getComposeIdsInOrg(
 	return rows.map((r) => r.composeId);
 }
 
-/**
- * All deployments for applications and compose in the org.
- * Pass accessedServices for members (only those services), null for owner/admin.
- */
-export const findAllDeploymentsCentralized = async (
+export type CentralizedDeploymentOptions = {
+	limit?: number;
+	status?: "running" | "done" | "error" | "cancelled";
+	since?: Date;
+	until?: Date;
+};
+
+async function getCentralizedDeploymentScope(
 	orgId: string,
 	accessedServices: string[] | null,
-) => {
+): Promise<{ whereClause: SQL; empty: boolean }> {
 	if (accessedServices !== null && accessedServices.length === 0) {
-		return [];
+		return { whereClause: sql`1 = 0`, empty: true };
 	}
 
 	const [appIds, compIds] = await Promise.all([
@@ -921,25 +934,85 @@ export const findAllDeploymentsCentralized = async (
 	]);
 
 	if (appIds.length === 0 && compIds.length === 0) {
-		return [];
+		return { whereClause: sql`1 = 0`, empty: true };
 	}
 
-	const conditions = [
+	const conditions: SQL[] = [
 		...(appIds.length > 0 ? [inArray(deployments.applicationId, appIds)] : []),
 		...(compIds.length > 0 ? [inArray(deployments.composeId, compIds)] : []),
 	];
+
 	const whereClause =
-		conditions.length === 0
-			? sql`1 = 0`
-			: conditions.length === 1
-				? conditions[0]
-				: or(...conditions);
+		conditions.length === 1 ? conditions[0]! : or(...conditions)!;
+
+	return { whereClause, empty: false };
+}
+
+function withDeploymentFilters(
+	baseWhere: SQL,
+	options?: CentralizedDeploymentOptions,
+): SQL {
+	const filters: SQL[] = [baseWhere];
+	if (options?.status) {
+		filters.push(eq(deployments.status, options.status));
+	}
+	if (options?.since) {
+		filters.push(gte(deployments.createdAt, options.since.toISOString()));
+	}
+	if (options?.until) {
+		filters.push(lt(deployments.createdAt, options.until.toISOString()));
+	}
+	return filters.length === 1 ? filters[0]! : and(...filters)!;
+}
+
+/**
+ * Deployments for applications and compose in the org.
+ * Pass accessedServices for members (only those services), null for owner/admin.
+ * Optional limit/status/since/until avoid loading the full history on home.
+ */
+export const findAllDeploymentsCentralized = async (
+	orgId: string,
+	accessedServices: string[] | null,
+	options?: CentralizedDeploymentOptions,
+) => {
+	const { whereClause, empty } = await getCentralizedDeploymentScope(
+		orgId,
+		accessedServices,
+	);
+	if (empty) {
+		return [];
+	}
 
 	return db.query.deployments.findMany({
-		where: whereClause,
+		where: withDeploymentFilters(whereClause, options),
 		orderBy: desc(deployments.createdAt),
+		limit: options?.limit,
 		with: centralizedDeploymentsWith,
 	});
+};
+
+/**
+ * Lightweight deployment counts for the home dashboard KPIs.
+ */
+export const countDeploymentsCentralized = async (
+	orgId: string,
+	accessedServices: string[] | null,
+	options?: Omit<CentralizedDeploymentOptions, "limit">,
+) => {
+	const { whereClause, empty } = await getCentralizedDeploymentScope(
+		orgId,
+		accessedServices,
+	);
+	if (empty) {
+		return 0;
+	}
+
+	const [row] = await db
+		.select({ count: sql<number>`cast(count(*) as integer)` })
+		.from(deployments)
+		.where(withDeploymentFilters(whereClause, options));
+
+	return row?.count ?? 0;
 };
 
 export const updateDeployment = async (


### PR DESCRIPTION
## Summary
- Expand `/dashboard/home` beyond welcome + recent deployments into an org overview: KPIs, needs-attention (errored services / failed deploys), deploy queue, recent projects, and a server summary (Dokploy host + remotes, infra health, version).
- Add `deployment.homeSummary` and limited/filterable `allCentralized` support so home no longer over-fetches full deployment history every 10s.
- Enrich `project.homeStats` with recent projects, errored services, and Dokploy-host vs remote service counts; prefetch home data on SSR when permitted.
- Fix user-nav **Projects** link to go to `/dashboard/projects` instead of home.

## Test plan
- [ ] Open `/dashboard/home` as owner/admin — KPIs, server summary (Dokploy host + remotes), queue, and recent projects render
- [ ] Confirm version shows a single `v` prefix (e.g. `v0.29.x`, not `vv…`)
- [ ] With no remotes, Dokploy host still appears and remote empty state links to add a server
- [ ] Member without `deployment.read` — deployments/queue gated; other inventory still loads
- [ ] Member without `server.read` — remote list gated; self-hosted still shows Dokploy host
- [ ] Force a failed deploy / errored service — Needs attention section appears with links
- [ ] User-nav → Projects lands on `/dashboard/projects`
- [ ] Deployments page still loads full list via `allCentralized` (backward compatible)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands the home page into an organization dashboard while reducing deployment-history over-fetching and correcting the Projects navigation target.
- Adds organization KPIs, attention items, deployment summaries and queue status, recent projects, and server health information.
- Adds bounded deployment summary queries and richer project statistics.
- Safely handles authenticated users without an active organization during SSR and hydration.
- Updates the user-nav Projects link to `/dashboard/projects`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (4): Last reviewed commit: ["fix: scope home dashboard server totals"](https://github.com/dokploy/dokploy/commit/db7fb6dc2e12a00a556a3dcc7d92994d70ab3670) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51104566)</sub>

**Context used:**

- Knowledge Base — [Authentication, Organizations, and Permissions](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/auth-and-organizations.md)

<!-- /greptile_comment -->