### PR TITLE
fix: File Mount with nested File Path created as directory instead of file

### DIFF
--- a/apps/dokploy/__test__/deploy/file-mount-nested-directory.test.ts
+++ b/apps/dokploy/__test__/deploy/file-mount-nested-directory.test.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import {
 	createFile,
@@ -61,6 +68,27 @@ describe("getCreateFileCommand", () => {
 		expect(statSync(fullPath).isFile()).toBe(true);
 		expect(readFileSync(fullPath, "utf8")).toBe("acl all\n");
 	});
+
+	it("refuses a filePath that escapes the base files directory", () => {
+		expect(() =>
+			getCreateFileCommand(baseFilesPath, "../../etc/cron.d/evil", "x"),
+		).toThrow(/resolves outside/);
+	});
+
+	it("does not destroy a populated directory sitting at the target path", () => {
+		const filePath = "nginx/conf.d";
+		const fullPath = join(baseFilesPath, filePath);
+		const survivingFile = join(fullPath, "important-existing-file.conf");
+		mkdirSync(fullPath, { recursive: true });
+		writeFileSync(survivingFile, "do not delete me\n");
+
+		const command = getCreateFileCommand(baseFilesPath, filePath, "x");
+		expect(() => execFileSync("bash", ["-c", command])).toThrow();
+
+		// the pre-existing directory and its contents must survive the failed write
+		expect(statSync(fullPath).isDirectory()).toBe(true);
+		expect(readFileSync(survivingFile, "utf8")).toBe("do not delete me\n");
+	});
 });
 
 describe("createFile", () => {
@@ -74,5 +102,25 @@ describe("createFile", () => {
 
 		expect(statSync(fullPath).isFile()).toBe(true);
 		expect(readFileSync(fullPath, "utf8")).toBe("app:\n  port: 8194\n");
+	});
+
+	it("refuses a filePath that escapes the base files directory", async () => {
+		await expect(
+			createFile(baseFilesPath, "../../etc/cron.d/evil", "x"),
+		).rejects.toThrow(/resolves outside/);
+	});
+
+	it("does not destroy a populated directory sitting at the target path", async () => {
+		const filePath = "nginx/conf.d";
+		const fullPath = join(baseFilesPath, filePath);
+		const survivingFile = join(fullPath, "important-existing-file.conf");
+		mkdirSync(fullPath, { recursive: true });
+		writeFileSync(survivingFile, "do not delete me\n");
+
+		await expect(createFile(baseFilesPath, filePath, "x")).rejects.toThrow();
+
+		// the pre-existing directory and its contents must survive the failed write
+		expect(statSync(fullPath).isDirectory()).toBe(true);
+		expect(readFileSync(survivingFile, "utf8")).toBe("do not delete me\n");
 	});
 });

--- a/apps/dokploy/__test__/deploy/file-mount-nested-directory.test.ts
+++ b/apps/dokploy/__test__/deploy/file-mount-nested-directory.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import {
+	createFile,
+	getCreateFileCommand,
+} from "@dokploy/server/utils/docker/utils";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Regression test for: a File Mount whose File Path contains a "/" (e.g.
+// "nginx/nginx.conf.template") was created as an empty directory instead of
+// a file. This reliably happens when something else (typically Docker's own
+// bind-mount fallback, when the compose service's volumes: declaration
+// references the path before any File Mount content exists for it) already
+// created an empty directory at that exact path — the old
+// mkdir-parent-then-redirect commands never checked for, or cleared, a
+// pre-existing directory at the *target* path itself, so the shell
+// redirection / fs.writeFileSync failed (silently, for updateFileMount).
+const appName = `file-mount-nested-directory-${process.pid}`;
+const baseFilesPath = join(
+	process.cwd(),
+	".docker",
+	"compose",
+	appName,
+	"files",
+);
+
+afterEach(() =>
+	rmSync(join(process.cwd(), ".docker", "compose", appName), {
+		force: true,
+		recursive: true,
+	}),
+);
+
+describe("getCreateFileCommand", () => {
+	it("writes a nested file even when a stale empty directory already occupies the path", () => {
+		const filePath = "nginx/nginx.conf.template";
+		const fullPath = join(baseFilesPath, filePath);
+		mkdirSync(fullPath, { recursive: true }); // simulate Docker's bind-mount fallback
+		expect(statSync(fullPath).isDirectory()).toBe(true);
+
+		const command = getCreateFileCommand(
+			baseFilesPath,
+			filePath,
+			"user nginx;\n",
+		);
+		execFileSync("bash", ["-c", command]);
+
+		expect(statSync(fullPath).isFile()).toBe(true);
+		expect(readFileSync(fullPath, "utf8")).toBe("user nginx;\n");
+	});
+
+	it("still creates a nested file normally when nothing occupies the path yet", () => {
+		const filePath = "ssrf_proxy/squid.conf.template";
+		const fullPath = join(baseFilesPath, filePath);
+		expect(existsSync(fullPath)).toBe(false);
+
+		const command = getCreateFileCommand(baseFilesPath, filePath, "acl all\n");
+		execFileSync("bash", ["-c", command]);
+
+		expect(statSync(fullPath).isFile()).toBe(true);
+		expect(readFileSync(fullPath, "utf8")).toBe("acl all\n");
+	});
+});
+
+describe("createFile", () => {
+	it("writes a nested file even when a stale empty directory already occupies the path", async () => {
+		const filePath = "sandbox/conf/config.yaml";
+		const fullPath = join(baseFilesPath, filePath);
+		mkdirSync(fullPath, { recursive: true }); // simulate Docker's bind-mount fallback
+		expect(statSync(fullPath).isDirectory()).toBe(true);
+
+		await createFile(baseFilesPath, filePath, "app:\n  port: 8194\n");
+
+		expect(statSync(fullPath).isFile()).toBe(true);
+		expect(readFileSync(fullPath, "utf8")).toBe("app:\n  port: 8194\n");
+	});
+});

--- a/packages/server/src/services/mount.ts
+++ b/packages/server/src/services/mount.ts
@@ -8,7 +8,6 @@ import {
 } from "@dokploy/server/db/schema";
 import {
 	createFile,
-	encodeBase64,
 	getCreateFileCommand,
 } from "@dokploy/server/utils/docker/utils";
 import { removeFileOrDirectory } from "@dokploy/server/utils/filesystem/directory";
@@ -261,19 +260,25 @@ export const updateFileMount = async (mountId: string) => {
 	const mount = await findMountById(mountId);
 	if (!mount || !mount.filePath) return;
 	const basePath = await getBaseFilesPath(mountId);
-	const fullPath = path.join(basePath, mount.filePath);
 
 	try {
 		const serverId = await getServerId(mount);
-		const encodedContent = encodeBase64(mount.content || "");
-		const command = `echo "${encodedContent}" | base64 -d > ${quote([fullPath])}`;
+		// Reuses the same mkdir-p + stale-directory-clearing logic as createFileMount,
+		// so editing a mount whose path was previously created as an empty directory
+		// (nested File Path, or a container's bind-mount fallback beating us to it)
+		// self-heals instead of silently failing.
+		const command = getCreateFileCommand(
+			basePath,
+			mount.filePath,
+			mount.content || "",
+		);
 		if (serverId) {
 			await execAsyncRemote(serverId, command);
 		} else {
 			await execAsync(command);
 		}
-	} catch {
-		console.log("Error updating file mount");
+	} catch (error) {
+		console.log("Error updating file mount", error);
 	}
 };
 

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -777,6 +777,14 @@ export const createFile = async (
 
 		const directory = path.dirname(fullPath);
 		fs.mkdirSync(directory, { recursive: true });
+
+		// A previous deploy may have left an empty directory at fullPath (e.g. Docker's
+		// bind-mount fallback creating one when the source didn't exist yet). Clear it
+		// first so fs.writeFileSync doesn't throw EISDIR.
+		if (fs.existsSync(fullPath) && fs.statSync(fullPath).isDirectory()) {
+			fs.rmSync(fullPath, { recursive: true, force: true });
+		}
+
 		fs.writeFileSync(fullPath, content || "");
 	} catch (error) {
 		throw error;
@@ -799,6 +807,7 @@ export const getCreateFileCommand = (
 	const encodedContent = encodeBase64(content);
 	return `
 		mkdir -p ${quote([directory])};
+		if [ -d ${quote([fullPath])} ]; then rm -rf ${quote([fullPath])}; fi;
 		echo "${encodedContent}" | base64 -d > ${quote([fullPath])};
 	`;
 };

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -763,6 +763,24 @@ export const generateFileMounts = (
 		});
 };
 
+// File Mounts are supposed to be sandboxed to the app's own "files" directory.
+// filePath comes straight from user input (the mount schema has no format
+// constraint on it), so without this check a value like "../../etc/cron.d/x"
+// would let mkdir/write/rm below operate anywhere the Dokploy process can
+// reach on the host.
+const assertPathIsContained = (outputPath: string, fullPath: string) => {
+	const resolvedBase = path.resolve(outputPath);
+	const resolvedFull = path.resolve(fullPath);
+	if (
+		resolvedFull !== resolvedBase &&
+		!resolvedFull.startsWith(`${resolvedBase}${path.sep}`)
+	) {
+		throw new Error(
+			`Invalid file mount path: "${fullPath}" resolves outside of "${outputPath}"`,
+		);
+	}
+};
+
 export const createFile = async (
 	outputPath: string,
 	filePath: string,
@@ -770,6 +788,7 @@ export const createFile = async (
 ) => {
 	try {
 		const fullPath = path.join(outputPath, filePath);
+		assertPathIsContained(outputPath, fullPath);
 		if (fullPath.endsWith(path.sep) || filePath.endsWith("/")) {
 			fs.mkdirSync(fullPath, { recursive: true });
 			return;
@@ -779,10 +798,15 @@ export const createFile = async (
 		fs.mkdirSync(directory, { recursive: true });
 
 		// A previous deploy may have left an empty directory at fullPath (e.g. Docker's
-		// bind-mount fallback creating one when the source didn't exist yet). Clear it
-		// first so fs.writeFileSync doesn't throw EISDIR.
-		if (fs.existsSync(fullPath) && fs.statSync(fullPath).isDirectory()) {
-			fs.rmSync(fullPath, { recursive: true, force: true });
+		// bind-mount fallback creating one when the source didn't exist yet). Only clear
+		// it if it's actually empty — a directory that already holds data is left alone,
+		// and fs.writeFileSync below will fail loudly (EISDIR) rather than destroy it.
+		if (
+			fs.existsSync(fullPath) &&
+			fs.statSync(fullPath).isDirectory() &&
+			fs.readdirSync(fullPath).length === 0
+		) {
+			fs.rmdirSync(fullPath);
 		}
 
 		fs.writeFileSync(fullPath, content || "");
@@ -799,6 +823,7 @@ export const getCreateFileCommand = (
 	content: string,
 ) => {
 	const fullPath = path.join(outputPath, filePath);
+	assertPathIsContained(outputPath, fullPath);
 	if (fullPath.endsWith(path.sep) || filePath.endsWith("/")) {
 		return `mkdir -p ${quote([fullPath])};`;
 	}
@@ -807,7 +832,7 @@ export const getCreateFileCommand = (
 	const encodedContent = encodeBase64(content);
 	return `
 		mkdir -p ${quote([directory])};
-		if [ -d ${quote([fullPath])} ]; then rm -rf ${quote([fullPath])}; fi;
+		rmdir ${quote([fullPath])} 2>/dev/null || true;
 		echo "${encodedContent}" | base64 -d > ${quote([fullPath])};
 	`;
 };


### PR DESCRIPTION
## Summary

Fixes #5152 — a File Mount whose **File Path** contains a `/` (e.g. `nginx/nginx.conf.template`) gets created as an **empty directory** instead of a file, both on Create and on Edit → Save, with the error silently swallowed.

## Root cause

- `updateFileMount` (`packages/server/src/services/mount.ts`) never ran `mkdir -p` on the parent directory, and never checked whether `fullPath` already existed as a directory before running `echo ... > fullPath`. If it did (typically because Docker's own bind-mount fallback created an empty directory there first, when the compose service's `volumes:` declaration referenced the path before any File Mount content existed for it), the shell redirection failed with `Is a directory` — and the bare `catch { console.log(...) }` swallowed it, so the UI reported success regardless.
- `createFileMount` → `getCreateFileCommand` (`packages/server/src/utils/docker/utils.ts`) already did `mkdir -p` the *parent* directory, but had the same blind spot for `fullPath` itself.

## Fix

- `getCreateFileCommand` and `createFile` now clear a pre-existing directory at `fullPath` before writing (`rm -rf`/`fs.rmSync` guarded by an existence+type check), so both the remote (shell) and local (fs) code paths self-heal instead of failing silently.
- `updateFileMount` now reuses `getCreateFileCommand` instead of duplicating a broken inline command — both create and update share the same fixed logic, and the duplicate `encodeBase64` construction is gone.
- `updateFileMount`'s catch block now logs the actual error instead of swallowing it, to make any future failure here visible in logs instead of silent.

## Test plan

Added `apps/dokploy/__test__/deploy/file-mount-nested-directory.test.ts`, following the existing pattern in `apps/dokploy/__test__/deploy/env-file-literals-dockerfile.test.ts` (build the shell command, execute it with `execFileSync`, assert on the resulting file).

- [x] Verified the new tests **fail** against the pre-fix code with the exact errors hit in production (`Is a directory` from the shell command, `EISDIR` from `createFile`) — confirmed by temporarily stashing the fix and re-running.
- [x] Verified the new tests **pass** against the fixed code.
- [x] `pnpm --filter=dokploy exec vitest run --config __test__/vitest.config.ts __test__/deploy` — same pre-existing failures in `application.real.test.ts` (network/Docker-build dependent "REAL Execution Tests") occur identically with or without this change; nothing in the affected file's test suite regressed.
- [x] `pnpm exec biome check` on the three changed files — clean (pre-existing, unrelated warnings elsewhere in `utils.ts` left untouched, out of scope for this fix).
- [x] `tsc --noEmit` on `packages/server` — clean.

Ran on a local clone (not a full server + UI click-through, since this fix is at the file-system/shell-command layer and is covered by the regression test above) — happy to also verify end-to-end against a running Dokploy instance if useful.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes nested file mounts that were mistakenly created as directories and incorporates safeguards requested in the previous review.
- Reuses the shared file-creation command when updating mounts.
- Rejects lexical paths outside the application’s files directory.
- Removes only empty directories occupying a file target, preserving populated directories.
- Adds regression tests for nested mounts, traversal attempts, and populated-directory preservation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["fix: address review — path containment +..."](https://github.com/dokploy/dokploy/commit/71212090278d7808e54506d094acfb31f5f7d691) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55541165)</sub>

<!-- /greptile_comment -->