### PR TITLE
fix: false "container is not running" on database password change

### DIFF
--- a/apps/dokploy/server/api/routers/mariadb.ts
+++ b/apps/dokploy/server/api/routers/mariadb.ts
@@ -11,7 +11,7 @@ import {
 	findProjectById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -410,17 +410,17 @@ export const mariadbRouter = createTRPCRouter({
 			const maria = await findMariadbById(mariadbId);
 			const { appName, serverId, databaseUser, databaseRootPassword } = maria;
 
-			const containerCmd = getServiceContainerCommand(appName);
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
 			const targetUser = type === "root" ? "root" : databaseUser;
 
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" mariadb -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
-			`;
+			const command = `docker exec ${container.Id} mariadb -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"`;
 
 			await db.transaction(async (tx) => {
 				const setData =

--- a/apps/dokploy/server/api/routers/mongo.ts
+++ b/apps/dokploy/server/api/routers/mongo.ts
@@ -11,7 +11,7 @@ import {
 	findProjectById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -431,15 +431,15 @@ export const mongoRouter = createTRPCRouter({
 			const mongo = await findMongoById(mongoId);
 			const { appName, serverId, databaseUser, databasePassword } = mongo;
 
-			const containerCmd = getServiceContainerCommand(appName);
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" mongosh -u '${databaseUser}' -p '${databasePassword}' --authenticationDatabase admin --eval "db.getSiblingDB('admin').changeUserPassword('${databaseUser}', '${password}')"
-			`;
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
+			const command = `docker exec ${container.Id} mongosh -u '${databaseUser}' -p '${databasePassword}' --authenticationDatabase admin --eval "db.getSiblingDB('admin').changeUserPassword('${databaseUser}', '${password}')"`;
 
 			await db.transaction(async (tx) => {
 				await tx

--- a/apps/dokploy/server/api/routers/mysql.ts
+++ b/apps/dokploy/server/api/routers/mysql.ts
@@ -11,7 +11,7 @@ import {
 	findProjectById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -428,17 +428,17 @@ export const mysqlRouter = createTRPCRouter({
 			const my = await findMySqlById(mysqlId);
 			const { appName, serverId, databaseUser, databaseRootPassword } = my;
 
-			const containerCmd = getServiceContainerCommand(appName);
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
 			const targetUser = type === "root" ? "root" : databaseUser;
 
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" mysql -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"
-			`;
+			const command = `docker exec ${container.Id} mysql -u root -p'${databaseRootPassword}' -e "ALTER USER '${targetUser}'@'%' IDENTIFIED BY '${password}'; FLUSH PRIVILEGES;"`;
 
 			await db.transaction(async (tx) => {
 				const setData =

--- a/apps/dokploy/server/api/routers/postgres.ts
+++ b/apps/dokploy/server/api/routers/postgres.ts
@@ -12,7 +12,7 @@ import {
 	getAccessibleServerIds,
 	getContainerLogs,
 	getMountPath,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -437,15 +437,15 @@ export const postgresRouter = createTRPCRouter({
 			const pg = await findPostgresById(postgresId);
 			const { appName, serverId, databaseUser } = pg;
 
-			const containerCmd = getServiceContainerCommand(appName);
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" psql -U ${databaseUser} -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"
-			`;
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
+			const command = `docker exec ${container.Id} psql -U ${databaseUser} -d postgres -c "ALTER USER \\"${databaseUser}\\" WITH PASSWORD '${password}';"`;
 
 			await db.transaction(async (tx) => {
 				await tx

--- a/apps/dokploy/server/api/routers/redis.ts
+++ b/apps/dokploy/server/api/routers/redis.ts
@@ -10,7 +10,7 @@ import {
 	findRedisById,
 	getAccessibleServerIds,
 	getContainerLogs,
-	getServiceContainerCommand,
+	getServiceContainer,
 	getWebServerSettings,
 	IS_CLOUD,
 	rebuildDatabase,
@@ -418,15 +418,15 @@ export const redisRouter = createTRPCRouter({
 			const rd = await findRedisById(redisId);
 			const { appName, serverId, databasePassword } = rd;
 
-			const containerCmd = getServiceContainerCommand(appName);
-			const command = `
-				CONTAINER_ID=$(${containerCmd})
-				if [ -z "$CONTAINER_ID" ]; then
-					echo "No running container found for ${appName}" >&2
-					exit 1
-				fi
-				docker exec "$CONTAINER_ID" redis-cli -a '${databasePassword}' CONFIG SET requirepass '${password}'
-			`;
+			const container = await getServiceContainer(appName, serverId);
+			if (!container) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: `No running container found for ${appName}`,
+				});
+			}
+
+			const command = `docker exec ${container.Id} redis-cli -a '${databasePassword}' CONFIG SET requirepass '${password}'`;
 
 			await db.transaction(async (tx) => {
 				await tx


### PR DESCRIPTION
Fixes #5108

`changePassword` for postgres/mysql/mariadb/mongo/redis detected the running container via a shell one-liner (`docker ps -q --filter status=running ... | head -n1`) run through `execAsync`/`execAsyncRemote`. If that shell command failed for any reason, `CONTAINER_ID` came back empty and the mutation reported the container as not running even though it was actively running.

Replaced it with `getServiceContainer()`, the dockerode-based lookup already used by `mount.ts` and `schedules/utils.ts` for the same purpose, and moved the check before the DB transaction so it fails fast with a clear error.

While testing this against a real running Postgres container, also found and fixed a second bug in the same code path: the `ALTER USER` command never selected a database (`psql -U $user`), so `psql` defaulted to connecting to a database named after the user, failing with `database "<user>" does not exist" whenever the db name differs from the username. Now explicitly connects to `-d postgres`.

Verified end-to-end against a running local Postgres service (change + revert).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces shell-based managed-database container discovery with the existing Docker API helper and performs the running-container check before credential persistence. It also makes Postgres password changes connect explicitly to the default administrative database.
- Applies the container lookup change consistently to Postgres, MySQL, MariaDB, MongoDB, and Redis.
- Preserves local and remote command execution paths.
- Adds a clearer early error when no running service container is found.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered failure identified.

The new helper follows the repository’s established server-scoped Swarm container lookup convention, and the credential mutations retain their prior execution and rollback behavior while failing earlier when no running container exists.

<sub>Reviews (1): Last reviewed commit: ["fix: use dockerode API instead of shell ..."](https://github.com/dokploy/dokploy/commit/41d355c7dc7fd1d1945a1720e57c4cbc7d7e634a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54281717)</sub>

**Context used:**

- Knowledge Base — [Managed Databases](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/managed-databases.md)

<!-- /greptile_comment -->