### PR TITLE
fix: lock sidebar-inset scroll while a modal is open

### DIFF
--- a/apps/dokploy/styles/globals.css
+++ b/apps/dokploy/styles/globals.css
@@ -132,6 +132,10 @@
 	}
 }
 
+body[data-scroll-locked] [data-slot="sidebar-inset"] {
+	overflow: hidden !important;
+}
+
 @utility no-scrollbar {
 	/* Chrome, Safari and Opera */
 	&::-webkit-scrollbar {


### PR DESCRIPTION
Fixes #5064

Radix marks `<body data-scroll-locked>` and sets `overflow: hidden` on it when a modal `Dialog`/`Sheet`/`AlertDialog` is open, but the dashboard's actual scroll container is the sidebar's `<main data-slot="sidebar-inset">`, not `<body>`. So the wheel scroll got blocked by Radix's JS interception, but dragging the scrollbar or using the keyboard still scrolled the background — most noticeable on the Requests page since it's one of the few pages tall enough to need scroll.

Extends the lock to the real scroll container via the same `data-scroll-locked` attribute Radix already sets, so it's a true CSS `overflow: hidden` on the actual scrolling element (covers wheel, scrollbar drag, and keyboard).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends Radix's modal scroll lock from the document body to the dashboard's actual scrolling container.
- Adds a global selector for the sidebar inset while `body[data-scroll-locked]` is active.
- Overrides the inset's normal scrolling so wheel, keyboard, and scrollbar interactions cannot move background content behind an open modal.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new rule targeting the single dashboard scroll container only while Radix's modal lock is active.

Modal content is portaled outside the sidebar inset, while the sole current inset is the background page container whose normal `overflow-auto` behavior should be disabled during modal interaction.

<sub>Reviews (1): Last reviewed commit: ["fix: lock sidebar-inset scroll while a m..."](https://github.com/dokploy/dokploy/commit/dc9c67129e1a96c2171174ff40d87141009590de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52753681)</sub>

**Context used:**

- Knowledge Base — [UI Overlay Primitives (dialog, sheet, popover, dropdown-menu, alert-dialog)](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/ui-component-primitives.md)

<!-- /greptile_comment -->