### PR TITLE
fix(server): log cleanup command failures instead of swallowing them in cleanupAll

### DIFF
--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -323,7 +323,14 @@ export const cleanupAll = async (serverId?: string) => {
 			} else {
 				await execAsync(dockerSafeExec(command));
 			}
-		} catch {}
+		} catch (error) {
+			const target = serverId ? `server ${serverId}` : "local web server";
+
+			console.error(
+				`Docker cleanup failed for "${key}" on ${target}: ${command}`,
+				error,
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
## What is this PR about?

`cleanupAll()` swallows every failure of every prune subcommand in an empty `catch {}`. That is the path the scheduled Docker Cleanup uses, so the schedule fires exactly as designed while nothing is ever pruned, and there is no log line, no error and no notification. The feature can stay broken indefinitely while looking healthy. We hit this on v0.29.14: 139 GB of unused images on a remote server and dangling layers roughly 9 months old on the Dokploy host itself.

Fixes #5044

## What this change does

Replaces the empty `catch {}` with a `console.error` that includes the failing command key, the command itself, the target (`server <serverId>` or `local web server`) and the error, mirroring the existing `console.error` style of the sibling helpers (`cleanupImages`, `cleanupContainers`, ...).

Behavior on success is unchanged, and a failing command still continues with the remaining commands exactly as before. This is step 1 of the issue's suggested fix; surfacing failures through `sendDockerCleanupNotifications` is deliberately left out of scope.

## Checklist

- [x] Dedicated branch based on `canary`.
- [x] Read the suggestions in CONTRIBUTING.md.
- [ ] Local instance test: the underlying bug was observed and traced on a running v0.29.14 instance (see the issue for the reproduction and the compiled `dist` evidence), but this specific one file logging change was not run through a full local dev stack. It adds no logic, only an error log in a previously empty catch.

## Issues related

closes #5044

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes individual `cleanupAll()` command failures visible while preserving best-effort cleanup behavior.
- Adds the cleanup key, static Docker command, and local or remote target to each failure log.
- Continues executing subsequent prune commands after a failure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The added catch body only reports fixed cleanup-command metadata and the existing error while retaining the prior behavior of continuing through the remaining commands.

<sub>Reviews (1): Last reviewed commit: ["fix(server): log cleanup command failure..."](https://github.com/dokploy/dokploy/commit/6cc7caac237947a4d2458b2e6b0b8c7fbe42c063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52162384)</sub>

<!-- /greptile_comment -->