### PR TITLE
fix: generate release notes ourselves for hotfix releases

### DIFF
--- a/.github/workflows/dokploy.yml
+++ b/.github/workflows/dokploy.yml
@@ -162,13 +162,44 @@ jobs:
           { head -1 install.sh; echo "DOKPLOY_VERSION=\"\${DOKPLOY_VERSION:-${{ steps.get_version.outputs.version }}}\""; tail -n +2 install.sh; } > install-pinned.sh
           mv install-pinned.sh install.sh
 
+      - name: Generate release notes
+        # Hotfixes land on main via `git cherry-pick` (hotfix-cherry-pick.yml),
+        # not a PR merged into main, so GitHub's own generate_release_notes
+        # can't associate any PR with these commits and comes back empty.
+        # Build the "What's Changed" list ourselves from the cherry-picked
+        # "Merge pull request #N ..." commit messages instead.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          RANGE="HEAD"
+          [ -n "$PREV_TAG" ] && RANGE="${PREV_TAG}..HEAD"
+
+          {
+            echo "## What's Changed"
+            git log "$RANGE" --reverse --format='%s' \
+              | grep -oE '^Merge pull request #[0-9]+' \
+              | grep -oE '[0-9]+' \
+              | while read -r PR; do
+                gh pr view "$PR" --repo "${{ github.repository }}" \
+                  --json title,author -q '"* \(.title) by @\(.author.login) in #'"$PR"'"' \
+                  2>/dev/null || true
+              done
+            if [ -n "$PREV_TAG" ]; then
+              echo ""
+              echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ steps.get_version.outputs.version }}"
+            fi
+          } > release-notes.md
+
+          cat release-notes.md
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
           target_commitish: ${{ github.sha }}
           name: ${{ steps.get_version.outputs.version }}
-          generate_release_notes: true
+          body_path: release-notes.md
           draft: false
           prerelease: false
           files: install.sh


### PR DESCRIPTION
Hotfixes land on `main` via `git cherry-pick` (`hotfix-cherry-pick.yml`), not a PR merged into `main`. GitHub's `generate_release_notes: true` builds its changelog by associating merged PRs with the target branch, so cherry-picked commits (new SHAs, no merge-into-main event) never match anything and the release body comes back empty — this is what happened on [v0.30.1](https://github.com/Dokploy/dokploy/releases/tag/v0.30.1).

Instead of relying on that, `generate-release` now builds the "What's Changed" list itself: it walks the `Merge pull request #N ...` commit messages between the previous tag and `HEAD` (these survive the cherry-pick since `hotfix-cherry-pick.yml` preserves the original commit message) and resolves each PR's title/author with `gh pr view`.

Needs the `hotfix` label so it reaches `main` before the next release, since `generate-release` only runs there.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces GitHub-generated release notes with a workflow step that extracts pull-request numbers from merge commit subjects and resolves their metadata through GitHub CLI.

- Builds a “What's Changed” list over commits since the nearest tag.
- Adds a full-changelog comparison link.
- Supplies the generated Markdown file to the release action instead of enabling automatic notes.

<h3>Confidence Score: 3/5</h3>

The release workflow should not merge until retries preserve the correct comparison range and pull-request lookup failures can no longer silently publish incomplete notes.

A rerun after tag creation can overwrite the release body using an empty self-range, and suppressed GitHub CLI failures allow partially generated notes to be published successfully.

**Files Needing Attention:** .github/workflows/dokploy.yml

<sub>Reviews (1): Last reviewed commit: ["fix: generate release notes ourselves fo..."](https://github.com/dokploy/dokploy/commit/56162eb3e0967b9e8c1011ce3521302a48953a40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54536986)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->