### PR TITLE
feat(backups): support custom PostgreSQL port for compose backups

### DIFF
--- a/apps/dokploy/__test__/backups/backup-schema.test.ts
+++ b/apps/dokploy/__test__/backups/backup-schema.test.ts
@@ -1,0 +1,60 @@
+import { apiCreateBackup, apiUpdateBackup } from "@dokploy/server/db/schema";
+import { describe, expect, it } from "vitest";
+
+const metadata = (databasePort: number) => ({
+	postgres: {
+		databaseUser: "postgres",
+		databasePort,
+	},
+});
+
+describe("PostgreSQL backup port validation", () => {
+	it.each([1, 5432, 65535])("accepts port %s on create", (databasePort) => {
+		const result = apiCreateBackup.safeParse({
+			schedule: "0 0 * * *",
+			prefix: "/",
+			destinationId: "destination-id",
+			database: "app",
+			databaseType: "postgres",
+			backupType: "compose",
+			composeId: "compose-id",
+			serviceName: "postgres",
+			metadata: metadata(databasePort),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it.each([0, 65536, 5432.5])("rejects port %s on create", (databasePort) => {
+		const result = apiCreateBackup.safeParse({
+			schedule: "0 0 * * *",
+			prefix: "/",
+			destinationId: "destination-id",
+			database: "app",
+			databaseType: "postgres",
+			backupType: "compose",
+			composeId: "compose-id",
+			serviceName: "postgres",
+			metadata: metadata(databasePort),
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an invalid port on update", () => {
+		const result = apiUpdateBackup.safeParse({
+			backupId: "backup-id",
+			schedule: "0 0 * * *",
+			enabled: true,
+			prefix: "/",
+			destinationId: "destination-id",
+			database: "app",
+			keepLatestCount: 5,
+			serviceName: "postgres",
+			databaseType: "postgres",
+			metadata: metadata(0),
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/apps/dokploy/__test__/backups/backup-schema.test.ts
+++ b/apps/dokploy/__test__/backups/backup-schema.test.ts
@@ -41,6 +41,38 @@ describe("PostgreSQL backup port validation", () => {
 		expect(result.success).toBe(false);
 	});
 
+	it("accepts null metadata on create", () => {
+		const result = apiCreateBackup.safeParse({
+			schedule: "0 0 * * *",
+			prefix: "/",
+			destinationId: "destination-id",
+			database: "app",
+			databaseType: "postgres",
+			backupType: "database",
+			postgresId: "postgres-id",
+			metadata: null,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a valid port on update", () => {
+		const result = apiUpdateBackup.safeParse({
+			backupId: "backup-id",
+			schedule: "0 0 * * *",
+			enabled: true,
+			prefix: "/",
+			destinationId: "destination-id",
+			database: "app",
+			keepLatestCount: 5,
+			serviceName: "postgres",
+			databaseType: "postgres",
+			metadata: metadata(5432),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
 	it("rejects an invalid port on update", () => {
 		const result = apiUpdateBackup.safeParse({
 			backupId: "backup-id",
@@ -56,5 +88,22 @@ describe("PostgreSQL backup port validation", () => {
 		});
 
 		expect(result.success).toBe(false);
+	});
+
+	it("accepts null metadata on update", () => {
+		const result = apiUpdateBackup.safeParse({
+			backupId: "backup-id",
+			schedule: "0 0 * * *",
+			enabled: true,
+			prefix: "/",
+			destinationId: "destination-id",
+			database: "app",
+			keepLatestCount: 5,
+			serviceName: "postgres",
+			databaseType: "postgres",
+			metadata: null,
+		});
+
+		expect(result.success).toBe(true);
 	});
 });

--- a/apps/dokploy/__test__/backups/db-backup-restore-injection.test.ts
+++ b/apps/dokploy/__test__/backups/db-backup-restore-injection.test.ts
@@ -99,8 +99,22 @@ describe("database backup/restore command injection", () => {
 		// Values live in -e assignments, never inline in the pg_dump text.
 		expect(cmd).toContain("-e DB_NAME=my-db_prod");
 		expect(cmd).toContain("-e DB_USER=app_user");
+		expect(cmd).toContain("-e DB_PORT=5432");
 		expect(cmd).toContain(
-			'pg_dump -Fc --no-acl --no-owner -h localhost -U "$DB_USER"',
+			'pg_dump -Fc --no-acl --no-owner -h localhost -p "$DB_PORT" -U "$DB_USER"',
+		);
+	});
+
+	it("uses a custom PostgreSQL port", () => {
+		const cmd = getPostgresBackupCommand("app", "app_user", 5544);
+
+		expect(cmd).toContain("-e DB_PORT=5544");
+		expect(cmd).toContain('-p "$DB_PORT"');
+	});
+
+	it.each([0, 65536, 5432.5])("rejects invalid PostgreSQL port %s", (port) => {
+		expect(() => getPostgresBackupCommand("app", "app_user", port)).toThrow(
+			"PostgreSQL port must be an integer between 1 and 65535",
 		);
 	});
 });

--- a/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
@@ -336,7 +336,7 @@ export const HandleBackup = ({
 			...getDatabaseId,
 			backupId: backupId ?? "",
 			backupType,
-			metadata: data.metadata,
+			metadata: data.metadata ?? null,
 		})
 			.then(async () => {
 				toast.success(`Backup ${backupId ? "Updated" : "Created"}`);

--- a/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
+++ b/apps/dokploy/components/dashboard/database/backups/handle-backup.tsx
@@ -92,6 +92,7 @@ const Schema = z
 				postgres: z
 					.object({
 						databaseUser: z.string(),
+						databasePort: z.coerce.number().int().min(1).max(65535),
 					})
 					.optional(),
 				mariadb: z
@@ -231,7 +232,10 @@ export const HandleBackup = ({
 			serviceName: null,
 			databaseType: backupType === "compose" ? undefined : databaseType,
 			backupType: backupType,
-			metadata: {},
+			metadata:
+				backupType === "compose" && databaseType === "postgres"
+					? { postgres: { databaseUser: "", databasePort: 5432 } }
+					: {},
 		},
 		resolver: zodResolver(Schema),
 	});
@@ -271,7 +275,19 @@ export const HandleBackup = ({
 			serviceName: backup?.serviceName ?? null,
 			databaseType: backup?.databaseType ?? databaseType,
 			backupType: backup?.backupType ?? backupType,
-			metadata: backup?.metadata ?? {},
+			metadata: backup?.metadata
+				? {
+						...backup.metadata,
+						postgres: backup.metadata.postgres
+							? {
+									...backup.metadata.postgres,
+									databasePort: backup.metadata.postgres.databasePort ?? 5432,
+								}
+							: undefined,
+					}
+				: backupType === "compose" && databaseType === "postgres"
+					? { postgres: { databaseUser: "", databasePort: 5432 } }
+					: {},
 		});
 	}, [form, form.reset, backupId, backup]);
 
@@ -383,7 +399,17 @@ export const HandleBackup = ({
 												value={field.value}
 												onValueChange={(value) => {
 													field.onChange(value as DatabaseType);
-													form.setValue("metadata", {});
+													form.setValue(
+														"metadata",
+														value === "postgres"
+															? {
+																	postgres: {
+																		databaseUser: "",
+																		databasePort: 5432,
+																	},
+																}
+															: {},
+													);
 												}}
 											>
 												<SelectTrigger className="w-full">
@@ -697,19 +723,39 @@ export const HandleBackup = ({
 							{backupType === "compose" && (
 								<>
 									{form.watch("databaseType") === "postgres" && (
-										<FormField
-											control={form.control}
-											name="metadata.postgres.databaseUser"
-											render={({ field }) => (
-												<FormItem>
-													<FormLabel>Database User</FormLabel>
-													<FormControl>
-														<Input placeholder="postgres" {...field} />
-													</FormControl>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
+										<>
+											<FormField
+												control={form.control}
+												name="metadata.postgres.databaseUser"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Database User</FormLabel>
+														<FormControl>
+															<Input placeholder="postgres" {...field} />
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={form.control}
+												name="metadata.postgres.databasePort"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Database Port</FormLabel>
+														<FormControl>
+															<Input
+																type="number"
+																placeholder="5432"
+																{...field}
+																value={field.value as number}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										</>
 									)}
 
 									{form.watch("databaseType") === "mariadb" && (

--- a/packages/server/src/db/schema/backups.ts
+++ b/packages/server/src/db/schema/backups.ts
@@ -166,7 +166,7 @@ const backupMetadataSchema = z
 			})
 			.optional(),
 	})
-	.optional();
+	.nullish();
 
 const createSchema = createInsertSchema(backups, {
 	backupId: z.string(),

--- a/packages/server/src/db/schema/backups.ts
+++ b/packages/server/src/db/schema/backups.ts
@@ -140,6 +140,34 @@ export const backupsRelations = relations(backups, ({ one, many }) => ({
 	deployments: many(deployments),
 }));
 
+const backupMetadataSchema = z
+	.object({
+		postgres: z
+			.object({
+				databaseUser: z.string(),
+				databasePort: z.number().int().min(1).max(65535).optional(),
+			})
+			.optional(),
+		mariadb: z
+			.object({
+				databaseUser: z.string(),
+				databasePassword: z.string(),
+			})
+			.optional(),
+		mongo: z
+			.object({
+				databaseUser: z.string(),
+				databasePassword: z.string(),
+			})
+			.optional(),
+		mysql: z
+			.object({
+				databaseRootPassword: z.string(),
+			})
+			.optional(),
+	})
+	.optional();
+
 const createSchema = createInsertSchema(backups, {
 	backupId: z.string(),
 	destinationId: z.string(),
@@ -163,7 +191,7 @@ const createSchema = createInsertSchema(backups, {
 	libsqlId: z.string().optional(),
 	userId: z.string().optional(),
 	includeEncryptionKey: z.boolean().optional(),
-	metadata: z.any().optional(),
+	metadata: backupMetadataSchema,
 });
 
 export const apiCreateBackup = createSchema.pick({

--- a/packages/server/src/db/schema/backups.ts
+++ b/packages/server/src/db/schema/backups.ts
@@ -86,6 +86,7 @@ export const backups = pgTable("backup", {
 		| {
 				postgres?: {
 					databaseUser: string;
+					databasePort?: number;
 				};
 				mariadb?: {
 					databaseUser: string;

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -99,8 +99,17 @@ export const getS3Credentials = (destination: Destination) => {
 export const getPostgresBackupCommand = (
 	database: string,
 	databaseUser: string,
+	databasePort = 5432,
 ) => {
-	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -i $CONTAINER_ID bash -c 'set -o pipefail; pg_dump -Fc --no-acl --no-owner -h localhost -U "$DB_USER" --no-password "$DB_NAME" | gzip'`;
+	if (
+		!Number.isInteger(databasePort) ||
+		databasePort < 1 ||
+		databasePort > 65535
+	) {
+		throw new Error("PostgreSQL port must be an integer between 1 and 65535");
+	}
+
+	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -e DB_PORT=${quote([String(databasePort)])} -i $CONTAINER_ID bash -c 'set -o pipefail; pg_dump -Fc --no-acl --no-owner -h localhost -p "$DB_PORT" -U "$DB_USER" --no-password "$DB_NAME" | gzip'`;
 };
 
 export const getMariadbBackupCommand = (
@@ -188,6 +197,7 @@ export const generateBackupCommand = (backup: BackupSchedule) => {
 				return getPostgresBackupCommand(
 					backup.database,
 					backup.metadata.postgres.databaseUser,
+					backup.metadata.postgres.databasePort,
 				);
 			}
 			break;


### PR DESCRIPTION
## What is this PR about?

This PR adds support for configuring the PostgreSQL port when creating or updating a Compose database backup.

PostgreSQL backups previously relied on the default port `5432`, causing `pg_dump` to fail when the database service was configured to listen on a different port.

The backup form now provides a database port field with `5432` as the default value and validates ports within the `1–65535` range. The configured port is passed safely to `pg_dump` through the `DB_PORT` environment
variable.

Existing backup configurations remain backward-compatible and continue using port `5432` when no port has been stored.

Tests were added for default, custom, and invalid PostgreSQL ports.

## Checklist

- [x] The change is focused on PostgreSQL Compose backups
- [x] Backward compatibility with existing backups is preserved
- [x] No database migration is required
- [x] Tests were added
- [x] Tested in a local Dokploy instance

## Screenshots (if applicable)

<img width="673" height="893" alt="image" src="https://github.com/user-attachments/assets/9e19e72b-7651-4b11-8825-a81e6500cf30" />

## Testing

  - `pnpm --filter=dokploy test --run __test__/backups/db-backup-restore-injection.test.ts -t "PostgreSQL port|uses a custom PostgreSQL port"` — passed (4 tests).
  - The complete test file reports timeouts in two pre-existing MongoDB command-injection cases. These cases were not modified by this PR and appear to invoke the locally installed `mongodump`, which waits for a MongoDB
connection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds configurable PostgreSQL ports for Compose backups while retaining port 5432 as the backward-compatible default.
- Adds the port field and validation to the backup form.
- Validates PostgreSQL ports in server-side create and update schemas.
- Passes the validated port to `pg_dump` through `DB_PORT`.
- Adds schema and command-generation coverage for default, custom, and invalid ports.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported persistence issue is fixed because both backup mutation procedures validate their inputs with schemas that reject invalid PostgreSQL ports before the service writes them, so no blocking failure remains.

<sub>Reviews (3): Last reviewed commit: ["fix(backups): preserve nullable metadata..."](https://github.com/dokploy/dokploy/commit/47489d24ab724e64ceaf24a9c3a0a8488b4caafe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51608553)</sub>

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->