### PR TITLE
feat(backup): add table data exclusion pattern for postgres backups

### DIFF
--- a/apps/dokploy/__test__/backups/db-backup-restore-injection.test.ts
+++ b/apps/dokploy/__test__/backups/db-backup-restore-injection.test.ts
@@ -100,7 +100,7 @@ describe("database backup/restore command injection", () => {
 		expect(cmd).toContain("-e DB_NAME=my-db_prod");
 		expect(cmd).toContain("-e DB_USER=app_user");
 		expect(cmd).toContain(
-			'pg_dump -Fc --no-acl --no-owner -h localhost -U "$DB_USER"',
+			'pg_dump -Fc --exclude-table-data="*__exclude_data" --no-acl --no-owner -h localhost -U "$DB_USER"',
 		);
 	});
 });

--- a/packages/server/src/utils/backups/utils.ts
+++ b/packages/server/src/utils/backups/utils.ts
@@ -100,7 +100,7 @@ export const getPostgresBackupCommand = (
 	database: string,
 	databaseUser: string,
 ) => {
-	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -i $CONTAINER_ID bash -c 'set -o pipefail; pg_dump -Fc --no-acl --no-owner -h localhost -U "$DB_USER" --no-password "$DB_NAME" | gzip'`;
+	return `docker exec -e DB_NAME=${quote([database])} -e DB_USER=${quote([databaseUser])} -i $CONTAINER_ID bash -c 'set -o pipefail; pg_dump -Fc --exclude-table-data="*__exclude_data" --no-acl --no-owner -h localhost -U "$DB_USER" --no-password "$DB_NAME" | gzip'`;
 };
 
 export const getMariadbBackupCommand = (


### PR DESCRIPTION
## What is this PR about?

This PR adds support for excluding table data from PostgreSQL backups using the `--exclude-table-data="*__exclude_data"` option.

Applications can suffix tables with `__exclude_data` (for example, log, cache, or temporary tables) to omit their data from backups while preserving their schema. This helps reduce backup size and duration without affecting the database structure.

## Checklist

Before submitting this PR, please make sure that:

* [x] You created a dedicated branch based on the `canary` branch.
* [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
* [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a PostgreSQL dump option that excludes data from tables ending in `__exclude_data` while retaining their schemas.
- Adds `--exclude-table-data="*__exclude_data"` to generated PostgreSQL backup commands.
- Updates the backup command assertion to match the new command structure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported assertion failure is fixed by updating the test expectation to include the newly inserted PostgreSQL option, and no blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["test(backup): update postgres dump asser..."](https://github.com/dokploy/dokploy/commit/cd62444bbb7fca2722010a70dc32dee2c64c1715) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54527640)</sub>

<!-- /greptile_comment -->