### PR TITLE
fix(github-webhook): apply preview limit only to new previews

### DIFF
--- a/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
+++ b/apps/dokploy/__test__/deploy/github-webhook-handler.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 	queueAdd: vi.fn(),
 	verify: vi.fn(),
 	shouldDeploy: vi.fn(),
+	createPreviewDeployment: vi.fn(),
+	findPreviewDeploymentByApplicationId: vi.fn(),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -64,10 +66,11 @@ vi.mock("@dokploy/server", () => ({
 	IS_CLOUD: false,
 	shouldDeploy: mocks.shouldDeploy,
 	checkUserRepositoryPermissions: vi.fn(),
-	createPreviewDeployment: vi.fn(),
+	createPreviewDeployment: mocks.createPreviewDeployment,
 	createSecurityBlockedComment: vi.fn(),
 	findGithubById: vi.fn(),
-	findPreviewDeploymentByApplicationId: vi.fn(),
+	findPreviewDeploymentByApplicationId:
+		mocks.findPreviewDeploymentByApplicationId,
 	findPreviewDeploymentsByPullRequestId: vi.fn(),
 	getBitbucketHeaders: vi.fn(() => ({})),
 	removePreviewDeployment: vi.fn(),
@@ -319,5 +322,159 @@ describe("GitHub app webhook auto-deploy", () => {
 		expect(mocks.queueAdd).not.toHaveBeenCalled();
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith({ message: "No apps to deploy" });
+	});
+});
+
+describe("GitHub app webhook preview deployments", () => {
+	const createApplication = (
+		overrides: Record<string, unknown> = {},
+	): Record<string, unknown> => ({
+		applicationId: "application-id",
+		name: "my-app",
+		serverId: null,
+		previewLabels: [],
+		previewLimit: 3,
+		previewDeployments: [],
+		previewRequireCollaboratorPermissions: false,
+		...overrides,
+	});
+
+	const createPreviewDeployments = (total: number) =>
+		Array.from({ length: total }, (_, index) => ({
+			previewDeploymentId: `existing-preview-${index}`,
+		}));
+
+	const createPullRequestRequest = (action: string) =>
+		({
+			headers: {
+				"x-hub-signature-256": "sha256=test-signature",
+				"x-github-event": "pull_request",
+			},
+			body: {
+				installation: {
+					id: 12345,
+				},
+				action,
+				pull_request: {
+					id: 987,
+					number: 42,
+					title: "feat: add preview",
+					html_url: "https://github.com/agentHits/dokploy/pull/42",
+					labels: [],
+					user: {
+						login: "agentHits",
+					},
+					head: {
+						ref: "feature",
+						sha: "abc123",
+					},
+					base: {
+						ref: "main",
+					},
+				},
+				repository: {
+					name: "dokploy",
+					owner: {
+						login: "agentHits",
+					},
+				},
+			},
+		}) as unknown as NextApiRequest;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.githubFindFirst.mockResolvedValue({
+			githubId: "github-provider-id",
+			githubInstallationId: 12345,
+			githubWebhookSecret: "webhook-secret",
+		});
+		mocks.verify.mockResolvedValue(true);
+		mocks.queueAdd.mockResolvedValue({ id: "job-id" });
+		mocks.createPreviewDeployment.mockResolvedValue({
+			previewDeploymentId: "new-preview-id",
+		});
+		mocks.findPreviewDeploymentByApplicationId.mockResolvedValue(undefined);
+	});
+
+	it("redeploys an existing preview even when the limit is reached", async () => {
+		mocks.applicationsFindMany.mockResolvedValue([
+			createApplication({
+				previewLimit: 2,
+				previewDeployments: createPreviewDeployments(3),
+			}),
+		]);
+		mocks.findPreviewDeploymentByApplicationId.mockResolvedValue({
+			previewDeploymentId: "existing-preview-0",
+		});
+		const res = createResponse();
+
+		await handler(createPullRequestRequest("synchronize"), res);
+
+		expect(mocks.createPreviewDeployment).not.toHaveBeenCalled();
+		expect(mocks.queueAdd).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationId: "application-id",
+				applicationType: "application-preview",
+				previewDeploymentId: "existing-preview-0",
+				type: "deploy",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it("does not create a new preview once the limit is reached", async () => {
+		mocks.applicationsFindMany.mockResolvedValue([
+			createApplication({
+				previewLimit: 2,
+				previewDeployments: createPreviewDeployments(2),
+			}),
+		]);
+		const res = createResponse();
+
+		await handler(createPullRequestRequest("opened"), res);
+
+		expect(mocks.createPreviewDeployment).not.toHaveBeenCalled();
+		expect(mocks.queueAdd).not.toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it("falls back to the default limit when none is configured", async () => {
+		mocks.applicationsFindMany.mockResolvedValue([
+			createApplication({
+				previewLimit: null,
+				previewDeployments: createPreviewDeployments(2),
+			}),
+		]);
+		const res = createResponse();
+
+		await handler(createPullRequestRequest("opened"), res);
+
+		expect(mocks.createPreviewDeployment).toHaveBeenCalledWith(
+			expect.objectContaining({
+				applicationId: "application-id",
+				branch: "feature",
+				pullRequestId: 987,
+				pullRequestNumber: 42,
+			}),
+		);
+		expect(mocks.queueAdd).toHaveBeenCalledWith(
+			"deployments",
+			expect.objectContaining({
+				applicationId: "application-id",
+				applicationType: "application-preview",
+				previewDeploymentId: "new-preview-id",
+				type: "deploy",
+			}),
+			expect.objectContaining({
+				removeOnComplete: true,
+				removeOnFail: true,
+			}),
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
 	});
 });

--- a/apps/dokploy/pages/api/deploy/github.ts
+++ b/apps/dokploy/pages/api/deploy/github.ts
@@ -484,10 +484,6 @@ export default async function handler(
 					if (!hasLabel) continue;
 				}
 
-				const previewLimit = app?.previewLimit || 0;
-				if (app?.previewDeployments?.length > previewLimit) {
-					continue;
-				}
 				const previewDeploymentResult =
 					await findPreviewDeploymentByApplicationId(app.applicationId, prId);
 
@@ -495,6 +491,15 @@ export default async function handler(
 					previewDeploymentResult?.previewDeploymentId || "";
 
 				if (!previewDeploymentResult && shouldCreateDeployment) {
+					// The limit only applies to new previews, existing ones must
+					// still be redeployed when the pull request is updated.
+					const previewLimit = app?.previewLimit ?? 3;
+					if ((app?.previewDeployments?.length ?? 0) >= previewLimit) {
+						console.warn(
+							`⚠️ Preview deployment limit (${previewLimit}) reached for ${app.name}, skipping preview for pull request #${prNumber}`,
+						);
+						continue;
+					}
 					const previewDeployment = await createPreviewDeployment({
 						applicationId: app.applicationId as string,
 						branch: prBranch,


### PR DESCRIPTION
The preview limit was checked before we looked up whether the pull request already had a preview. Once an app hit the limit, every `synchronize` event was dropped, so open previews stopped rebuilding while GitHub still got a 200 back.

I moved the check inside the branch that creates a new preview, so an update to an existing preview always goes through. Two smaller things in the same check. The fallback was `|| 0`, so an app with no limit configured was treated as limit zero. It now uses `?? 3` to match the schema default. The comparison is `>=` instead of `>`, so a limit of 3 means 3 previews and not 4. Hitting the limit now logs a warning rather than dropping the event with no trace.

Tests are in apps/dokploy/__test__/deploy/github-webhook-handler.test.ts. The three new cases fail on canary and pass with this change. I could not run the suite locally, so please check CI.

Closes #4074
