### PR TITLE
fix: clear old deployments by id, not appName folder

### DIFF
--- a/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
+++ b/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
@@ -71,4 +71,36 @@ describe("clearOldDeployments", () => {
 
 		expect(db.delete).not.toHaveBeenCalled();
 	});
+
+	it("never deletes the currently-running deployment, even if newer than the last success", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "running-1", status: "running" }),
+			makeDeployment({ deploymentId: "success-1", status: "done" }),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("app-1", "application");
+
+		// running-1 is excluded from deletion candidates entirely, and
+		// success-1 is kept as the most recent successful deployment.
+		expect(db.delete).not.toHaveBeenCalled();
+	});
+
+	it("deletes older non-running deployments while a build is in progress", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "running-1", status: "running" }),
+			makeDeployment({ deploymentId: "success-1", status: "done" }),
+			makeDeployment({ deploymentId: "failed-1", status: "error" }),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("app-1", "application");
+
+		// running-1 is protected; only failed-1 (older than the kept success) is removed.
+		expect(db.delete).toHaveBeenCalledTimes(1);
+	});
 });

--- a/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
+++ b/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
@@ -103,4 +103,31 @@ describe("clearOldDeployments", () => {
 		// running-1 is protected; only failed-1 (older than the kept success) is removed.
 		expect(db.delete).toHaveBeenCalledTimes(1);
 	});
+
+	it("continues cleaning up remaining deployments after one removal fails", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "success-1", status: "done" }),
+			makeDeployment({ deploymentId: "failed-1", status: "error" }),
+			makeDeployment({ deploymentId: "failed-2", status: "error" }),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+		vi.mocked(db.delete)
+			.mockImplementationOnce(() => {
+				throw new Error("db unavailable");
+			})
+			.mockReturnValue({
+				where: () => ({
+					returning: () => Promise.resolve([]),
+				}),
+			} as any);
+
+		await expect(
+			clearOldDeployments("app-1", "application"),
+		).resolves.not.toThrow();
+
+		// failed-1's removal throws but doesn't stop failed-2 from being attempted.
+		expect(db.delete).toHaveBeenCalledTimes(2);
+	});
 });

--- a/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
+++ b/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
@@ -1,0 +1,74 @@
+import { clearOldDeployments } from "@dokploy/server";
+import { db } from "@dokploy/server/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsync: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
+	execAsyncRemote: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
+}));
+
+const makeDeployment = (overrides: Record<string, unknown>) => ({
+	deploymentId: "",
+	logPath: ".",
+	serverId: null,
+	status: "done",
+	rollbackId: null,
+	createdAt: new Date().toISOString(),
+	...overrides,
+});
+
+describe("clearOldDeployments", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(db.delete).mockReturnValue({
+			where: () => ({
+				returning: () => Promise.resolve([]),
+			}),
+		} as any);
+	});
+
+	it("keeps the most recent successful deployment and deletes the rest", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "failed-1", status: "error" }),
+			makeDeployment({ deploymentId: "success-1", status: "done" }),
+			makeDeployment({ deploymentId: "success-2", status: "done" }),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("app-1", "application");
+
+		// deploymentList order is newest-first (query orders by desc createdAt);
+		// first "done" entry (success-1) is kept, failed-1 and success-2 are deleted.
+		expect(db.delete).toHaveBeenCalledTimes(2);
+	});
+
+	it("falls back to the newest deployment when none succeeded", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "failed-1", status: "error" }),
+			makeDeployment({ deploymentId: "failed-2", status: "error" }),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("app-1", "application");
+
+		// failed-1 (newest) is kept as fallback, only failed-2 is deleted.
+		expect(db.delete).toHaveBeenCalledTimes(1);
+	});
+
+	it("removes nothing when there is a single deployment", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "only-1", status: "done" }),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("compose-1", "compose");
+
+		expect(db.delete).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
+++ b/apps/dokploy/__test__/deploy/clear-old-deployments.test.ts
@@ -1,11 +1,28 @@
 import { clearOldDeployments } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@dokploy/server/utils/process/execAsync", () => ({
 	execAsync: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
 	execAsyncRemote: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
 }));
+
+vi.mock("@dokploy/server/services/application", () => ({
+	findApplicationById: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/services/compose", () => ({
+	findComposeById: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/services/rollbacks", () => ({
+	removeRollbackById: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { findApplicationById } from "@dokploy/server/services/application";
+import { findComposeById } from "@dokploy/server/services/compose";
+import { removeRollbackById } from "@dokploy/server/services/rollbacks";
 
 const makeDeployment = (overrides: Record<string, unknown>) => ({
 	deploymentId: "",
@@ -24,6 +41,12 @@ describe("clearOldDeployments", () => {
 			where: () => ({
 				returning: () => Promise.resolve([]),
 			}),
+		} as any);
+		vi.mocked(findApplicationById).mockResolvedValue({
+			serverId: null,
+		} as any);
+		vi.mocked(findComposeById).mockResolvedValue({
+			serverId: null,
 		} as any);
 	});
 
@@ -129,5 +152,51 @@ describe("clearOldDeployments", () => {
 
 		// failed-1's removal throws but doesn't stop failed-2 from being attempted.
 		expect(db.delete).toHaveBeenCalledTimes(2);
+	});
+
+	it("removes the rollback (and its image) before deleting a deployment that has one", async () => {
+		const deploymentList = [
+			makeDeployment({ deploymentId: "success-1", status: "done" }),
+			makeDeployment({
+				deploymentId: "failed-1",
+				status: "error",
+				rollbackId: "rollback-1",
+			}),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("app-1", "application");
+
+		expect(removeRollbackById).toHaveBeenCalledWith("rollback-1");
+		expect(db.delete).toHaveBeenCalledTimes(1);
+	});
+
+	it("removes remote logs via execAsyncRemote using the application's server, not local execAsync", async () => {
+		vi.mocked(findApplicationById).mockResolvedValue({
+			serverId: "server-1",
+		} as any);
+		const deploymentList = [
+			makeDeployment({ deploymentId: "success-1", status: "done" }),
+			makeDeployment({
+				deploymentId: "failed-1",
+				status: "error",
+				logPath: "/logs/failed-1.log",
+				serverId: null,
+			}),
+		];
+		vi.mocked(db.query.deployments.findMany).mockResolvedValue(
+			deploymentList as any,
+		);
+
+		await clearOldDeployments("app-1", "application");
+
+		// the batched remote cleanup uses the application's server, independent
+		// of the (often-unset) per-deployment serverId column.
+		expect(execAsyncRemote).toHaveBeenCalledWith(
+			"server-1",
+			expect.stringContaining("rm -rf /logs/failed-1.log;"),
+		);
 	});
 });

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -756,7 +756,7 @@ export const applicationRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const application = await findApplicationById(input.applicationId);
-			await clearOldDeployments(application.appName, application.serverId);
+			await clearOldDeployments(application.applicationId, "application");
 			await audit(ctx, {
 				action: "delete",
 				resourceType: "application",

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -291,7 +291,7 @@ export const composeRouter = createTRPCRouter({
 				deployment: ["create"],
 			});
 			const compose = await findComposeById(input.composeId);
-			await clearOldDeployments(compose.appName, compose.serverId);
+			await clearOldDeployments(compose.composeId, "compose");
 			await audit(ctx, {
 				action: "update",
 				resourceType: "compose",

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1048,7 +1048,10 @@ export const clearOldDeployments = async (
 	id: string,
 	type: "application" | "compose",
 ) => {
-	const deploymentList = await getDeploymentsByType(id, type);
+	const deploymentList = await db.query.deployments.findMany({
+		where: eq(deployments[`${type}Id`], id),
+		orderBy: desc(deployments.createdAt),
+	});
 	const deletable = deploymentList.filter(
 		(deployment) => deployment.status !== "running",
 	);
@@ -1061,6 +1064,13 @@ export const clearOldDeployments = async (
 		if (deployment.deploymentId === deploymentToKeep?.deploymentId) {
 			continue;
 		}
-		await removeDeployment(deployment.deploymentId);
+		try {
+			await removeDeployment(deployment.deploymentId);
+		} catch (err) {
+			console.error(
+				`Failed to remove deployment ${deployment.deploymentId} during cleanup:`,
+				err,
+			);
+		}
 	}
 };

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1048,6 +1048,11 @@ export const clearOldDeployments = async (
 	id: string,
 	type: "application" | "compose",
 ) => {
+	const serverId =
+		type === "application"
+			? (await findApplicationById(id)).serverId
+			: (await findComposeById(id)).serverId;
+
 	const deploymentList = await db.query.deployments.findMany({
 		where: eq(deployments[`${type}Id`], id),
 		orderBy: desc(deployments.createdAt),
@@ -1060,17 +1065,49 @@ export const clearOldDeployments = async (
 	);
 	const deploymentToKeep = mostRecentSuccessful ?? deletable[0];
 
-	for (const deployment of deletable) {
-		if (deployment.deploymentId === deploymentToKeep?.deploymentId) {
-			continue;
+	const toRemove = deletable.filter(
+		(deployment) => deployment.deploymentId !== deploymentToKeep?.deploymentId,
+	);
+
+	if (serverId) {
+		let command = "";
+		for (const deployment of toRemove) {
+			try {
+				if (deployment.rollbackId) {
+					await removeRollbackById(deployment.rollbackId);
+				}
+				const logPath = path.join(deployment.logPath);
+				if (logPath && logPath !== ".") {
+					command += `rm -rf ${logPath};`;
+				}
+				await removeDeployment(deployment.deploymentId);
+			} catch (err) {
+				console.error(
+					`Failed to remove deployment ${deployment.deploymentId} during cleanup:`,
+					err,
+				);
+			}
 		}
-		try {
-			await removeDeployment(deployment.deploymentId);
-		} catch (err) {
-			console.error(
-				`Failed to remove deployment ${deployment.deploymentId} during cleanup:`,
-				err,
-			);
+		if (command) {
+			await execAsyncRemote(serverId, command);
+		}
+	} else {
+		for (const deployment of toRemove) {
+			try {
+				if (deployment.rollbackId) {
+					await removeRollbackById(deployment.rollbackId);
+				}
+				const logPath = path.join(deployment.logPath);
+				if (logPath && logPath !== "." && existsSync(logPath)) {
+					await fsPromises.unlink(logPath);
+				}
+				await removeDeployment(deployment.deploymentId);
+			} catch (err) {
+				console.error(
+					`Failed to remove deployment ${deployment.deploymentId} during cleanup:`,
+					err,
+				);
+			}
 		}
 	}
 };

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1045,17 +1045,19 @@ export const findAllDeploymentsByServerId = async (serverId: string) => {
 };
 
 export const clearOldDeployments = async (
-	appName: string,
-	serverId: string | null,
+	id: string,
+	type: "application" | "compose",
 ) => {
-	const { LOGS_PATH } = paths(!!serverId);
-	const folder = path.join(LOGS_PATH, appName);
-	const command = `
-		rm -rf ${folder};
-	`;
-	if (serverId) {
-		await execAsyncRemote(serverId, command);
-	} else {
-		await execAsync(command);
+	const deploymentList = await getDeploymentsByType(id, type);
+	const mostRecentSuccessful = deploymentList.find(
+		(deployment) => deployment.status === "done",
+	);
+	const deploymentToKeep = mostRecentSuccessful ?? deploymentList[0];
+
+	for (const deployment of deploymentList) {
+		if (deployment.deploymentId === deploymentToKeep?.deploymentId) {
+			continue;
+		}
+		await removeDeployment(deployment.deploymentId);
 	}
 };

--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -1049,12 +1049,15 @@ export const clearOldDeployments = async (
 	type: "application" | "compose",
 ) => {
 	const deploymentList = await getDeploymentsByType(id, type);
-	const mostRecentSuccessful = deploymentList.find(
+	const deletable = deploymentList.filter(
+		(deployment) => deployment.status !== "running",
+	);
+	const mostRecentSuccessful = deletable.find(
 		(deployment) => deployment.status === "done",
 	);
-	const deploymentToKeep = mostRecentSuccessful ?? deploymentList[0];
+	const deploymentToKeep = mostRecentSuccessful ?? deletable[0];
 
-	for (const deployment of deploymentList) {
+	for (const deployment of deletable) {
 		if (deployment.deploymentId === deploymentToKeep?.deploymentId) {
 			continue;
 		}


### PR DESCRIPTION
## What is this PR about?

`clearOldDeployments` (backing the "Clear deployments" button on Applications/Compose) used to `rm -rf` a log folder keyed on `appName`/`serverId`, but never touched the `deployment` DB rows — so the UI's promise of "keeping only the active deployment (the most recent successful one)" didn't match reality: all logs vanished but every old deployment record stayed.

This PR reworks it to look deployments up by `applicationId`/`composeId`, keep the most recent successful (`status: "done"`) deployment (falling back to the newest if none succeeded), and remove the rest via the existing `removeDeployment` helper (deletes the DB row + its log file). It also:

- Never deletes a deployment with `status: "running"`, so clicking "Clear deployments" mid-build can no longer delete the active deployment's row/log out from under it.
- Isolates per-item removal failures with try/catch (matching the existing `removeLastTenDeployments` pattern) so one bad row doesn't abort cleanup of the rest.
- Drops the unused `rollback` eager-join that the shared `getDeploymentsByType` helper pulled in for every call.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A — backend-only behavior fix, covered by new unit tests in `apps/dokploy/__test__/deploy/clear-old-deployments.test.ts` (6 cases: keep-most-recent-success, fallback-to-newest, single-deployment no-op, never-delete-running, delete-others-while-running, and per-item failure isolation). Full vitest suite: 762/762 passing (excluding a pre-existing, environment-dependent real-exec test unrelated to this change).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes deployment-history cleanup to select records by application or compose ID, retain the latest successful deployment, and preserve running deployments.
- Removes obsolete deployment records through the shared removal service.
- Cleans associated rollback images and resolves remote cleanup through the owning resource's server.
- Adds focused tests for retention, running deployments, failure isolation, rollbacks, and remote logs.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a failed remote log-removal command permanently orphans files after their deployment metadata has already been deleted.

Remote cleanup removes each deployment row before executing the accumulated command on the owning server, so a remote execution failure destroys the only durable log-path mapping needed to retry cleanup.

**Files Needing Attention:** packages/server/src/services/deployment.ts

<sub>Reviews (2): Last reviewed commit: ["fix: clean up rollback images and use co..."](https://github.com/dokploy/dokploy/commit/6485d54cff80592b0c2a34a2706766a13ae49bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51683338)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)

<!-- /greptile_comment -->