### PR TITLE
fix: allow Option/Alt composed characters in terminals on macOS

### DIFF
--- a/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
+++ b/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
@@ -5,6 +5,7 @@ import "@xterm/xterm/css/xterm.css";
 import { AttachAddon } from "@xterm/addon-attach";
 import { useTheme } from "next-themes";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fixMacOsAltKeys } from "@/lib/terminal-keyboard";
 
 interface Props {
 	id: string;
@@ -45,6 +46,7 @@ export const DockerTerminal: React.FC<Props> = ({
 		const ws = new WebSocket(wsUrl);
 
 		const addonAttach = new AttachAddon(ws);
+		fixMacOsAltKeys(term);
 		// @ts-ignore
 		term.open(termRef.current);
 		// @ts-ignore

--- a/apps/dokploy/components/dashboard/settings/web-server/terminal.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/terminal.tsx
@@ -6,6 +6,7 @@ import "@xterm/xterm/css/xterm.css";
 import { AttachAddon } from "@xterm/addon-attach";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { useTheme } from "next-themes";
+import { fixMacOsAltKeys } from "@/lib/terminal-keyboard";
 import { getLocalServerData } from "./local-server-config";
 
 interface Props {
@@ -58,6 +59,7 @@ export const Terminal: React.FC<Props> = ({ id, serverId }) => {
 		const addonAttach = new AttachAddon(ws);
 		const clipboardAddon = new ClipboardAddon();
 		term.loadAddon(clipboardAddon);
+		fixMacOsAltKeys(term);
 
 		// @ts-ignore
 		term.open(termRef.current);

--- a/apps/dokploy/lib/terminal-keyboard.ts
+++ b/apps/dokploy/lib/terminal-keyboard.ts
@@ -1,0 +1,25 @@
+import type { Terminal } from "@xterm/xterm";
+
+// xterm's platform detection mistakes the bundled Next.js `process` polyfill
+// for Node.js, so it never treats Option/Alt as third-level shift on macOS and
+// swallows composed characters like Option+L (@ on German layouts).
+// https://github.com/Dokploy/dokploy/issues/4297
+export const fixMacOsAltKeys = (term: Terminal) => {
+	if (!/Mac/.test(navigator.platform)) {
+		return;
+	}
+	term.attachCustomKeyEventHandler((event) => {
+		if (
+			event.type === "keydown" &&
+			event.altKey &&
+			!event.ctrlKey &&
+			!event.metaKey &&
+			event.key.length === 1
+		) {
+			event.preventDefault();
+			term.input(event.key);
+			return false;
+		}
+		return true;
+	});
+};


### PR DESCRIPTION
Fixes #4297

Option+key combinations (e.g. `Option+L` for `@` on German Mac layouts) were silently swallowed in the container and web server terminals.

Root cause: Next.js injects its `process` polyfill (`process.title = "browser"`) into the `@xterm/xterm` bundle, so xterm's `isNode = 'title' in process` check thinks it's running in Node → `isMac` is `false` → Option is never treated as third-level shift and xterm cancels the keydown before the browser composes the character.

Upstream fixed the platform detection only in xterm master/6.1.0-beta (not in 5.5.0 or 6.0.0 stable), so this adds an app-level workaround: `fixMacOsAltKeys` intercepts Alt keydowns that carry a composed printable character and injects it via `term.input()`. Dead keys (Option+U), Alt+arrows, etc. are untouched. Can be removed once we upgrade to `@xterm/xterm` ≥ 6.1.0.

Verified end-to-end against a running container terminal by emulating a German Mac layout via CDP key events: `a`, `Option+L`, `Option+N`, `b` now produces `a@~b` in bash with no duplicates.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a shared macOS keyboard workaround for xterm and installs it in both container and web-server terminals.
- Intercepts Alt-only keydowns carrying a single printable character.
- Sends the composed character through xterm’s input path while leaving dead keys and modified navigation keys untouched.
- Applies the behavior consistently to both terminal implementations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered failure identified.

The handler is limited to macOS Alt-only printable keydowns, explicitly excludes Ctrl, Meta, dead keys, and non-character navigation events, and is applied consistently to both affected terminals.

<sub>Reviews (1): Last reviewed commit: ["fix: allow Option/Alt composed character..."](https://github.com/dokploy/dokploy/commit/b20348908f0525093169524b99db5088199d85d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51549563)</sub>

**Context used:**

- Knowledge Base — [Monitoring and Live Terminal/Log Streaming](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/monitoring-and-terminal.md)

<!-- /greptile_comment -->