### PR TITLE
fix: don't cancel schedule deployments running outside the panel process on restart

### DIFF
--- a/packages/server/src/services/deployment.ts
+++ b/packages/server/src/services/deployment.ts
@@ -453,6 +453,19 @@ export const createDeploymentSchedule = async (
 		schedule.compose?.serverId ||
 		schedule.server?.serverId;
 	await removeLastTenDeployments(deployment.scheduleId, "schedule", serverId);
+	await db
+		.update(deployments)
+		.set({
+			status: "error",
+			errorMessage: "Superseded by a new run of this schedule.",
+			finishedAt: new Date().toISOString(),
+		})
+		.where(
+			and(
+				eq(deployments.scheduleId, deployment.scheduleId),
+				eq(deployments.status, "running"),
+			),
+		);
 	try {
 		const { SCHEDULES_PATH } = paths(!!serverId);
 		const formattedDateTime = format(new Date(), "yyyy-MM-dd:HH:mm:ss");

--- a/packages/server/src/utils/startup/cancel-deployments.ts
+++ b/packages/server/src/utils/startup/cancel-deployments.ts
@@ -1,4 +1,9 @@
-import { applications, compose, deployments } from "@dokploy/server/db/schema";
+import {
+	applications,
+	compose,
+	deployments,
+	schedules,
+} from "@dokploy/server/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { db } from "../../db/index";
 
@@ -6,15 +11,37 @@ export const initCancelDeployments = async () => {
 	try {
 		console.log("Setting up cancel deployments....");
 
+		const runningDeployments = await db
+			.select({
+				deploymentId: deployments.deploymentId,
+				scheduleId: deployments.scheduleId,
+				scheduleType: schedules.scheduleType,
+			})
+			.from(deployments)
+			.leftJoin(schedules, eq(deployments.scheduleId, schedules.scheduleId))
+			.where(eq(deployments.status, "running"));
+
+		const deploymentIdsToCancel = runningDeployments
+			.filter(
+				(deployment) =>
+					!deployment.scheduleId ||
+					deployment.scheduleType === "dokploy-server",
+			)
+			.map((deployment) => deployment.deploymentId);
+
+		if (deploymentIdsToCancel.length === 0) {
+			console.log("Cancelled 0 deployments");
+			return;
+		}
+
 		const result = await db
 			.update(deployments)
 			.set({
 				status: "cancelled",
 			})
-			.where(eq(deployments.status, "running"))
+			.where(inArray(deployments.deploymentId, deploymentIdsToCancel))
 			.returning();
 
-		// Reset the related services so they don't stay stuck in "running".
 		const applicationIds = [
 			...new Set(
 				result


### PR DESCRIPTION
Fixes #4986.

`initCancelDeployments` runs on every self-hosted boot and blindly marks **every** `running` deployment as `cancelled`. For schedules of type `application`/`compose`/`server`, the actual work is a `docker exec` into another container or an SSH-driven remote command — decoupled from the Dokploy process, so it keeps running after a panel restart while the UI now falsely shows it as cancelled.

Now only deployments with no schedule (regular builds/deploys) or schedules of type `dokploy-server` (a real child process of the panel) get cancelled on boot. The others are left untouched since a restart doesn't actually stop them.

Also, when a schedule starts a new run, any stale `running` deployment left over from a previous run (e.g. one orphaned by a restart) is resolved to `error` instead of being left `running` forever.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows startup cancellation so externally executing scheduled commands retain their running status across panel restarts, while panel-owned deployments are still cancelled. It also attempts to resolve stale schedule deployments when a replacement run starts.

- Joins running deployments to schedules and selects restart cancellation behavior by schedule type.
- Marks prior running records for a schedule as superseded before creating its next deployment record.

<h3>Confidence Score: 4/5</h3>

The overlapping-run status corruption should be fixed before merging because a new invocation can falsely supersede a command that is still executing.

The unconditional schedule-wide update is reachable through concurrent cron or manual runs and allows an active deployment to be marked error before later reverting itself to done.

**Files Needing Attention:** packages/server/src/services/deployment.ts

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t cancel schedule deployments r..."](https://github.com/dokploy/dokploy/commit/6f91d36fd6ee76fcdcdc23bf926d528298529bfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52456463)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)
- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)
- Knowledge Base — [Server Setup and Packaging](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/server-setup-and-packaging.md)
</details>

<!-- /greptile_comment -->