### PR TITLE
feat: track cloud sign_up event in dataLayer

### DIFF
--- a/apps/dokploy/components/proprietary/auth/sign-in-with-github.tsx
+++ b/apps/dokploy/components/proprietary/auth/sign-in-with-github.tsx
@@ -13,6 +13,8 @@ export function SignInWithGithub() {
 		try {
 			const { error } = await authClient.signIn.social({
 				provider: "github",
+				callbackURL: "/dashboard/home",
+				newUserCallbackURL: "/dashboard/home?signup=github",
 				errorCallbackURL: "/",
 			});
 			if (error) {

--- a/apps/dokploy/components/proprietary/auth/sign-in-with-google.tsx
+++ b/apps/dokploy/components/proprietary/auth/sign-in-with-google.tsx
@@ -13,6 +13,8 @@ export function SignInWithGoogle() {
 		try {
 			const { error } = await authClient.signIn.social({
 				provider: "google",
+				callbackURL: "/dashboard/home",
+				newUserCallbackURL: "/dashboard/home?signup=google",
 				errorCallbackURL: "/",
 			});
 			if (error) {

--- a/apps/dokploy/pages/invitation.tsx
+++ b/apps/dokploy/pages/invitation.tsx
@@ -21,6 +21,7 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { pushToDataLayer } from "@/lib/analytics";
 import { authClient } from "@/lib/auth-client";
 import { api } from "@/utils/api";
 import { useWhitelabelingPublic } from "@/utils/hooks/use-whitelabeling";
@@ -139,6 +140,9 @@ const Invitation = ({
 			});
 
 			toast.success("Account created successfully");
+			if (isCloud) {
+				pushToDataLayer("sign_up", { method: "invitation" });
+			}
 			router.push("/dashboard/home");
 		} catch {
 			toast.error("An error occurred while creating your account");

--- a/apps/dokploy/pages/register.tsx
+++ b/apps/dokploy/pages/register.tsx
@@ -24,6 +24,7 @@ import {
 	FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { pushToDataLayer } from "@/lib/analytics";
 import { authClient } from "@/lib/auth-client";
 import { useWhitelabelingPublic } from "@/utils/hooks/use-whitelabeling";
 
@@ -116,6 +117,7 @@ const Register = ({ isCloud }: Props) => {
 			if (!isCloud) {
 				router.push("/");
 			} else {
+				pushToDataLayer("sign_up", { method: "email" });
 				setData(data);
 			}
 		}


### PR DESCRIPTION
Wires up the `sign_up` dataLayer event (read by GTM, added in #5083) for the three signup paths on the cloud version:

- **Email/password** (`register.tsx`): fires `pushToDataLayer("sign_up", { method: "email" })` directly on successful `signUp.email` — no redirect needed, it's an SPA call.
- **GitHub / Google OAuth**: uses better-auth's native `newUserCallbackURL`, separate from `callbackURL`, so only genuinely new accounts redirect through `?signup=github`/`?signup=google` — returning-user logins keep using the plain `callbackURL` and don't fire the event. The existing `Analytics` component already reads `?signup=` and strips it from the URL.
- **Invitation acceptance** (`invitation.tsx`): fires `method: "invitation"` before the redirect to the dashboard.

All three are gated behind `isCloud`, consistent with the rest of the analytics wiring — nothing fires on self-hosted.

Verified locally with Playwright (`IS_CLOUD=true`):
- Email signup: `window.dataLayer` shows `{event: "sign_up", method: "email"}` right after a successful registration.
- GitHub OAuth: called `/api/auth/sign-in/social` directly with `newUserCallbackURL` — server accepts it (200) and encodes it into the OAuth `state`, matching what `callback.mjs` uses to pick `newUserURL` over `callbackURL` only when `isRegister` is true.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds cloud-only `sign_up` analytics tracking across email, invitation, GitHub, and Google registration flows.
- Emits direct data-layer events after successful email and invitation account creation.
- Uses OAuth new-user callback URLs to distinguish new registrations from returning-user logins.
- Routes OAuth signup query parameters through the existing application-wide analytics component.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The new analytics calls occur only after successful account creation, remain cloud-gated, and the OAuth callbacks distinguish genuinely new users from returning users.

<sub>Reviews (1): Last reviewed commit: ["feat: track cloud sign\_up event in dataL..."](https://github.com/dokploy/dokploy/commit/d8b7c1ea5e892c93b408b3d9dfcddb0fdb3c50af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53364412)</sub>

<!-- /greptile_comment -->