### PR TITLE
fix(api): configurable body size limits for OpenAPI catch-all route

### DIFF
--- a/apps/dokploy/pages/api/[...trpc].ts
+++ b/apps/dokploy/pages/api/[...trpc].ts
@@ -16,17 +16,22 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 		return;
 	}
 
-	// getMultipartBody (trpc-openapi) doesn't accept maxBodySize, so multipart
-	// uploads have no cap unless enforced here before the handler reads the stream.
-	const contentLength = Number(req.headers["content-length"] ?? 0);
+	// getMultipartBody doesn't accept maxBodySize, so we cap it here instead.
+	const contentLength = Number(req.headers["content-length"]);
 	const isMultipart = req.headers["content-type"]?.startsWith(
 		"multipart/form-data",
 	);
+
+	if (isMultipart && !Number.isFinite(contentLength)) {
+		res.status(411).json({ message: "Content-Length required" });
+		return;
+	}
+
 	const limit = isMultipart
 		? OPENAPI_MAX_UPLOAD_SIZE
 		: OPENAPI_MAX_JSON_BODY_SIZE;
 
-	if (contentLength > limit) {
+	if (Number.isFinite(contentLength) && contentLength > limit) {
 		res.status(413).json({ message: "Payload too large" });
 		return;
 	}

--- a/apps/dokploy/pages/api/[...trpc].ts
+++ b/apps/dokploy/pages/api/[...trpc].ts
@@ -1,4 +1,8 @@
-import { validateRequest } from "@dokploy/server";
+import {
+	OPENAPI_MAX_JSON_BODY_SIZE,
+	OPENAPI_MAX_UPLOAD_SIZE,
+	validateRequest,
+} from "@dokploy/server";
 import { createOpenApiNextHandler } from "@dokploy/trpc-openapi";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { appRouter } from "@/server/api/root";
@@ -12,10 +16,26 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 		return;
 	}
 
+	// getMultipartBody (trpc-openapi) doesn't accept maxBodySize, so multipart
+	// uploads have no cap unless enforced here before the handler reads the stream.
+	const contentLength = Number(req.headers["content-length"] ?? 0);
+	const isMultipart = req.headers["content-type"]?.startsWith(
+		"multipart/form-data",
+	);
+	const limit = isMultipart
+		? OPENAPI_MAX_UPLOAD_SIZE
+		: OPENAPI_MAX_JSON_BODY_SIZE;
+
+	if (contentLength > limit) {
+		res.status(413).json({ message: "Payload too large" });
+		return;
+	}
+
 	// @ts-ignore
 	return createOpenApiNextHandler({
 		router: appRouter,
 		createContext: createTRPCContext,
+		maxBodySize: OPENAPI_MAX_JSON_BODY_SIZE,
 		onError:
 			process.env.NODE_ENV === "development"
 				? ({ path, error }: { path: string | undefined; error: Error }) => {
@@ -28,3 +48,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 };
 
 export default handler;
+
+export const config = {
+	api: {
+		bodyParser: false,
+	},
+};

--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -13,6 +13,18 @@ export const DOKPLOY_DOCKER_PORT = process.env.DOKPLOY_DOCKER_PORT
 
 export const CLEANUP_CRON_JOB = "50 23 * * *";
 
+// Body size limits for the OpenAPI catch-all route (pages/api/[...trpc].ts).
+// JSON/urlencoded bodies are capped by trpc-openapi's own default (100kb) unless
+// we pass an explicit limit; multipart uploads (e.g. drop-deployment zips) have
+// no built-in cap at all, so we enforce one manually via content-length.
+export const OPENAPI_MAX_JSON_BODY_SIZE = process.env.OPENAPI_MAX_JSON_BODY_SIZE
+	? Number.parseInt(process.env.OPENAPI_MAX_JSON_BODY_SIZE, 10)
+	: 10 * 1024 * 1024; // 10mb
+
+export const OPENAPI_MAX_UPLOAD_SIZE = process.env.OPENAPI_MAX_UPLOAD_SIZE
+	? Number.parseInt(process.env.OPENAPI_MAX_UPLOAD_SIZE, 10)
+	: 1024 * 1024 * 1024; // 1gb
+
 type DockerSocketCandidate = {
 	label: string;
 	path: string;

--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -14,16 +14,26 @@ export const DOKPLOY_DOCKER_PORT = process.env.DOKPLOY_DOCKER_PORT
 export const CLEANUP_CRON_JOB = "50 23 * * *";
 
 // Body size limits for the OpenAPI catch-all route (pages/api/[...trpc].ts).
-// JSON/urlencoded bodies are capped by trpc-openapi's own default (100kb) unless
-// we pass an explicit limit; multipart uploads (e.g. drop-deployment zips) have
-// no built-in cap at all, so we enforce one manually via content-length.
-export const OPENAPI_MAX_JSON_BODY_SIZE = process.env.OPENAPI_MAX_JSON_BODY_SIZE
-	? Number.parseInt(process.env.OPENAPI_MAX_JSON_BODY_SIZE, 10)
-	: 10 * 1024 * 1024; // 10mb
+const parseByteSize = (envVar: string, fallback: number): number => {
+	const raw = process.env[envVar];
+	if (!raw) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		console.warn(`Invalid ${envVar}="${raw}", using default ${fallback}`);
+		return fallback;
+	}
+	return parsed;
+};
 
-export const OPENAPI_MAX_UPLOAD_SIZE = process.env.OPENAPI_MAX_UPLOAD_SIZE
-	? Number.parseInt(process.env.OPENAPI_MAX_UPLOAD_SIZE, 10)
-	: 1024 * 1024 * 1024; // 1gb
+export const OPENAPI_MAX_JSON_BODY_SIZE = parseByteSize(
+	"OPENAPI_MAX_JSON_BODY_SIZE",
+	10 * 1024 * 1024, // 10mb
+);
+
+export const OPENAPI_MAX_UPLOAD_SIZE = parseByteSize(
+	"OPENAPI_MAX_UPLOAD_SIZE",
+	1024 * 1024 * 1024, // 1gb
+);
 
 type DockerSocketCandidate = {
 	label: string;

--- a/packages/server/src/constants/index.ts
+++ b/packages/server/src/constants/index.ts
@@ -17,8 +17,8 @@ export const CLEANUP_CRON_JOB = "50 23 * * *";
 const parseByteSize = (envVar: string, fallback: number): number => {
 	const raw = process.env[envVar];
 	if (!raw) return fallback;
-	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed <= 0) {
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed <= 0) {
 		console.warn(`Invalid ${envVar}="${raw}", using default ${fallback}`);
 		return fallback;
 	}


### PR DESCRIPTION
## What is this PR about?

Application.dropDeployment 500s on any multipart upload today, since Next's default bodyParser consumes the stream before getMultipartBody can read it. Disabling bodyParser fixes that but drops trpc-openapi's JSON body limit to its internal 100KB default (no maxBodySize passed), breaking compose.import/processTemplate/previewTemplate on anything over 100KB. Multipart uploads also end up with no cap at all, since getMultipartBody ignores maxBodySize.

Pass `maxBodySize` explicitly and add a `Content-Length` guard for multipart. Both configurable via `OPENAPI_MAX_JSON_BODY_SIZE` / `OPENAPI_MAX_UPLOAD_SIZE` (default 10mb / 1gb).

extends https://github.com/Dokploy/dokploy/pull/4770 implementation

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #4236, #4315

## Screenshots (if applicable)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes OpenAPI request-body limits configurable while preserving raw multipart streams.
- Disables Next.js body parsing for the catch-all OpenAPI route.
- Applies separate JSON and multipart upload limits.
- Requires multipart requests to provide a finite Content-Length.
- Validates configured limits as positive integers and otherwise uses defaults.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (3): Last reviewed commit: ["fix(api): reject non-integer body size e..."](https://github.com/dokploy/dokploy/commit/529f54e2a52738c23e2c6266eb983b31d32091e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52308128)</sub>

<!-- /greptile_comment -->