### PR TITLE
Add local development teardown command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,18 @@ pnpm run dokploy:dev
 
 Go to http://localhost:3000 to see the development server
 
+When you are done with local development, stop the development server with
+`Ctrl-C`, then remove the Docker resources created by the setup step:
+
+```bash
+pnpm run dokploy:dev:down
+```
+
+> [!WARNING]
+> This command removes the local Dokploy Traefik container, Postgres service and
+> its data volume, the `dokploy-network` network, and leaves the local Docker
+> Swarm. Run it only for a disposable local development environment.
+
 > [!NOTE]
 > This project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.
 

--- a/apps/dokploy/down.ts
+++ b/apps/dokploy/down.ts
@@ -1,0 +1,43 @@
+import { docker, dockerSwarmInitialized } from "@dokploy/server";
+
+const ignoreNotFound = async (action: () => Promise<unknown>) => {
+	try {
+		await action();
+	} catch (error: any) {
+		if (error?.statusCode !== 404) {
+			throw error;
+		}
+	}
+};
+
+const removeDevelopmentResources = async () => {
+	await ignoreNotFound(() =>
+		docker.getContainer("dokploy-traefik").remove({ force: true }),
+	);
+	console.log("Dokploy Traefik removed ✅");
+
+	await ignoreNotFound(() => docker.getService("dokploy-postgres").remove());
+	console.log("Dokploy Postgres service removed ✅");
+
+	await ignoreNotFound(() => docker.getVolume("dokploy-postgres").remove());
+	console.log("Dokploy Postgres data volume removed ✅");
+
+	await ignoreNotFound(() => docker.getNetwork("dokploy-network").remove());
+	console.log("Dokploy network removed ✅");
+};
+
+(async () => {
+	try {
+		await removeDevelopmentResources();
+
+		if (await dockerSwarmInitialized()) {
+			await docker.swarmLeave({ force: true });
+			console.log("Docker Swarm left ✅");
+		}
+
+		console.log("Dokploy development environment removed");
+	} catch (error) {
+		console.error("Error removing Dokploy development environment", error);
+		process.exitCode = 1;
+	}
+})();

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -10,6 +10,7 @@
 		"build-server": "tsx esbuild.config.ts",
 		"build-next": "next build --webpack",
 		"setup": "tsx -r dotenv/config setup.ts && sleep 5 && pnpm run migration:run",
+		"down": "tsx -r dotenv/config down.ts",
 		"wait-for-postgres": "node -r dotenv/config dist/wait-for-postgres.mjs",
 		"wait-for-postgres-dev": "tsx -r dotenv/config wait-for-postgres.ts",
 		"reset-password": "node -r dotenv/config dist/reset-password.mjs",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"dokploy:setup": "pnpm --filter=dokploy run setup",
 		"dokploy:dev": "pnpm --filter=dokploy run dev",
+		"dokploy:dev:down": "pnpm --filter=dokploy run down",
 		"dokploy:build": "pnpm --filter=dokploy run build",
 		"dokploy:start": "pnpm --filter=dokploy run start",
 		"test": "pnpm --filter=dokploy run test",


### PR DESCRIPTION
## Summary

- add `pnpm dokploy:dev:down` as an explicit teardown counterpart to the local setup workflow
- remove the local development Traefik container, Postgres service and data volume, Dokploy network, and Swarm state
- document the command and its destructive scope for contributors

## Why

`pnpm dokploy:setup` creates persistent Docker and Swarm resources, while stopping `pnpm dokploy:dev` only exits the development server. This gives contributors a documented way to clean up a disposable local environment.

Closes #5028

## Validation

- `pnpm --filter=dokploy run typecheck`
- `pnpm exec biome check apps/dokploy/down.ts apps/dokploy/package.json package.json CONTRIBUTING.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an explicit local-development teardown command and contributor documentation for its destructive scope.
- Adds a `down.ts` script that removes local Traefik, Postgres, network, volume, and Swarm resources.
- Exposes the teardown through application- and repository-level pnpm scripts.
- Documents invocation and warns contributors that persisted development data is removed.

<h3>Confidence Score: 4/5</h3>

The teardown should be fixed before merging because it can abort midway while Postgres service tasks are still releasing their volume and network.

The new command assumes service deletion immediately releases task-mounted resources, so a normal resource-in-use response prevents the remaining cleanup and Swarm departure.

**Files Needing Attention:** apps/dokploy/down.ts

<sub>Reviews (1): Last reviewed commit: ["feat: add local dev teardown command"](https://github.com/dokploy/dokploy/commit/7d9bfc33085b382e8a8518c912e436a64529dbff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51622965)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server Setup and Packaging](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/server-setup-and-packaging.md)

<!-- /greptile_comment -->