### PR TITLE
fix: do not wrap safe Environment-tab values in extra quotes

### DIFF
--- a/apps/dokploy/__test__/env/environment.test.ts
+++ b/apps/dokploy/__test__/env/environment.test.ts
@@ -664,9 +664,30 @@ describe("prepareEnvironmentVariablesForFile (no extra quotes)", () => {
 		const value = stackLiteralValue(line ?? "");
 
 		expect(value[0]).toBe("h");
-		expect(value.at(-1)).toBe("4");
-		expect(value.length).toBe(92);
+		expect(value.startsWith('"')).toBe(false);
+		expect(value.endsWith('"')).toBe(false);
+		expect(value.length).toBe(dsn.length);
 		expect(value).toBe(dsn);
+	});
+
+	it("still quotes values that dotenv or Compose would otherwise alter", () => {
+		const serviceEnv = `
+PASSWORD=pa$$word
+HASH="abc#de"
+SPACED=hello world
+`;
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+		const byKey = Object.fromEntries(
+			resolved.map((line) => {
+				const separator = line.indexOf("=");
+				return [line.slice(0, separator), line.slice(separator + 1)];
+			}),
+		);
+
+		expect(byKey.PASSWORD).toBe('"pa\\$\\$word"');
+		expect(byKey.HASH).toBe('"abc#de"');
+		expect(byKey.SPACED).toBe('"hello world"');
 	});
 
 	it("does not wrap values just because they contain : / @ = _", () => {

--- a/apps/dokploy/__test__/env/environment.test.ts
+++ b/apps/dokploy/__test__/env/environment.test.ts
@@ -1,8 +1,16 @@
 import {
 	prepareEnvironmentVariables,
+	prepareEnvironmentVariablesForFile,
 	prepareEnvironmentVariablesForShell,
 } from "@dokploy/server/index";
 import { describe, expect, it } from "vitest";
+
+// docker stack deploy treats everything after the first "=" as the literal
+// value — it does not strip dotenv quotes the way `docker compose` does.
+const stackLiteralValue = (line: string) => {
+	const separator = line.indexOf("=");
+	return line.slice(separator + 1);
+};
 
 const projectEnv = `
 ENVIRONMENT=staging
@@ -640,5 +648,48 @@ SPECIAL=café résumé naïve
 		expect(resolved[0]).toContain("🌍");
 		expect(resolved[1]).toContain("你好");
 		expect(resolved[2]).toContain("café");
+	});
+});
+
+describe("prepareEnvironmentVariablesForFile (no extra quotes)", () => {
+	it("emits a Sentry DSN exactly as entered so stack deploy does not keep surrounding quotes", () => {
+		const dsn =
+			"https://examplePublicKey@o0000000000000000.ingest.sentry.io/0000000000000000";
+		const [line] = prepareEnvironmentVariablesForFile(
+			`QUARKUS_LOG_SENTRY_DSN=${dsn}`,
+			"",
+			"",
+		);
+
+		const value = stackLiteralValue(line ?? "");
+
+		expect(value[0]).toBe("h");
+		expect(value.at(-1)).toBe("4");
+		expect(value.length).toBe(92);
+		expect(value).toBe(dsn);
+	});
+
+	it("does not wrap values just because they contain : / @ = _", () => {
+		const serviceEnv = `
+COLON=https://example.com
+SLASH=a/b/c
+AT=user@host
+EQUALS=foo=bar
+UNDERSCORE=hello_world
+`;
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+		const values = Object.fromEntries(
+			resolved.map((line) => {
+				const separator = line.indexOf("=");
+				return [line.slice(0, separator), stackLiteralValue(line)];
+			}),
+		);
+
+		expect(values.COLON).toBe("https://example.com");
+		expect(values.SLASH).toBe("a/b/c");
+		expect(values.AT).toBe("user@host");
+		expect(values.EQUALS).toBe("foo=bar");
+		expect(values.UNDERSCORE).toBe("hello_world");
 	});
 });

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -532,6 +532,13 @@ export const prepareEnvironmentVariablesForShell = (
 	return envVars.map((env) => quote([env]));
 };
 
+// Quote only when dotenv / `docker compose` would otherwise alter the value.
+// Characters such as `: / @ = _` are safe unquoted. Wrapping every value in
+// `"..."` makes those quotes part of the value under `docker stack deploy`,
+// which does not strip dotenv quotes (#5096).
+const requiresDotenvQuotes = (value: string): boolean =>
+	/[\s#"$\\]/.test(value);
+
 export const prepareEnvironmentVariablesForFile = (
 	serviceEnv: string | null,
 	projectEnv?: string | null,
@@ -545,6 +552,9 @@ export const prepareEnvironmentVariablesForFile = (
 
 	return envVars.map((pair) => {
 		const [key, value] = parseEnvironmentKeyValuePair(pair);
+		if (!requiresDotenvQuotes(value)) {
+			return `${key}=${value}`;
+		}
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')


### PR DESCRIPTION
## What is this PR about?

Environment-tab values were always written to the generated `.env` as `KEY="value"`. That is valid dotenv for `docker compose`, but `docker stack deploy` does not strip those quotes, so they become part of the value.

A Sentry DSN such as `https://examplePublicKey@o0000000000000000.ingest.sentry.io/0000000000000000` was deployed as `"https://..."` (quotes became part of the value) instead of the entered URL, which breaks URL parsing.

`prepareEnvironmentVariablesForFile` now emits values exactly as entered when they do not need dotenv quoting. Characters such as `: / @ = _` no longer add quotes. Values that still need quoting for Compose (`$`, `#`, whitespace, `"`, `\`) keep the existing escape path so #4694 stays fixed.

## Checklist

- [x] Dedicated branch based on `canary`
- [x] Tests added: RED on current canary (extra surrounding quotes), GREEN with this change
- [x] Focused unit coverage for the Sentry DSN case and `: / @ = _`

## Issues related (if applicable)

Fixes #5096

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates generated `.env` files to leave dotenv-safe values unquoted, preventing Docker Stack from preserving unwanted quote characters.

- Adds selective quoting for whitespace and dotenv-sensitive characters while leaving URL-safe characters unchanged.
- Adds focused tests for Sentry DSNs, safe punctuation, and values that still require quoting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The generated environment-file output preserves unquoted safe values for Docker Stack while continuing to quote and escape values containing dotenv-sensitive characters.

<sub>Reviews (1): Last reviewed commit: ["test: assert Sentry DSN is emitted witho..."](https://github.com/dokploy/dokploy/commit/b3a8bf391af7acaff65156329897e2ba001c8b55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53960323)</sub>

**Context used:**

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)

<!-- /greptile_comment -->