### PR TITLE
fix(auth): link SCIM-provisioned users through SSO and surface sign-in errors

### DIFF
--- a/apps/dokploy/components/proprietary/auth/sign-in-with-github.tsx
+++ b/apps/dokploy/components/proprietary/auth/sign-in-with-github.tsx
@@ -13,6 +13,7 @@ export function SignInWithGithub() {
 		try {
 			const { error } = await authClient.signIn.social({
 				provider: "github",
+				errorCallbackURL: "/",
 			});
 			if (error) {
 				toast.error(error.message);

--- a/apps/dokploy/components/proprietary/auth/sign-in-with-google.tsx
+++ b/apps/dokploy/components/proprietary/auth/sign-in-with-google.tsx
@@ -13,6 +13,7 @@ export function SignInWithGoogle() {
 		try {
 			const { error } = await authClient.signIn.social({
 				provider: "google",
+				errorCallbackURL: "/",
 			});
 			if (error) {
 				toast.error(error.message);

--- a/apps/dokploy/components/proprietary/sso/sign-in-with-sso.tsx
+++ b/apps/dokploy/components/proprietary/sso/sign-in-with-sso.tsx
@@ -50,6 +50,7 @@ export function SignInWithSSO({
 			const { data, error } = await authClient.signIn.sso({
 				email: values.email,
 				callbackURL: "/dashboard/home",
+				errorCallbackURL: "/",
 			});
 			if (error) {
 				toast.error(error.message ?? "Failed to sign in with SSO");

--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -10,7 +10,7 @@ import { Fingerprint } from "lucide-react";
 import type { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { type ReactElement, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -84,6 +84,29 @@ export default function Home({ IS_CLOUD, enforceSSO }: Props) {
 			password: "",
 		},
 	});
+
+	useEffect(() => {
+		const queryError = router.query.error;
+		if (!queryError) return;
+
+		const raw = Array.isArray(queryError) ? queryError[0] : queryError;
+		if (!raw) return;
+		const normalized = raw.replace(/[+_]/g, " ").toLowerCase();
+
+		setError(
+			normalized.includes("account not linked")
+				? "This account already exists but isn't linked to that sign-in provider yet. Contact your administrator to link it."
+				: normalized.includes("access denied")
+					? "Access was denied by the identity provider."
+					: "We couldn't complete sign-in. Please try again or contact your administrator.",
+		);
+
+		const { error: _removed, ...rest } = router.query;
+		router.replace({ pathname: router.pathname, query: rest }, undefined, {
+			shallow: true,
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [router.query.error]);
 
 	const onSubmit = async (values: LoginForm) => {
 		setIsLoginLoading(true);

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -77,6 +77,9 @@ const createBetterAuth = () =>
 			...(!IS_CLOUD ? ["/verify-email"] : []),
 		],
 		secret: betterAuthSecret,
+		onAPIError: {
+			errorURL: "/",
+		},
 		...(!IS_CLOUD
 			? {
 					advanced: {
@@ -165,6 +168,9 @@ const createBetterAuth = () =>
 			user: {
 				create: {
 					before: async (_user, context) => {
+						if (context?.path.includes("/scim")) {
+							return { data: { emailVerified: true } };
+						}
 						if (!IS_CLOUD) {
 							const xDokployToken =
 								context?.request?.headers?.get("x-dokploy-token");
@@ -197,8 +203,7 @@ const createBetterAuth = () =>
 								}
 							} else {
 								const isSSORequest = context?.path.includes("/sso");
-								const isSCIMRequest = context?.path.includes("/scim");
-								if (isSSORequest || isSCIMRequest) {
+								if (isSSORequest) {
 									return;
 								}
 								const isAdminPresent = await db.query.member.findFirst({
@@ -251,6 +256,20 @@ const createBetterAuth = () =>
 						}
 
 						if (isSCIMRequest) {
+							const membership = await db.query.member.findFirst({
+								where: eq(schema.member.userId, user.id),
+							});
+							if (membership) {
+								const defaultRole = await resolveOrganizationDefaultRole(
+									membership.organizationId,
+								);
+								if (defaultRole !== membership.role) {
+									await db
+										.update(schema.member)
+										.set({ role: defaultRole })
+										.where(eq(schema.member.id, membership.id));
+								}
+							}
 							return;
 						}
 


### PR DESCRIPTION
## What is this PR about?

SCIM provisioning creates users via `internalAdapter.createUser({ email, name })`, which leaves `emailVerified: false`. When that user later signs in through the matching SSO provider, better-auth's account-linking guard (`requireLocalEmailVerified`) refuses to link the SSO identity because the local user isn't verified — the callback redirects with `error=account_not_linked`.

On top of that, the redirect had nowhere good to land: no `errorCallbackURL` was set, so it fell back to better-auth's own generic `/error` page (unbranded, `CODE: UNKNOWN`) instead of anything Dokploy owns, and the sign-in page never read the `error` query param anyway.

### Changes

- `packages/server/src/lib/auth.ts`
  - SCIM-provisioned users are marked `emailVerified: true` at creation (same trust rationale as admin-invited credential users — the org's SCIM token already vouches for the identity).
  - The membership SCIM creates is synced to the organization's configured default role instead of the hardcoded `"member"` the SCIM plugin writes.
  - `onAPIError.errorURL` points back at the sign-in page instead of better-auth's default `/error`.
- `sign-in-with-sso.tsx`, `sign-in-with-github.tsx`, `sign-in-with-google.tsx`
  - Pass `errorCallbackURL: "/"` so failed callbacks land back on Dokploy's sign-in page.
- `pages/index.tsx`
  - Read the `error` query param on mount and show a friendly message via the existing `AlertBlock` (mapped for `account_not_linked` / `access_denied`, generic fallback otherwise), then strip it from the URL.

### Verified locally

Reproduced end-to-end against a real Zitadel instance (Docker) + a local Dokploy dev server:
- SCIM-provisioned user + matching SSO login → previously landed on better-auth's bare error page with `error=account+not+linked`; now signs in successfully, and the membership role matches the organization's default role.
- A genuinely unverified local user (not SCIM-provisioned) attempting SSO login is still correctly rejected — confirms the fix is scoped to SCIM and doesn't weaken the account-linking guard generally — and now shows the friendly in-app message instead of the bare error page.

## Issues related

Fixes #4973

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR marks SCIM-created users as email-verified, redirects authentication failures to Dokploy's sign-in page, and displays friendly callback errors.

- Adds SCIM membership role synchronization to the organization's configured default role.
- Adds root error callback URLs for GitHub, Google, and enterprise SSO.
- Reads, presents, and removes authentication error query parameters on the sign-in page.

<h3>Confidence Score: 4/5</h3>

The SCIM role synchronization should be fixed before merging because it runs before the target membership exists and therefore does not apply the organization's default role.

The new after hook either finds no membership for a newly provisioned user or can select an unrelated existing membership, while the SCIM target membership is created later with the hardcoded member role.

**Files Needing Attention:** packages/server/src/lib/auth.ts

<sub>Reviews (1): Last reviewed commit: ["fix(auth): link SCIM-provisioned users t..."](https://github.com/dokploy/dokploy/commit/a1a672b672647b3a65b14f04860f930184e99517) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52890209)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Authentication, Organizations, and Permissions](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/auth-and-organizations.md)

<!-- /greptile_comment -->