### PR TITLE
feat: enable Google Tag Manager on cloud version only

### DIFF
--- a/apps/dokploy/pages/_app.tsx
+++ b/apps/dokploy/pages/_app.tsx
@@ -9,6 +9,7 @@ import NextTopLoader from "nextjs-toploader";
 import type { ReactElement, ReactNode } from "react";
 import { SearchCommand } from "@/components/dashboard/search-command";
 import { WhitelabelingProvider } from "@/components/proprietary/whitelabeling/whitelabeling-provider";
+import { Analytics } from "@/components/shared/analytics";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { api } from "@/utils/api";
@@ -52,6 +53,7 @@ const MyApp = ({
 				>
 					<NextTopLoader color="hsl(var(--sidebar-ring))" />
 					<WhitelabelingProvider />
+					<Analytics />
 					<Toaster richColors />
 					<SearchCommand />
 					{getLayout(<Component {...pageProps} />)}


### PR DESCRIPTION
Mounts the existing `Analytics` component (`components/shared/analytics.tsx`) in `_app.tsx`. That component already loads Google Tag Manager (`GTM-PWBFB2V2`, same container used on dokploy.com) and the HubSpot script gated behind `api.settings.isCloud`, but it was never mounted anywhere, so it never actually ran.

Verified locally with Playwright by toggling `IS_CLOUD` in `.env`:
- `IS_CLOUD=false`: no `dataLayer`, no GTM/HubSpot scripts injected, no requests to google.com/hubapi.com.
- `IS_CLOUD=true`: GTM loads, `dataLayer` populates with `gtm.js`/`gtm.dom`/`gtm.load`, HubSpot script loads, and GTM's configured tags fire real network requests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Mounts the existing analytics component globally so Google Tag Manager and HubSpot run only in cloud deployments.
- Adds the shared `Analytics` import to the application entry point.
- Renders analytics within the existing application provider tree.
- Leaves self-hosted installations unaffected through the component’s server-derived cloud gate.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with analytics remaining disabled for self-hosted deployments.

The mounted component receives its required router and tRPC contexts, handles unresolved or failed cloud-setting queries by rendering nothing, and injects third-party scripts only when the server reports a cloud deployment.

<sub>Reviews (1): Last reviewed commit: ["feat: enable Google Tag Manager on cloud..."](https://github.com/dokploy/dokploy/commit/aedb35b8dfee9731d44152d7e8e3b0647cd42981) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53356484)</sub>

<!-- /greptile_comment -->