### PR TITLE
fix: redact registry password from build failure logs and emails

### DIFF
--- a/apps/dokploy/__test__/registry/redact-secrets.test.ts
+++ b/apps/dokploy/__test__/registry/redact-secrets.test.ts
@@ -1,0 +1,65 @@
+import { redactExecError, redactSecrets } from "@dokploy/server/services/registry";
+import { ExecError } from "@dokploy/server/utils/process/execAsync";
+import { describe, expect, it } from "vitest";
+
+describe("redactSecrets", () => {
+	it("replaces a secret with ***", () => {
+		const command = `printf %s 'sup3r-secret' | docker login registry.example.com -u user --password-stdin`;
+		expect(redactSecrets(command, ["sup3r-secret"])).toBe(
+			"printf %s '***' | docker login registry.example.com -u user --password-stdin",
+		);
+	});
+
+	it("redacts every occurrence of a secret", () => {
+		expect(redactSecrets("pw=abc and again abc", ["abc"])).toBe(
+			"pw=*** and again ***",
+		);
+	});
+
+	it("redacts multiple secrets", () => {
+		expect(redactSecrets("a then b", ["a", "b"])).toBe("*** then ***");
+	});
+
+	it("ignores empty, null and undefined secrets", () => {
+		const text = "nothing to redact";
+		expect(redactSecrets(text, ["", null, undefined])).toBe(text);
+	});
+
+	it("leaves the text untouched when the secret is absent", () => {
+		const text = "no secret here";
+		expect(redactSecrets(text, ["other"])).toBe(text);
+	});
+
+	it("redacts a shell-escaped password", () => {
+		const escaped = "'a'\\''b'"; // shEscape("a'b")
+		const command = `printf %s ${escaped} | docker login`;
+		expect(redactSecrets(command, [escaped])).toBe(
+			"printf %s *** | docker login",
+		);
+	});
+});
+
+describe("redactExecError", () => {
+	it("redacts the secret from an ExecError message and command", () => {
+		const error = new ExecError("Command execution failed: pw=hunter2", {
+			command: "docker login -p hunter2",
+			stderr: "auth failed for hunter2",
+		});
+		const redacted = redactExecError(error, ["hunter2"]);
+		expect(redacted).toBeInstanceOf(ExecError);
+		const execError = redacted as ExecError;
+		expect(execError.message).toBe("Command execution failed: pw=***");
+		expect(execError.command).toBe("docker login -p ***");
+		expect(execError.stderr).toBe("auth failed for ***");
+	});
+
+	it("redacts the secret from a plain Error message", () => {
+		const error = new Error("failed with token abc123");
+		const redacted = redactExecError(error, ["abc123"]) as Error;
+		expect(redacted.message).toBe("failed with token ***");
+	});
+
+	it("returns non-error values unchanged", () => {
+		expect(redactExecError("just a string", ["x"])).toBe("just a string");
+	});
+});

--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -40,6 +40,11 @@ import {
 } from "./deployment";
 import { type Domain, getDomainHost } from "./domain";
 import {
+	getRegistryPasswords,
+	redactExecError,
+	redactSecrets,
+} from "./registry";
+import {
 	createPreviewDeploymentComment,
 	getIssueComment,
 	issueCommentExists,
@@ -246,11 +251,17 @@ export const deployApplication = async ({
 		});
 	} catch (error) {
 		let command = "";
+		const passwords = await getRegistryPasswords([
+			application.registryId,
+			application.buildRegistryId,
+			application.rollbackRegistryId,
+		]);
+		const rawMessage = error instanceof Error ? error.message : String(error);
+		const safeMessage = redactSecrets(rawMessage, passwords);
 
 		// Only log details for non-ExecError errors
 		if (!(error instanceof ExecError)) {
-			const message = error instanceof Error ? error.message : String(error);
-			const encodedMessage = encodeBase64(message);
+			const encodedMessage = encodeBase64(safeMessage);
 			command += `echo "${encodedMessage}" | base64 -d >> "${deployment.logPath}";`;
 		}
 
@@ -267,13 +278,12 @@ export const deployApplication = async ({
 			projectName: application.environment.project.name,
 			applicationName: application.name,
 			applicationType: "application",
-			// @ts-ignore
-			errorMessage: error?.message || "Error building",
+			errorMessage: safeMessage || "Error building",
 			buildLink,
 			organizationId: application.environment.project.organizationId,
 		});
 
-		throw error;
+		throw redactExecError(error, passwords);
 	} finally {
 		// Only extract commit info for non-docker sources
 		if (application.sourceType !== "docker") {
@@ -337,11 +347,16 @@ export const rebuildApplication = async ({
 		});
 	} catch (error) {
 		let command = "";
+		const passwords = await getRegistryPasswords([
+			application.registryId,
+			application.buildRegistryId,
+			application.rollbackRegistryId,
+		]);
 
 		// Only log details for non-ExecError errors
 		if (!(error instanceof ExecError)) {
 			const message = error instanceof Error ? error.message : String(error);
-			const encodedMessage = encodeBase64(message);
+			const encodedMessage = encodeBase64(redactSecrets(message, passwords));
 			command += `echo "${encodedMessage}" | base64 -d >> "${deployment.logPath}";`;
 		}
 
@@ -353,7 +368,7 @@ export const rebuildApplication = async ({
 		}
 		await updateDeploymentStatus(deployment.deploymentId, "error");
 		await updateApplicationStatus(applicationId, "error");
-		throw error;
+		throw redactExecError(error, passwords);
 	}
 
 	return true;
@@ -579,11 +594,16 @@ export const rebuildPreviewApplication = async ({
 		});
 	} catch (error) {
 		let command = "";
+		const passwords = await getRegistryPasswords([
+			application.registryId,
+			application.buildRegistryId,
+			application.rollbackRegistryId,
+		]);
 
 		// Only log details for non-ExecError errors
 		if (!(error instanceof ExecError)) {
 			const message = error instanceof Error ? error.message : String(error);
-			const encodedMessage = encodeBase64(message);
+			const encodedMessage = encodeBase64(redactSecrets(message, passwords));
 			command += `echo "${encodedMessage}" | base64 -d >> "${deployment.logPath}";`;
 		}
 
@@ -604,7 +624,7 @@ export const rebuildPreviewApplication = async ({
 		await updatePreviewDeployment(previewDeploymentId, {
 			previewStatus: "error",
 		});
-		throw error;
+		throw redactExecError(error, passwords);
 	}
 
 	return true;

--- a/packages/server/src/services/registry.ts
+++ b/packages/server/src/services/registry.ts
@@ -3,9 +3,10 @@ import { type apiCreateRegistry, registry } from "@dokploy/server/db/schema";
 import {
 	execAsync,
 	execAsyncRemote,
+	ExecError,
 } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import type { z } from "zod";
 import { IS_CLOUD } from "../constants";
 
@@ -36,6 +37,55 @@ function sanitizeRegistryError(
 	if (!password) return message;
 	return message.split(password).join("***");
 }
+
+export const redactSecrets = (
+	text: string,
+	secrets: (string | null | undefined)[],
+): string => {
+	let result = text;
+	for (const secret of secrets) {
+		if (secret) {
+			result = result.split(secret).join("***");
+		}
+	}
+	return result;
+};
+
+export const getRegistryPasswords = async (
+	registryIds: (string | null | undefined)[],
+): Promise<(string | null)[]> => {
+	const uniqueIds = [...new Set(registryIds.filter((id): id is string => !!id))];
+	if (uniqueIds.length === 0) {
+		return [];
+	}
+	const rows = await db.query.registry.findMany({
+		where: inArray(registry.registryId, uniqueIds),
+		columns: { password: true },
+	});
+	return rows.flatMap((row) =>
+		row.password ? [row.password, shEscape(row.password)] : [row.password],
+	);
+};
+
+export const redactExecError = (
+	error: unknown,
+	secrets: (string | null | undefined)[],
+): unknown => {
+	if (error instanceof ExecError) {
+		return new ExecError(redactSecrets(error.message, secrets), {
+			command: redactSecrets(error.command, secrets),
+			stdout: error.stdout ? redactSecrets(error.stdout, secrets) : error.stdout,
+			stderr: error.stderr ? redactSecrets(error.stderr, secrets) : error.stderr,
+			exitCode: error.exitCode,
+			originalError: undefined,
+			serverId: error.serverId,
+		});
+	}
+	if (error instanceof Error) {
+		error.message = redactSecrets(error.message, secrets);
+	}
+	return error;
+};
 
 export const createRegistry = async (
 	input: z.infer<typeof apiCreateRegistry>,


### PR DESCRIPTION
## What is this PR about?

The docker login command built for deployments embeds the registry password (`printf %s '<password>' | docker login … --password-stdin`). When a deploy fails, that command lands in the error message, which is written to the deployment logs and sent in build-failure emails, leaking the password in plain text (#4693).

This adds `redactSecrets` / `redactRegistryPasswords` in the registry service and scrubs the application's registry, build and rollback passwords from the error before it is logged or emailed, across the deploy/rebuild/preview paths.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

## Issues related (if applicable)

closes #4693

## Screenshots (if applicable)

N/A - covered by a unit test for the redaction helper (`apps/dokploy/__test__/registry/redact-secrets.test.ts`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents application deployment failures from exposing registry passwords through deployment logs, build-failure notifications, or propagated execution errors.
- Adds reusable redaction for raw and shell-escaped registry passwords.
- Reconstructs `ExecError` instances with sanitized fields and removes the nested original error.
- Applies sanitization across standard deploy, rebuild, and preview-rebuild failure paths.
- Adds unit coverage for literal, repeated, multiple, shell-escaped, and structured execution-error redaction.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported raw rethrow, nested execution-error, and shell-escaped password disclosure paths are addressed, and no blocking failure remains.

<sub>Reviews (4): Last reviewed commit: ["fix: redact registry password from build..."](https://github.com/dokploy/dokploy/commit/81afaf45e242ba56d41981d19ee53e1f6cb2590b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52703091)</sub>

**Context used:**

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)
- Knowledge Base — [Global Settings, Docker Registries, and Notifications](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/settings-registry-notifications.md)

<!-- /greptile_comment -->