### PR TITLE
fix: preserve # in unquoted environment variable values

### DIFF
--- a/apps/dokploy/__test__/env/comment-handling.test.ts
+++ b/apps/dokploy/__test__/env/comment-handling.test.ts
@@ -1,0 +1,199 @@
+import {
+	getEnvironmentVariablesObject,
+	prepareEnvironmentVariables,
+	prepareEnvironmentVariablesForShell,
+} from "@dokploy/server/index";
+import { describe, expect, it } from "vitest";
+
+describe("prepareEnvironmentVariables (# in values)", () => {
+	it("preserves a trailing # in an unquoted value", () => {
+		const serviceEnv = `
+PASSWORD=secret#
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["PASSWORD=secret#"]);
+	});
+
+	it("preserves # in the middle of an unquoted value", () => {
+		const serviceEnv = `
+PASSWORD=sec#ret
+MULTI=a#b#c
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["PASSWORD=sec#ret", "MULTI=a#b#c"]);
+	});
+
+	it("preserves a value starting with #", () => {
+		const serviceEnv = `
+SHEBANG=#!secret
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["SHEBANG=#!secret"]);
+	});
+
+	it("still strips inline comments preceded by whitespace", () => {
+		const serviceEnv = `
+WITH_SPACE=value # this is a comment
+WITH_TAB=value	# this is a comment
+QUOTED="value" # this is a comment
+ONLY_COMMENT= # this is a comment
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual([
+			"WITH_SPACE=value",
+			"WITH_TAB=value",
+			"QUOTED=value",
+			"ONLY_COMMENT=",
+		]);
+	});
+
+	it("preserves # inside quoted values", () => {
+		const serviceEnv = `
+DOUBLE="val#ue"
+SINGLE='val#ue'
+TRAILING="secret#"
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual([
+			"DOUBLE=val#ue",
+			"SINGLE=val#ue",
+			"TRAILING=secret#",
+		]);
+	});
+
+	it("skips full-line comments", () => {
+		const serviceEnv = `
+# leading comment
+FIRST=one
+  # indented comment
+SECOND=two
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["FIRST=one", "SECOND=two"]);
+	});
+
+	it("preserves # in values containing =", () => {
+		const serviceEnv = `
+CONN=user=admin;password=b#c
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["CONN=user=admin;password=b#c"]);
+	});
+
+	it("preserves # through project, environment and self references", () => {
+		const projectEnv = `
+DB_PASS=secret#end
+`;
+		const environmentEnv = `
+API_KEY=key#123
+`;
+		const serviceEnv = `
+DATABASE_URL=postgres://user:\${{project.DB_PASS}}@db:5432/app
+TOKEN=\${{environment.API_KEY}}
+LOCAL_SECRET=self#value
+COPY=\${{LOCAL_SECRET}}
+`;
+
+		const resolved = prepareEnvironmentVariables(
+			serviceEnv,
+			projectEnv,
+			environmentEnv,
+		);
+
+		expect(resolved).toEqual([
+			"DATABASE_URL=postgres://user:secret#end@db:5432/app",
+			"TOKEN=key#123",
+			"LOCAL_SECRET=self#value",
+			"COPY=self#value",
+		]);
+	});
+});
+
+describe("getEnvironmentVariablesObject (# in values)", () => {
+	it("returns untruncated values containing #", () => {
+		const serviceEnv = `
+PASSWORD=secret#
+MID=sec#ret
+`;
+
+		const jsonObject = getEnvironmentVariablesObject(serviceEnv, "", "");
+
+		expect(jsonObject).toEqual({
+			PASSWORD: "secret#",
+			MID: "sec#ret",
+		});
+	});
+});
+
+describe("prepareEnvironmentVariablesForShell (# in values)", () => {
+	it("keeps # in shell-quoted output", () => {
+		const serviceEnv = `
+PASSWORD=secret#
+`;
+
+		const resolved = prepareEnvironmentVariablesForShell(serviceEnv, "", "");
+
+		expect(resolved).toHaveLength(1);
+		// shell-quote escapes special characters, so unescape before comparing
+		expect(resolved[0]?.replace(/\\/g, "")).toBe("PASSWORD=secret#");
+	});
+});
+
+describe("parser parity with previous dotenv behavior", () => {
+	it("supports the export prefix", () => {
+		const serviceEnv = `
+export EXPORTED=value
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["EXPORTED=value"]);
+	});
+
+	it("supports multiline double-quoted values", () => {
+		const serviceEnv = `
+MULTILINE="line1
+line2"
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["MULTILINE=line1\nline2"]);
+	});
+
+	it("expands \\n escape sequences inside double quotes", () => {
+		const serviceEnv = `
+ESCAPED="line1\\nline2"
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["ESCAPED=line1\nline2"]);
+	});
+
+	it("handles empty values", () => {
+		const serviceEnv = `
+EMPTY=
+EMPTY_DOUBLE=""
+EMPTY_SINGLE=''
+`;
+
+		const resolved = prepareEnvironmentVariables(serviceEnv, "", "");
+
+		expect(resolved).toEqual(["EMPTY=", "EMPTY_DOUBLE=", "EMPTY_SINGLE="]);
+	});
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -105,6 +105,7 @@ export * from "./utils/docker/compose/secrets";
 export * from "./utils/docker/compose/service";
 export * from "./utils/docker/compose/volume";
 export * from "./utils/docker/domain";
+export * from "./utils/docker/env-parser";
 export * from "./utils/docker/types";
 export * from "./utils/docker/utils";
 export * from "./utils/filesystem/directory";

--- a/packages/server/src/utils/docker/env-parser.ts
+++ b/packages/server/src/utils/docker/env-parser.ts
@@ -1,0 +1,58 @@
+// Based on the `parse` function of dotenv v16.4.5 (BSD-2-Clause)
+// https://github.com/motdotla/dotenv
+//
+// Modified to follow Docker Compose comment semantics: a `#` starts an
+// inline comment only when preceded by whitespace, so unquoted values such
+// as PASSWORD=secret# or KEY=sec#ret keep the `#` instead of being
+// truncated. This also matches how docker compose reads the generated
+// `.env` files.
+
+const LINE =
+	/(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^\r\n]+)?\s*(?:#.*)?(?:$|$)/gm;
+
+const QUOTE_WRAPPED = /^(['"`])([\s\S]*)\1$/;
+
+export const parseEnvVariables = (src: string): Record<string, string> => {
+	const obj: Record<string, string> = {};
+
+	// Strip a leading BOM and normalize line breaks
+	const lines = src.replace(/^\uFEFF/, "").replace(/\r\n?/gm, "\n");
+
+	let match = LINE.exec(lines);
+	while (match != null) {
+		const key = match[1] as string;
+
+		// Default undefined or null to empty string
+		let value = match[2] || "";
+
+		// A `#` starts an inline comment only when the value is not fully
+		// quoted and the `#` is preceded by whitespace (Docker Compose rule)
+		if (!QUOTE_WRAPPED.test(value.trim())) {
+			const commentIndex = value.search(/\s#/);
+			if (commentIndex !== -1) {
+				value = value.slice(0, commentIndex);
+			}
+		}
+
+		// Remove whitespace
+		value = value.trim();
+
+		// Check if double quoted
+		const maybeQuote = value[0];
+
+		// Remove surrounding quotes
+		value = value.replace(QUOTE_WRAPPED, "$2");
+
+		// Expand newlines if double quoted
+		if (maybeQuote === '"') {
+			value = value.replace(/\\n/g, "\n");
+			value = value.replace(/\\r/g, "\r");
+		}
+
+		obj[key] = value;
+
+		match = LINE.exec(lines);
+	}
+
+	return obj;
+};

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -4,7 +4,6 @@ import type { Readable } from "node:stream";
 import { docker, paths } from "@dokploy/server/constants";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { ContainerInfo, ResourceRequirements } from "dockerode";
-import { parse } from "dotenv";
 import { quote } from "shell-quote";
 import type { ApplicationNested } from "../builders";
 import type { LibsqlNested } from "../databases/libsql";
@@ -16,6 +15,7 @@ import type { RedisNested } from "../databases/redis";
 import { execAsync, execAsyncRemote } from "../process/execAsync";
 import { spawnAsync } from "../process/spawnAsync";
 import { getRemoteDocker } from "../servers/remote-docker";
+import { parseEnvVariables } from "./env-parser";
 
 interface RegistryAuth {
 	username: string;
@@ -468,9 +468,9 @@ export const prepareEnvironmentVariables = (
 			);
 		}
 	}
-	const projectVars = parse(projectEnv ?? "");
-	const environmentVars = parse(environmentEnv ?? "");
-	const serviceVars = parse(serviceEnv ?? "");
+	const projectVars = parseEnvVariables(projectEnv ?? "");
+	const environmentVars = parseEnvVariables(environmentEnv ?? "");
+	const serviceVars = parseEnvVariables(serviceEnv ?? "");
 
 	const resolvedVars = Object.entries(serviceVars).map(([key, value]) => {
 		let resolvedValue = value;


### PR DESCRIPTION
## Summary

Fixes #5095 (related: #4694)

User environment variables containing `#` were silently truncated. `prepareEnvironmentVariables` parsed all user env text (service, project, and environment level) with `dotenv.parse`, whose unquoted-value regex `[^#\r\n]+` treats any `#` as the start of an inline comment:

- `PASSWORD=secret#` → `secret`
- `MID=sec#ret` → `sec`

The truncated values propagated to Docker service `Env` arrays (applications and databases), the generated `.env` for Compose deployments, and shell env preparation. In #5095, the reporter's Postgres password ended with `#`: the database container received the full password (Dokploy's internal template quotes it), but their app's env var was truncated — so the app authenticated with the wrong password and crashed.

## Fix

Replace `dotenv.parse` on user env text with a parser (`packages/server/src/utils/docker/env-parser.ts`, a modified copy of dotenv v16.4.5's `parse`, BSD-2-Clause) that follows **Docker Compose comment semantics**: a `#` starts an inline comment only at line start or when preceded by whitespace. This also makes Dokploy's parsing agree with how `docker compose` itself reads the `.env` files Dokploy generates.

| Input | Before | After |
|---|---|---|
| `KEY=secret#` | `secret` | `secret#` |
| `KEY=sec#ret` | `sec` | `sec#ret` |
| `KEY=#foo` | *(empty)* | `#foo` |
| `KEY=value # comment` | `value` | `value` (unchanged) |
| `KEY="val#ue"` | `val#ue` | `val#ue` (unchanged) |

Quoted values, inline comments after whitespace, multiline values, `\n`/`\r` escape expansion, the `export` prefix, and empty values all behave exactly as before — the three pre-existing env test files pass unchanged.

> Note: values relying on dotenv's no-space inline comments (`KEY=value#comment`) now keep the literal value. This is the intended semantic change and matches Docker Compose.

`dotenv` remains a dependency (still used for Dokploy's own boot env in `apps/dokploy`).

## Tests

- New `apps/dokploy/__test__/env/comment-handling.test.ts` (14 tests), written before the fix — the 7 `#` cases failed with the exact truncated values, locking in the repro.
- All 92 env tests pass; full suite, typecheck, and Biome clean.

## Manual verification (local dev, Docker Swarm)

- Created a Postgres database with password `mysecret#`: container env shows `POSTGRES_PASSWORD=mysecret#`; `psql` over the overlay network (where scram auth is enforced) authenticates with `mysecret#` and rejects the truncated `mysecret` with `password authentication failed` — the exact error from #5095, now only occurring for genuinely wrong passwords.
- Compose deployment (drawio template) with `TEST_PASSWORD=mysecret#` in Environment Settings, referenced as `${TEST_PASSWORD}`: running container env shows the full value.
- `docker compose config` round-trip on a generated `.env` confirms Docker parses `mysecret#`/`sec#ret` identically to Dokploy's new parser.
- Regression: `KEY=value # comment` entries still resolve to `value`.

## Tested with app
<img width="1422" height="936" alt="app-3" src="https://github.com/user-attachments/assets/2c0167d1-8e94-4673-bf00-133a9ce2694d" />
<img width="1904" height="972" alt="app-4" src="https://github.com/user-attachments/assets/754c3c8e-1b95-4efa-9f94-579c8c51213d" />
<img width="1116" height="784" alt="app-2" src="https://github.com/user-attachments/assets/90b23a7e-37c8-4cac-9ddb-449717040fdf" />
<img width="1382" height="792" alt="app-1" src="https://github.com/user-attachments/assets/596a6951-958f-4ac5-89e4-c2cfd0bdf34b" />

## Tested with postgres
<img width="2138" height="992" alt="pg-3" src="https://github.com/user-attachments/assets/2c2dd7ef-3799-4f97-8f77-b53bad46db4d" />
<img width="1142" height="1444" alt="pg-2" src="https://github.com/user-attachments/assets/d0941ced-da76-4021-8f53-ab2197043011" />
<img width="1492" height="1436" alt="pg-1" src="https://github.com/user-attachments/assets/1ecf1cd9-373d-4bb7-8b6e-bcdfa7ac8149" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces `dotenv.parse` for user-supplied environment text with a Compose-compatible parser that preserves unquoted `#` characters unless preceded by whitespace.

- Applies the parser consistently to service, project, and environment-level variables.
- Exports the parser from the server package.
- Adds regression coverage for comments, references, quoted values, multiline values, escapes, and empty values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed behavior.

The parser retains dotenv’s established parsing behavior outside the explicitly documented hash-comment semantic change, and the shared deployment paths receive the intended untruncated values.

<sub>Reviews (1): Last reviewed commit: ["fix: preserve # in unquoted environment ..."](https://github.com/dokploy/dokploy/commit/a47157efa3e4215410415405198891860f24eabc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53989753)</sub>

**Context used:**

- Knowledge Base — [Application Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/application-deployment.md)

<!-- /greptile_comment -->