### PR TITLE
fix: add clipboard addon to docker container terminal

### DIFF
--- a/apps/dokploy/__test__/compose/domain/enabled-filter.test.ts
+++ b/apps/dokploy/__test__/compose/domain/enabled-filter.test.ts
@@ -3,24 +3,15 @@ import type { Domain } from "@dokploy/server/services/domain";
 import { addDomainToCompose } from "@dokploy/server/utils/docker/domain";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// addDomainToCompose reads the compose file from disk through loadDockerCompose
-// (existsSync + readFileSync). Mock node:fs so the function runs its real
-// label-generation logic against an in-memory compose spec.
+// With sourceType "raw", addDomainToCompose parses compose.composeFile
+// directly instead of reading from disk, so baseCompose exposes it as a
+// getter that always reflects the current composeYaml for each test case.
 const baseComposeYaml = `
 services:
   frigate:
     image: frigate
 `;
 let composeYaml = baseComposeYaml;
-
-vi.mock("node:fs", async (importOriginal) => {
-	const actual = await importOriginal<typeof import("node:fs")>();
-	return {
-		...actual,
-		existsSync: vi.fn(() => true),
-		readFileSync: vi.fn(() => composeYaml),
-	};
-});
 
 const baseCompose = {
 	appName: "test-app",
@@ -31,6 +22,9 @@ const baseCompose = {
 	isolatedDeployment: false,
 	randomize: false,
 	suffix: "",
+	get composeFile() {
+		return composeYaml;
+	},
 } as unknown as Compose;
 
 const baseDomain: Domain = {

--- a/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
+++ b/apps/dokploy/components/dashboard/docker/terminal/docker-terminal.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from "react";
 import { FitAddon } from "xterm-addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { AttachAddon } from "@xterm/addon-attach";
+import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { useTheme } from "next-themes";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fixMacOsAltKeys } from "@/lib/terminal-keyboard";
@@ -46,6 +47,8 @@ export const DockerTerminal: React.FC<Props> = ({
 		const ws = new WebSocket(wsUrl);
 
 		const addonAttach = new AttachAddon(ws);
+		const clipboardAddon = new ClipboardAddon();
+		term.loadAddon(clipboardAddon);
 		fixMacOsAltKeys(term);
 		// @ts-ignore
 		term.open(termRef.current);
@@ -55,6 +58,7 @@ export const DockerTerminal: React.FC<Props> = ({
 		addonFit.fit();
 		return () => {
 			ws.readyState === WebSocket.OPEN && ws.close();
+			term.dispose();
 		};
 	}, [containerId, activeWay, id]);
 

--- a/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/actions/toggle-docker-cleanup.tsx
@@ -70,9 +70,9 @@ export const ToggleDockerCleanup = ({ serverId }: Props) => {
 					<TooltipContent side="top" className="max-w-sm">
 						<p>
 							Runs a full Docker cleanup daily, pruning stopped containers,
-							unused images, build cache, and system resources. This
-							may remove images built for Compose services that run on-demand
-							(backup runners, cron jobs, one-off tasks).
+							unused images, build cache, and system resources. This may remove
+							images built for Compose services that run on-demand (backup
+							runners, cron jobs, one-off tasks).
 						</p>
 						<p className="mt-1">
 							For custom cleanup strategies, use{" "}


### PR DESCRIPTION
## What is this PR about?

The docker container terminal did not load xterm's `ClipboardAddon`, so pasting into it (e.g. a MariaDB shell) broke the cursor and left the pasted text uneditable (#5065). The web server terminal already loads this addon; this brings the container terminal in line with it.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #5065

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR loads xterm’s clipboard addon in Docker container terminals and now disposes the terminal during effect cleanup, resolving the previously reported addon lifecycle issue.
- Adds and loads `ClipboardAddon` for container terminal sessions.
- Disposes the xterm instance and its loaded addons on unmount.
- Updates a Compose test fixture to supply raw Compose content directly.
- Reformats Docker cleanup tooltip text without changing behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The added terminal disposal resolves the prior resource-lifecycle finding, and no blocking failure remains.

<sub>Reviews (4): Last reviewed commit: ["test: fix stale composeFile mock in doma..."](https://github.com/dokploy/dokploy/commit/795f6f094e7dc332757b337240fb7414118527d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52658324)</sub>

**Context used:**

- Knowledge Base — [Monitoring and Live Terminal/Log Streaming](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/monitoring-and-terminal.md)

<!-- /greptile_comment -->