### PR TITLE
fix(volume-backups): clear retention amount when the field is emptied

### DIFF
--- a/apps/dokploy/__test__/utils/volume-backup-retention.test.ts
+++ b/apps/dokploy/__test__/utils/volume-backup-retention.test.ts
@@ -19,8 +19,10 @@ describe("prepareKeepLatestCount", () => {
 		expect(prepareKeepLatestCount("", 3)).toBeNull();
 	});
 
-	test("normalizes a missing form value to null", () => {
-		expect(prepareKeepLatestCount("3", undefined)).toBeNull();
-		expect(prepareKeepLatestCount("3", null)).toBeNull();
+	test("leaves the stored retention alone when the input is not a valid amount", () => {
+		// A non-empty input with no parsed value is rejected by the form schema.
+		// Clearing the column here would silently disable pruning.
+		expect(prepareKeepLatestCount("3.5", undefined)).toBeUndefined();
+		expect(prepareKeepLatestCount("abc", null)).toBeUndefined();
 	});
 });

--- a/apps/dokploy/__test__/utils/volume-backup-retention.test.ts
+++ b/apps/dokploy/__test__/utils/volume-backup-retention.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { prepareKeepLatestCount } from "@/components/dashboard/application/volume-backups/utils";
+
+describe("prepareKeepLatestCount", () => {
+	test("keeps the retention amount when a value is entered", () => {
+		expect(prepareKeepLatestCount("3", 3)).toBe(3);
+		expect(prepareKeepLatestCount("10", 10)).toBe(10);
+	});
+
+	test("returns null when the field is cleared", () => {
+		expect(prepareKeepLatestCount("", undefined)).toBeNull();
+		expect(prepareKeepLatestCount("   ", undefined)).toBeNull();
+	});
+
+	test("returns null instead of undefined so the column is cleared", () => {
+		// `undefined` is dropped from the update statement, which would leave the
+		// previously stored retention in place. See issue #4184.
+		expect(prepareKeepLatestCount("", 3)).not.toBeUndefined();
+		expect(prepareKeepLatestCount("", 3)).toBeNull();
+	});
+
+	test("normalizes a missing form value to null", () => {
+		expect(prepareKeepLatestCount("3", undefined)).toBeNull();
+		expect(prepareKeepLatestCount("3", null)).toBeNull();
+	});
+});

--- a/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
@@ -58,7 +58,7 @@ const formSchema = z
 		prefix: z.string(),
 		keepLatestCount: z.coerce
 			.number()
-			.int()
+			.int("Must be a whole number")
 			.gte(1, "Must be at least 1")
 			.optional()
 			.nullable(),
@@ -587,11 +587,10 @@ export const HandleVolumeBackups = ({
 											onChange={(e) => {
 												const raw = e.target.value;
 												setKeepLatestCountInput(raw);
-												if (raw === "") {
-													field.onChange(undefined);
-												} else if (/^\d+$/.test(raw)) {
-													field.onChange(Number(raw));
-												}
+												// Hand the raw value to the form so anything that is
+												// not a whole number is rejected by the schema
+												// instead of being dropped and treated as "cleared".
+												field.onChange(raw === "" ? undefined : raw);
 											}}
 										/>
 									</FormControl>

--- a/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
+++ b/apps/dokploy/components/dashboard/application/volume-backups/handle-volume-backups.tsx
@@ -42,6 +42,7 @@ import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 import type { CacheType } from "../domains/handle-domain";
 import { ScheduleFormField } from "../schedules/handle-schedules";
+import { prepareKeepLatestCount } from "./utils";
 
 const formSchema = z
 	.object({
@@ -203,12 +204,14 @@ export const HandleVolumeBackups = ({
 	const onSubmit = async (values: z.infer<typeof formSchema>) => {
 		if (!id && !volumeBackupId) return;
 
-		const preparedKeepLatestCount =
-			keepLatestCountInput === "" ? null : (values.keepLatestCount ?? null);
+		const preparedKeepLatestCount = prepareKeepLatestCount(
+			keepLatestCountInput,
+			values.keepLatestCount,
+		);
 
 		await mutateAsync({
 			...values,
-			keepLatestCount: preparedKeepLatestCount ?? undefined,
+			keepLatestCount: preparedKeepLatestCount,
 			destinationId: values.destinationId,
 			volumeBackupId: volumeBackupId || "",
 			serviceType: volumeBackupType,

--- a/apps/dokploy/components/dashboard/application/volume-backups/utils.ts
+++ b/apps/dokploy/components/dashboard/application/volume-backups/utils.ts
@@ -4,14 +4,18 @@
  * An empty input means "keep every backup", which has to be sent as an explicit
  * `null` so the column is cleared. Sending `undefined` instead would drop the
  * field from the update statement and silently keep the previous retention.
+ *
+ * A non-empty input with no parsed number is an invalid entry. The form rejects
+ * it before submit, so this returns `undefined` to leave the stored retention
+ * untouched rather than clearing it by accident.
  */
 export const prepareKeepLatestCount = (
 	rawInput: string,
 	value?: number | null,
-): number | null => {
+): number | null | undefined => {
 	if (rawInput.trim() === "") {
 		return null;
 	}
 
-	return value ?? null;
+	return value ?? undefined;
 };

--- a/apps/dokploy/components/dashboard/application/volume-backups/utils.ts
+++ b/apps/dokploy/components/dashboard/application/volume-backups/utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalizes the raw "Keep Latest Backups" input into the value sent to the API.
+ *
+ * An empty input means "keep every backup", which has to be sent as an explicit
+ * `null` so the column is cleared. Sending `undefined` instead would drop the
+ * field from the update statement and silently keep the previous retention.
+ */
+export const prepareKeepLatestCount = (
+	rawInput: string,
+	value?: number | null,
+): number | null => {
+	if (rawInput.trim() === "") {
+		return null;
+	}
+
+	return value ?? null;
+};


### PR DESCRIPTION
Clearing "Keep Latest Backups" did not remove the limit. The submit handler worked out a `null` for the empty field and then turned it straight back into `undefined` with `?? undefined`. Drizzle leaves undefined columns out of the UPDATE, so the old count stayed in the database and kept pruning backups the user thought were being kept.

It now sends the `null`, which is what the database backup form already does. I moved that bit of normalizing into a small helper so it can be tested.

The input's onChange also used to drop anything that was not all digits, so typing `3.5` left the last good number sitting in the form state. It now passes the raw value to the schema, which rejects it and shows an error instead.

To check by hand: set a retention value, save, reload, then clear the field and save. It should stay empty. Tests are in apps/dokploy/__test__/utils/volume-backup-retention.test.ts.

Closes #4184
