### PR TITLE
fix(auth): respect HTTPS when setting secure cookies on self-hosted

### DIFF
--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -82,11 +82,18 @@ const createBetterAuth = () =>
 		},
 		...(!IS_CLOUD
 			? {
+					// Self-hosted instances behind a TLS-terminating reverse proxy
+					// (Traefik, Cloudflare, Nginx) need Secure cookies so that
+					// browsers honour the __Secure-* cookie prefix over HTTPS.
+					// Set SECURE_COOKIES=true in your environment / docker-compose
+					// when serving Dokploy over HTTPS.
+					// Without this, BetterAuth emits non-Secure cookies, the browser
+					// silently drops them on HTTPS, and every tRPC request returns 403.
 					advanced: {
-						useSecureCookies: false,
+						useSecureCookies: process.env.SECURE_COOKIES === "true",
 						defaultCookieAttributes: {
-							sameSite: "lax",
-							secure: false,
+							sameSite: "lax" as const,
+							secure: process.env.SECURE_COOKIES === "true",
 							httpOnly: true,
 							path: "/",
 						},


### PR DESCRIPTION
## Summary

Fixes a **critical authentication bug** affecting all self-hosted Dokploy instances served over an HTTPS custom domain behind a TLS-terminating reverse proxy (Traefik, Cloudflare, Nginx).

Closes #5143
Related: #4709

---

## Problem

When a self-hosted Dokploy instance is accessed via an HTTPS custom domain, **every tRPC request returns `403 Forbidden`**, making the dashboard completely unusable over HTTPS.

### Root Cause

In `packages/server/src/lib/auth.ts`, `useSecureCookies` and `secure` are hardcoded to `false` for all self-hosted deployments:

```ts
advanced: {
  useSecureCookies: false,   // ← hardcoded regardless of protocol
  defaultCookieAttributes: {
    secure: false,           // ← hardcoded regardless of protocol
  },
},
```

When a browser connects over HTTPS, it silently drops any cookie without the `Secure` attribute. Every tRPC request then has no valid session → **403 Forbidden**. Accessing over `http://<IP>:3000` works fine, making this hard to diagnose.

---

## Fix

Introduce a `SECURE_COOKIES` environment variable operators can set when serving Dokploy over HTTPS:

```ts
advanced: {
  useSecureCookies: process.env.SECURE_COOKIES === "true",
  defaultCookieAttributes: {
    sameSite: "lax" as const,
    secure: process.env.SECURE_COOKIES === "true",
    httpOnly: true,
    path: "/",
  },
},
```

Add to `docker-compose.yml`:

```yaml
services:
  dokploy:
    environment:
      SECURE_COOKIES: "true"
```

---

## Impact

| Scenario | Before | After |
|---|---|---|
| `http://<IP>:3000` | ✅ Works | ✅ Works |
| `https://<domain>` without env var | ❌ 403 | ❌ Same (opt-in required) |
| `https://<domain>` + `SECURE_COOKIES=true` | ❌ 403 | ✅ Fixed |
| Cloud deployments | ✅ Works | ✅ Works |

Non-breaking change — existing deployments without the env var are unaffected.

---

## Testing

Tested on a live self-hosted instance (Azure VPS, Traefik + Cloudflare, v0.30.2). Without fix: 403 on all tRPC routes over HTTPS. With `SECURE_COOKIES=true`: dashboard fully functional.

---

## Checklist
- [x] Branch based on `canary`
- [x] Read CONTRIBUTING.md
- [x] Tested on a live self-hosted instance
- [x] Non-breaking change

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Better Auth’s secure-cookie behavior configurable for self-hosted deployments through `SECURE_COOKIES`.
- Applies the setting to both Better Auth’s secure-cookie mode and default cookie attributes.
- Preserves the existing non-secure default for self-hosted HTTP deployments.
- Does not add the new setting to checked-in operator-facing configuration or environment examples.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking configuration-documentation gap that may prevent self-hosted operators from activating the fix.

The cookie configuration consistently applies the new boolean to both relevant Better Auth settings, but no checked-in operator-facing configuration advertises or supplies the required environment variable.

**Files Needing Attention:** packages/server/src/lib/auth.ts

<sub>Reviews (1): Last reviewed commit: ["fix(auth): respect HTTPS when setting se..."](https://github.com/dokploy/dokploy/commit/ac32b04b8b73270846c994235b662ea7e3490752) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55371178)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->