### PR TITLE
fix: disable recharts animation on monitoring charts

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-block-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-block-chart.tsx
@@ -85,6 +85,7 @@ export const DockerBlockChart = ({ accumulativeData }: Props) => {
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="readMb"
 					stroke="var(--color-readMb)"
 					fill="url(#fillBlockRead)"
@@ -92,6 +93,7 @@ export const DockerBlockChart = ({ accumulativeData }: Props) => {
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="writeMb"
 					stroke="var(--color-writeMb)"
 					fill="url(#fillBlockWrite)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-cpu-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-cpu-chart.tsx
@@ -69,6 +69,7 @@ export const DockerCpuChart = ({ accumulativeData }: Props) => {
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="usage"
 					stroke="var(--color-usage)"
 					fill="url(#fillCpu)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-disk-chart.tsx
@@ -71,6 +71,7 @@ export const DockerDiskChart = ({ accumulativeData, diskTotal }: Props) => {
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="usedGb"
 					stroke="var(--color-usedGb)"
 					fill="url(#fillDiskUsed)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-memory-chart.tsx
@@ -75,6 +75,7 @@ export const DockerMemoryChart = ({
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="usage"
 					stroke="var(--color-usage)"
 					fill="url(#fillMemory)"

--- a/apps/dokploy/components/dashboard/monitoring/free/container/docker-network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/docker-network-chart.tsx
@@ -81,6 +81,7 @@ export const DockerNetworkChart = ({ accumulativeData }: Props) => {
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="inMB"
 					stroke="var(--color-inMB)"
 					fill="url(#fillNetIn)"
@@ -88,6 +89,7 @@ export const DockerNetworkChart = ({ accumulativeData }: Props) => {
 				/>
 				<Area
 					type="monotone"
+					isAnimationActive={false}
 					dataKey="outMB"
 					stroke="var(--color-outMB)"
 					fill="url(#fillNetOut)"

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-block-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-block-chart.tsx
@@ -154,6 +154,7 @@ export const ContainerBlockChart = ({ data }: Props) => {
 							name="Write"
 							dataKey="write"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillWrite)"
 							stroke="hsl(142, 71%, 45%)"
 							strokeWidth={2}
@@ -163,6 +164,7 @@ export const ContainerBlockChart = ({ data }: Props) => {
 							name="Read"
 							dataKey="read"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillRead)"
 							stroke="hsl(217, 91%, 60%)"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-cpu-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-cpu-chart.tsx
@@ -111,6 +111,7 @@ export const ContainerCPUChart = ({ data }: Props) => {
 							name="CPU"
 							dataKey="cpu"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillCPU)"
 							stroke="hsl(var(--chart-1))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-memory-chart.tsx
@@ -132,6 +132,7 @@ export const ContainerMemoryChart = ({ data }: Props) => {
 							name="Memory"
 							dataKey="memory"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillMemory)"
 							stroke="hsl(var(--chart-2))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/container/container-network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/container/container-network-chart.tsx
@@ -161,6 +161,7 @@ export const ContainerNetworkChart = ({ data }: Props) => {
 							name="Input"
 							dataKey="input"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillInput)"
 							stroke="hsl(var(--chart-3))"
 							strokeWidth={2}
@@ -169,6 +170,7 @@ export const ContainerNetworkChart = ({ data }: Props) => {
 							name="Output"
 							dataKey="output"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillOutput)"
 							stroke="hsl(var(--chart-4))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/cpu-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/cpu-chart.tsx
@@ -98,6 +98,7 @@ export function CPUChart({ data }: CPUChartProps) {
 							name="CPU"
 							dataKey="cpu"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillCPU)"
 							stroke="hsl(var(--chart-1))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/memory-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/memory-chart.tsx
@@ -115,6 +115,7 @@ export function MemoryChart({ data }: MemoryChartProps) {
 							yAxisId="left"
 							dataKey="memUsed"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillMemory)"
 							stroke="hsl(var(--chart-2))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/network-chart.tsx
@@ -120,6 +120,7 @@ export function NetworkChart({ data }: NetworkChartProps) {
 							name="Network In"
 							dataKey="networkIn"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillNetworkIn)"
 							stroke="hsl(var(--chart-3))"
 							strokeWidth={2}
@@ -128,6 +129,7 @@ export function NetworkChart({ data }: NetworkChartProps) {
 							name="Network Out"
 							dataKey="networkOut"
 							type="monotone"
+							isAnimationActive={false}
 							fill="url(#fillNetworkOut)"
 							stroke="hsl(var(--chart-4))"
 							strokeWidth={2}

--- a/apps/dokploy/components/dashboard/requests/request-distribution-chart.tsx
+++ b/apps/dokploy/components/dashboard/requests/request-distribution-chart.tsx
@@ -91,6 +91,7 @@ export const RequestDistributionChart = ({
 				<Area
 					dataKey="count"
 					type="monotone"
+					isAnimationActive={false}
 					fill="hsl(var(--chart-1))"
 					fillOpacity={0.4}
 					stroke="hsl(var(--chart-1))"


### PR DESCRIPTION
Fixes #4414

Recharts' default animation interpolates old→new Y-values on every data refresh, which combined with `type="monotone"" morphing made peaks look exaggerated/misleading (see the video in the issue). Monotone interpolation itself doesn't overshoot data points, so the smoothing is kept and only the animation is disabled.

Adds `isAnimationActive={false}` to all 18 `<Area>` series across the monitoring charts (free/paid, container/server) and `request-distribution-chart.tsx`.

Note: the Safari-only layout glitch mentioned in the issue comments is a separate CSS bug, not addressed here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables Recharts area-series animation so frequently refreshed monitoring data renders its current values directly instead of visually interpolating between samples.

- Adds `isAnimationActive={false}` to all affected free container-monitoring charts.
- Applies the same behavior to paid container and server-monitoring charts.
- Disables animation on the request-distribution chart.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the narrowly scoped property additions consistently disabling animation on the intended chart series.

The changes only opt existing Recharts area series out of animation and leave data transformation, polling, axes, tooltips, and rendering configuration otherwise unchanged.

<sub>Reviews (1): Last reviewed commit: ["fix: disable recharts animation on monit..."](https://github.com/dokploy/dokploy/commit/bd7fb8f23c4d8229d909e90f4b3b962cbc764e8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51554490)</sub>

**Context used:**

- Knowledge Base — [Monitoring and Live Terminal/Log Streaming](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/monitoring-and-terminal.md)

<!-- /greptile_comment -->