### PR TITLE
fix(volume-backups): restart services after backup failure

### DIFF
--- a/apps/dokploy/__test__/backups/volume-backup-restart.test.ts
+++ b/apps/dokploy/__test__/backups/volume-backup-restart.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import { createRestartSafeBackupCommand } from "@dokploy/server/utils/volume-backups/backup";
+import { describe, expect, it } from "vitest";
+
+const runCommand = (command: string) =>
+	spawnSync("bash", ["-c", command], {
+		encoding: "utf8",
+	});
+
+const outputLines = (stdout: string) =>
+	stdout
+		.trim()
+		.split("\n")
+		.filter((line) => line.length > 0);
+
+describe("createRestartSafeBackupCommand", () => {
+	it("restarts the service and preserves the backup error status", () => {
+		const result = runCommand(
+			createRestartSafeBackupCommand({
+				stopCommand: 'echo "stop"',
+				backupCommand: 'echo "backup"; exit 23',
+				startCommand: 'echo "start"',
+				uploadCommand: 'echo "upload"',
+			}),
+		);
+
+		expect(result.status).toBe(23);
+		expect(outputLines(result.stdout)).toEqual(["stop", "backup", "start"]);
+	});
+
+	it("uploads only after a successful backup and service restart", () => {
+		const result = runCommand(
+			createRestartSafeBackupCommand({
+				stopCommand: 'echo "stop"',
+				backupCommand: 'echo "backup"',
+				startCommand: 'echo "start"',
+				uploadCommand: 'echo "upload"',
+			}),
+		);
+
+		expect(result.status).toBe(0);
+		expect(outputLines(result.stdout)).toEqual([
+			"stop",
+			"backup",
+			"start",
+			"upload",
+		]);
+	});
+});

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -9,6 +9,33 @@ import {
 	normalizeS3Path,
 } from "../backups/utils";
 
+interface RestartSafeBackupCommandOptions {
+	stopCommand: string;
+	backupCommand: string;
+	startCommand: string;
+	uploadCommand: string;
+}
+
+export const createRestartSafeBackupCommand = ({
+	stopCommand,
+	backupCommand,
+	startCommand,
+	uploadCommand,
+}: RestartSafeBackupCommandOptions) => `
+	${stopCommand}
+	set +e
+	(
+		${backupCommand}
+	)
+	DOKPLOY_VOLUME_BACKUP_STATUS=$?
+	set -e
+	${startCommand}
+	if [ "$DOKPLOY_VOLUME_BACKUP_STATUS" -ne 0 ]; then
+		exit "$DOKPLOY_VOLUME_BACKUP_STATUS"
+	fi
+	${uploadCommand}
+`;
+
 export const getVolumeServiceAppName = (
 	volumeBackup: Awaited<ReturnType<typeof findVolumeBackupById>>,
 ): string => {
@@ -117,16 +144,20 @@ export const backupVolume = async (
 	);
 
 	if (serviceType === "application") {
-		return lockWrapper(`
-		echo "Stopping application to 0 replicas"
-		ACTUAL_REPLICAS=$(docker service inspect ${volumeBackup.application?.appName} --format "{{.Spec.Mode.Replicated.Replicas}}")
-		echo "Actual replicas: $ACTUAL_REPLICAS"
-		docker service update --replicas=0 ${volumeBackup.application?.appName}
-        ${backupCommand}
-		echo "Starting application to $ACTUAL_REPLICAS replicas"
-        docker service update --replicas=$ACTUAL_REPLICAS --with-registry-auth ${volumeBackup.application?.appName}
-		${uploadCommand}
-  `);
+		return lockWrapper(
+			createRestartSafeBackupCommand({
+				stopCommand: `
+				echo "Stopping application to 0 replicas"
+				ACTUAL_REPLICAS=$(docker service inspect ${volumeBackup.application?.appName} --format "{{.Spec.Mode.Replicated.Replicas}}")
+				echo "Actual replicas: $ACTUAL_REPLICAS"
+				docker service update --replicas=0 ${volumeBackup.application?.appName}`,
+				backupCommand,
+				startCommand: `
+				echo "Starting application to $ACTUAL_REPLICAS replicas"
+				docker service update --replicas=$ACTUAL_REPLICAS --with-registry-auth ${volumeBackup.application?.appName}`,
+				uploadCommand,
+			}),
+		);
 	}
 	if (serviceType === "compose") {
 		const compose = await findComposeById(
@@ -158,11 +189,13 @@ export const backupVolume = async (
 			echo "Compose container started"
 			`;
 		}
-		return lockWrapper(`
-        ${stopCommand}
-        ${backupCommand}
-        ${startCommand}
-		${uploadCommand}
-  `);
+		return lockWrapper(
+			createRestartSafeBackupCommand({
+				stopCommand,
+				backupCommand,
+				startCommand,
+				uploadCommand,
+			}),
+		);
 	}
 };


### PR DESCRIPTION
## Problem

When **Turn Off Container During Backup** is enabled, the generated volume-backup script stops the application or Compose service before creating the archive. Because the script runs with `set -e`, a backup failure exits immediately and skips the restart command, leaving the service offline until someone restarts it manually.

This is especially disruptive for transient failures such as an unavailable image registry or a failed `ubuntu` image pull.

## What changed

- Run the backup step in a subshell and capture its exit status.
- Always execute the service restart after the backup attempt.
- Preserve and return the original backup failure status after the restart, so the deployment remains marked as failed and the upload is skipped.
- Use the same restart-safe command flow for applications, Compose stacks, and regular Compose containers.
- Add regression tests covering both failure and success command sequences.

## Impact

Services that are intentionally stopped for a consistent volume backup are brought back online even when archive creation fails. Successful backup and upload behavior remains unchanged.

## Validation

- `pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts run __test__/backups` — 21 tests passed
- `pnpm --filter=@dokploy/server typecheck`
- `pnpm --filter=dokploy typecheck`
- Biome check on the changed files

Fixes #4263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes volume-backup command generation so stopped application and Compose services are restarted after archive failures while retaining failure signaling.
- Introduces a shared restart-safe shell-command generator.
- Applies the flow to application, Compose stack, and regular Compose-container backups.
- Adds regression coverage for successful backups and backup failures followed by successful restarts.

<h3>Confidence Score: 4/5</h3>

The restart sequencing needs correction before merging because a failed restart can override the original backup failure that this change promises to preserve.

The saved backup status is checked only after a fallible restart executes under errexit, so simultaneous backup and restart failures surface the wrong exit status and diagnostics.

**Files Needing Attention:** packages/server/src/utils/volume-backups/backup.ts

<sub>Reviews (1): Last reviewed commit: ["fix(volume-backups): restart services af..."](https://github.com/dokploy/dokploy/commit/2598a6277153e32638b4bf31e365f9b5f1e833b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53315124)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->