### PR TITLE
feat: Cloudflare DNS record proxy toggle

### DIFF
--- a/apps/dokploy/__test__/dns/cloudflare.test.ts
+++ b/apps/dokploy/__test__/dns/cloudflare.test.ts
@@ -68,6 +68,7 @@ describe("cloudflareClient.listRecords", () => {
 					name: "app.example.com",
 					content: "1.2.3.4",
 					ttl: 1,
+					proxied: true,
 				},
 			]),
 		);
@@ -81,9 +82,37 @@ describe("cloudflareClient.listRecords", () => {
 				name: "app.example.com",
 				content: "1.2.3.4",
 				ttl: 1,
+				proxied: true,
 			},
 		]);
 		expect(mockFetch.mock.calls[0]?.[0]).toContain("/zones/zone-1/dns_records");
+	});
+
+	it("maps proxied true and false from Cloudflare", async () => {
+		mockFetch.mockResolvedValue(
+			cfSuccess([
+				{
+					id: "r1",
+					type: "A",
+					name: "app.example.com",
+					content: "1.2.3.4",
+					ttl: 1,
+					proxied: true,
+				},
+				{
+					id: "r2",
+					type: "CNAME",
+					name: "www.example.com",
+					content: "example.com",
+					ttl: 1,
+					proxied: false,
+				},
+			]),
+		);
+
+		const records = await cloudflareClient.listRecords(config, "zone-1");
+
+		expect(records.map((record) => record.proxied)).toEqual([true, false]);
 	});
 });
 

--- a/apps/dokploy/__test__/dns/cloudflare.test.ts
+++ b/apps/dokploy/__test__/dns/cloudflare.test.ts
@@ -171,6 +171,64 @@ describe("cloudflareClient.upsertRecord", () => {
 		const body = JSON.parse(createInit.body as string);
 		expect(body.ttl).toBe(1);
 	});
+
+	it("sends proxied true and forces ttl 1", async () => {
+		mockFetch
+			.mockResolvedValueOnce(cfSuccess([]))
+			.mockResolvedValueOnce(cfSuccess({ id: "new-1" }));
+
+		await cloudflareClient.upsertRecord(config, {
+			zoneId: "zone-1",
+			type: "A",
+			name: "app.example.com",
+			content: "1.2.3.4",
+			proxied: true,
+			ttl: 300,
+		});
+
+		const [, createInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+		expect(JSON.parse(createInit.body as string)).toMatchObject({
+			proxied: true,
+			ttl: 1,
+		});
+	});
+
+	it("sends proxied false and keeps the given ttl", async () => {
+		mockFetch
+			.mockResolvedValueOnce(cfSuccess([]))
+			.mockResolvedValueOnce(cfSuccess({ id: "new-1" }));
+
+		await cloudflareClient.upsertRecord(config, {
+			zoneId: "zone-1",
+			type: "A",
+			name: "app.example.com",
+			content: "1.2.3.4",
+			proxied: false,
+			ttl: 300,
+		});
+
+		const [, createInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+		expect(JSON.parse(createInit.body as string)).toMatchObject({
+			proxied: false,
+			ttl: 300,
+		});
+	});
+
+	it("defaults omitted proxied to true", async () => {
+		mockFetch
+			.mockResolvedValueOnce(cfSuccess([]))
+			.mockResolvedValueOnce(cfSuccess({ id: "new-1" }));
+
+		await cloudflareClient.upsertRecord(config, {
+			zoneId: "zone-1",
+			type: "CNAME",
+			name: "www.example.com",
+			content: "example.com",
+		});
+
+		const [, createInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+		expect(JSON.parse(createInit.body as string).proxied).toBe(true);
+	});
 });
 
 describe("cloudflareClient.updateRecord", () => {
@@ -182,6 +240,7 @@ describe("cloudflareClient.updateRecord", () => {
 			name: "app.example.com",
 			content: "9.9.9.9",
 			ttl: 300,
+			proxied: false,
 		});
 
 		expect(result).toEqual({ id: "r1" });
@@ -193,6 +252,24 @@ describe("cloudflareClient.updateRecord", () => {
 			name: "app.example.com",
 			content: "9.9.9.9",
 			ttl: 300,
+			proxied: false,
+		});
+	});
+
+	it("includes proxied in the PUT body", async () => {
+		mockFetch.mockResolvedValue(cfSuccess({ id: "r1" }));
+
+		await cloudflareClient.updateRecord(config, "zone-1", "r1", {
+			type: "A",
+			name: "app.example.com",
+			content: "9.9.9.9",
+			proxied: true,
+		});
+
+		const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(JSON.parse(init.body as string)).toMatchObject({
+			proxied: true,
+			ttl: 1,
 		});
 	});
 });

--- a/apps/dokploy/__test__/dns/dns-record-schema.test.ts
+++ b/apps/dokploy/__test__/dns/dns-record-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+	apiCreateDnsRecord,
+	apiUpdateDnsRecord,
+} from "@dokploy/server/db/schema";
+
+const base = {
+	dnsProviderId: "prov-1",
+	zoneId: "zone-1",
+	type: "A" as const,
+	name: "app.example.com",
+	content: "1.2.3.4",
+};
+
+describe("apiCreateDnsRecord", () => {
+	it("accepts optional proxied", () => {
+		expect(apiCreateDnsRecord.parse({ ...base, proxied: true }).proxied).toBe(
+			true,
+		);
+		expect(apiCreateDnsRecord.parse({ ...base, proxied: false }).proxied).toBe(
+			false,
+		);
+	});
+
+	it("allows omitting proxied", () => {
+		expect(apiCreateDnsRecord.parse(base).proxied).toBeUndefined();
+	});
+});
+
+describe("apiUpdateDnsRecord", () => {
+	it("accepts optional proxied", () => {
+		const parsed = apiUpdateDnsRecord.parse({
+			...base,
+			recordId: "r1",
+			proxied: false,
+		});
+		expect(parsed.proxied).toBe(false);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/dns/handle-dns-record.tsx
+++ b/apps/dokploy/components/dashboard/settings/dns/handle-dns-record.tsx
@@ -32,6 +32,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { api } from "@/utils/api";
 
 const DnsRecordSchema = z.object({
@@ -39,6 +40,7 @@ const DnsRecordSchema = z.object({
 	name: z.string().min(1, { message: "Name is required" }),
 	content: z.string().min(1, { message: "Content is required" }),
 	ttl: z.string(),
+	proxied: z.boolean(),
 });
 
 type DnsRecordForm = z.infer<typeof DnsRecordSchema>;
@@ -49,20 +51,27 @@ interface DnsRecordValue {
 	name: string;
 	content: string;
 	ttl: number;
+	proxied?: boolean;
 }
 
 interface Props {
 	dnsProviderId: string;
 	zoneId: string;
 	zoneName: string;
+	providerType: "cloudflare" | "route53";
 	record?: DnsRecordValue;
+	lastCloudflareProxied?: boolean;
+	onCloudflareProxiedSubmit?: (proxied: boolean) => void;
 }
 
 export const HandleDnsRecord = ({
 	dnsProviderId,
 	zoneId,
 	zoneName,
+	providerType,
 	record,
+	lastCloudflareProxied,
+	onCloudflareProxiedSubmit,
 }: Props) => {
 	const utils = api.useUtils();
 	const [isOpen, setIsOpen] = useState(false);
@@ -93,6 +102,13 @@ export const HandleDnsRecord = ({
 			!!suggestion.ip && all.findIndex((s) => s.ip === suggestion.ip) === index,
 	);
 
+	const defaultProxied =
+		providerType === "cloudflare"
+			? record
+				? record.proxied === true
+				: (lastCloudflareProxied ?? true)
+			: false;
+
 	const form = useForm<DnsRecordForm>({
 		defaultValues: record
 			? {
@@ -100,12 +116,20 @@ export const HandleDnsRecord = ({
 					name: record.name,
 					content: record.content,
 					ttl: record.ttl && record.ttl !== 1 ? String(record.ttl) : "",
+					proxied: defaultProxied,
 				}
-			: { type: "A", name: "", content: "", ttl: "" },
+			: {
+					type: "A",
+					name: "",
+					content: "",
+					ttl: "",
+					proxied: defaultProxied,
+				},
 		resolver: zodResolver(DnsRecordSchema),
 	});
 
 	const type = form.watch("type");
+	const proxied = form.watch("proxied");
 
 	const onSubmit = async (data: DnsRecordForm) => {
 		const name = data.name.trim() === "@" ? zoneName : data.name;
@@ -116,12 +140,16 @@ export const HandleDnsRecord = ({
 			name,
 			content: data.content,
 			ttl: data.ttl ? Number(data.ttl) : undefined,
+			...(providerType === "cloudflare" && { proxied: data.proxied }),
 			...(record && { recordId: record.id }),
 		};
 		await mutateAsync(payload as any)
 			.then(() => {
 				toast.success(record ? "Record updated" : "Record created");
 				utils.dnsProvider.listRecords.invalidate({ dnsProviderId, zoneId });
+				if (providerType === "cloudflare") {
+					onCloudflareProxiedSubmit?.(data.proxied);
+				}
 				setIsOpen(false);
 			})
 			.catch(() => {});
@@ -252,12 +280,45 @@ export const HandleDnsRecord = ({
 								<FormItem>
 									<FormLabel>TTL (optional)</FormLabel>
 									<FormControl>
-										<Input type="number" placeholder="Auto" {...field} />
+										<Input
+											type="number"
+											placeholder="Auto"
+											disabled={providerType === "cloudflare" && proxied}
+											{...field}
+										/>
 									</FormControl>
+									{providerType === "cloudflare" && proxied && (
+										<FormDescription>
+											Cloudflare uses Auto TTL when Proxy is on.
+										</FormDescription>
+									)}
 									<FormMessage />
 								</FormItem>
 							)}
 						/>
+						{providerType === "cloudflare" && (
+							<FormField
+								control={form.control}
+								name="proxied"
+								render={({ field }) => (
+									<FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
+										<div className="space-y-0.5">
+											<FormLabel>Proxy</FormLabel>
+											<FormDescription>
+												Orange cloud — traffic goes through Cloudflare. Off is
+												DNS only.
+											</FormDescription>
+										</div>
+										<FormControl>
+											<Switch
+												checked={field.value}
+												onCheckedChange={field.onChange}
+											/>
+										</FormControl>
+									</FormItem>
+								)}
+							/>
+						)}
 						<DialogFooter>
 							<Button type="submit" isLoading={isPending}>
 								{record ? "Update" : "Create"}

--- a/apps/dokploy/components/dashboard/settings/dns/show-dns-provider-zones.tsx
+++ b/apps/dokploy/components/dashboard/settings/dns/show-dns-provider-zones.tsx
@@ -134,6 +134,7 @@ const ZoneRecords = ({
 			{canWrite && (
 				<div className="pt-1">
 					<HandleDnsRecord
+						key={`add-${lastCloudflareProxied}`}
 						dnsProviderId={dnsProviderId}
 						zoneId={zoneId}
 						zoneName={zoneName}
@@ -172,6 +173,7 @@ export const ShowDnsProviderZones = ({
 				setIsOpen(open);
 				if (!open) {
 					setExpandedZoneId(null);
+					setLastCloudflareProxied(true);
 				}
 			}}
 		>

--- a/apps/dokploy/components/dashboard/settings/dns/show-dns-provider-zones.tsx
+++ b/apps/dokploy/components/dashboard/settings/dns/show-dns-provider-zones.tsx
@@ -25,9 +25,19 @@ interface ZoneRecordsProps {
 	dnsProviderId: string;
 	zoneId: string;
 	zoneName: string;
+	providerType: "cloudflare" | "route53";
+	lastCloudflareProxied: boolean;
+	onCloudflareProxiedSubmit: (proxied: boolean) => void;
 }
 
-const ZoneRecords = ({ dnsProviderId, zoneId, zoneName }: ZoneRecordsProps) => {
+const ZoneRecords = ({
+	dnsProviderId,
+	zoneId,
+	zoneName,
+	providerType,
+	lastCloudflareProxied,
+	onCloudflareProxiedSubmit,
+}: ZoneRecordsProps) => {
 	const utils = api.useUtils();
 	const { data, isLoading, isError, error } =
 		api.dnsProvider.listRecords.useQuery({ dnsProviderId, zoneId });
@@ -68,11 +78,20 @@ const ZoneRecords = ({ dnsProviderId, zoneId, zoneName }: ZoneRecordsProps) => {
 						<span className="text-muted-foreground truncate flex-1">
 							→ {record.content}
 						</span>
+						{providerType === "cloudflare" &&
+							typeof record.proxied === "boolean" && (
+								<Badge variant="outline" className="shrink-0">
+									{record.proxied ? "Proxied" : "DNS only"}
+								</Badge>
+							)}
 						{canWrite && isEditable && (
 							<HandleDnsRecord
 								dnsProviderId={dnsProviderId}
 								zoneId={zoneId}
 								zoneName={zoneName}
+								providerType={providerType}
+								lastCloudflareProxied={lastCloudflareProxied}
+								onCloudflareProxiedSubmit={onCloudflareProxiedSubmit}
 								record={record}
 							/>
 						)}
@@ -118,6 +137,9 @@ const ZoneRecords = ({ dnsProviderId, zoneId, zoneName }: ZoneRecordsProps) => {
 						dnsProviderId={dnsProviderId}
 						zoneId={zoneId}
 						zoneName={zoneName}
+						providerType={providerType}
+						lastCloudflareProxied={lastCloudflareProxied}
+						onCloudflareProxiedSubmit={onCloudflareProxiedSubmit}
 					/>
 				</div>
 			)}
@@ -128,14 +150,17 @@ const ZoneRecords = ({ dnsProviderId, zoneId, zoneName }: ZoneRecordsProps) => {
 interface Props {
 	dnsProviderId: string;
 	providerName: string;
+	providerType: "cloudflare" | "route53";
 }
 
 export const ShowDnsProviderZones = ({
 	dnsProviderId,
 	providerName,
+	providerType,
 }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [expandedZoneId, setExpandedZoneId] = useState<string | null>(null);
+	const [lastCloudflareProxied, setLastCloudflareProxied] = useState(true);
 
 	const { data, isLoading, isError, error } =
 		api.dnsProvider.listZones.useQuery({ dnsProviderId }, { enabled: isOpen });
@@ -205,6 +230,9 @@ export const ShowDnsProviderZones = ({
 											dnsProviderId={dnsProviderId}
 											zoneId={zone.id}
 											zoneName={zone.name}
+											providerType={providerType}
+											lastCloudflareProxied={lastCloudflareProxied}
+											onCloudflareProxiedSubmit={setLastCloudflareProxied}
 										/>
 									)}
 								</div>

--- a/apps/dokploy/components/dashboard/settings/dns/show-dns-providers.tsx
+++ b/apps/dokploy/components/dashboard/settings/dns/show-dns-providers.tsx
@@ -85,6 +85,7 @@ export const ShowDnsProviders = () => {
 																<ShowDnsProviderZones
 																	dnsProviderId={provider.dnsProviderId}
 																	providerName={provider.name}
+																	providerType={provider.providerType}
 																/>
 																{permissions?.dnsProvider.update && (
 																	<HandleDnsProvider

--- a/apps/dokploy/server/api/routers/dns-provider.ts
+++ b/apps/dokploy/server/api/routers/dns-provider.ts
@@ -162,6 +162,7 @@ export const dnsProviderRouter = createTRPCRouter({
 				name: input.name,
 				content: input.content,
 				ttl: input.ttl,
+				proxied: input.proxied,
 			});
 			await audit(ctx, {
 				action: "create",
@@ -188,6 +189,7 @@ export const dnsProviderRouter = createTRPCRouter({
 					name: input.name,
 					content: input.content,
 					ttl: input.ttl,
+					proxied: input.proxied,
 				},
 			);
 			await audit(ctx, {

--- a/packages/server/src/db/schema/dns-provider.ts
+++ b/packages/server/src/db/schema/dns-provider.ts
@@ -101,6 +101,7 @@ const dnsRecordFieldsSchema = z.object({
 	name: z.string().min(1),
 	content: z.string().min(1),
 	ttl: z.number().int().positive().optional(),
+	proxied: z.boolean().optional(),
 });
 
 export const apiCreateDnsRecord = dnsRecordFieldsSchema.extend({

--- a/packages/server/src/utils/dns/cloudflare.ts
+++ b/packages/server/src/utils/dns/cloudflare.ts
@@ -1,5 +1,6 @@
 import type { cloudflareDnsConfigSchema } from "@dokploy/server/db/schema";
 import type { z } from "zod";
+import type { DnsRecordInput } from "./types";
 import { type DnsClient, dnsFetch } from "./types";
 
 type CloudflareConfig = z.infer<typeof cloudflareDnsConfigSchema>;
@@ -35,6 +36,17 @@ const cfFetch = async <T>(
 		);
 	}
 	return body.result;
+};
+
+const cloudflareRecordPayload = (record: Omit<DnsRecordInput, "zoneId">) => {
+	const proxied = record.proxied ?? true;
+	return {
+		type: record.type,
+		name: record.name,
+		content: record.content,
+		ttl: proxied ? 1 : (record.ttl ?? 1),
+		proxied,
+	};
 };
 
 export const cloudflareClient: DnsClient<CloudflareConfig> = {
@@ -100,12 +112,7 @@ export const cloudflareClient: DnsClient<CloudflareConfig> = {
 			`/zones/${record.zoneId}/dns_records?type=${record.type}&name=${encodeURIComponent(record.name)}`,
 		);
 
-		const payload = {
-			type: record.type,
-			name: record.name,
-			content: record.content,
-			ttl: record.ttl ?? 1,
-		};
+		const payload = cloudflareRecordPayload(record);
 
 		const existingRecord = existing[0];
 		if (existingRecord) {
@@ -131,12 +138,7 @@ export const cloudflareClient: DnsClient<CloudflareConfig> = {
 			`/zones/${zoneId}/dns_records/${recordId}`,
 			{
 				method: "PUT",
-				body: JSON.stringify({
-					type: record.type,
-					name: record.name,
-					content: record.content,
-					ttl: record.ttl ?? 1,
-				}),
+				body: JSON.stringify(cloudflareRecordPayload(record)),
 			},
 		);
 		return { id: updated.id };

--- a/packages/server/src/utils/dns/cloudflare.ts
+++ b/packages/server/src/utils/dns/cloudflare.ts
@@ -62,6 +62,7 @@ export const cloudflareClient: DnsClient<CloudflareConfig> = {
 			name: string;
 			content: string;
 			ttl: number;
+			proxied?: boolean;
 		}[] = [];
 		let page = 1;
 		while (true) {
@@ -72,9 +73,19 @@ export const cloudflareClient: DnsClient<CloudflareConfig> = {
 					name: string;
 					content: string;
 					ttl: number;
+					proxied?: boolean;
 				}[]
 			>(config, `/zones/${zoneId}/dns_records?per_page=50&page=${page}`);
-			records.push(...result);
+			records.push(
+				...result.map((row) => ({
+					id: row.id,
+					type: row.type,
+					name: row.name,
+					content: row.content,
+					ttl: row.ttl,
+					...(typeof row.proxied === "boolean" ? { proxied: row.proxied } : {}),
+				})),
+			);
 			if (result.length < 50) {
 				break;
 			}

--- a/packages/server/src/utils/dns/types.ts
+++ b/packages/server/src/utils/dns/types.ts
@@ -11,6 +11,7 @@ export interface DnsRecordInput {
 	name: string;
 	content: string;
 	ttl?: number;
+	proxied?: boolean;
 }
 
 export interface DnsRecord {
@@ -19,6 +20,7 @@ export interface DnsRecord {
 	name: string;
 	content: string;
 	ttl: number;
+	proxied?: boolean;
 }
 
 export interface DnsClient<C extends DnsProviderConfig = DnsProviderConfig> {


### PR DESCRIPTION
## Summary
- Adds a per-record **Proxy** switch for Cloudflare A/CNAME records in Settings → DNS Providers.
- New records default to proxied (orange cloud). The last submitted value is reused for later adds in the same View Domains session.
- Edit uses the record's current `proxied` value. TTL is forced to Auto when Proxy is on.
- Route53 is unchanged.

Follow-up to #5057. Cloudflare's `proxied` field was never sent, so every record was DNS-only.

## Test plan
- [ ] Connect a Cloudflare provider, open View Domains, add an A record with Proxy on — record is proxied in Cloudflare.
- [ ] Add another record — Proxy defaults to the last choice.
- [ ] Turn Proxy off, save — record is DNS only; custom TTL is kept.
- [ ] Edit a proxied record and turn Proxy off (and the reverse).
- [ ] Route53 provider has no Proxy switch or list badge.
- [ ] `pnpm test -- __test__/dns/` in `apps/dokploy`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Cloudflare proxy-state support throughout DNS record validation, API routing, provider payloads, tests, and the record-management UI.
- Adds a Cloudflare-only Proxy switch and record-status badge.
- Sends `proxied` during Cloudflare creates and updates and forces Auto TTL while proxying.
- Retains the last submitted proxy choice for subsequent additions within the View Domains session.
- Leaves Route53 behavior unchanged.

<h3>Confidence Score: 4/5</h3>

The proxy integration should not merge until cancelled Cloudflare record edits are prevented from leaking into later submissions.

The persistent edit form retains a newly changed proxy value after cancellation, allowing a subsequent save to apply a proxy-mode change the user had discarded.

**Files Needing Attention:** apps/dokploy/components/dashboard/settings/dns/handle-dns-record.tsx

<sub>Reviews (1): Last reviewed commit: ["fix(dns): reset proxy session default an..."](https://github.com/dokploy/dokploy/commit/cba2059477dbad22f34331b8c30692a3fb6a15b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53653641)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [DNS and Vault Providers](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dns-and-vault-providers.md)

<!-- /greptile_comment -->