### PR TITLE
fix: hide scrollbar on overflowing tab bars, add edge fade cue

### DIFF
--- a/apps/dokploy/components/dashboard/application/general/generic/show.tsx
+++ b/apps/dokploy/components/dashboard/application/general/generic/show.tsx
@@ -14,6 +14,7 @@ import {
 	GitIcon,
 	GitlabIcon,
 } from "@/components/icons/data-tools-icons";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/utils/api";
@@ -153,7 +154,7 @@ export const ShowProviderForm = ({ applicationId }: Props) => {
 						setSab(e as TabState);
 					}}
 				>
-					<div className="flex flex-row items-center justify-between w-full overflow-auto">
+					<ScrollFadeContainer className="flex flex-row items-center justify-between w-full">
 						<TabsList
 							variant="line"
 							className="flex gap-4 justify-start bg-transparent"
@@ -208,7 +209,7 @@ export const ShowProviderForm = ({ applicationId }: Props) => {
 								Drop
 							</TabsTrigger>
 						</TabsList>
-					</div>
+					</ScrollFadeContainer>
 
 					<TabsContent value="github" className="w-full p-2">
 						{githubProviders && githubProviders?.length > 0 ? (

--- a/apps/dokploy/components/dashboard/compose/general/generic/show.tsx
+++ b/apps/dokploy/components/dashboard/compose/general/generic/show.tsx
@@ -10,6 +10,7 @@ import {
 	GitIcon,
 	GitlabIcon,
 } from "@/components/icons/data-tools-icons";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/utils/api";
@@ -142,7 +143,7 @@ export const ShowProviderFormCompose = ({ composeId }: Props) => {
 						setSab(e as TabState);
 					}}
 				>
-					<div className="flex flex-row items-center justify-between w-full overflow-auto">
+					<ScrollFadeContainer className="flex flex-row items-center justify-between w-full">
 						<TabsList
 							variant="line"
 							className="flex gap-4 justify-start bg-transparent"
@@ -189,7 +190,7 @@ export const ShowProviderFormCompose = ({ composeId }: Props) => {
 								Raw
 							</TabsTrigger>
 						</TabsList>
-					</div>
+					</ScrollFadeContainer>
 
 					<TabsContent value="github" className="w-full p-2">
 						{githubProviders && githubProviders?.length > 0 ? (

--- a/apps/dokploy/components/shared/scroll-fade-container.tsx
+++ b/apps/dokploy/components/shared/scroll-fade-container.tsx
@@ -1,13 +1,10 @@
 import { cn } from "@/lib/utils";
-import { useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 
-interface Props {
-	children: React.ReactNode;
-	className?: string;
-}
-
-export const ScrollFadeContainer = ({ children, className }: Props) => {
-	const ref = useRef<HTMLDivElement>(null);
+export const useScrollFade = <T extends HTMLElement>(
+	deps: unknown[] = [],
+): [RefObject<T | null>, boolean, boolean] => {
+	const ref = useRef<T>(null);
 	const [canScrollLeft, setCanScrollLeft] = useState(false);
 	const [canScrollRight, setCanScrollRight] = useState(false);
 
@@ -32,7 +29,43 @@ export const ScrollFadeContainer = ({ children, className }: Props) => {
 			el.removeEventListener("scroll", updateFades);
 			resizeObserver.disconnect();
 		};
-	}, [children]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps);
+
+	return [ref, canScrollLeft, canScrollRight];
+};
+
+export const ScrollFadeEdges = ({
+	canScrollLeft,
+	canScrollRight,
+}: {
+	canScrollLeft: boolean;
+	canScrollRight: boolean;
+}) => (
+	<>
+		<div
+			className={cn(
+				"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-background to-transparent transition-opacity",
+				canScrollLeft ? "opacity-100" : "opacity-0",
+			)}
+		/>
+		<div
+			className={cn(
+				"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent transition-opacity",
+				canScrollRight ? "opacity-100" : "opacity-0",
+			)}
+		/>
+	</>
+);
+
+interface Props {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export const ScrollFadeContainer = ({ children, className }: Props) => {
+	const [ref, canScrollLeft, canScrollRight] =
+		useScrollFade<HTMLDivElement>([children]);
 
 	return (
 		<div className="relative min-w-0">
@@ -42,17 +75,9 @@ export const ScrollFadeContainer = ({ children, className }: Props) => {
 			>
 				{children}
 			</div>
-			<div
-				className={cn(
-					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-background to-transparent transition-opacity",
-					canScrollLeft ? "opacity-100" : "opacity-0",
-				)}
-			/>
-			<div
-				className={cn(
-					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent transition-opacity",
-					canScrollRight ? "opacity-100" : "opacity-0",
-				)}
+			<ScrollFadeEdges
+				canScrollLeft={canScrollLeft}
+				canScrollRight={canScrollRight}
 			/>
 		</div>
 	);

--- a/apps/dokploy/components/shared/scroll-fade-container.tsx
+++ b/apps/dokploy/components/shared/scroll-fade-container.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils";
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+	children: React.ReactNode;
+	className?: string;
+}
+
+export const ScrollFadeContainer = ({ children, className }: Props) => {
+	const ref = useRef<HTMLDivElement>(null);
+	const [canScrollLeft, setCanScrollLeft] = useState(false);
+	const [canScrollRight, setCanScrollRight] = useState(false);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		const updateFades = () => {
+			setCanScrollLeft(el.scrollLeft > 0);
+			setCanScrollRight(
+				Math.ceil(el.scrollLeft + el.clientWidth) < el.scrollWidth,
+			);
+		};
+
+		updateFades();
+
+		el.addEventListener("scroll", updateFades, { passive: true });
+		const resizeObserver = new ResizeObserver(updateFades);
+		resizeObserver.observe(el);
+
+		return () => {
+			el.removeEventListener("scroll", updateFades);
+			resizeObserver.disconnect();
+		};
+	}, [children]);
+
+	return (
+		<div className="relative min-w-0">
+			<div
+				ref={ref}
+				className={cn("overflow-x-auto no-scrollbar", className)}
+			>
+				{children}
+			</div>
+			<div
+				className={cn(
+					"pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-background to-transparent transition-opacity",
+					canScrollLeft ? "opacity-100" : "opacity-0",
+				)}
+			/>
+			<div
+				className={cn(
+					"pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent transition-opacity",
+					canScrollRight ? "opacity-100" : "opacity-0",
+				)}
+			/>
+		</div>
+	);
+};

--- a/apps/dokploy/components/ui/table.tsx
+++ b/apps/dokploy/components/ui/table.tsx
@@ -2,18 +2,30 @@
 
 import type * as React from "react";
 
+import {
+	ScrollFadeEdges,
+	useScrollFade,
+} from "@/components/shared/scroll-fade-container";
 import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
+	const [ref, canScrollLeft, canScrollRight] =
+		useScrollFade<HTMLDivElement>([props.children]);
+
 	return (
 		<div
+			ref={ref}
 			data-slot="table-container"
-			className="relative w-full overflow-x-auto"
+			className="relative w-full overflow-x-auto no-scrollbar"
 		>
 			<table
 				data-slot="table"
 				className={cn("w-full caption-bottom text-sm", className)}
 				{...props}
+			/>
+			<ScrollFadeEdges
+				canScrollLeft={canScrollLeft}
+				canScrollRight={canScrollRight}
 			/>
 		</div>
 	);

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -48,6 +48,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
 	Tooltip,
@@ -233,7 +234,7 @@ const Service = (
 										router.push(newPath);
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full overflow-auto">
+									<ScrollFadeContainer className="flex flex-row items-center justify-between w-full">
 										<TabsList className="flex gap-8 max-md:gap-4 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											{permissions?.envVars.read && (
@@ -278,7 +279,7 @@ const Service = (
 												<TabsTrigger value="advanced">Advanced</TabsTrigger>
 											)}
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -36,6 +36,7 @@ import { AssignComposeNetworks } from "@/components/dashboard/networks/assign-co
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -224,7 +225,7 @@ const Service = (
 										router.push(newPath);
 									}}
 								>
-									<div className="flex flex-row items-center w-full overflow-auto">
+									<ScrollFadeContainer className="flex flex-row items-center w-full">
 										<TabsList className="flex gap-8 max-md:gap-4 justify-start">
 											<TabsTrigger value="general">General</TabsTrigger>
 											{permissions?.envVars.read && (
@@ -270,7 +271,7 @@ const Service = (
 												<TabsTrigger value="advanced">Advanced</TabsTrigger>
 											)}
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/libsql/[libsqlId].tsx
@@ -27,6 +27,7 @@ import { LibsqlIcon } from "@/components/icons/data-tools-icons";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -185,7 +186,7 @@ const Libsql = (
 										router.push(newPath, undefined, { shallow: true });
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-auto">
+									<ScrollFadeContainer className="flex flex-row items-center justify-between w-full gap-4">
 										<TabsList
 											className={cn(
 												"md:grid md:w-fit max-md:overflow-y-scroll justify-start",
@@ -205,7 +206,7 @@ const Libsql = (
 											<TabsTrigger value="backups">Backups</TabsTrigger>
 											<TabsTrigger value="advanced">Advanced</TabsTrigger>
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mariadb/[mariadbId].tsx
@@ -27,6 +27,7 @@ import { MariadbIcon } from "@/components/icons/data-tools-icons";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -199,7 +200,7 @@ const Mariadb = (
 										router.push(newPath, undefined, { shallow: true });
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-auto">
+									<ScrollFadeContainer className="flex flex-row items-center justify-between w-full gap-4">
 										<TabsList
 											className={cn(
 												"md:grid md:w-fit max-md:overflow-y-scroll justify-start",
@@ -230,7 +231,7 @@ const Mariadb = (
 												<TabsTrigger value="advanced">Advanced</TabsTrigger>
 											)}
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mongo/[mongoId].tsx
@@ -27,6 +27,7 @@ import { MongodbIcon } from "@/components/icons/data-tools-icons";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -199,7 +200,7 @@ const Mongo = (
 										router.push(newPath, undefined, { shallow: true });
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-auto">
+									<ScrollFadeContainer className="flex flex-row items-center justify-between w-full gap-4">
 										<TabsList
 											className={cn(
 												"md:grid md:w-fit max-md:overflow-y-scroll justify-start",
@@ -230,7 +231,7 @@ const Mongo = (
 												<TabsTrigger value="advanced">Advanced</TabsTrigger>
 											)}
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/mysql/[mysqlId].tsx
@@ -27,6 +27,7 @@ import { MysqlIcon } from "@/components/icons/data-tools-icons";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -199,7 +200,7 @@ const MySql = (
 											router.push(newPath, undefined, { shallow: true });
 										}}
 									>
-										<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-auto">
+										<ScrollFadeContainer className="flex flex-row items-center justify-between w-full gap-4">
 											<TabsList
 												className={cn(
 													"md:grid md:w-fit max-md:overflow-y-scroll justify-start ",
@@ -230,7 +231,7 @@ const MySql = (
 													<TabsTrigger value="advanced">Advanced</TabsTrigger>
 												)}
 											</TabsList>
-										</div>
+										</ScrollFadeContainer>
 
 										<TabsContent value="general">
 											<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/postgres/[postgresId].tsx
@@ -27,6 +27,7 @@ import { PostgresqlIcon } from "@/components/icons/data-tools-icons";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -200,7 +201,7 @@ const Postgresql = (
 										});
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-auto">
+									<ScrollFadeContainer className="flex flex-row items-center justify-between w-full gap-4">
 										<TabsList
 											className={cn(
 												"md:grid md:w-fit max-md:overflow-y-scroll justify-start",
@@ -231,7 +232,7 @@ const Postgresql = (
 												<TabsTrigger value="advanced">Advanced</TabsTrigger>
 											)}
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/redis/[redisId].tsx
@@ -26,6 +26,7 @@ import { RedisIcon } from "@/components/icons/data-tools-icons";
 import { DashboardLayout } from "@/components/layouts/dashboard-layout";
 import { AdvanceBreadcrumb } from "@/components/shared/advance-breadcrumb";
 import { StatusTooltip } from "@/components/shared/status-tooltip";
+import { ScrollFadeContainer } from "@/components/shared/scroll-fade-container";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -198,7 +199,7 @@ const Redis = (
 										router.push(newPath, undefined, { shallow: true });
 									}}
 								>
-									<div className="flex flex-row items-center justify-between w-full gap-4 overflow-x-auto">
+									<ScrollFadeContainer className="flex flex-row items-center justify-between w-full gap-4">
 										<TabsList
 											className={cn(
 												"md:grid md:w-fit max-md:overflow-y-scroll justify-start",
@@ -228,7 +229,7 @@ const Redis = (
 												<TabsTrigger value="advanced">Advanced</TabsTrigger>
 											)}
 										</TabsList>
-									</div>
+									</ScrollFadeContainer>
 
 									<TabsContent value="general">
 										<div className="flex flex-col gap-4 pt-2.5">


### PR DESCRIPTION
## Summary
- The service detail page tab row (General / Environment / Domains / Deployments / …) uses `overflow-x-auto` and shows the browser's native horizontal scrollbar track whenever the tabs don't fit the viewport width.
- Adds a shared `ScrollFadeContainer` component (`apps/dokploy/components/shared/scroll-fade-container.tsx`) that hides the native scrollbar (reusing the existing `no-scrollbar` utility) and renders a soft gradient fade on whichever edge still has scrollable content — updating live via scroll + `ResizeObserver`, so it always matches actual scroll position.
- Swapped the raw wrapper `<div>` for `<ScrollFadeContainer>` on all 8 service detail pages: `application`, `compose`, `mongo`, `postgres`, `mysql`, `mariadb`, `redis`, `libsql`.
- Repo-wide scan turned up two more instances of the exact same issue, now fixed in a follow-up commit:
  - The Application/Compose "General" tab's source-provider picker (GitHub/GitLab/Bitbucket/Gitea/Git/Raw/Docker/Drop) had the same bare `overflow-auto` tab row.
  - The shared `ui/table.tsx` container — used by nearly every data table in the app — wraps its `<table>` in `overflow-x-auto` with no scroll affordance at all.
- Refactored the scroll-fade logic into a reusable `useScrollFade` hook + `ScrollFadeEdges` overlay so `Table` can attach the fade directly to its own existing container div instead of adding an extra wrapper. `ScrollFadeContainer`'s own API/behavior is unchanged.

## Why
Hiding the scrollbar with `no-scrollbar` alone removes the user's only visual signal that a row has more content off-screen. The edge fade restores that affordance without bringing back the native scrollbar track.

## Test plan
- [ ] Resize the application/compose/database detail page to a narrow viewport and confirm the tab row scrolls horizontally with no visible scrollbar track
- [ ] Confirm a left/right edge fade appears only when there are hidden tabs in that direction, and disappears once scrolled fully to that edge
- [ ] Repeat for the Application/Compose "General" tab source-provider picker
- [ ] Repeat for a wide data table (e.g. Deployments, Audit Log, Networks) on a narrow viewport
- [ ] Verify drag/trackpad/shift+wheel scrolling still works identically to before
- [ ] Spot check both light and dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a reusable horizontal-scroll container with dynamic edge fades and applies it to service tab bars and tables.
- Hides native horizontal scrollbars while retaining scrolling behavior.
- Calculates left and right overflow state from scroll position and container resizing.
- Adopts the shared treatment across application, Compose, managed-database, provider-selection, and table interfaces.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix: extend scroll-fade treatment to pro..."](https://github.com/dokploy/dokploy/commit/e0ffda82e482c583f002eef869d9dd276609ee32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464047)</sub>

<!-- /greptile_comment -->