### PR TITLE
fix: deploy monitoring as a swarm service instead of a standalone container

### DIFF
--- a/packages/server/src/setup/monitoring-setup.ts
+++ b/packages/server/src/setup/monitoring-setup.ts
@@ -1,16 +1,13 @@
 import { findServerById } from "@dokploy/server/services/server";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
-import type { ContainerCreateOptions } from "dockerode";
+import type { CreateServiceOptions } from "dockerode";
 import { IS_CLOUD } from "../constants";
 import { getDokployImageTag } from "../services/settings";
 import { pullImage, pullRemoteImage } from "../utils/docker/utils";
 import { execAsync, execAsyncRemote } from "../utils/process/execAsync";
 import { getRemoteDocker } from "../utils/servers/remote-docker";
 
-export const setupMonitoring = async (serverId: string) => {
-	const server = await findServerById(serverId);
-
-	const containerName = "dokploy-monitoring";
+const getMonitoringImage = () => {
 	let imageName = "dokploy/monitoring:latest";
 
 	if (
@@ -21,134 +18,174 @@ export const setupMonitoring = async (serverId: string) => {
 		imageName = "dokploy/monitoring:canary";
 	}
 
-	const settings: ContainerCreateOptions = {
-		name: containerName,
-		Env: [`METRICS_CONFIG=${JSON.stringify(server?.metricsConfig)}`],
-		Image: imageName,
-		HostConfig: {
-			// Memory: 100 * 1024 * 1024, // 100MB en bytes
-			// PidMode: "host",
-			// CapAdd: ["NET_ADMIN", "SYS_ADMIN"],
-			// Privileged: true,
-			RestartPolicy: {
-				Name: "always",
+	return imageName;
+};
+
+const deployMonitoringService = async (
+	docker: Awaited<ReturnType<typeof getRemoteDocker>>,
+	serviceName: string,
+	settings: CreateServiceOptions,
+) => {
+	try {
+		const service = docker.getService(serviceName);
+		const inspect = await service.inspect();
+		await service.update({
+			version: Number.parseInt(inspect.Version.Index),
+			...settings,
+			TaskTemplate: {
+				...settings.TaskTemplate,
+				ForceUpdate: (inspect.Spec.TaskTemplate.ForceUpdate ?? 0) + 1,
 			},
-			PortBindings: {
-				[`${server.metricsConfig.server.port}/tcp`]: [
+		});
+		console.log("Monitoring Updated ✅");
+	} catch (error: any) {
+		if (error?.statusCode && error.statusCode !== 404) {
+			throw error;
+		}
+		await docker.createService(settings);
+		console.log("Monitoring Started ✅");
+	}
+};
+
+export const setupMonitoring = async (serverId: string) => {
+	const server = await findServerById(serverId);
+
+	const serviceName = "dokploy-monitoring";
+	const imageName = getMonitoringImage();
+
+	const settings: CreateServiceOptions = {
+		Name: serviceName,
+		TaskTemplate: {
+			ContainerSpec: {
+				Image: imageName,
+				Env: [`METRICS_CONFIG=${JSON.stringify(server?.metricsConfig)}`],
+				Mounts: [
 					{
-						HostPort: server.metricsConfig.server.port.toString(),
+						Type: "bind",
+						Source: "/var/run/docker.sock",
+						Target: "/var/run/docker.sock",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/sys",
+						Target: "/host/sys",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/etc/os-release",
+						Target: "/etc/os-release",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/proc",
+						Target: "/host/proc",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/etc/dokploy/monitoring/monitoring.db",
+						Target: "/app/monitoring.db",
 					},
 				],
 			},
-			Binds: [
-				"/var/run/docker.sock:/var/run/docker.sock:ro",
-				"/sys:/host/sys:ro",
-				"/etc/os-release:/etc/os-release:ro",
-				"/proc:/host/proc:ro",
-				"/etc/dokploy/monitoring/monitoring.db:/app/monitoring.db",
-			],
-			NetworkMode: "host",
+			Networks: [{ Target: "host" }],
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
-		ExposedPorts: {
-			[`${server.metricsConfig.server.port}/tcp`]: {},
+		Mode: {
+			Replicated: {
+				Replicas: 1,
+			},
 		},
 	};
+
 	const docker = await getRemoteDocker(serverId);
-	try {
-		await execAsyncRemote(
-			serverId,
-			"mkdir -p /etc/dokploy/monitoring && touch /etc/dokploy/monitoring/monitoring.db",
-		);
-		if (serverId) {
-			await pullRemoteImage(imageName, serverId);
-		}
 
-		// Check if container exists
-		const container = docker.getContainer(containerName);
-		try {
-			await container.inspect();
-			await container.remove({ force: true });
-			console.log("Removed existing container");
-		} catch {
-			// Container doesn't exist, continue
-		}
-
-		await docker.createContainer(settings);
-		const newContainer = docker.getContainer(containerName);
-		await newContainer.start();
-
-		console.log("Monitoring Started ");
-	} catch (error) {
-		console.log("Monitoring Not Found: Starting ", error);
-	}
+	await execAsyncRemote(
+		serverId,
+		"mkdir -p /etc/dokploy/monitoring && touch /etc/dokploy/monitoring/monitoring.db",
+	);
+	await pullRemoteImage(imageName, serverId);
+	await deployMonitoringService(docker, serviceName, settings);
 };
 
 export const setupWebMonitoring = async () => {
 	const webServerSettings = await getWebServerSettings();
 
-	const containerName = "dokploy-monitoring";
-	let imageName = "dokploy/monitoring:latest";
+	const serviceName = "dokploy-monitoring";
+	const imageName = getMonitoringImage();
+	const port = webServerSettings?.metricsConfig?.server?.port;
 
-	if (
-		(getDokployImageTag() !== "latest" ||
-			process.env.NODE_ENV === "development") &&
-		!IS_CLOUD
-	) {
-		imageName = "dokploy/monitoring:canary";
-	}
-
-	const settings: ContainerCreateOptions = {
-		name: containerName,
-		Env: [`METRICS_CONFIG=${JSON.stringify(webServerSettings?.metricsConfig)}`],
-		Image: imageName,
-		HostConfig: {
-			// Memory: 100 * 1024 * 1024, // 100MB en bytes
-			// PidMode: "host",
-			// CapAdd: ["NET_ADMIN", "SYS_ADMIN"],
-			// Privileged: true,
-			RestartPolicy: {
-				Name: "always",
-			},
-			PortBindings: {
-				[`${webServerSettings?.metricsConfig?.server?.port}/tcp`]: [
+	const settings: CreateServiceOptions = {
+		Name: serviceName,
+		TaskTemplate: {
+			ContainerSpec: {
+				Image: imageName,
+				Env: [
+					`METRICS_CONFIG=${JSON.stringify(webServerSettings?.metricsConfig)}`,
+				],
+				Mounts: [
 					{
-						HostPort: webServerSettings?.metricsConfig?.server?.port.toString(),
+						Type: "bind",
+						Source: "/var/run/docker.sock",
+						Target: "/var/run/docker.sock",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/sys",
+						Target: "/host/sys",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/etc/os-release",
+						Target: "/etc/os-release",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/proc",
+						Target: "/host/proc",
+						ReadOnly: true,
+					},
+					{
+						Type: "bind",
+						Source: "/etc/dokploy/monitoring/monitoring.db",
+						Target: "/app/monitoring.db",
 					},
 				],
 			},
-			Binds: [
-				"/var/run/docker.sock:/var/run/docker.sock:ro",
-				"/sys:/host/sys:ro",
-				"/etc/os-release:/etc/os-release:ro",
-				"/proc:/host/proc:ro",
-				"/etc/dokploy/monitoring/monitoring.db:/app/monitoring.db",
-			],
-			// NetworkMode: "host",
+			Placement: {
+				Constraints: ["node.role==manager"],
+			},
 		},
-		ExposedPorts: {
-			[`${webServerSettings?.metricsConfig?.server?.port}/tcp`]: {},
+		Mode: {
+			Replicated: {
+				Replicas: 1,
+			},
+		},
+		EndpointSpec: {
+			Ports: [
+				{
+					TargetPort: port,
+					PublishedPort: port,
+					Protocol: "tcp",
+					PublishMode: "host",
+				},
+			],
 		},
 	};
+
 	const docker = await getRemoteDocker();
-	try {
-		await execAsync(
-			"mkdir -p /etc/dokploy/monitoring && touch /etc/dokploy/monitoring/monitoring.db",
-		);
-		await pullImage(imageName);
 
-		const container = docker.getContainer(containerName);
-		try {
-			await container.inspect();
-			await container.remove({ force: true });
-			console.log("Removed existing container");
-		} catch {}
-
-		await docker.createContainer(settings);
-		const newContainer = docker.getContainer(containerName);
-		await newContainer.start();
-
-		console.log("Monitoring Started ");
-	} catch (error) {
-		console.log("Monitoring Not Found: Starting ", error);
-	}
+	await execAsync(
+		"mkdir -p /etc/dokploy/monitoring && touch /etc/dokploy/monitoring/monitoring.db",
+	);
+	await pullImage(imageName);
+	await deployMonitoringService(docker, serviceName, settings);
 };


### PR DESCRIPTION
Monitoring was the only component in the codebase still using `docker.createContainer` directly instead of `docker.createService`, unlike postgres/traefik/forward-auth/etc. That meant it never got Swarm's own task reconciliation — it only had Docker's restart policy on a standalone container, with no self-healing if the daemon didn't come back cleanly after a host reboot.

Also removed the `try/catch` around the whole setup flow that silently swallowed any error (image pull failures, SSH errors, etc), which made the UI always report success even when monitoring failed to start.

- `setupMonitoring` (remote servers) now creates/updates a `dokploy-monitoring` swarm service with `Networks: [{ Target: "host" }]` for host networking, same restart guarantees but via Swarm's orchestrator instead of a bare restart policy.
- `setupWebMonitoring` (panel's own host) follows the same create-or-update-service pattern, publishing the port with `PublishMode: "host"`.
- Verified locally against a real swarm (host networking confirmed via inspecting the running task's network namespace, force-update redeploy, and killing a task to confirm Swarm restarts it without manual intervention) and against a real remote server end-to-end through the actual Setup Server > Monitoring UI flow, confirming the resulting container runs as a proper swarm task and metrics keep flowing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR migrates local and remote monitoring from standalone Docker containers to reconciled Swarm services and propagates setup failures instead of swallowing them.
- Adds shared create-or-update service deployment with forced task refreshes.
- Preserves monitoring configuration, host mounts, manager placement, and single-replica operation.
- Uses host networking remotely and host-mode port publishing on the panel host.

<h3>Confidence Score: 4/5</h3>

The upgrade path needs to remove the legacy monitoring container before the new Swarm service is deployed, or existing installations can fail to start the service.

Previous releases leave a standalone monitoring container bound to the configured host port, while the new service-only lookup creates a competing Swarm task without retiring that container.

**Files Needing Attention:** packages/server/src/setup/monitoring-setup.ts

<sub>Reviews (1): Last reviewed commit: ["fix: deploy monitoring as a swarm servic..."](https://github.com/dokploy/dokploy/commit/eeae2697daf63fecd0812e16c9cef872d229bda8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52498652)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server Setup and Packaging](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/server-setup-and-packaging.md)

<!-- /greptile_comment -->