### PR TITLE
feat: add local development teardown command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,19 @@ pnpm run dokploy:dev
 
 Go to http://localhost:3000 to see the development server
 
+When you are done with local development, stop the development server with
+`Ctrl-C`, then remove the Docker resources created by the setup step:
+
+```bash
+pnpm run dokploy:dev:down
+```
+
+> [!WARNING]
+> This command removes the local Dokploy Traefik container, Postgres service and
+> its data volume, the `dokploy-network` network, and leaves the local Docker
+> Swarm only when `dokploy:setup` initialized it. Run it only for a disposable
+> local development environment.
+
 > [!NOTE]
 > This project uses Biome. If your editor is configured to use another formatter such as Prettier, it's recommended to either change it to use Biome or turn it off.
 

--- a/apps/dokploy/down.ts
+++ b/apps/dokploy/down.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { docker, paths } from "@dokploy/server/constants";
+
+const ignoreNotFound = async (action: () => Promise<unknown>) => {
+	try {
+		await action();
+	} catch (error: any) {
+		if (error?.statusCode !== 404) {
+			throw error;
+		}
+	}
+};
+
+const removeStandaloneResources = async () => {
+	await ignoreNotFound(() =>
+		docker.getContainer("dokploy-traefik").remove({ force: true }),
+	);
+	console.log("Dokploy Traefik removed ✅");
+};
+
+const removeSwarmResources = async () => {
+	await ignoreNotFound(() => docker.getService("dokploy-postgres").remove());
+	console.log("Dokploy Postgres service removed ✅");
+
+	await ignoreNotFound(() => docker.getVolume("dokploy-postgres").remove());
+	console.log("Dokploy Postgres data volume removed ✅");
+};
+
+const swarmMarkerPath = join(paths().BASE_PATH, ".dokploy-dev-swarm");
+
+const getSwarmId = async () => {
+	try {
+		return (await docker.swarmInspect()).ID;
+	} catch {
+		return undefined;
+	}
+};
+
+(async () => {
+	try {
+		await removeStandaloneResources();
+		const swarmId = await getSwarmId();
+		const markedSwarmId = existsSync(swarmMarkerPath)
+			? readFileSync(swarmMarkerPath, "utf8").trim()
+			: undefined;
+
+		if (swarmId && markedSwarmId === swarmId) {
+			await removeSwarmResources();
+			await docker.swarmLeave({ force: true });
+			console.log("Docker Swarm left ✅");
+
+			await ignoreNotFound(() => docker.getNetwork("dokploy-network").remove());
+			console.log("Dokploy network removed ✅");
+			rmSync(swarmMarkerPath, { force: true });
+		} else if (swarmId) {
+			console.log(
+				"Docker Swarm was not initialized by Dokploy; leaving it unchanged",
+			);
+		} else {
+			console.log("Docker Swarm is already inactive; skipping Swarm resources");
+			rmSync(swarmMarkerPath, { force: true });
+		}
+
+		console.log("Dokploy development environment removed");
+	} catch (error) {
+		console.error("Error removing Dokploy development environment", error);
+		process.exitCode = 1;
+	}
+})();

--- a/apps/dokploy/package.json
+++ b/apps/dokploy/package.json
@@ -10,6 +10,7 @@
 		"build-server": "tsx esbuild.config.ts",
 		"build-next": "next build --webpack",
 		"setup": "tsx -r dotenv/config setup.ts && sleep 5 && pnpm run migration:run",
+		"down": "tsx -r dotenv/config down.ts",
 		"wait-for-postgres": "node -r dotenv/config dist/wait-for-postgres.mjs",
 		"wait-for-postgres-dev": "tsx -r dotenv/config wait-for-postgres.ts",
 		"reset-password": "node -r dotenv/config dist/reset-password.mjs",

--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -1,9 +1,12 @@
 import { exec } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { exit } from "node:process";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
 
+import { docker, paths } from "@dokploy/server/constants";
 import { setupDirectories } from "@dokploy/server/setup/config-paths";
 import { initializePostgres } from "@dokploy/server/setup/postgres-setup";
 import {
@@ -22,7 +25,11 @@ import {
 	try {
 		setupDirectories();
 		createDefaultMiddlewares();
-		await initializeSwarm();
+		const swarmWasInitialized = await initializeSwarm();
+		if (swarmWasInitialized) {
+			const swarm = await docker.swarmInspect();
+			writeFileSync(join(paths().BASE_PATH, ".dokploy-dev-swarm"), swarm.ID);
+		}
 		await initializeNetwork();
 		createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"dokploy:setup": "pnpm --filter=dokploy run setup",
 		"dokploy:dev": "pnpm --filter=dokploy run dev",
+		"dokploy:dev:down": "pnpm --filter=dokploy run down",
 		"dokploy:build": "pnpm --filter=dokploy run build",
 		"dokploy:start": "pnpm --filter=dokploy run start",
 		"test": "pnpm --filter=dokploy run test",

--- a/packages/server/src/setup/setup.ts
+++ b/packages/server/src/setup/setup.ts
@@ -4,13 +4,15 @@ export const initializeSwarm = async () => {
 	const swarmInitialized = await dockerSwarmInitialized();
 	if (swarmInitialized) {
 		console.log("Swarm is already initialized");
-	} else {
-		await docker.swarmInit({
-			AdvertiseAddr: "127.0.0.1",
-			ListenAddr: "0.0.0.0",
-		});
-		console.log("Swarm was initialized");
+		return false;
 	}
+
+	await docker.swarmInit({
+		AdvertiseAddr: "127.0.0.1",
+		ListenAddr: "0.0.0.0",
+	});
+	console.log("Swarm was initialized");
+	return true;
 };
 
 export const dockerSwarmInitialized = async () => {


### PR DESCRIPTION
## Summary

- add `pnpm dokploy:dev:down` as an explicit teardown counterpart to the local setup workflow
- remove local Dokploy development resources when they are owned by this setup
- preserve a pre-existing Docker Swarm: setup records ownership only when it initialized the Swarm, and teardown only force-leaves when that marker is present
- document the command and its destructive scope for contributors

## Why

`pnpm dokploy:setup` creates persistent Docker and Swarm resources, while stopping `pnpm dokploy:dev` only exits the development server. This gives contributors a documented way to clean up a disposable local environment without disrupting an existing Swarm.

## Validation

- `pnpm run dokploy:dev:down` with an inactive Swarm
- `pnpm --filter=dokploy run typecheck`
- `pnpm --filter=server run typecheck`
- `pnpm exec biome check apps/dokploy/down.ts apps/dokploy/setup.ts packages/server/src/setup/setup.ts CONTRIBUTING.md`