### PR TITLE
fix: invalid replacement placeholder in redirect form

### DIFF
--- a/apps/dokploy/components/dashboard/application/advanced/redirects/handle-redirect.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/redirects/handle-redirect.tsx
@@ -234,7 +234,7 @@ export const HandleRedirect = ({
 									<FormItem>
 										<FormLabel>Replacement</FormLabel>
 										<FormControl>
-											<Input placeholder="http://mydomain/$${1}" {...field} />
+											<Input placeholder="http://mydomain/$1" {...field} />
 										</FormControl>
 
 										<FormMessage />


### PR DESCRIPTION
Fixes #5047

Placeholder in the replacement field of the redirect form used `$${1}` (invalid regex group reference), which caused the resulting redirect URL to be URL-encoded. Changed to `$1`, matching the fix already applied to `add-redirect.tsx` in #717.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the redirect replacement-field placeholder so it demonstrates the valid `$1` regex capture-group syntax.

- Replaces the invalid `$${1}` example with `http://mydomain/$1`.
- Does not alter form submission, validation, or redirect-processing behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no identified blocking or non-blocking issues.

The change only corrects instructional placeholder text from an invalid capture-group example to `$1`; submitted values and runtime redirect behavior are unchanged.

<sub>Reviews (1): Last reviewed commit: ["fix: invalid replacement placeholder in ..."](https://github.com/dokploy/dokploy/commit/5520300af39c689c5d7c4072a694bfe579ce545f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52445732)</sub>

<!-- /greptile_comment -->