### PR TITLE
fix: correct switch thumb translate-x for checked state

### DIFF
--- a/apps/dokploy/components/ui/switch.tsx
+++ b/apps/dokploy/components/ui/switch.tsx
@@ -22,7 +22,7 @@ function Switch({
 		>
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
-				className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+				className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[18px] group-data-[size=sm]/switch:data-checked:translate-x-[10px] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
 			/>
 		</SwitchPrimitive.Root>
 	);


### PR DESCRIPTION
Fixes #5120

The `default` size track is `w-9` (36px) with a 16px thumb, but the checked-state translate used `calc(100%-2px)`, which only resolves correctly when track width = 2× thumb width (true for the original shadcn `w-8` sizing, not for our `w-9`). The thumb stopped short of the right edge instead of docking against it.

Replaced the percentage trick with the actual pixel offsets per size:
- `default`: 36px − 2px border − 16px thumb = 18px
- `sm`: 24px − 2px border − 12px thumb = 10px (unchanged, was already correct)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the checked-state thumb position for both supported switch sizes by replacing percentage-based transforms with offsets matching the declared track and thumb dimensions.
- Uses an 18px checked translation for the 36px default track.
- Retains the geometrically correct 10px checked translation for the 24px small track.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new offsets match both declared switch geometries and remain valid under the repository's Tailwind pipeline.

No blocking or independently actionable issue remains; the default thumb now travels 18px and the small thumb 10px, docking each against the right-side inset.

<sub>Reviews (1): Last reviewed commit: ["fix: correct switch thumb translate-x fo..."](https://github.com/dokploy/dokploy/commit/76c2416613fd947f179c68d6efd9215904c38304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54511564)</sub>

<!-- /greptile_comment -->