### PR TITLE
fix: don't quote .env values for stack deploys

### DIFF
--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -7,6 +7,7 @@ import { writeDomainsToCompose } from "../docker/domain";
 import {
 	encodeBase64,
 	getEnvironmentVariablesObject,
+	prepareEnvironmentVariables,
 	prepareEnvironmentVariablesForFile,
 } from "../docker/utils";
 import { withResolvedVaultRefs } from "../vault";
@@ -157,10 +158,18 @@ export const getCreateEnvFileCommand = (compose: ComposeNested) => {
 		envContent += `\nCOMPOSE_PREFIX=${compose.suffix}`;
 	}
 
-	const envFileContent = prepareEnvironmentVariablesForFile(
-		envContent,
-		compose.environment.project.env,
-		compose.environment.env,
+	const envFileContent = (
+		compose.composeType === "stack"
+			? prepareEnvironmentVariables(
+					envContent,
+					compose.environment.project.env,
+					compose.environment.env,
+				)
+			: prepareEnvironmentVariablesForFile(
+					envContent,
+					compose.environment.project.env,
+					compose.environment.env,
+				)
 	).join("\n");
 
 	const encodedContent = encodeBase64(envFileContent);


### PR DESCRIPTION
Fixes #5096, fixes #5110.

`docker stack deploy` reads `env_file` literally and doesn't strip quotes (unlike `docker compose`). The quoting/escaping added to fix #4694 shipped literal quote characters into stack containers, e.g. `QUARKUS_LOG_SENTRY_DSN="https://..."` instead of `QUARKUS_LOG_SENTRY_DSN=https://...`.

For `composeType: stack`, `getCreateEnvFileCommand` now writes the raw (unquoted) values instead of the escaped ones. The docker-compose path is untouched, so #4694 stays fixed there.

Verified against the exact repro from #5096 (`environment: VAR: \${VAR:?...}` interpolation) with a real `docker stack deploy`, inspecting the actual container env.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes generated `.env` files for Docker Stack deployments to emit resolved values without Compose-style quoting, preventing quote characters from reaching container environments. Docker Compose deployments retain the existing escaped and quoted serialization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The serialization branch is limited to Docker Stack deployments and directly addresses Stack’s literal treatment of quoted `env_file` values while leaving Docker Compose serialization unchanged.

<sub>Reviews (1): Last reviewed commit: ["fix: don&#39;t quote .env values for stack d..."](https://github.com/dokploy/dokploy/commit/d183018201c05c578a1dc26da126dc0f58c6ecc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54534961)</sub>

**Context used:**

- Knowledge Base — [Compose Deployment Flow](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/compose-deployment.md)

<!-- /greptile_comment -->