### PR TITLE
fix(queues): reset deployment status to error when a job fails

### DIFF
--- a/apps/dokploy/__test__/queues/deployments-queue.test.ts
+++ b/apps/dokploy/__test__/queues/deployments-queue.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { processDeploymentJob } from "../../server/queues/deployments-queue";
+import type { InMemoryJob } from "../../server/queues/in-memory-queue";
+import type { DeploymentJob } from "../../server/queues/queue-types";
+
+const mocks = vi.hoisted(() => ({
+	deployApplication: vi.fn(),
+	deployCompose: vi.fn(),
+	deployPreviewApplication: vi.fn(),
+	rebuildApplication: vi.fn(),
+	rebuildCompose: vi.fn(),
+	rebuildPreviewApplication: vi.fn(),
+	updateApplicationStatus: vi.fn(),
+	updateCompose: vi.fn(),
+	updatePreviewDeployment: vi.fn(),
+}));
+
+vi.mock("@dokploy/server", () => mocks);
+
+const toJob = (data: DeploymentJob): InMemoryJob => ({
+	id: "job-1",
+	name: "deployments",
+	data,
+	timestamp: 0,
+	getState: () => Promise.resolve("active"),
+	remove: () => Promise.resolve(),
+});
+
+const applicationJob: DeploymentJob = {
+	applicationId: "app-1",
+	titleLog: "deploy",
+	descriptionLog: "",
+	type: "deploy",
+	applicationType: "application",
+};
+
+const composeJob: DeploymentJob = {
+	composeId: "compose-1",
+	titleLog: "deploy",
+	descriptionLog: "",
+	type: "deploy",
+	applicationType: "compose",
+};
+
+const previewJob: DeploymentJob = {
+	applicationId: "app-1",
+	previewDeploymentId: "preview-1",
+	titleLog: "deploy",
+	descriptionLog: "",
+	type: "deploy",
+	applicationType: "application-preview",
+};
+
+describe("processDeploymentJob", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	it("keeps the running status when the deploy succeeds", async () => {
+		await processDeploymentJob(toJob(applicationJob));
+
+		expect(mocks.deployApplication).toHaveBeenCalledTimes(1);
+		expect(mocks.updateApplicationStatus).toHaveBeenCalledTimes(1);
+		expect(mocks.updateApplicationStatus).toHaveBeenCalledWith(
+			"app-1",
+			"running",
+		);
+	});
+
+	it("marks the application as error when the deploy throws", async () => {
+		mocks.deployApplication.mockRejectedValueOnce(new Error("boom"));
+
+		await processDeploymentJob(toJob(applicationJob));
+
+		expect(mocks.updateApplicationStatus).toHaveBeenLastCalledWith(
+			"app-1",
+			"error",
+		);
+	});
+
+	it("marks the application as error when the rebuild throws", async () => {
+		mocks.rebuildApplication.mockRejectedValueOnce(new Error("boom"));
+
+		await processDeploymentJob(toJob({ ...applicationJob, type: "redeploy" }));
+
+		expect(mocks.updateApplicationStatus).toHaveBeenLastCalledWith(
+			"app-1",
+			"error",
+		);
+	});
+
+	it("marks the compose as error when the deploy throws", async () => {
+		mocks.deployCompose.mockRejectedValueOnce(new Error("boom"));
+
+		await processDeploymentJob(toJob(composeJob));
+
+		expect(mocks.updateCompose).toHaveBeenLastCalledWith("compose-1", {
+			composeStatus: "error",
+		});
+	});
+
+	it("marks the preview deployment as error when the deploy throws", async () => {
+		mocks.deployPreviewApplication.mockRejectedValueOnce(new Error("boom"));
+
+		await processDeploymentJob(toJob(previewJob));
+
+		expect(mocks.updatePreviewDeployment).toHaveBeenLastCalledWith(
+			"preview-1",
+			{ previewStatus: "error" },
+		);
+	});
+
+	it("swallows a failing status rollback", async () => {
+		mocks.deployApplication.mockRejectedValueOnce(new Error("boom"));
+		mocks.updateApplicationStatus.mockResolvedValueOnce(undefined);
+		mocks.updateApplicationStatus.mockRejectedValueOnce(new Error("db down"));
+
+		await expect(
+			processDeploymentJob(toJob(applicationJob)),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/dokploy/__test__/queues/deployments-queue.test.ts
+++ b/apps/dokploy/__test__/queues/deployments-queue.test.ts
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
 	deployApplication: vi.fn(),
 	deployCompose: vi.fn(),
 	deployPreviewApplication: vi.fn(),
+	findApplicationById: vi.fn(),
+	findComposeById: vi.fn(),
+	findPreviewDeploymentById: vi.fn(),
 	rebuildApplication: vi.fn(),
 	rebuildCompose: vi.fn(),
 	rebuildPreviewApplication: vi.fn(),
@@ -55,6 +58,13 @@ describe("processDeploymentJob", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.spyOn(console, "log").mockImplementation(() => {});
+		mocks.findApplicationById.mockResolvedValue({
+			applicationStatus: "running",
+		});
+		mocks.findComposeById.mockResolvedValue({ composeStatus: "running" });
+		mocks.findPreviewDeploymentById.mockResolvedValue({
+			previewStatus: "running",
+		});
 	});
 
 	it("keeps the running status when the deploy succeeds", async () => {
@@ -109,6 +119,53 @@ describe("processDeploymentJob", () => {
 			"preview-1",
 			{ previewStatus: "error" },
 		);
+	});
+
+	it("keeps the done status when the application already finished", async () => {
+		mocks.deployApplication.mockRejectedValueOnce(new Error("boom"));
+		mocks.findApplicationById.mockResolvedValue({
+			applicationStatus: "done",
+		});
+
+		await processDeploymentJob(toJob(applicationJob));
+
+		expect(mocks.updateApplicationStatus).toHaveBeenCalledTimes(1);
+		expect(mocks.updateApplicationStatus).toHaveBeenLastCalledWith(
+			"app-1",
+			"running",
+		);
+	});
+
+	it("keeps the done status when the compose already finished", async () => {
+		mocks.deployCompose.mockRejectedValueOnce(new Error("boom"));
+		mocks.findComposeById.mockResolvedValue({ composeStatus: "done" });
+
+		await processDeploymentJob(toJob(composeJob));
+
+		expect(mocks.updateCompose).toHaveBeenCalledTimes(1);
+		expect(mocks.updateCompose).toHaveBeenLastCalledWith("compose-1", {
+			composeStatus: "running",
+		});
+	});
+
+	it("keeps the error status the helper already wrote", async () => {
+		mocks.deployApplication.mockRejectedValueOnce(new Error("boom"));
+		mocks.findApplicationById.mockResolvedValue({
+			applicationStatus: "error",
+		});
+
+		await processDeploymentJob(toJob(applicationJob));
+
+		expect(mocks.updateApplicationStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("swallows a failing status lookup", async () => {
+		mocks.deployApplication.mockRejectedValueOnce(new Error("boom"));
+		mocks.findApplicationById.mockRejectedValue(new Error("db down"));
+
+		await expect(
+			processDeploymentJob(toJob(applicationJob)),
+		).resolves.toBeUndefined();
 	});
 
 	it("swallows a failing status rollback", async () => {

--- a/apps/dokploy/server/queues/deployments-queue.ts
+++ b/apps/dokploy/server/queues/deployments-queue.ts
@@ -10,6 +10,34 @@ import {
 	updatePreviewDeployment,
 } from "@dokploy/server";
 import type { InMemoryJob } from "./in-memory-queue";
+import type { DeploymentJob } from "./queue-types";
+
+/**
+ * Marks the service as failed when the job throws.
+ *
+ * The deploy/rebuild helpers already set the status to `error` on their own
+ * failure path, but anything that throws outside of it (resolving the service,
+ * creating the deployment row, an unreachable server while writing the error
+ * log) would otherwise leave the service pinned to the `running` status set at
+ * the start of the job, with no way to clear it from the UI.
+ */
+const markJobAsFailed = async (data: DeploymentJob) => {
+	try {
+		if (data.applicationType === "application") {
+			await updateApplicationStatus(data.applicationId, "error");
+		} else if (data.applicationType === "compose") {
+			await updateCompose(data.composeId, {
+				composeStatus: "error",
+			});
+		} else if (data.applicationType === "application-preview") {
+			await updatePreviewDeployment(data.previewDeploymentId, {
+				previewStatus: "error",
+			});
+		}
+	} catch (error) {
+		console.log("Error resetting the deployment status", error);
+	}
+};
 
 /**
  * Processes a single deployment job. Shared by the in-memory queue worker and
@@ -73,5 +101,6 @@ export const processDeploymentJob = async (job: InMemoryJob) => {
 		}
 	} catch (error) {
 		console.log("Error", error);
+		await markJobAsFailed(job.data);
 	}
 };

--- a/apps/dokploy/server/queues/deployments-queue.ts
+++ b/apps/dokploy/server/queues/deployments-queue.ts
@@ -2,6 +2,9 @@ import {
 	deployApplication,
 	deployCompose,
 	deployPreviewApplication,
+	findApplicationById,
+	findComposeById,
+	findPreviewDeploymentById,
 	rebuildApplication,
 	rebuildCompose,
 	rebuildPreviewApplication,
@@ -20,16 +23,35 @@ import type { DeploymentJob } from "./queue-types";
  * creating the deployment row, an unreachable server while writing the error
  * log) would otherwise leave the service pinned to the `running` status set at
  * the start of the job, with no way to clear it from the UI.
+ *
+ * The status is only rolled back while it is still `running`. A helper that
+ * already wrote `done` or `error` keeps its own result, so a late throw (the
+ * commit metadata write in the helper's `finally` block, for example) cannot
+ * relabel a successful deployment as failed.
  */
 const markJobAsFailed = async (data: DeploymentJob) => {
 	try {
 		if (data.applicationType === "application") {
+			const application = await findApplicationById(data.applicationId);
+			if (application.applicationStatus !== "running") {
+				return;
+			}
 			await updateApplicationStatus(data.applicationId, "error");
 		} else if (data.applicationType === "compose") {
+			const compose = await findComposeById(data.composeId);
+			if (compose.composeStatus !== "running") {
+				return;
+			}
 			await updateCompose(data.composeId, {
 				composeStatus: "error",
 			});
 		} else if (data.applicationType === "application-preview") {
+			const previewDeployment = await findPreviewDeploymentById(
+				data.previewDeploymentId,
+			);
+			if (previewDeployment.previewStatus !== "running") {
+				return;
+			}
 			await updatePreviewDeployment(data.previewDeploymentId, {
 				previewStatus: "error",
 			});


### PR DESCRIPTION
The deployment worker sets the service status to running before it calls the deploy or rebuild helpers, and the catch block only logged the error. The helpers set the status to error when they fail, but a throw outside that path, like resolving the service or an unreachable server while writing the error log, left applications, compose stacks and preview deployments stuck on running with no way to clear it from the UI.

The catch block now rolls the status back to error, but only while it is still running. A helper that already wrote done or error keeps its own result, so a late throw cannot relabel a deployment that actually succeeded. The rollback has its own try/catch so a failed write does not take the worker down.

Tests are in apps/dokploy/__test__/queues/deployments-queue.test.ts. They cover deploy, rebuild, compose and preview failures, and the done/error cases that should be left alone.

Closes #4083
