### PR TITLE
fix: assign tags created from the project dialog

### DIFF
--- a/apps/dokploy/components/dashboard/settings/tags/handle-tag.tsx
+++ b/apps/dokploy/components/dashboard/settings/tags/handle-tag.tsx
@@ -53,9 +53,14 @@ type Tag = z.infer<typeof TagSchema>;
 
 interface HandleTagProps {
 	tagId?: string;
+	/**
+	 * Called with the new tag's id after it is created, so callers embedding
+	 * this dialog (e.g. the tag selector) can select the tag right away.
+	 */
+	onCreated?: (tagId: string) => void;
 }
 
-export const HandleTag = ({ tagId }: HandleTagProps) => {
+export const HandleTag = ({ tagId, onCreated }: HandleTagProps) => {
 	const utils = api.useUtils();
 	const [isOpen, setIsOpen] = useState(false);
 	const colorInputRef = useRef<HTMLInputElement>(null);
@@ -101,8 +106,11 @@ export const HandleTag = ({ tagId }: HandleTagProps) => {
 			color: data.color,
 			tagId: tagId || "",
 		})
-			.then(async () => {
+			.then(async (result) => {
 				await utils.tag.all.invalidate();
+				if (!tagId && result?.tagId) {
+					onCreated?.(result.tagId);
+				}
 				toast.success(tagId ? "Tag Updated" : "Tag Created");
 				setIsOpen(false);
 				form.reset();
@@ -139,9 +147,18 @@ export const HandleTag = ({ tagId }: HandleTagProps) => {
 				</DialogHeader>
 				{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
 				<Form {...form}>
+					{/*
+					 * This dialog can be rendered inside another form (e.g. the tag
+					 * selector in the project dialog). React propagates events through the
+					 * React tree, not the DOM tree, so without stopPropagation submitting
+					 * this form would also submit the outer one.
+					 */}
 					<form
 						id="hook-form-tag"
-						onSubmit={form.handleSubmit(onSubmit)}
+						onSubmit={(e) => {
+							e.stopPropagation();
+							form.handleSubmit(onSubmit)(e);
+						}}
 						className="grid w-full gap-4"
 					>
 						<FormField

--- a/apps/dokploy/components/shared/tag-selector.tsx
+++ b/apps/dokploy/components/shared/tag-selector.tsx
@@ -147,7 +147,13 @@ export function TagSelector({
 								})}
 							</CommandGroup>
 							<div className="flex items-center justify-center p-2 border-t">
-								<HandleTag />
+								<HandleTag
+									onCreated={(tagId) => {
+										if (!selectedTags.includes(tagId)) {
+											onTagsChange([...selectedTags, tagId]);
+										}
+									}}
+								/>
 							</div>
 						</CommandList>
 					</Command>


### PR DESCRIPTION
Fixes #5117

## Problem

Creating a tag from the **Create Project** dialog immediately created the project with no tags attached, and closed the dialog before a second tag could be selected.

The tag dialog's form is nested inside the project dialog's form in the React tree:

```
<form id="hook-form-add-project">            handle-project.tsx
  └ TagSelector → Popover → PopoverContent   tag-selector.tsx
      └ HandleTag → Dialog → DialogContent   handle-tag.tsx
          └ <form id="hook-form-tag">
```

Both are rendered through portals, but React propagates events along the React tree rather than the DOM tree, so the inner form's `submit` reached the outer form's `onSubmit`.

Separately, a newly created tag was never added to `selectedTagIds`, so `tag.bulkAssign` would have run with an empty array anyway.

## Changes

- `handle-tag.tsx` — `e.stopPropagation()` in the tag form's `onSubmit` so it cannot submit an enclosing form.
- `handle-tag.tsx` — optional `onCreated` prop, called with the id returned by `tag.create`.
- `tag-selector.tsx` — selects the new tag through `onCreated`.

`onCreated` is optional, so the standalone usages in `tag-manager.tsx` and `tag-filter.tsx` are unchanged.

## Testing

Tested locally against a dev instance (v0.30.0).

- Create Project → Create Tag: only the tag is created, the dialog stays open with the tag selected.
- Adding a second tag keeps both selected; saving assigns both (verified in `project_tag`).
- Same flow in the project Update dialog.
- Settings → Tags creates and edits tags as before.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes tag creation from project dialogs by preventing the nested tag form’s submit event from reaching the project form and by selecting the newly created tag.
- Adds an optional `onCreated` callback to `HandleTag`.
- Passes the created tag ID to `TagSelector`, which appends it to the current selection.
- Stops nested submit-event propagation while preserving React Hook Form handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the nested-form submission and created-tag selection paths handled consistently.

The created tag ID is propagated into project selection, and stopping event propagation prevents the enclosing project form from submitting without disrupting the inner form’s submission behavior.

<sub>Reviews (1): Last reviewed commit: ["fix: assign tags created from the projec..."](https://github.com/dokploy/dokploy/commit/0ea7de7d31d3a958a60e318be198960bf66de5c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54324736)</sub>

<!-- /greptile_comment -->