### PR TITLE
fix: auto-generate .env.production files in docker build script

### DIFF
--- a/apps/dokploy/docker/build.sh
+++ b/apps/dokploy/docker/build.sh
@@ -10,6 +10,12 @@ else
     TAG="$VERSION"
 fi
 
+# The Dockerfile expects these files to exist in the build context (see
+# CONTRIBUTING.md#docker); generate them from the example if missing so the
+# build doesn't fail with a confusing "file not found" error.
+[ -f .env.production ] || cp apps/dokploy/.env.production.example .env.production
+[ -f apps/dokploy/.env.production ] || cp apps/dokploy/.env.production.example apps/dokploy/.env.production
+
 BUILDER=$(docker buildx create --use)
 
 docker buildx build --platform linux/amd64,linux/arm64 --pull --rm -t "dokploy/dokploy:${TAG}" -f 'Dockerfile' .


### PR DESCRIPTION
## What is this PR about?

`apps/dokploy/docker/build.sh` (wired up as `pnpm run docker:build:canary`) builds the Docker image via `docker buildx build`, but the `Dockerfile` requires a `.env.production` file at the repo root and at `apps/dokploy/.env.production` that neither file is committed nor generated by the script. CONTRIBUTING.md documents two manual `cp` commands to create them before building, but since they aren't part of the script itself, running the documented npm command on a fresh clone fails with an opaque BuildKit checksum error (`"/.env.production": not found`) instead of building.

This PR makes `build.sh` generate both files from `apps/dokploy/.env.production.example` automatically, but only if they don't already exist, so it won't clobber a contributor's customized env file and stays consistent with the manual steps already documented in CONTRIBUTING.md.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. Verified the guard creates both env files from the example when missing, leaves them untouched when already present (idempotency check with a custom marker line survived a re-run), and confirmed a full `docker buildx build --platform linux/amd64,linux/arm64 --push` succeeds end-to-end using this script's logic.

## Issues related (if applicable)

Fixes #5100

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the canary Docker build self-contained by creating its two required `.env.production` files from the existing example when they are absent.
- Preserves customized environment files through existence guards.
- Prevents fresh-clone builds from failing because required build-context files are missing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The guarded copies satisfy the Docker build’s existing file requirements while preserving any files contributors have already customized.

<sub>Reviews (1): Last reviewed commit: ["fix: auto-generate .env.production files..."](https://github.com/dokploy/dokploy/commit/f4c936820959586158ca621849bd5c08582d987f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53906722)</sub>

<!-- /greptile_comment -->