### PR TITLE
fix: show stack containers running on worker nodes

### DIFF
--- a/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
+++ b/apps/dokploy/components/dashboard/compose/containers/show-compose-containers.tsx
@@ -114,6 +114,7 @@ export const ShowComposeContainers = ({
 									<TableHead>Name</TableHead>
 									<TableHead>State</TableHead>
 									<TableHead>Status</TableHead>
+									{appType === "stack" && <TableHead>Node</TableHead>}
 									<TableHead>Container ID</TableHead>
 									<TableHead className="text-right" />
 								</TableRow>
@@ -121,8 +122,9 @@ export const ShowComposeContainers = ({
 							<TableBody>
 								{data.map((container) => (
 									<ContainerRow
-										key={container.containerId}
+										key={container.name}
 										container={container}
+										appType={appType}
 										serverId={serverId}
 										serviceId={serviceId}
 										onActionComplete={() => refetch()}
@@ -143,7 +145,9 @@ interface ContainerRowProps {
 		name: string;
 		state: string;
 		status: string;
+		node?: string;
 	};
+	appType: "stack" | "docker-compose";
 	serverId?: string;
 	serviceId?: string;
 	onActionComplete: () => void;
@@ -151,6 +155,7 @@ interface ContainerRowProps {
 
 const ContainerRow = ({
 	container,
+	appType,
 	serverId,
 	serviceId,
 	onActionComplete,
@@ -192,7 +197,13 @@ const ContainerRow = ({
 					variant={
 						container.state === "running"
 							? "default"
-							: container.state === "exited"
+							: [
+										"exited",
+										"pending",
+										"preparing",
+										"starting",
+										"ready",
+									].includes(container.state)
 								? "secondary"
 								: "destructive"
 					}
@@ -201,96 +212,99 @@ const ContainerRow = ({
 				</Badge>
 			</TableCell>
 			<TableCell>{container.status}</TableCell>
+			{appType === "stack" && <TableCell>{container.node || "-"}</TableCell>}
 			<TableCell className="font-mono text-sm text-muted-foreground">
-				{container.containerId}
+				{container.containerId || "-"}
 			</TableCell>
 			<TableCell className="text-right">
-				<Dialog open={logsOpen} onOpenChange={setLogsOpen}>
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button variant="ghost" className="h-8 w-8 p-0">
-								{actionLoading ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : (
-									<MoreHorizontal className="h-4 w-4" />
-								)}
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end">
-							<DropdownMenuLabel>Actions</DropdownMenuLabel>
-							<DialogTrigger asChild>
+				{!container.containerId ? null : (
+					<Dialog open={logsOpen} onOpenChange={setLogsOpen}>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button variant="ghost" className="h-8 w-8 p-0">
+									{actionLoading ? (
+										<Loader2 className="h-4 w-4 animate-spin" />
+									) : (
+										<MoreHorizontal className="h-4 w-4" />
+									)}
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								<DropdownMenuLabel>Actions</DropdownMenuLabel>
+								<DialogTrigger asChild>
+									<DropdownMenuItem
+										className="cursor-pointer"
+										onSelect={(e) => e.preventDefault()}
+									>
+										View Logs
+									</DropdownMenuItem>
+								</DialogTrigger>
+								<ShowContainerConfig
+									containerId={container.containerId}
+									serverId={serverId || ""}
+								/>
+								<ShowContainerMounts
+									containerId={container.containerId}
+									serverId={serverId || ""}
+								/>
+								<ShowContainerNetworks
+									containerId={container.containerId}
+									serverId={serverId || ""}
+								/>
+								<DockerTerminalModal
+									containerId={container.containerId}
+									serverId={serverId || ""}
+									serviceId={serviceId}
+								>
+									Terminal
+								</DockerTerminalModal>
+								<DropdownMenuSeparator />
 								<DropdownMenuItem
 									className="cursor-pointer"
-									onSelect={(e) => e.preventDefault()}
+									disabled={actionLoading !== null}
+									onClick={() => handleAction("restart", restartMutation)}
 								>
-									View Logs
+									Restart
 								</DropdownMenuItem>
-							</DialogTrigger>
-							<ShowContainerConfig
-								containerId={container.containerId}
-								serverId={serverId || ""}
-							/>
-							<ShowContainerMounts
-								containerId={container.containerId}
-								serverId={serverId || ""}
-							/>
-							<ShowContainerNetworks
-								containerId={container.containerId}
-								serverId={serverId || ""}
-							/>
-							<DockerTerminalModal
-								containerId={container.containerId}
-								serverId={serverId || ""}
-								serviceId={serviceId}
-							>
-								Terminal
-							</DockerTerminalModal>
-							<DropdownMenuSeparator />
-							<DropdownMenuItem
-								className="cursor-pointer"
-								disabled={actionLoading !== null}
-								onClick={() => handleAction("restart", restartMutation)}
-							>
-								Restart
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="cursor-pointer"
-								disabled={actionLoading !== null}
-								onClick={() => handleAction("start", startMutation)}
-							>
-								Start
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="cursor-pointer"
-								disabled={actionLoading !== null}
-								onClick={() => handleAction("stop", stopMutation)}
-							>
-								Stop
-							</DropdownMenuItem>
-							<DropdownMenuItem
-								className="cursor-pointer text-red-500 focus:text-red-600"
-								disabled={actionLoading !== null}
-								onClick={() => handleAction("kill", killMutation)}
-							>
-								Kill
-							</DropdownMenuItem>
-						</DropdownMenuContent>
-					</DropdownMenu>
-					<DialogContent className="sm:max-w-7xl">
-						<DialogHeader>
-							<DialogTitle>View Logs</DialogTitle>
-							<DialogDescription>Logs for {container.name}</DialogDescription>
-						</DialogHeader>
-						<div className="flex flex-col gap-4 pt-2.5">
-							<DockerLogsId
-								containerId={container.containerId}
-								serverId={serverId}
-								runType="native"
-								serviceId={serviceId}
-							/>
-						</div>
-					</DialogContent>
-				</Dialog>
+								<DropdownMenuItem
+									className="cursor-pointer"
+									disabled={actionLoading !== null}
+									onClick={() => handleAction("start", startMutation)}
+								>
+									Start
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									className="cursor-pointer"
+									disabled={actionLoading !== null}
+									onClick={() => handleAction("stop", stopMutation)}
+								>
+									Stop
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									className="cursor-pointer text-red-500 focus:text-red-600"
+									disabled={actionLoading !== null}
+									onClick={() => handleAction("kill", killMutation)}
+								>
+									Kill
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+						<DialogContent className="sm:max-w-7xl">
+							<DialogHeader>
+								<DialogTitle>View Logs</DialogTitle>
+								<DialogDescription>Logs for {container.name}</DialogDescription>
+							</DialogHeader>
+							<div className="flex flex-col gap-4 pt-2.5">
+								<DockerLogsId
+									containerId={container.containerId}
+									serverId={serverId}
+									runType="native"
+									serviceId={serviceId}
+								/>
+							</div>
+						</DialogContent>
+					</Dialog>
+				)}
 			</TableCell>
 		</TableRow>
 	);

--- a/apps/dokploy/components/dashboard/compose/logs/show-stack.tsx
+++ b/apps/dokploy/components/dashboard/compose/logs/show-stack.tsx
@@ -57,7 +57,7 @@ export const ShowDockerLogsStack = ({
 			},
 		);
 
-	const { data: containers, isPending: containersLoading } =
+	const { data, isPending: containersLoading } =
 		api.docker.getContainersByAppNameMatch.useQuery(
 			{
 				appName,
@@ -68,6 +68,8 @@ export const ShowDockerLogsStack = ({
 				enabled: !!appName && option === "native",
 			},
 		);
+
+	const containers = data?.filter((container) => container.containerId);
 
 	useEffect(() => {
 		if (option === "native") {

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -108,6 +108,9 @@ export const getContainersByAppNameMatch = async (
 	serverId?: string,
 ) => {
 	try {
+		if (appType === "stack") {
+			return await getStackTaskContainers(appName, serverId);
+		}
 		let result: string[] = [];
 		const cmd =
 			"docker ps -a --format 'CONTAINER ID : {{.ID}} | Name: {{.Names}} | State: {{.State}} | Status: {{.Status}}'";
@@ -166,6 +169,66 @@ export const getContainersByAppNameMatch = async (
 	return [];
 };
 
+const getStackTaskContainers = async (appName: string, serverId?: string) => {
+	try {
+		const divider = "__DOKPLOY_DIVIDER__";
+		const tasksCommand = `docker stack ps ${appName} --no-trunc --filter "desired-state=running" --format 'TASK : {{.ID}} | Name: {{.Name}} | Node: {{.Node}} | CurrentState: {{.CurrentState}} | Error: {{.Error}}'`;
+		const inspectCommand = `docker stack ps ${appName} -q --no-trunc --filter "desired-state=running" | xargs -r docker inspect --format '{{if .Status.ContainerStatus}}TASK : {{.ID}} | ContainerId: {{.Status.ContainerStatus.ContainerID}}{{end}}' 2>/dev/null`;
+		const command = `${tasksCommand} && echo "${divider}" && (${inspectCommand} || true)`;
+
+		let stdout = "";
+
+		if (serverId) {
+			const result = await execAsyncRemote(serverId, command);
+			stdout = result.stdout;
+		} else {
+			const result = await execAsync(command);
+			stdout = result.stdout;
+		}
+
+		if (!stdout) return [];
+
+		const [tasksSection = "", inspectSection = ""] = stdout.split(divider);
+
+		const containerIdByTask = new Map<string, string>();
+		for (const line of inspectSection.trim().split("\n")) {
+			const parts = line.split(" | ");
+			const taskId = parts[0]?.replace("TASK : ", "").trim();
+			const containerId = parts[1]?.replace("ContainerId: ", "").trim();
+			if (taskId && containerId) {
+				containerIdByTask.set(taskId, containerId);
+			}
+		}
+
+		const containers = [];
+
+		for (const line of tasksSection.trim().split("\n")) {
+			if (!line) continue;
+			const parts = line.split(" | ");
+			const taskId = parts[0]?.replace("TASK : ", "").trim() ?? "";
+			const name = parts[1]?.replace("Name: ", "").trim() ?? "";
+			const node = parts[2]?.replace("Node: ", "").trim() ?? "";
+			const currentState = parts[3]
+				? parts[3].replace("CurrentState: ", "").trim()
+				: "";
+			const error = parts[4] ? parts[4].replace("Error: ", "").trim() : "";
+			const containerId = containerIdByTask.get(taskId) ?? "";
+
+			containers.push({
+				containerId: containerId.slice(0, 12),
+				name: `${name}.${taskId}`,
+				node,
+				state: currentState.split(" ")[0]?.toLowerCase() ?? "No state",
+				status: error ? `${currentState} (${error})` : currentState,
+			});
+		}
+
+		return containers;
+	} catch {}
+
+	return [];
+};
+
 export const getStackContainersByAppName = async (
 	appName: string,
 	serverId?: string,
@@ -175,7 +238,6 @@ export const getStackContainersByAppName = async (
 
 		const command = `docker stack ps ${appName} --no-trunc --format 'CONTAINER ID : {{.ID}} | Name: {{.Name}} | State: {{.DesiredState}} | Node: {{.Node}} | CurrentState: {{.CurrentState}} | Error: {{.Error}}'`;
 
-		console.log("command	", command);
 		if (serverId) {
 			const { stdout, stderr } = await execAsyncRemote(serverId, command);
 


### PR DESCRIPTION
Fixes #4520

For `stack` compose type, the Containers tab listed containers with `docker ps` on the manager node, which only sees local containers. Stacks with placement constraints targeting worker nodes showed "No containers found".

- `getContainersByAppNameMatch` for stacks now uses `docker stack ps` (sees tasks on every node) and maps each task to its real container ID via `docker inspect` on the task objects (stored in the manager's raft store), in a single exec so remote servers pay one SSH roundtrip.
- Tasks without a container yet (pending/preparing) are included with their node and scheduling error, so the page explains why nothing is running instead of showing an empty state.
- Containers tab shows a Node column for stacks; rows without a container render without the actions menu.
- Native logs selector filters tasks without a container ID.

Note: container actions (terminal, native logs, restart) still exec against the manager, so they won't work for containers living on a worker node — the Node column makes that visible. Cross-node exec and the backup lookup mentioned in the issue comments are separate work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes stack container discovery to query Swarm tasks on the manager and resolve their container IDs, allowing worker-node tasks and pending tasks to appear in the dashboard.
- Adds stack-specific task discovery and container-ID resolution in one local or remote command.
- Displays each stack task’s node and scheduling status and suppresses actions when no container exists.
- Excludes unresolved tasks from the native-log container selector.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new stack path preserves the expected container response shape, includes unresolved tasks for status visibility, and prevents container-only actions and native-log selection when no container ID exists.

<sub>Reviews (1): Last reviewed commit: ["fix: list stack containers across swarm ..."](https://github.com/dokploy/dokploy/commit/1f73ebd0b0f89e827e3294d044a46ac7a29c7539) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51610092)</sub>

**Context used:**

- Knowledge Base — [Compose Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/compose-deployment.md)

<!-- /greptile_comment -->