### PR TITLE
fix: docker cleanup hangs silently on false-positive busy-wait match

### DIFF
--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -153,19 +153,27 @@ export const getContainerByName = (name: string): Promise<ContainerInfo> => {
  */
 export const dockerSafeExec = (exec: string) => `
 CHECK_INTERVAL=10
+MAX_WAIT=300
+WAITED=0
 
 echo "Preparing for execution..."
 
 while true; do
-    PROCESSES=$(ps aux | grep -E "^.*docker [A-Za-z]" | grep -v grep)
+    PROCESSES=$(ps -eo args | awk '$1 ~ /(^|\\/)docker$/')
 
     if [ -z "$PROCESSES" ]; then
         echo "Docker is idle. Starting execution..."
         break
-    else
-        echo "Docker is busy. Will check again in $CHECK_INTERVAL seconds..."
-        sleep $CHECK_INTERVAL
     fi
+
+    if [ "$WAITED" -ge "$MAX_WAIT" ]; then
+        echo "Docker still busy after \${MAX_WAIT}s, proceeding anyway." >&2
+        break
+    fi
+
+    echo "Docker is busy. Will check again in $CHECK_INTERVAL seconds..."
+    sleep $CHECK_INTERVAL
+    WAITED=$((WAITED + CHECK_INTERVAL))
 done
 
 ${exec}
@@ -323,7 +331,12 @@ export const cleanupAll = async (serverId?: string) => {
 			} else {
 				await execAsync(dockerSafeExec(command));
 			}
-		} catch {}
+		} catch (error) {
+			console.error(
+				`Docker cleanup: "${key}" failed${serverId ? ` on server ${serverId}` : ""}`,
+				error,
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
Fixes #5044.

`dockerSafeExec`'s busy-wait matched any process with `docker <letter>` anywhere in its argv, not just actual `docker` invocations. On a host running something like Grafana (`--packaging=docker cfg:default.log.mode=console`), the wait loop spins forever and the scheduled cleanup never runs — with no error, since a hang never throws.

Reproduced live against a remote server: spawning a decoy process with that argv pattern hung the original loop (timeout/exit 124); with the fix it no longer matches.

Changes:
- Match `ps -eo args` on argv[0] (`(^|/)docker$`) instead of a substring grep over the whole command line, so only real `docker` invocations count as "busy".
- Add a `MAX_WAIT` ceiling (300s) so a genuinely stuck docker process can't hang cleanup forever either — it logs a warning and proceeds.
- Log failures in `cleanupAll`'s catch instead of swallowing them silently, since the scheduled cleanup path only goes through this function.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows Docker busy-process detection to actual Docker CLI invocations, caps cleanup waiting at five minutes, and makes cleanup failures visible.
- Replaces substring-based process matching with argv[0]-based matching.
- Adds a bounded wait before cleanup proceeds.
- Logs failures from each `cleanupAll` operation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The revised process filter targets actual Docker CLI processes, the bounded wait is an explicit behavioral choice, and cleanup errors are now surfaced rather than swallowed.

<sub>Reviews (1): Last reviewed commit: ["fix: docker cleanup hangs silently on fa..."](https://github.com/dokploy/dokploy/commit/c24a5704b6a4e2e03c44a07a96300a0f7f57df30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52448568)</sub>

<!-- /greptile_comment -->