### PR TITLE
fix(gitlab): handle missing expires_in in OAuth token response

### DIFF
--- a/apps/dokploy/pages/api/providers/gitlab/callback.ts
+++ b/apps/dokploy/pages/api/providers/gitlab/callback.ts
@@ -53,7 +53,9 @@ export default async function handler(
 		return res.status(400).json({ error: "Missing or invalid code" });
 	}
 
-	const expiresAt = Math.floor(Date.now() / 1000) + result.expires_in;
+	const expiresAt = result.expires_in
+		? Math.floor(Date.now() / 1000) + result.expires_in
+		: null;
 	await updateGitlab(gitlab.gitlabId, {
 		accessToken: result.access_token,
 		refreshToken: result.refresh_token,

--- a/packages/server/src/utils/providers/gitlab.ts
+++ b/packages/server/src/utils/providers/gitlab.ts
@@ -44,7 +44,9 @@ export const refreshGitlabToken = async (gitlabProviderId: string) => {
 
 	const data = await response.json();
 
-	const expiresAt = Math.floor(Date.now() / 1000) + data.expires_in;
+	const expiresAt = data.expires_in
+		? Math.floor(Date.now() / 1000) + data.expires_in
+		: null;
 
 	await updateGitlab(gitlabProviderId, {
 		accessToken: data.access_token,


### PR DESCRIPTION
Some self-hosted GitLab instances (older versions, or ones without `expires_in` configured in doorkeeper) omit `expires_in` from the OAuth token response. `Math.floor(Date.now() / 1000) + result.expires_in` then evaluates to `NaN`, which Postgres rejects on the `expires_at` integer column:

```
PostgresError: invalid input syntax for type integer: "NaN"
```

This crashes both the initial OAuth callback and the token refresh flow with a 500.

Falls back to `null` when `expires_in` is absent, matching the existing Gitea callback behavior (`apps/dokploy/pages/api/providers/gitea/callback.ts`).

Verified end-to-end against a real self-hosted GitLab instance whose OAuth response omits `expires_in`: reproduced the exact `NaN` Postgres crash on the unpatched code, then confirmed the fix stores `expires_at = NULL` and completes the OAuth flow without error.

Closes #4362

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents GitLab OAuth callbacks and token refreshes from persisting `NaN` when self-hosted instances omit `expires_in`.
- Stores a nullable expiry during initial GitLab OAuth linking.
- Applies the same fallback when refreshing GitLab tokens.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concern that providers lacking expiry metadata will refresh their token before every GitLab operation.

The change fixes the reported database failure, but the nullable expiry is interpreted by the existing guard as always requiring refresh, adding an avoidable network dependency to each provider operation.

**Files Needing Attention:** packages/server/src/utils/providers/gitlab.ts; apps/dokploy/pages/api/providers/gitlab/callback.ts

<sub>Reviews (1): Last reviewed commit: ["fix(gitlab): handle missing expires\_in i..."](https://github.com/dokploy/dokploy/commit/fc5b8d03e5423010a7b005677cf6b3d1db18fb74) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53119961)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Git Providers and Domains](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/git-providers-and-domains.md)

<!-- /greptile_comment -->