### PR TITLE
fix(project): restrict service columns in project.one for members

### DIFF
--- a/apps/dokploy/__test__/permissions/project-one-service-columns.test.ts
+++ b/apps/dokploy/__test__/permissions/project-one-service-columns.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Postgres allows at most 100 arguments per function call. Drizzle builds one
+// json_build_array per nested relation with a single argument per column, so
+// pulling a whole service table inside a `with` makes the query fail at runtime
+// (the application table is already at 101 columns).
+// The member branch of project.one was the only query missing `columns:`.
+const PG_MAX_FUNCTION_ARGS = 100;
+
+const SERVICE_RELATIONS = [
+	"applications",
+	"compose",
+	"libsql",
+	"mariadb",
+	"mongo",
+	"mysql",
+	"postgres",
+	"redis",
+] as const;
+
+const readSource = (relativePath: string) =>
+	readFileSync(path.resolve(__dirname, "../..", relativePath), "utf8");
+
+const countTableColumns = (source: string, table: string) => {
+	const start = source.indexOf(`pgTable("${table}"`);
+	const body = source.slice(start, source.indexOf("\n);", start));
+	return [...body.matchAll(/^\t(\w+):/gm)].length;
+};
+
+describe("project.one — member branch", () => {
+	it("application exceeds the Postgres function argument limit", () => {
+		const schema = readSource(
+			"../../packages/server/src/db/schema/application.ts",
+		);
+
+		// Once this no longer holds the risk is gone, but while it does no query
+		// may pull the whole table inside a `with`.
+		expect(countTableColumns(schema, "application")).toBeGreaterThan(
+			PG_MAX_FUNCTION_ARGS,
+		);
+	});
+
+	it("restricts columns on every service relation", () => {
+		const router = readSource("server/api/routers/project.ts");
+		const memberBranch = router.slice(
+			router.indexOf("one: protectedProcedure"),
+			router.indexOf("all: protectedProcedure"),
+		);
+		expect(memberBranch).not.toHaveLength(0);
+
+		for (const relation of SERVICE_RELATIONS) {
+			const start = memberBranch.indexOf(`${relation}: {`);
+			expect(start, `missing relation ${relation}`).toBeGreaterThan(-1);
+
+			const block = memberBranch.slice(start);
+			expect(
+				block.slice(0, block.indexOf("\n\t\t\t\t\t\t\t},")),
+				`${relation} would pull the whole table and break the query`,
+			).toContain("columns:");
+		}
+	});
+});

--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -121,6 +121,20 @@ export const projectRouter = createTRPCRouter({
 					});
 				}
 
+				// Select explicit columns, same as findProjectById does for owners/admins.
+				// Drizzle builds one json_build_array per nested relation with a single
+				// argument per column, and Postgres allows at most 100 arguments per
+				// function call. The application table is already at 101 columns, so
+				// pulling the whole table inside a `with` makes the query fail.
+				const serviceColumns = {
+					name: true,
+					description: true,
+					appName: true,
+					createdAt: true,
+					serverId: true,
+					applicationStatus: true,
+				} as const;
+
 				const project = await db.query.projects.findFirst({
 					where: and(
 						eq(projects.projectId, input.projectId),
@@ -130,39 +144,55 @@ export const projectRouter = createTRPCRouter({
 						environments: {
 							with: {
 								applications: {
+									columns: {
+										...serviceColumns,
+										applicationId: true,
+										icon: true,
+									},
 									where: buildServiceFilter(
 										applications.applicationId,
 										accessedServices,
 									),
 								},
 								compose: {
+									columns: {
+										...serviceColumns,
+										composeId: true,
+										composeStatus: true,
+									},
 									where: buildServiceFilter(
 										compose.composeId,
 										accessedServices,
 									),
 								},
 								libsql: {
+									columns: { ...serviceColumns, libsqlId: true },
 									where: buildServiceFilter(libsql.libsqlId, accessedServices),
 								},
 								mariadb: {
+									columns: { ...serviceColumns, mariadbId: true },
 									where: buildServiceFilter(
 										mariadb.mariadbId,
 										accessedServices,
 									),
 								},
 								mongo: {
+									columns: { ...serviceColumns, mongoId: true },
 									where: buildServiceFilter(mongo.mongoId, accessedServices),
 								},
 								mysql: {
+									columns: { ...serviceColumns, mysqlId: true },
 									where: buildServiceFilter(mysql.mysqlId, accessedServices),
 								},
 								postgres: {
+									columns: { ...serviceColumns, postgresId: true },
 									where: buildServiceFilter(
 										postgres.postgresId,
 										accessedServices,
 									),
 								},
 								redis: {
+									columns: { ...serviceColumns, redisId: true },
 									where: buildServiceFilter(redis.redisId, accessedServices),
 								},
 							},


### PR DESCRIPTION
## What is this PR about?

Members with valid project access cannot open their projects: they see the project card, but clicking it redirects them away and they never reach their services. Owners and admins are unaffected.

The member branch of `project.one` pulls the whole service tables inside a `with`. Drizzle builds one `json_build_array` per nested relation with a single argument per column, and **Postgres allows at most 100 arguments per function call**. The `application` table is now at **101 columns**, so the query fails with `INTERNAL_SERVER_ERROR`. `getServerSideProps` catches that error and redirects out of the project, which is why it looks like a permissions problem rather than a query failure.

Owners and admins go through `findProjectById`, which already selects explicit columns — that is why only members hit this.

This PR mirrors that same column selection in the member branch while keeping the `accessedServices` filters untouched. No behavioural change: members now receive exactly the same fields owners already receive.

### Reproducing the underlying limit

On any Postgres instance:

```sql
SELECT json_build_array(1, 2, ..., 100);  -- ok
SELECT json_build_array(1, 2, ..., 101);  -- ERROR: cannot pass more than 100 arguments to a function
```

Quick one-liner:

```bash
psql -c "SELECT json_build_array($(seq -s, 1 101)) IS NOT NULL;"
```

### Note for maintainers

`project.all` and `findEnvironmentsByProjectId` already restrict columns, so they are safe. This was the only remaining query selecting a full service table inside a nested relation. Since the limit is now only one column away from being crossed again by other tables, the added test asserts every service relation in the member branch keeps an explicit `columns:` selection.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

Tested on a self-hosted instance running v0.30.0: before the change a member was redirected out of the project and the server logged the failing query; after the change the member opens the project and sees the services they were granted. `typecheck` is clean and the permissions test suite passes (47 tests).

## Issues related (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents PostgreSQL’s function-argument limit from breaking `project.one` for members by explicitly selecting service columns while preserving existing access filters.
- Adds restricted column selections for all eight nested service relations in the member query.
- Adds regression tests covering the application-table limit and explicit service selections.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression identified.

The member query now limits every nested service relation while retaining the existing project organization scope and per-service access filters, and the selected response fields align with the established owner/admin query pattern.

<sub>Reviews (1): Last reviewed commit: ["fix(project): restrict service columns i..."](https://github.com/dokploy/dokploy/commit/0ce6a9dc6a7074fe3ed8b2c25110d91c8bb91213) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53399015)</sub>

<!-- /greptile_comment -->