### PR TITLE
fix: compose preview not reflecting patches

### DIFF
--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -2,10 +2,10 @@ import fs, { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import { db } from "@dokploy/server/db";
-import { network } from "@dokploy/server/db/schema";
+import { network, patch } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { parse, stringify } from "yaml";
 import { execAsyncRemote } from "../process/execAsync";
 import { cloneBitbucketRepository } from "../providers/bitbucket";
@@ -134,6 +134,38 @@ exit 1;
 		`;
 	}
 };
+export const applyComposeFilePatch = async (
+	compose: Compose,
+): Promise<ComposeSpecification | null> => {
+	if (compose.sourceType === "raw") {
+		return null;
+	}
+
+	const composePatches = await db.query.patch.findMany({
+		where: eq(patch.composeId, compose.composeId),
+	});
+
+	const composeFilePatch = composePatches.find(
+		(p) =>
+			p.enabled &&
+			p.type !== "delete" &&
+			join(p.filePath) === join(compose.composePath),
+	);
+
+	if (!composeFilePatch?.content) {
+		return null;
+	}
+
+	try {
+		const parsed = parse(composeFilePatch.content, {
+			maxAliasCount: 10000,
+		}) as ComposeSpecification;
+		return parsed ?? null;
+	} catch {
+		return null;
+	}
+};
+
 export const addDomainToCompose = async (
 	compose: Compose,
 	domains: Domain[],
@@ -151,6 +183,8 @@ export const addDomainToCompose = async (
 	if (!result) {
 		return null;
 	}
+
+	result = (await applyComposeFilePatch(compose)) ?? result;
 
 	if (compose.isolatedDeployment) {
 		const randomized = randomizeDeployableSpecificationFile(


### PR DESCRIPTION
## Summary

Fixes #4243.

The compose preview (`getConvertedCompose`) read the compose file from the `code` directory on disk, which the UI constantly overwrites with a pristine clone (`fetchSourceType`, `loadServices`). Since patches are only written to disk during deployments, the preview always showed the original compose file without patches — making users believe patches were broken (the deploy path itself applies them correctly since #4161).

`addDomainToCompose` now uses the enabled patch content from the DB as the base when a patch targets the service's `composePath`, falling back to the on-disk file otherwise. Patches are full-file replacements, so deploy output is unchanged; as a side effect, deploys are no longer vulnerable to a UI-triggered re-clone reverting the patched compose file between the patch step and the build.

Verified end-to-end on a local dev instance: reproduced the stale preview on current canary (container running patched env while preview showed the original file), then confirmed the fix shows patch + injected domain labels in the preview and produces an identical deployment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates compose conversion and domain injection to use an enabled full-file patch from the database instead of relying exclusively on the mutable checked-out file.
- Adds database lookup and YAML parsing for a patch targeting the compose path.
- Uses the parsed patch as the base before applying isolation, domain, and network transformations.
- Retains the disk-loaded compose as a fallback when no usable patch is found.

<h3>Confidence Score: 4/5</h3>

The invalid-patch fallback should be fixed before merging because it can make the preview silently display the original compose despite an enabled replacement patch.

Enabled patch content is not YAML-validated when stored, and the new parser suppresses syntax errors as if no patch existed, causing getConvertedCompose to return a successful but stale preview.

**Files Needing Attention:** packages/server/src/utils/docker/domain.ts

<sub>Reviews (1): Last reviewed commit: ["fix: apply compose file patches in previ..."](https://github.com/dokploy/dokploy/commit/bc935ae3adc77010ba3428bc41a574d9e383a884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51552444)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Compose Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/compose-deployment.md)

<!-- /greptile_comment -->