### PR TITLE
feat(ui): make topbar a sticky sidebar-styled container

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -75,7 +75,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
-import { Separator } from "@/components/ui/separator";
 import {
 	SIDEBAR_COOKIE_NAME,
 	Sidebar,
@@ -988,7 +987,7 @@ export default function Page({ children }: Props) {
 			}
 		>
 			<MobileCloser />
-			<Sidebar collapsible="icon" variant="floating">
+			<Sidebar collapsible="icon" variant="floating" className="z-30">
 				<SidebarHeader>
 					{/* <SidebarMenuButton
 						className="group-data-[collapsible=icon]:p-0!"
@@ -1223,13 +1222,12 @@ export default function Page({ children }: Props) {
 				</SidebarFooter>
 				<SidebarRail />
 			</Sidebar>
-			<SidebarInset>
+			<SidebarInset className="h-svh md:-ml-2">
 				{!includesProjects && (
-					<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-						<div className="flex items-center justify-between w-full px-4">
+					<header className="sticky top-0 z-20 mb-px flex shrink-0 items-center bg-background px-4 py-2 md:pl-2 md:pr-2">
+						<div className="flex h-12 w-full items-center justify-between rounded-lg bg-sidebar px-4 shadow-sm ring-1 ring-sidebar-border">
 							<div className="flex items-center gap-2">
 								<SidebarTrigger className="-ml-1" />
-								<Separator orientation="vertical" className="mr-2 h-4" />
 								<Breadcrumb>
 									<BreadcrumbList>
 										<BreadcrumbItem className="block">
@@ -1250,7 +1248,9 @@ export default function Page({ children }: Props) {
 					</header>
 				)}
 
-				<div className="flex flex-col w-full p-4 pt-0">{children}</div>
+				<div className="flex flex-col w-full p-4 pt-0 md:pl-2 md:pr-2">
+					{children}
+				</div>
 			</SidebarInset>
 		</SidebarProvider>
 	);

--- a/apps/dokploy/components/shared/advance-breadcrumb.tsx
+++ b/apps/dokploy/components/shared/advance-breadcrumb.tsx
@@ -328,10 +328,9 @@ export const AdvanceBreadcrumb = () => {
 	// If we're just on the projects page, show simple breadcrumb
 	if (!projectId) {
 		return (
-			<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-				<div className="flex items-center gap-2">
+			<header className="sticky top-0 z-20 -mx-4 mb-px flex shrink-0 items-center bg-background px-4 py-2 md:-mx-2 md:px-2">
+				<div className="flex h-12 w-full items-center gap-2 rounded-lg bg-sidebar px-4 shadow-sm ring-1 ring-sidebar-border">
 					<SidebarTrigger className="-ml-1" />
-					<Separator orientation="vertical" className="mr-2 h-4" />
 					<div className="flex items-center gap-2">
 						<FolderInput className="size-4 text-muted-foreground" />
 						<span className="font-medium">Projects</span>
@@ -342,10 +341,9 @@ export const AdvanceBreadcrumb = () => {
 	}
 
 	return (
-		<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-			<div className="flex items-center gap-2">
+		<header className="sticky top-0 z-20 -mx-4 mb-px flex shrink-0 items-center bg-background px-4 py-2 md:-mx-2 md:px-2">
+			<div className="flex h-12 w-full items-center gap-2 rounded-lg bg-sidebar px-4 shadow-sm ring-1 ring-sidebar-border">
 				<SidebarTrigger className="-ml-1" />
-				<Separator orientation="vertical" className="mr-2 h-4" />
 
 				<div className="flex items-center">
 					{/* Project Selector */}

--- a/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
+++ b/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
@@ -15,7 +15,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { TimeBadge } from "@/components/ui/time-badge";
 import { api } from "@/utils/api";
@@ -37,11 +36,10 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 
 	return (
-		<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-			<div className="flex items-center justify-between w-full px-4">
+		<header className="sticky top-0 z-20 -mx-4 mb-px flex shrink-0 items-center bg-background px-4 py-2 md:-mx-2 md:px-2">
+			<div className="flex h-12 w-full items-center justify-between rounded-lg bg-sidebar px-4 shadow-sm ring-1 ring-sidebar-border">
 				<div className="flex items-center gap-2">
 					<SidebarTrigger className="-ml-1" />
-					<Separator orientation="vertical" className="mr-2 h-4" />
 					<Breadcrumb>
 						<BreadcrumbList>
 							{list.map((item, index) => (


### PR DESCRIPTION
The topbar had no container of its own, so it read as loose controls sitting next to the sidebar card. This gives it the same floating card as the sidebar and keeps it in place while the page scrolls.

## What changed

- The topbar now sits in a card with the same background, radius, ring and shadow as the floating sidebar.
- Removed the vertical separator next to the sidebar toggle.
- The topbar stays put on scroll and the content passes under it. The header background reaches the edges of the inset, so nothing shows up beside the bar while scrolling.
- The gap between the sidebar and the main container is now 8px, matching the gap between the topbar and the content below it. It was 24px before.
- `SidebarInset` gets `h-svh`. It only had `min-h-svh` with `overflow-auto`, so it grew instead of scrolling, the page scrolled instead, and `position: sticky` had nothing to stick to.
- The topbar moves to `z-20` and the sidebar to `z-30`. Service cards place their status dot and selection button at `z-10`, and those were painting over the bar.

Three files are touched: `layouts/side.tsx`, `shared/advance-breadcrumb.tsx` and `shared/breadcrumb-sidebar.tsx`. All four headers get the same treatment, so the projects list, the environment view and the service pages behave the same way.

No behaviour outside the layout shell changes. Tooltips, popovers and dialogs are portaled at `z-50` or higher and still render above the bar.

## Screenshots

Before / after: <!-- add images -->
Scrolling with the topbar pinned: <!-- add a short clip -->

## Testing

Tested locally with `pnpm run dokploy:dev`:

- [x] Projects list, at rest and scrolled
- [x] Project and environment view
- [x] Service pages (application, compose, database)
- [x] Sidebar expanded and collapsed to icons
- [x] Light and dark theme
- [x] Mobile width, where the sidebar is a sheet

<img width="1800" height="1014" alt="Screenshot" src="https://github.com/user-attachments/assets/33adb3e7-5b47-4034-b36f-45c05d50c2ca" />


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restyles the dashboard topbar as a floating card and makes it sticky within a viewport-height scrolling inset.
- Aligns topbar styling and spacing with the floating sidebar.
- Makes `SidebarInset` the viewport-height scroll container.
- Adjusts sidebar and topbar stacking levels to prevent service-card controls from painting above the header.
- Applies the same sticky header treatment across project, environment, service, and non-project dashboard views.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed headers remain within the intended `SidebarInset` scroll container, route gating prevents duplicate topbars, responsive margin and padding adjustments align, and mobile sheets and portaled overlays remain above the updated sidebar and header stacking levels.

<sub>Reviews (1): Last reviewed commit: ["feat(ui): make topbar a sticky sidebar-s..."](https://github.com/dokploy/dokploy/commit/77c16a2fbcbc5e11d5b1531e41d02777e92e1a34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55586061)</sub>

<!-- /greptile_comment -->