### PR TITLE
fix: mark session cookie as Secure when served over HTTPS

### DIFF
--- a/apps/dokploy/__test__/lib/secure-cookies.test.ts
+++ b/apps/dokploy/__test__/lib/secure-cookies.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { isHttpsRequest, secureSetCookie } from "@/lib/secure-cookies";
+
+describe("isHttpsRequest", () => {
+	it("returns true when X-Forwarded-Proto is https", () => {
+		expect(isHttpsRequest("https")).toBe(true);
+	});
+
+	it("returns false for http or a missing header", () => {
+		expect(isHttpsRequest("http")).toBe(false);
+		expect(isHttpsRequest(undefined)).toBe(false);
+	});
+
+	it("uses the left-most value of a proxy chain", () => {
+		expect(isHttpsRequest("https, http")).toBe(true);
+		expect(isHttpsRequest("http, https")).toBe(false);
+	});
+
+	it("handles an array header value and is case-insensitive", () => {
+		expect(isHttpsRequest(["HTTPS", "http"])).toBe(true);
+	});
+});
+
+describe("secureSetCookie", () => {
+	it("adds Secure to a cookie that lacks it", () => {
+		expect(
+			secureSetCookie("better-auth.session_token=abc; Path=/; HttpOnly"),
+		).toBe("better-auth.session_token=abc; Path=/; HttpOnly; Secure");
+	});
+
+	it("does not duplicate Secure when already present", () => {
+		const cookie = "better-auth.session_token=abc; Path=/; Secure; HttpOnly";
+		expect(secureSetCookie(cookie)).toBe(cookie);
+	});
+
+	it("applies to every cookie in an array", () => {
+		expect(secureSetCookie(["a=1; Path=/", "b=2; Path=/; Secure"])).toEqual([
+			"a=1; Path=/; Secure",
+			"b=2; Path=/; Secure",
+		]);
+	});
+
+	it("passes a numeric header value through untouched", () => {
+		expect(secureSetCookie(123)).toBe(123);
+	});
+});

--- a/apps/dokploy/lib/secure-cookies.ts
+++ b/apps/dokploy/lib/secure-cookies.ts
@@ -1,0 +1,25 @@
+export const isHttpsRequest = (
+	forwardedProto: string | string[] | undefined,
+): boolean => {
+	if (!forwardedProto) return false;
+	const value = Array.isArray(forwardedProto)
+		? forwardedProto[0]
+		: forwardedProto;
+	// take the first value in case a proxy chain sent a list
+	return value?.split(",")[0]?.trim().toLowerCase() === "https";
+};
+
+const hasSecureAttribute = (cookie: string): boolean =>
+	/;\s*secure(?:\s*;|\s*$)/i.test(cookie);
+
+const withSecure = (cookie: string): string =>
+	hasSecureAttribute(cookie) ? cookie : `${cookie}; Secure`;
+
+// Add Secure to a Set-Cookie header value (string or string[]).
+export const secureSetCookie = (
+	value: string | number | readonly string[],
+): string | number | string[] => {
+	if (typeof value === "number") return value;
+	if (Array.isArray(value)) return value.map(withSecure);
+	return withSecure(value as string);
+};

--- a/apps/dokploy/pages/api/auth/[...all].ts
+++ b/apps/dokploy/pages/api/auth/[...all].ts
@@ -1,7 +1,30 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { auth } from "@dokploy/server/index";
 import { toNodeHandler } from "better-auth/node";
+import { isHttpsRequest, secureSetCookie } from "@/lib/secure-cookies";
 
 // Disallow body parsing, we will parse it manually
 export const config = { api: { bodyParser: false } };
 
-export default toNodeHandler(auth.handler);
+const handler = toNodeHandler(auth.handler);
+
+// Mark the session cookie as Secure when the request comes over HTTPS
+export default function authHandler(req: IncomingMessage, res: ServerResponse) {
+	if (isHttpsRequest(req.headers["x-forwarded-proto"])) {
+		const setHeader = res.setHeader.bind(res);
+		res.setHeader = (name, value) =>
+			String(name).toLowerCase() === "set-cookie"
+				? setHeader(name, secureSetCookie(value))
+				: setHeader(name, value);
+
+		const appendHeader = res.appendHeader?.bind(res);
+		if (appendHeader) {
+			res.appendHeader = (name, value) =>
+				String(name).toLowerCase() === "set-cookie"
+					? appendHeader(name, secureSetCookie(value) as string | string[])
+					: appendHeader(name, value);
+		}
+	}
+
+	return handler(req, res);
+}


### PR DESCRIPTION
## What is this PR about?

Self-hosted Dokploy issues the `better-auth.session_token` cookie without the `Secure` attribute even when served over HTTPS, so the browser can replay the session token over plain HTTP (#4709). The auth config disables secure cookies to keep plain-HTTP access (`http://<ip>:3000`) working, and better-auth resolves the flag once at startup, so it can't vary per request from the config alone.

This wraps the auth route handler and adds `Secure` to the outgoing Set-Cookie headers when the request arrived over HTTPS (`X-Forwarded-Proto: https`, what Traefik sends on TLS). Plain-HTTP requests are left untouched, so IP-based access keeps working.

Verified on a local instance: signing in over `/api/auth/sign-in/email` returns the cookie without `Secure` when no forwarded-proto header is present, and with `Secure` when `X-Forwarded-Proto: https` is sent. Unit tests cover the proto detection and the cookie rewriting.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4709

## Testing evidence (curl)

Sign-in without a forwarded-proto header (no `Secure`):
`better-auth.session_token=...; Max-Age=259200; Path=/; HttpOnly; SameSite=Lax`

Sign-in with `X-Forwarded-Proto: https` (`Secure` added):
`better-auth.session_token=...; Max-Age=259200; Path=/; HttpOnly; SameSite=Lax; Secure`

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR conditionally adds the `Secure` attribute to authentication response cookies when the request was forwarded over HTTPS, while preserving cookies for direct plain-HTTP access.
- Adds helpers for forwarded-protocol detection and Set-Cookie rewriting.
- Wraps the Better Auth route’s response header methods.
- Adds unit coverage for protocol parsing and cookie transformations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The wrapper preserves the existing Better Auth handler behavior while conditionally and idempotently adding Secure to supported Set-Cookie header shapes on forwarded HTTPS requests.

<sub>Reviews (1): Last reviewed commit: ["fix: mark session cookie as Secure when ..."](https://github.com/dokploy/dokploy/commit/f5c21db1ef47b47f0a1bf3180eaed60373f13c4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51595412)</sub>

**Context used:**

- Knowledge Base — [Authentication, Organizations, and Permissions](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/auth-and-organizations.md)

<!-- /greptile_comment -->