### PR TITLE
Feat(UI) :Improve Docker Image Tab

### DIFF
--- a/apps/dokploy/components/dashboard/docker/images/show-images.tsx
+++ b/apps/dokploy/components/dashboard/docker/images/show-images.tsx
@@ -11,8 +11,15 @@ import {
 	useReactTable,
 } from "@tanstack/react-table";
 import type { inferRouterOutputs } from "@trpc/server";
-import { ArrowUpDown, Eye, Layers, Loader2, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import {
+	ArrowUpDown,
+	Download,
+	Eye,
+	Layers,
+	Loader2,
+	Trash2,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AlertBlock } from "@/components/shared/alert-block";
 import { CodeEditor } from "@/components/shared/code-editor";
@@ -46,6 +53,13 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Table,
 	TableBody,
 	TableCell,
@@ -59,10 +73,15 @@ import { api } from "@/utils/api";
 type ImageBase =
 	inferRouterOutputs<AppRouter>["dockerImage"]["getImages"][number];
 type ImageRow = ImageBase & { key: string };
+type ImageOutdatedStatus =
+	inferRouterOutputs<AppRouter>["dockerImage"]["getImagesOutdatedStatus"][number];
 
 interface Props {
 	serverId?: string;
 }
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200];
+const OUTDATED_STATUS_CHUNK_SIZE = 250;
 
 const SIZE_UNITS: Record<string, number> = {
 	b: 1,
@@ -83,6 +102,18 @@ const getReference = (image: ImageBase) =>
 	image.Repository !== "<none>" && image.Tag !== "<none>"
 		? `${image.Repository}:${image.Tag}`
 		: image.ID;
+
+const hasTagReference = (image: ImageBase) =>
+	image.Repository !== "<none>" && image.Tag !== "<none>";
+
+const splitIntoChunks = <T,>(items: T[], size: number) => {
+	if (size <= 0) return [items];
+	const chunks: T[][] = [];
+	for (let i = 0; i < items.length; i += size) {
+		chunks.push(items.slice(i, i + size));
+	}
+	return chunks;
+};
 
 const FORCE_HINT_REGEX =
 	/must be forced|image is being used|referenced in multiple repositories/i;
@@ -175,10 +206,14 @@ export const ShowImages = ({ serverId }: Props) => {
 		image: ImageRow;
 		message: string;
 	} | null>(null);
+	const [pullingReferences, setPullingReferences] = useState<
+		Record<string, boolean>
+	>({});
 
 	const { data: images, isLoading } = api.dockerImage.getImages.useQuery({
 		serverId,
 	});
+	const { mutateAsync: pullImage } = api.dockerImage.pullImage.useMutation();
 	const { mutateAsync: removeImage } =
 		api.dockerImage.removeImage.useMutation();
 
@@ -190,6 +225,48 @@ export const ShowImages = ({ serverId }: Props) => {
 			})),
 		[images],
 	);
+
+	const tagReferences = useMemo(
+		() => [
+			...new Set(rows.filter(hasTagReference).map((row) => getReference(row))),
+		],
+		[rows],
+	);
+
+	const outdatedStatusChunks = useMemo(
+		() => splitIntoChunks(tagReferences, OUTDATED_STATUS_CHUNK_SIZE),
+		[tagReferences],
+	);
+
+	const outdatedStatusQueries = api.useQueries((t) =>
+		outdatedStatusChunks.map((chunk) =>
+			t.dockerImage.getImagesOutdatedStatus(
+				{ references: chunk, serverId },
+				{
+					enabled: chunk.length > 0,
+					staleTime: 1000 * 60 * 60 * 24, // Data stays fresh for 24 hours
+					refetchOnWindowFocus: false, // Don't refetch just because user alt-tabbed
+				},
+			),
+		),
+	);
+
+	const outdatedStatuses = useMemo(
+		() => outdatedStatusQueries.flatMap((query) => query.data ?? []),
+		[outdatedStatusQueries],
+	);
+
+	const isOutdatedStatusLoading = outdatedStatusQueries.some(
+		(query) => query.isLoading,
+	);
+
+	const outdatedStatusMap = useMemo(() => {
+		const map = new Map<string, ImageOutdatedStatus>();
+		for (const status of outdatedStatuses ?? []) {
+			map.set(status.reference, status);
+		}
+		return map;
+	}, [outdatedStatuses]);
 
 	const filteredData = useMemo(() => {
 		if (!globalFilter.trim()) {
@@ -204,6 +281,41 @@ export const ShowImages = ({ serverId }: Props) => {
 		);
 	}, [rows, globalFilter]);
 
+	useEffect(() => {
+		setPagination((current) =>
+			current.pageIndex === 0 ? current : { ...current, pageIndex: 0 },
+		);
+	}, [filteredData.length, serverId]);
+
+	const handlePull = async (image: ImageRow) => {
+		if (!hasTagReference(image)) {
+			return;
+		}
+
+		const reference = getReference(image);
+		setPullingReferences((prev) => ({ ...prev, [reference]: true }));
+		try {
+			await pullImage({
+				imageRef: reference,
+				serverId,
+			});
+			toast.success("Image pulled");
+			await Promise.all([
+				utils.dockerImage.getImages.invalidate(),
+				utils.dockerImage.getImagesOutdatedStatus.invalidate(),
+			]);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.error("Error pulling image", { description: message });
+		} finally {
+			setPullingReferences((prev) => {
+				const next = { ...prev };
+				delete next[reference];
+				return next;
+			});
+		}
+	};
+
 	const handleDelete = async (image: ImageRow, force = false) => {
 		try {
 			await removeImage({
@@ -216,6 +328,7 @@ export const ShowImages = ({ serverId }: Props) => {
 			toast.success("Image deleted");
 			setForcePrompt(null);
 			await utils.dockerImage.getImages.invalidate();
+			await utils.dockerImage.getImagesOutdatedStatus.invalidate();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			if (!force && FORCE_HINT_REGEX.test(message)) {
@@ -279,6 +392,72 @@ export const ShowImages = ({ serverId }: Props) => {
 				),
 			},
 			{
+				id: "Outdated",
+				accessorFn: (image) => {
+					if (!hasTagReference(image)) return -1;
+					const status = outdatedStatusMap.get(getReference(image))?.status;
+					if (status === "outdated") return 2;
+					if (status === "up_to_date") return 1;
+					return 0;
+				},
+				header: ({ column }) => (
+					<SortableHeader column={column} title="Outdated" />
+				),
+				cell: ({ row }) => {
+					if (!hasTagReference(row.original)) {
+						return <Badge variant="blank">N/A</Badge>;
+					}
+
+					if (isOutdatedStatusLoading && outdatedStatuses.length === 0) {
+						return (
+							<span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+								<Loader2 className="size-3 animate-spin" />
+								Checking
+							</span>
+						);
+					}
+
+					const status = outdatedStatusMap.get(getReference(row.original));
+
+					if (!status && isOutdatedStatusLoading) {
+						return (
+							<span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+								<Loader2 className="size-3 animate-spin" />
+								Checking
+							</span>
+						);
+					}
+
+					if (!status || status.status === "unknown") {
+						return (
+							<Badge
+								variant="blank"
+								title={status?.reason ?? "Status unavailable"}
+							>
+								Unknown
+							</Badge>
+						);
+					}
+
+					if (status.status === "outdated") {
+						return (
+							<Badge
+								variant="yellow"
+								title={
+									status.localDigest && status.remoteDigest
+										? `Local: ${status.localDigest} | Remote: ${status.remoteDigest}`
+										: undefined
+								}
+							>
+								Outdated
+							</Badge>
+						);
+					}
+
+					return <Badge variant="green">Up to date</Badge>;
+				},
+			},
+			{
 				id: "actions",
 				enableSorting: false,
 				header: () => <div className="text-right">Actions</div>,
@@ -288,6 +467,28 @@ export const ShowImages = ({ serverId }: Props) => {
 							imageRef={getReference(row.original)}
 							serverId={serverId}
 						/>
+						{hasTagReference(row.original) && (
+							<DialogAction
+								title="Pull image"
+								description={`The image "${getReference(row.original)}" will be pulled from its registry.`}
+								onClick={() => handlePull(row.original)}
+								type="default"
+								disabled={!!pullingReferences[getReference(row.original)]}
+							>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									aria-label="Pull image"
+									disabled={!!pullingReferences[getReference(row.original)]}
+								>
+									{pullingReferences[getReference(row.original)] ? (
+										<Loader2 className="size-4 animate-spin text-green-600" />
+									) : (
+										<Download className="size-4 text-green-600" />
+									)}
+								</Button>
+							</DialogAction>
+						)}
 						<DialogAction
 							title="Delete image"
 							description={`The image "${getReference(row.original)}" will be removed from Docker. This action cannot be undone.`}
@@ -301,7 +502,15 @@ export const ShowImages = ({ serverId }: Props) => {
 				),
 			},
 		],
-		[serverId],
+		[
+			handleDelete,
+			handlePull,
+			isOutdatedStatusLoading,
+			outdatedStatusMap,
+			outdatedStatuses.length,
+			pullingReferences,
+			serverId,
+		],
 	);
 
 	const table = useReactTable({
@@ -358,7 +567,13 @@ export const ShowImages = ({ serverId }: Props) => {
 									<Input
 										placeholder="Search by repository, tag or id..."
 										value={globalFilter}
-										onChange={(e) => setGlobalFilter(e.target.value)}
+										onChange={(e) => {
+											setGlobalFilter(e.target.value);
+											setPagination((current) => ({
+												...current,
+												pageIndex: 0,
+											}));
+										}}
 										className="max-w-xs"
 									/>
 								</div>
@@ -407,11 +622,36 @@ export const ShowImages = ({ serverId }: Props) => {
 										</TableBody>
 									</Table>
 								</div>
-								{table.getPageCount() > 1 && (
-									<div className="flex items-center justify-end gap-4">
-										<span className="text-sm text-muted-foreground">
+								<div className="flex items-center justify-between text-sm text-muted-foreground">
+									<span>
+										{filteredData.length}{" "}
+										{filteredData.length === 1 ? "image" : "images"} total
+									</span>
+									<div className="flex items-center gap-3">
+										<div className="flex items-center gap-2">
+											<span className="whitespace-nowrap">Rows per page</span>
+											<Select
+												value={String(table.getState().pagination.pageSize)}
+												onValueChange={(value) => {
+													table.setPageSize(Number(value));
+													table.setPageIndex(0);
+												}}
+											>
+												<SelectTrigger className="w-[80px] h-8">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{PAGE_SIZE_OPTIONS.map((size) => (
+														<SelectItem key={size} value={String(size)}>
+															{size}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
+										<span className="whitespace-nowrap">
 											Page {table.getState().pagination.pageIndex + 1} of{" "}
-											{table.getPageCount()}
+											{Math.max(1, table.getPageCount())}
 										</span>
 										<div className="flex gap-2">
 											<Button
@@ -432,7 +672,7 @@ export const ShowImages = ({ serverId }: Props) => {
 											</Button>
 										</div>
 									</div>
-								)}
+								</div>
 							</>
 						)}
 					</CardContent>

--- a/apps/dokploy/components/dashboard/docker/images/show-images.tsx
+++ b/apps/dokploy/components/dashboard/docker/images/show-images.tsx
@@ -17,6 +17,7 @@ import {
 	Eye,
 	Layers,
 	Loader2,
+	RefreshCw,
 	Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -216,6 +217,8 @@ export const ShowImages = ({ serverId }: Props) => {
 	const { mutateAsync: pullImage } = api.dockerImage.pullImage.useMutation();
 	const { mutateAsync: removeImage } =
 		api.dockerImage.removeImage.useMutation();
+	const { mutateAsync: checkUpdates } =
+		api.dockerImage.checkUpdates.useMutation();
 
 	const rows = useMemo<ImageRow[]>(
 		() =>
@@ -244,8 +247,8 @@ export const ShowImages = ({ serverId }: Props) => {
 				{ references: chunk, serverId },
 				{
 					enabled: chunk.length > 0,
-					staleTime: 1000 * 60 * 60 * 24, // Data stays fresh for 24 hours
-					refetchOnWindowFocus: false, // Don't refetch just because user alt-tabbed
+					staleTime: 1000 * 60 * 60 * 24,
+					refetchOnWindowFocus: false,
 				},
 			),
 		),
@@ -257,7 +260,7 @@ export const ShowImages = ({ serverId }: Props) => {
 	);
 
 	const isOutdatedStatusLoading = outdatedStatusQueries.some(
-		(query) => query.isLoading,
+		(query) => query.isFetching,
 	);
 
 	const outdatedStatusMap = useMemo(() => {
@@ -312,6 +315,19 @@ export const ShowImages = ({ serverId }: Props) => {
 				const next = { ...prev };
 				delete next[reference];
 				return next;
+			});
+		}
+	};
+
+	const handleCheckUpdates = async () => {
+		try {
+			await checkUpdates({ serverId });
+
+			await utils.dockerImage.getImagesOutdatedStatus.invalidate();
+			toast.success("Update Check Completed");
+		} catch (error) {
+			toast.error("Error checking for updates", {
+				description: error instanceof Error ? error.message : "Unknown error",
 			});
 		}
 	};
@@ -563,7 +579,7 @@ export const ShowImages = ({ serverId }: Props) => {
 							</div>
 						) : (
 							<>
-								<div className="flex flex-wrap items-center gap-2">
+								<div className="flex items-center justify-between w-full gap-4">
 									<Input
 										placeholder="Search by repository, tag or id..."
 										value={globalFilter}
@@ -576,6 +592,16 @@ export const ShowImages = ({ serverId }: Props) => {
 										}}
 										className="max-w-xs"
 									/>
+									<Button
+										variant="outline"
+										onClick={handleCheckUpdates}
+										disabled={isOutdatedStatusLoading}
+									>
+										<RefreshCw
+											className={`mr-2 size-4 ${isOutdatedStatusLoading ? "animate-spin" : ""}`}
+										/>
+										Check Updates
+									</Button>
 								</div>
 								<div className="rounded-md border overflow-x-auto">
 									<Table>

--- a/apps/dokploy/server/api/routers/docker-image.ts
+++ b/apps/dokploy/server/api/routers/docker-image.ts
@@ -2,6 +2,10 @@ import {
 	findServerById,
 	getImageConfig,
 	getImages,
+	getImagesOutdatedStatus,
+	invalidateRemoteDigestCache,
+	pullImage as pullDockerImage,
+	pullRemoteImage,
 	removeImage,
 } from "@dokploy/server";
 import { TRPCError } from "@trpc/server";
@@ -26,6 +30,35 @@ export const dockerImageRouter = createTRPCRouter({
 			return await getImages(input.serverId);
 		}),
 
+	getImagesOutdatedStatus: withPermission("docker", "read")
+		.input(
+			z.object({
+				references: z.array(z.string().min(1)).max(5000),
+				serverId: z.string().optional(),
+			}),
+		)
+		.query(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+
+			const chunkSize = 250;
+			const statuses = [];
+			for (let i = 0; i < input.references.length; i += chunkSize) {
+				const chunk = input.references.slice(i, i + chunkSize);
+				const chunkStatuses = await getImagesOutdatedStatus(
+					chunk,
+					input.serverId,
+				);
+				statuses.push(...chunkStatuses);
+			}
+
+			return statuses;
+		}),
+
 	getImageConfig: withPermission("docker", "read")
 		.input(
 			z.object({
@@ -41,6 +74,36 @@ export const dockerImageRouter = createTRPCRouter({
 				}
 			}
 			return await getImageConfig(input.imageRef, input.serverId);
+		}),
+
+	pullImage: withPermission("docker", "read")
+		.input(
+			z.object({
+				imageRef: z.string().min(1),
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+
+			if (input.serverId) {
+				await pullRemoteImage(input.imageRef, input.serverId);
+			} else {
+				await pullDockerImage(input.imageRef);
+			}
+			invalidateRemoteDigestCache(input.imageRef, input.serverId);
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "docker",
+				resourceId: input.imageRef,
+				resourceName: input.imageRef,
+			});
 		}),
 
 	removeImage: withPermission("docker", "read")

--- a/apps/dokploy/server/api/routers/docker-image.ts
+++ b/apps/dokploy/server/api/routers/docker-image.ts
@@ -1,4 +1,5 @@
 import {
+	clearRemoteDigestCache,
 	findServerById,
 	getImageConfig,
 	getImages,
@@ -74,6 +75,22 @@ export const dockerImageRouter = createTRPCRouter({
 				}
 			}
 			return await getImageConfig(input.imageRef, input.serverId);
+		}),
+
+	checkUpdates: withPermission("docker", "read")
+		.input(
+			z.object({
+				serverId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session?.activeOrganizationId) {
+					throw new TRPCError({ code: "UNAUTHORIZED" });
+				}
+			}
+			clearRemoteDigestCache(input.serverId);
 		}),
 
 	pullImage: withPermission("docker", "read")

--- a/packages/server/src/services/docker-image.ts
+++ b/packages/server/src/services/docker-image.ts
@@ -78,7 +78,7 @@ const remoteDigestCache = new Map<
 	string,
 	{ digests: string[]; timestamp: number }
 >();
-const CACHE_TTL = 1000 * 60 * 60 * 24; // 24 hours in milliseconds
+const CACHE_TTL = 1000 * 60 * 60 * 24;
 
 const getRemoteDigestCacheKey = (reference: string, serverId?: string) =>
 	`${serverId ?? "local"}-${reference}`;
@@ -96,6 +96,15 @@ export const invalidateRemoteDigestCache = (
 	serverId?: string,
 ) => {
 	remoteDigestCache.delete(getRemoteDigestCacheKey(reference, serverId));
+};
+
+export const clearRemoteDigestCache = (serverId?: string) => {
+	const prefix = `${serverId ?? "local"}-`;
+	for (const key of remoteDigestCache.keys()) {
+		if (key.startsWith(prefix)) {
+			remoteDigestCache.delete(key);
+		}
+	}
 };
 
 const getRemoteDigestCandidates = async (
@@ -212,7 +221,6 @@ const buildOutdatedStatus = async (
 
 		const localSet = new Set([local.id, ...local.digests]);
 
-		// Try to find a direct match
 		const match = remoteCandidates.find((candidate) => localSet.has(candidate));
 
 		if (match) {
@@ -224,13 +232,10 @@ const buildOutdatedStatus = async (
 			};
 		}
 
-		// If no match is found, it means the local digests are completely different
-		// from what is currently on the remote registry. The image is outdated.
 		return {
 			reference,
 			status: "outdated",
 			localDigest: local.digests[0] ?? local.id,
-			// Return the first digest (which is the Index digest we hashed)
 			remoteDigest: remoteCandidates[0] ?? null,
 			reason: "Digest differs",
 		};

--- a/packages/server/src/services/docker-image.ts
+++ b/packages/server/src/services/docker-image.ts
@@ -17,12 +17,238 @@ export interface DockerImage {
 	VirtualSize?: string;
 }
 
+export type ImageVersionStatus = "outdated" | "up_to_date" | "unknown";
+
+export interface ImageOutdatedStatus {
+	reference: string;
+	status: ImageVersionStatus;
+	localDigest: string | null;
+	remoteDigest: string | null;
+	reason?: string;
+}
+
+interface LocalImageInfo {
+	id: string;
+	digests: string[];
+}
+
+const STATUS_CHECK_CONCURRENCY = 5;
+
+const runDockerCommand = async (command: string, serverId?: string) => {
+	return serverId
+		? await execAsyncRemote(serverId, command)
+		: await execAsync(command);
+};
+
+const extractDigest = (value?: string | null) => {
+	if (!value) return null;
+	const match = value.match(/sha256:[a-fA-F0-9]{64}/);
+	return match?.[0] ?? null;
+};
+
+const collectDigests = (values: Array<string | null | undefined>) => {
+	const digests = new Set<string>();
+	for (const value of values) {
+		const digest = extractDigest(value);
+		if (digest) {
+			digests.add(digest);
+		}
+	}
+	return [...digests];
+};
+
+const getLocalImageInfo = async (
+	reference: string,
+	serverId?: string,
+): Promise<LocalImageInfo> => {
+	const command = `docker image inspect ${quote([reference])} --format '{{json .}}'`;
+	const { stdout } = await runDockerCommand(command, serverId);
+	const parsed = JSON.parse(stdout.trim()) as {
+		Id?: string;
+		RepoDigests?: string[];
+	};
+
+	return {
+		id: parsed.Id ?? "",
+		digests: collectDigests(parsed.RepoDigests ?? []),
+	};
+};
+
+const remoteDigestCache = new Map<
+	string,
+	{ digests: string[]; timestamp: number }
+>();
+const CACHE_TTL = 1000 * 60 * 60 * 24; // 24 hours in milliseconds
+
+const getRemoteDigestCacheKey = (reference: string, serverId?: string) =>
+	`${serverId ?? "local"}-${reference}`;
+
+const pruneExpiredRemoteDigestCache = (now: number) => {
+	for (const [key, entry] of remoteDigestCache) {
+		if (now - entry.timestamp >= CACHE_TTL) {
+			remoteDigestCache.delete(key);
+		}
+	}
+};
+
+export const invalidateRemoteDigestCache = (
+	reference: string,
+	serverId?: string,
+) => {
+	remoteDigestCache.delete(getRemoteDigestCacheKey(reference, serverId));
+};
+
+const getRemoteDigestCandidates = async (
+	reference: string,
+	serverId?: string,
+): Promise<string[]> => {
+	const now = Date.now();
+	pruneExpiredRemoteDigestCache(now);
+
+	const cacheKey = getRemoteDigestCacheKey(reference, serverId);
+	const cached = remoteDigestCache.get(cacheKey);
+
+	if (cached && now - cached.timestamp < CACHE_TTL) {
+		return cached.digests;
+	}
+
+	const command = `docker buildx imagetools inspect ${quote([reference])}`;
+	const { stdout } = await runDockerCommand(command, serverId);
+
+	const candidates = new Set<string>();
+	const lines = stdout.split("\n");
+
+	for (const line of lines) {
+		if (line.trim().startsWith("Digest:")) {
+			const digest = extractDigest(line);
+			if (digest) candidates.add(digest);
+		}
+		if (line.includes("sha256:")) {
+			const digest = extractDigest(line);
+			if (digest) candidates.add(digest);
+		}
+	}
+
+	const results = [...candidates];
+
+	if (results.length > 0) {
+		remoteDigestCache.set(cacheKey, {
+			digests: results,
+			timestamp: Date.now(),
+		});
+	}
+
+	return results;
+};
+
+const mapWithConcurrency = async <T, R>(
+	items: T[],
+	concurrency: number,
+	mapper: (item: T, index: number) => Promise<R>,
+) => {
+	if (items.length === 0) return [] as R[];
+	const results = new Array<R>(items.length);
+	let nextIndex = 0;
+
+	const workers = Array.from({
+		length: Math.min(concurrency, items.length),
+	}).map(async () => {
+		while (true) {
+			const current = nextIndex;
+			nextIndex += 1;
+			if (current >= items.length) return;
+			results[current] = await mapper(items[current] as T, current);
+		}
+	});
+
+	await Promise.all(workers);
+	return results;
+};
+
+const buildOutdatedStatus = async (
+	reference: string,
+	serverId?: string,
+): Promise<ImageOutdatedStatus> => {
+	try {
+		const local = await getLocalImageInfo(reference, serverId);
+		if (!local.id && local.digests.length === 0) {
+			return {
+				reference,
+				status: "unknown",
+				localDigest: null,
+				remoteDigest: null,
+				reason: "No local image data found",
+			};
+		}
+
+		let remoteCandidates: string[];
+		try {
+			remoteCandidates = await getRemoteDigestCandidates(reference, serverId);
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : "Lookup failed";
+			const isRateLimit =
+				msg.toLowerCase().includes("toomanyrequests") ||
+				msg.toLowerCase().includes("rate limit");
+			return {
+				reference,
+				status: "unknown",
+				localDigest: local.digests[0] ?? local.id,
+				remoteDigest: null,
+				reason: isRateLimit
+					? "Registry rate limited"
+					: "Registry lookup failed",
+			};
+		}
+
+		if (remoteCandidates.length === 0) {
+			return {
+				reference,
+				status: "unknown",
+				localDigest: local.digests[0] ?? local.id,
+				remoteDigest: null,
+				reason: "No remote digest found",
+			};
+		}
+
+		const localSet = new Set([local.id, ...local.digests]);
+
+		// Try to find a direct match
+		const match = remoteCandidates.find((candidate) => localSet.has(candidate));
+
+		if (match) {
+			return {
+				reference,
+				status: "up_to_date",
+				localDigest: match,
+				remoteDigest: match,
+			};
+		}
+
+		// If no match is found, it means the local digests are completely different
+		// from what is currently on the remote registry. The image is outdated.
+		return {
+			reference,
+			status: "outdated",
+			localDigest: local.digests[0] ?? local.id,
+			// Return the first digest (which is the Index digest we hashed)
+			remoteDigest: remoteCandidates[0] ?? null,
+			reason: "Digest differs",
+		};
+	} catch (error) {
+		return {
+			reference,
+			status: "unknown",
+			localDigest: null,
+			remoteDigest: null,
+			reason: error instanceof Error ? error.message : "Unknown error",
+		};
+	}
+};
+
 export const getImages = async (serverId?: string) => {
 	try {
 		const command = "docker images --format '{{json .}}'";
-		const { stdout } = serverId
-			? await execAsyncRemote(serverId, command)
-			: await execAsync(command);
+		const { stdout } = await runDockerCommand(command, serverId);
 
 		return stdout
 			.trim()
@@ -35,11 +261,24 @@ export const getImages = async (serverId?: string) => {
 	}
 };
 
+export const getImagesOutdatedStatus = async (
+	references: string[],
+	serverId?: string,
+) => {
+	const uniqueReferences = [...new Set(references.filter(Boolean))];
+
+	const statusEntries = await mapWithConcurrency(
+		uniqueReferences,
+		STATUS_CHECK_CONCURRENCY,
+		(reference) => buildOutdatedStatus(reference, serverId),
+	);
+
+	return statusEntries;
+};
+
 export const getImageConfig = async (imageRef: string, serverId?: string) => {
 	const command = `docker image inspect ${quote([String(imageRef ?? "")])}`;
-	const { stdout } = serverId
-		? await execAsyncRemote(serverId, command)
-		: await execAsync(command);
+	const { stdout } = await runDockerCommand(command, serverId);
 
 	return JSON.parse(stdout.trim())[0];
 };


### PR DESCRIPTION
## What is this PR about?

Improves the Docker Images tab with better image management and update visibility.

### Changes
- Add a per-image Pull action alongside the existing View and Delete actions.
- Show a loading state while an image is being pulled.
- Add image update status with `Outdated`, `Up to date`, `Unknown`, and `N/A` states.
- Add a manual **Check Updates** action.
- Cache registry digest checks to avoid unnecessary repeated requests.
- Refresh update status after pulling or deleting an image.
- Add a Rows per page selector with multiple page-size options for consistency with other pages like dashboard/overview.
- Handle dangling `<none>` images correctly.
- Limit concurrent registry checks to avoid excessive load.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #5093 

## Screenshots (if applicable)
<img width="1300" height="862" alt="image" src="https://github.com/user-attachments/assets/53c71408-6026-47fa-aabd-f38b698e35df" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Docker image pulling, registry digest-based update checks, cache invalidation, status badges, and configurable table pagination.

- Adds local and remote image pull actions with loading and refresh behavior.
- Compares local image metadata with registry digests using bounded concurrency and a 24-hour server-side cache.
- Adds update-state presentation, manual checks, dangling-image handling, and rows-per-page controls.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The new Docker image operations preserve server organization checks, quote image references, bound registry-check concurrency, and degrade lookup failures to an explicit unknown status.

<sub>Reviews (1): Last reviewed commit: ["feat: add manual check update button, an..."](https://github.com/dokploy/dokploy/commit/935e91111d6d80c5476b9551e856a63bfaeb9d72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54740059)</sub>

**Context used:**

- Knowledge Base — [Docker Resource Management and Server Health](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/docker-resource-management.md)

<!-- /greptile_comment -->