### PR TITLE
fix(volume-backups): restart services after backup failure

### DIFF
--- a/apps/dokploy/__test__/backups/volume-backup-restart.test.ts
+++ b/apps/dokploy/__test__/backups/volume-backup-restart.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import { createRestartSafeBackupCommand } from "@dokploy/server/utils/volume-backups/backup";
+import { describe, expect, it } from "vitest";
+
+const runCommand = (command: string) =>
+	spawnSync("bash", ["-c", command], {
+		encoding: "utf8",
+	});
+
+const outputLines = (stdout: string) =>
+	stdout
+		.trim()
+		.split("\n")
+		.filter((line) => line.length > 0);
+
+describe("createRestartSafeBackupCommand", () => {
+	it("restarts the service and preserves the backup error status", () => {
+		const result = runCommand(
+			createRestartSafeBackupCommand({
+				stopCommand: 'echo "stop"',
+				backupCommand: 'echo "backup"; exit 23',
+				startCommand: 'echo "start"',
+				uploadCommand: 'echo "upload"',
+			}),
+		);
+
+		expect(result.status).toBe(23);
+		expect(outputLines(result.stdout)).toEqual(["stop", "backup", "start"]);
+	});
+
+	it("uploads only after a successful backup and service restart", () => {
+		const result = runCommand(
+			createRestartSafeBackupCommand({
+				stopCommand: 'echo "stop"',
+				backupCommand: 'echo "backup"',
+				startCommand: 'echo "start"',
+				uploadCommand: 'echo "upload"',
+			}),
+		);
+
+		expect(result.status).toBe(0);
+		expect(outputLines(result.stdout)).toEqual([
+			"stop",
+			"backup",
+			"start",
+			"upload",
+		]);
+	});
+});

--- a/apps/dokploy/__test__/backups/volume-backup-restart.test.ts
+++ b/apps/dokploy/__test__/backups/volume-backup-restart.test.ts
@@ -28,6 +28,39 @@ describe("createRestartSafeBackupCommand", () => {
 		expect(outputLines(result.stdout)).toEqual(["stop", "backup", "start"]);
 	});
 
+	it("preserves the backup error status when the restart also fails", () => {
+		const result = runCommand(
+			createRestartSafeBackupCommand({
+				stopCommand: 'echo "stop"',
+				backupCommand: 'echo "backup"; exit 23',
+				startCommand: 'echo "start"; exit 17',
+				uploadCommand: 'echo "upload"',
+			}),
+		);
+
+		expect(result.status).toBe(23);
+		expect(outputLines(result.stdout)).toEqual([
+			"stop",
+			"backup",
+			"start",
+			"Service restart also failed with exit code 17",
+		]);
+	});
+
+	it("returns the restart error status when the backup succeeds", () => {
+		const result = runCommand(
+			createRestartSafeBackupCommand({
+				stopCommand: 'echo "stop"',
+				backupCommand: 'echo "backup"',
+				startCommand: 'echo "start"; exit 17',
+				uploadCommand: 'echo "upload"',
+			}),
+		);
+
+		expect(result.status).toBe(17);
+		expect(outputLines(result.stdout)).toEqual(["stop", "backup", "start"]);
+	});
+
 	it("uploads only after a successful backup and service restart", () => {
 		const result = runCommand(
 			createRestartSafeBackupCommand({

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -28,10 +28,20 @@ export const createRestartSafeBackupCommand = ({
 		${backupCommand}
 	)
 	DOKPLOY_VOLUME_BACKUP_STATUS=$?
+	(
+		set -e
+		${startCommand}
+	)
+	DOKPLOY_VOLUME_RESTART_STATUS=$?
 	set -e
-	${startCommand}
 	if [ "$DOKPLOY_VOLUME_BACKUP_STATUS" -ne 0 ]; then
+		if [ "$DOKPLOY_VOLUME_RESTART_STATUS" -ne 0 ]; then
+			echo "Service restart also failed with exit code $DOKPLOY_VOLUME_RESTART_STATUS"
+		fi
 		exit "$DOKPLOY_VOLUME_BACKUP_STATUS"
+	fi
+	if [ "$DOKPLOY_VOLUME_RESTART_STATUS" -ne 0 ]; then
+		exit "$DOKPLOY_VOLUME_RESTART_STATUS"
 	fi
 	${uploadCommand}
 `;

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -9,6 +9,33 @@ import {
 	normalizeS3Path,
 } from "../backups/utils";
 
+interface RestartSafeBackupCommandOptions {
+	stopCommand: string;
+	backupCommand: string;
+	startCommand: string;
+	uploadCommand: string;
+}
+
+export const createRestartSafeBackupCommand = ({
+	stopCommand,
+	backupCommand,
+	startCommand,
+	uploadCommand,
+}: RestartSafeBackupCommandOptions) => `
+	${stopCommand}
+	set +e
+	(
+		${backupCommand}
+	)
+	DOKPLOY_VOLUME_BACKUP_STATUS=$?
+	set -e
+	${startCommand}
+	if [ "$DOKPLOY_VOLUME_BACKUP_STATUS" -ne 0 ]; then
+		exit "$DOKPLOY_VOLUME_BACKUP_STATUS"
+	fi
+	${uploadCommand}
+`;
+
 export const getVolumeServiceAppName = (
 	volumeBackup: Awaited<ReturnType<typeof findVolumeBackupById>>,
 ): string => {
@@ -117,16 +144,20 @@ export const backupVolume = async (
 	);
 
 	if (serviceType === "application") {
-		return lockWrapper(`
-		echo "Stopping application to 0 replicas"
-		ACTUAL_REPLICAS=$(docker service inspect ${volumeBackup.application?.appName} --format "{{.Spec.Mode.Replicated.Replicas}}")
-		echo "Actual replicas: $ACTUAL_REPLICAS"
-		docker service update --replicas=0 ${volumeBackup.application?.appName}
-        ${backupCommand}
-		echo "Starting application to $ACTUAL_REPLICAS replicas"
-        docker service update --replicas=$ACTUAL_REPLICAS --with-registry-auth ${volumeBackup.application?.appName}
-		${uploadCommand}
-  `);
+		return lockWrapper(
+			createRestartSafeBackupCommand({
+				stopCommand: `
+				echo "Stopping application to 0 replicas"
+				ACTUAL_REPLICAS=$(docker service inspect ${volumeBackup.application?.appName} --format "{{.Spec.Mode.Replicated.Replicas}}")
+				echo "Actual replicas: $ACTUAL_REPLICAS"
+				docker service update --replicas=0 ${volumeBackup.application?.appName}`,
+				backupCommand,
+				startCommand: `
+				echo "Starting application to $ACTUAL_REPLICAS replicas"
+				docker service update --replicas=$ACTUAL_REPLICAS --with-registry-auth ${volumeBackup.application?.appName}`,
+				uploadCommand,
+			}),
+		);
 	}
 	if (serviceType === "compose") {
 		const compose = await findComposeById(
@@ -158,11 +189,13 @@ export const backupVolume = async (
 			echo "Compose container started"
 			`;
 		}
-		return lockWrapper(`
-        ${stopCommand}
-        ${backupCommand}
-        ${startCommand}
-		${uploadCommand}
-  `);
+		return lockWrapper(
+			createRestartSafeBackupCommand({
+				stopCommand,
+				backupCommand,
+				startCommand,
+				uploadCommand,
+			}),
+		);
 	}
 };


### PR DESCRIPTION
## Problem

When **Turn Off Container During Backup** is enabled, the generated volume-backup script stops the application or Compose service before creating the archive. Because the script runs with `set -e`, a backup failure exits immediately and skips the restart command, leaving the service offline until someone restarts it manually.

This is especially disruptive for transient failures such as an unavailable image registry or a failed `ubuntu` image pull.

## What changed

- Run the backup step in a subshell and capture its exit status.
- Always execute the service restart after the backup attempt.
- Preserve and return the original backup failure status after the restart, so the deployment remains marked as failed and the upload is skipped.
- Use the same restart-safe command flow for applications, Compose stacks, and regular Compose containers.
- Add regression tests covering both failure and success command sequences.

## Impact

Services that are intentionally stopped for a consistent volume backup are brought back online even when archive creation fails. Successful backup and upload behavior remains unchanged.

## Validation

- `pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts run __test__/backups` — 23 tests passed
- `pnpm --filter=@dokploy/server typecheck`
- `pnpm --filter=dokploy typecheck`
- Biome check on the changed files

Fixes #4263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes volume backups restart stopped services even when backup creation fails, while preserving the appropriate failure status.
- Runs backup and restart operations in separately controlled shell contexts.
- Preserves the original backup status when both backup and restart fail.
- Skips upload unless backup and restart both succeed.
- Adds regression coverage for all backup/restart success and failure combinations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported failure is fixed: a failed restart can no longer terminate the outer shell before the saved backup status is restored, and no blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix(volume-backups): preserve backup fai..."](https://github.com/dokploy/dokploy/commit/c6ab76fe09093dfacd6d11ddde36e3b7f77719ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53315775)</sub>

**Context used:**

- Knowledge Base — [Backups and Schedules](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-schedules.md)

<!-- /greptile_comment -->