### PR TITLE
fix: run database dump once per backup and clean up partial uploads on failure

### DIFF
--- a/packages/server/src/utils/backups/compose.ts
+++ b/packages/server/src/utils/backups/compose.ts
@@ -37,11 +37,10 @@ export const runComposeBackup = async (
 	try {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
 		const backupCommand = getBackupCommand(
 			backup,
-			rcloneCommand,
+			rcloneFlags,
+			rcloneDestination,
 			deployment.logPath,
 		);
 		if (compose.serverId) {

--- a/packages/server/src/utils/backups/libsql.ts
+++ b/packages/server/src/utils/backups/libsql.ts
@@ -36,12 +36,10 @@ export const runLibsqlBackup = async (
 	try {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
 		const backupCommand = getBackupCommand(
 			backup,
-			rcloneCommand,
+			rcloneFlags,
+			rcloneDestination,
 			deployment.logPath,
 		);
 		if (libsql.serverId) {

--- a/packages/server/src/utils/backups/mariadb.ts
+++ b/packages/server/src/utils/backups/mariadb.ts
@@ -35,11 +35,10 @@ export const runMariadbBackup = async (
 	try {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
 		const backupCommand = getBackupCommand(
 			backup,
-			rcloneCommand,
+			rcloneFlags,
+			rcloneDestination,
 			deployment.logPath,
 		);
 		if (mariadb.serverId) {

--- a/packages/server/src/utils/backups/mongo.ts
+++ b/packages/server/src/utils/backups/mongo.ts
@@ -32,11 +32,10 @@ export const runMongoBackup = async (mongo: Mongo, backup: BackupSchedule) => {
 	try {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
 		const backupCommand = getBackupCommand(
 			backup,
-			rcloneCommand,
+			rcloneFlags,
+			rcloneDestination,
 			deployment.logPath,
 		);
 

--- a/packages/server/src/utils/backups/mysql.ts
+++ b/packages/server/src/utils/backups/mysql.ts
@@ -33,12 +33,10 @@ export const runMySqlBackup = async (mysql: MySql, backup: BackupSchedule) => {
 	try {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
 		const backupCommand = getBackupCommand(
 			backup,
-			rcloneCommand,
+			rcloneFlags,
+			rcloneDestination,
 			deployment.logPath,
 		);
 

--- a/packages/server/src/utils/backups/postgres.ts
+++ b/packages/server/src/utils/backups/postgres.ts
@@ -36,12 +36,10 @@ export const runPostgresBackup = async (
 	try {
 		const rcloneFlags = getS3Credentials(destination);
 		const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
-
-		const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
-
 		const backupCommand = getBackupCommand(
 			backup,
-			rcloneCommand,
+			rcloneFlags,
+			rcloneDestination,
 			deployment.logPath,
 		);
 		if (postgres.serverId) {

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -259,11 +259,14 @@ export const generateBackupCommand = (backup: BackupSchedule) => {
 
 export const getBackupCommand = (
 	backup: BackupSchedule,
-	rcloneCommand: string,
+	rcloneFlags: string[],
+	rcloneDestination: string,
 	logPath: string,
 ) => {
 	const containerSearch = getContainerSearchCommand(backup);
 	const backupCommand = generateBackupCommand(backup);
+	const rcloneCommand = `rclone rcat ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
+	const rcloneDeleteCommand = `rclone deletefile ${rcloneFlags.join(" ")} "${rcloneDestination}"`;
 
 	logger.info(
 		{
@@ -279,33 +282,24 @@ export const getBackupCommand = (
 	set -eo pipefail;
 	echo "[$(date)] Starting backup process..." >> ${logPath};
 	echo "[$(date)] Executing backup command..." >> ${logPath};
-	CONTAINER_ID=$(${containerSearch})
+	CONTAINER_ID=$(${containerSearch});
 
 	if [ -z "$CONTAINER_ID" ]; then
 		echo "[$(date)] ❌ Error: Container not found" >> ${logPath};
 		exit 1;
-	fi
+	fi;
 
 	echo "[$(date)] Container Up: $CONTAINER_ID" >> ${logPath};
+	echo "[$(date)] Starting backup and upload to S3..." >> ${logPath};
 
-	# Run the backup command and capture the exit status
-	BACKUP_OUTPUT=$(${backupCommand} 2>&1 >/dev/null) || {
+	UPLOAD_OUTPUT=$({ ${backupCommand} | ${rcloneCommand}; } 2>&1 >/dev/null) || {
 		echo "[$(date)] ❌ Error: Backup failed" >> ${logPath};
-		echo "Error: $BACKUP_OUTPUT" >> ${logPath};
-		exit 1;
-	}
-
-	echo "[$(date)] ✅ backup completed successfully" >> ${logPath};
-	echo "[$(date)] Starting upload to S3..." >> ${logPath};
-
-	# Run the upload command and capture the exit status
-	UPLOAD_OUTPUT=$(${backupCommand} | ${rcloneCommand} 2>&1 >/dev/null) || {
-		echo "[$(date)] ❌ Error: Upload to S3 failed" >> ${logPath};
 		echo "Error: $UPLOAD_OUTPUT" >> ${logPath};
+		${rcloneDeleteCommand} >/dev/null 2>&1 || true;
 		exit 1;
-	}
+	};
 
-	echo "[$(date)] ✅ Upload to S3 completed successfully" >> ${logPath};
+	echo "[$(date)] ✅ Backup uploaded to S3 successfully" >> ${logPath};
 	echo "Backup done ✅" >> ${logPath};
 	`;
 };


### PR DESCRIPTION
The backup script generated by `getBackupCommand` ran the database dump **twice**: once as a "test" with the output discarded, then again piped to rclone for the actual upload. Every backup doubled the dump time and database load, and the uploaded dump could differ from the verified one.

## Changes

- Run the dump exactly once, piped directly to rclone (`set -o pipefail` propagates dump failures through the pipe).
- Group the pipeline with `{ ...; } 2>&1` so the deployment log captures the real dump error (previously only rclone's stderr was captured, so the actual failure reason was lost when removing the test run).
- On failure, delete the partial object with `rclone deletefile` — a failed dump no longer leaves a corrupt/empty file in the bucket that retention (`keepLatestNBackups`) would rotate against good backups.
- Terminate every statement in the generated script with `;` so it stays valid even when newlines get collapsed (#4235).
- `getBackupCommand` now takes `rcloneFlags` + `rcloneDestination` and builds the upload/delete commands itself; all six callers (postgres, mysql, mariadb, mongo, libsql, compose) updated.

Verified end-to-end against a local MinIO + Postgres: exactly one `pg_dump` connection per backup (confirmed via `log_connections`), uploaded dump restores correctly, and a failing dump exits 1, logs the real pg_dump error, and leaves no orphan object in the bucket.

Closes #4222
Closes #4915
Closes #4235

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes database and compose backups to stream each dump to object storage exactly once and removes the destination object when the combined dump/upload pipeline fails.

- Moves construction of the rclone upload and deletion commands into `getBackupCommand`.
- Captures errors from the grouped dump/upload pipeline and logs them through the deployment log.
- Updates all six callers to pass rclone flags and destination separately.
- Adds statement terminators throughout the generated backup script.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code failures identified.

The revised command performs one dump/upload pipeline, propagates failures, logs combined stderr, and limits cleanup to the unique destination key generated for that invocation.

<sub>Reviews (1): Last reviewed commit: ["fix: run database dump once per backup a..."](https://github.com/dokploy/dokploy/commit/f633d4b0a35a9b099f5a632b1bc485c726be846b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51615039)</sub>

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->