### PR TITLE
fix: prevent Postgres 100-arg limit crash and restore data parity for restricted-member project access

### DIFF
--- a/apps/dokploy/server/api/routers/project.ts
+++ b/apps/dokploy/server/api/routers/project.ts
@@ -38,6 +38,7 @@ import {
 	checkProjectAccess,
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
+import { serviceColumns } from "@dokploy/server/services/project";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
@@ -130,39 +131,63 @@ export const projectRouter = createTRPCRouter({
 						environments: {
 							with: {
 								applications: {
+									columns: {
+										...serviceColumns,
+										applicationId: true,
+										icon: true,
+									},
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(
 										applications.applicationId,
 										accessedServices,
 									),
 								},
 								compose: {
+									columns: {
+										...serviceColumns,
+										composeId: true,
+										composeStatus: true,
+									},
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(
 										compose.composeId,
 										accessedServices,
 									),
 								},
 								libsql: {
+									columns: { ...serviceColumns, libsqlId: true },
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(libsql.libsqlId, accessedServices),
 								},
 								mariadb: {
+									columns: { ...serviceColumns, mariadbId: true },
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(
 										mariadb.mariadbId,
 										accessedServices,
 									),
 								},
 								mongo: {
+									columns: { ...serviceColumns, mongoId: true },
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(mongo.mongoId, accessedServices),
 								},
 								mysql: {
+									columns: { ...serviceColumns, mysqlId: true },
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(mysql.mysqlId, accessedServices),
 								},
 								postgres: {
+									columns: { ...serviceColumns, postgresId: true },
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(
 										postgres.postgresId,
 										accessedServices,
 									),
 								},
 								redis: {
+									columns: { ...serviceColumns, redisId: true },
+									with: { server: { columns: { name: true } } },
 									where: buildServiceFilter(redis.redisId, accessedServices),
 								},
 							},

--- a/packages/server/src/services/project.ts
+++ b/packages/server/src/services/project.ts
@@ -47,16 +47,16 @@ export const createProject = async (
 	};
 };
 
-export const findProjectById = async (projectId: string) => {
-	const serviceColumns = {
-		name: true,
-		description: true,
-		appName: true,
-		createdAt: true,
-		serverId: true,
-		applicationStatus: true,
-	} as const;
+export const serviceColumns = {
+	name: true,
+	description: true,
+	appName: true,
+	createdAt: true,
+	serverId: true,
+	applicationStatus: true,
+} as const;
 
+export const findProjectById = async (projectId: string) => {
 	const project = await db.query.projects.findFirst({
 		where: eq(projects.projectId, projectId),
 		with: {


### PR DESCRIPTION
## What is this PR about?

The `applications` table has 101 columns. In `project.one`'s restricted-member branch (`apps/dokploy/server/api/routers/project.ts`), the `applications`/`compose`/`libsql`/`mariadb`/`mongo`/`mysql`/`postgres`/`redis` relations were queried without any `columns:` narrowing. Drizzle's relational query builder encodes each nested row as `json_build_array(col1, col2, ...)` — one function argument per column — and Postgres's `FUNC_MAX_ARGS` is a hard limit of 100. So any non-owner/admin member with access to a project containing an application hit `PostgresError: cannot pass more than 100 arguments to a function`, surfaced by tRPC as a generic `INTERNAL_SERVER_ERROR`, redirecting them away from the project page.

Separately, this same branch was missing the `server` relation that the owner/admin path (`findProjectById` in `packages/server/src/services/project.ts`) already includes, so restricted members would see less data than an owner/admin for the exact same project even once the crash is fixed.

This PR:
- Extracts the existing `serviceColumns` selection (already used by `findProjectById`) to a module-level export in `packages/server/src/services/project.ts`.
- Applies `serviceColumns` (plus the relation's own ID column) and the `server` relation to all 8 service relations in the restricted-member query path in `project.ts`, matching the owner/admin path exactly.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. Ran `pnpm --filter=@dokploy/server run typecheck` and `pnpm --filter=./apps/dokploy run typecheck` — both pass with no errors. Verified all 5 frontend consumers of `project.one` and 17+ backend callers of `findProjectById` only read top-level fields unaffected by the column narrowing, so no data any caller relies on is dropped.

## Issues related (if applicable)

Fixes #5102

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents restricted-member project queries from exceeding PostgreSQL's function argument limit and aligns their service response shape with the owner/admin path.
- Extracts the common service-column selection into a reusable export.
- Narrows all eight restricted-member service relations to the required columns.
- Includes each service's server name for role-independent response parity.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code defects identified.

The restricted-member query now uses the same bounded service selections and server relation as the established owner/admin path, and checked consumers do not depend on omitted fields.

<sub>Reviews (1): Last reviewed commit: ["fix: prevent Postgres 100-argument limit..."](https://github.com/dokploy/dokploy/commit/2cb499fb64f05ddfccbc6b539b091d605935122c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53908159)</sub>

<!-- /greptile_comment -->