### PR TITLE
fix(compose): preserve env interpolation references

### DIFF
--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getCreateEnvFileCommand } from "@dokploy/server/utils/builders/compose";
+import { prepareEnvironmentVariablesForFile } from "@dokploy/server/utils/docker/utils";
 import { afterEach, describe, expect, it } from "vitest";
 
 // Regression coverage for https://github.com/Dokploy/dokploy/issues/4694 —
@@ -23,6 +24,9 @@ afterEach(() => {
 });
 
 const cases: Record<string, string> = {
+	APP_URL: "https://example.com",
+	ASSET_URL: "https://example.com",
+	UNBRACED_URL: "https://example.com",
 	PASSWORD: "pa$$word",
 	SPECIAL: '!"#$%&/()=?',
 	NESTED_JSON: '{"nested":{"a":1}}',
@@ -37,6 +41,9 @@ const cases: Record<string, string> = {
 // How each value must be typed in the UI so the (unchanged) dotenv input
 // parser resolves it to the raw string in `cases` above.
 const inputEncoding: Record<string, string> = {
+	APP_URL: "https://example.com",
+	ASSET_URL: "${APP_URL}",
+	UNBRACED_URL: "$APP_URL",
 	PASSWORD: "pa$$word",
 	SPECIAL: `'!"#$%&/()=?'`,
 	NESTED_JSON: '{"nested":{"a":1}}',
@@ -47,6 +54,21 @@ const inputEncoding: Record<string, string> = {
 	UNICODE: "héllo wörld 日本語 🚀",
 	MULTILINE_PEM: '"-----BEGIN KEY-----\nabc123\n-----END KEY-----"',
 };
+
+describe("prepareEnvironmentVariablesForFile", () => {
+	it("preserves Docker Compose interpolation references", () => {
+		const resolved = prepareEnvironmentVariablesForFile(
+			"APP_URL=https://example.com\nASSET_URL=${APP_URL}\nUNBRACED_URL=$APP_URL\nPASSWORD=pa$$word",
+		);
+
+		expect(resolved).toEqual([
+			'APP_URL="https://example.com"',
+			'ASSET_URL="${APP_URL}"',
+			'UNBRACED_URL="$APP_URL"',
+			'PASSWORD="pa\\$\\$word"',
+		]);
+	});
+});
 
 describe("getCreateEnvFileCommand", () => {
 	it("writes special environment values that Docker Compose reads back literally", () => {

--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -28,6 +28,11 @@ const cases: Record<string, string> = {
 	ASSET_URL: "https://example.com",
 	UNBRACED_URL: "https://example.com",
 	PASSWORD: "pa$$word",
+	MISSING: "expanded",
+	SERVICE_SOURCE: "serviceexpanded",
+	FROM_SERVICE_LITERAL: "service$MISSING",
+	FROM_PROJECT_LITERAL: "project$MISSING",
+	FROM_ENVIRONMENT_LITERAL: "environment${MISSING}",
 	SPECIAL: '!"#$%&/()=?',
 	NESTED_JSON: '{"nested":{"a":1}}',
 	MAIL_PASSWORD: "abc#de",
@@ -45,6 +50,11 @@ const inputEncoding: Record<string, string> = {
 	ASSET_URL: "${APP_URL}",
 	UNBRACED_URL: "$APP_URL",
 	PASSWORD: "pa$$word",
+	MISSING: "expanded",
+	SERVICE_SOURCE: "service$MISSING",
+	FROM_SERVICE_LITERAL: "${{SERVICE_SOURCE}}",
+	FROM_PROJECT_LITERAL: "${{project.PROJECT_LITERAL}}",
+	FROM_ENVIRONMENT_LITERAL: "${{environment.ENVIRONMENT_LITERAL}}",
 	SPECIAL: `'!"#$%&/()=?'`,
 	NESTED_JSON: '{"nested":{"a":1}}',
 	MAIL_PASSWORD: `"abc#de"`,
@@ -68,6 +78,30 @@ describe("prepareEnvironmentVariablesForFile", () => {
 			'PASSWORD="pa\\$\\$word"',
 		]);
 	});
+
+	it("escapes Compose-looking values introduced by Dokploy placeholders", () => {
+		const resolved = prepareEnvironmentVariablesForFile(
+			[
+				"FROM_PROJECT=${{project.PROJECT_SECRET}}",
+				"FROM_ENVIRONMENT=${{environment.ENVIRONMENT_SECRET}}",
+				"FROM_SERVICE=${{SERVICE_SECRET}}",
+				"DIRECT=$MISSING",
+				"DIRECT_BRACED=${MISSING}",
+				"SERVICE_SECRET=service$MISSING",
+			].join("\n"),
+			"PROJECT_SECRET=project$MISSING",
+			"ENVIRONMENT_SECRET=environment${MISSING}",
+		);
+
+		expect(resolved).toEqual([
+			'FROM_PROJECT="project\\$MISSING"',
+			'FROM_ENVIRONMENT="environment\\${MISSING}"',
+			'FROM_SERVICE="service\\$MISSING"',
+			'DIRECT="$MISSING"',
+			'DIRECT_BRACED="${MISSING}"',
+			'SERVICE_SECRET="service$MISSING"',
+		]);
+	});
 });
 
 describe("getCreateEnvFileCommand", () => {
@@ -85,7 +119,10 @@ describe("getCreateEnvFileCommand", () => {
 			randomize: false,
 			suffix: "",
 			serverId: null,
-			environment: { project: { env: "" }, env: "" },
+			environment: {
+				project: { env: "PROJECT_LITERAL=project$MISSING" },
+				env: "ENVIRONMENT_LITERAL=environment${MISSING}",
+			},
 		} as Parameters<typeof getCreateEnvFileCommand>[0]);
 
 		execFileSync("bash", ["-c", command]);

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -548,7 +548,16 @@ export const prepareEnvironmentVariablesForFile = (
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')
-			.replace(/\$/g, "\\$");
+			.replace(/\$/g, (match, offset: number, source: string) => {
+				const suffix = source.slice(offset + 1);
+				const isVariableReference =
+					source[offset - 1] !== "$" &&
+					(/^\{[A-Za-z_][A-Za-z0-9_]*(?:(?::[-+?]|[-+?])[^}]*)?\}/.test(
+						suffix,
+					) ||
+						/^[A-Za-z_][A-Za-z0-9_]*/.test(suffix));
+				return isVariableReference ? match : `\\${match}`;
+			});
 		return `${key}="${escapedValue}"`;
 	});
 };

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -456,10 +456,11 @@ export const removeService = async (
 	}
 };
 
-export const prepareEnvironmentVariables = (
+const prepareEnvironmentVariablesInternal = (
 	serviceEnv: string | null,
 	projectEnv?: string | null,
 	environmentEnv?: string | null,
+	composeReferenceMarker?: string,
 ) => {
 	for (const source of [serviceEnv, projectEnv, environmentEnv]) {
 		if (source?.includes("${{vault.")) {
@@ -471,6 +472,10 @@ export const prepareEnvironmentVariables = (
 	const projectVars = parse(projectEnv ?? "");
 	const environmentVars = parse(environmentEnv ?? "");
 	const serviceVars = parse(serviceEnv ?? "");
+	const resolveReplacement = (value: string) =>
+		composeReferenceMarker
+			? value.replaceAll(composeReferenceMarker, "$")
+			: value;
 
 	const resolvedVars = Object.entries(serviceVars).map(([key, value]) => {
 		let resolvedValue = value;
@@ -481,7 +486,7 @@ export const prepareEnvironmentVariables = (
 				/\$\{\{project\.(.*?)\}\}/g,
 				(_, ref) => {
 					if (projectVars[ref] !== undefined) {
-						return projectVars[ref];
+						return resolveReplacement(projectVars[ref] as string);
 					}
 					throw new Error(
 						`Invalid project environment variable: project.${ref}`,
@@ -496,7 +501,7 @@ export const prepareEnvironmentVariables = (
 				/\$\{\{environment\.(.*?)\}\}/g,
 				(_, ref) => {
 					if (environmentVars[ref] !== undefined) {
-						return environmentVars[ref];
+						return resolveReplacement(environmentVars[ref] as string);
 					}
 					throw new Error(`Invalid environment variable: environment.${ref}`);
 				},
@@ -506,7 +511,7 @@ export const prepareEnvironmentVariables = (
 		// Replace self-references (service variables)
 		resolvedValue = resolvedValue.replace(/\$\{\{(.*?)\}\}/g, (_, ref) => {
 			if (serviceVars[ref] !== undefined) {
-				return serviceVars[ref];
+				return resolveReplacement(serviceVars[ref] as string);
 			}
 			throw new Error(`Invalid service environment variable: ${ref}`);
 		});
@@ -516,6 +521,13 @@ export const prepareEnvironmentVariables = (
 
 	return resolvedVars;
 };
+
+export const prepareEnvironmentVariables = (
+	serviceEnv: string | null,
+	projectEnv?: string | null,
+	environmentEnv?: string | null,
+) =>
+	prepareEnvironmentVariablesInternal(serviceEnv, projectEnv, environmentEnv);
 
 export const prepareEnvironmentVariablesForShell = (
 	serviceEnv: string | null,
@@ -537,10 +549,31 @@ export const prepareEnvironmentVariablesForFile = (
 	projectEnv?: string | null,
 	environmentEnv?: string | null,
 ): string[] => {
-	const envVars = prepareEnvironmentVariables(
-		serviceEnv,
+	let composeReferenceMarker = "__DOKPLOY_COMPOSE_REFERENCE__";
+	while (
+		[serviceEnv, projectEnv, environmentEnv].some((source) =>
+			source?.includes(composeReferenceMarker),
+		)
+	) {
+		composeReferenceMarker += "_";
+	}
+
+	const protectedServiceEnv = (serviceEnv ?? "").replace(
+		/\$/g,
+		(match, offset: number, source: string) => {
+			const suffix = source.slice(offset + 1);
+			const isVariableReference =
+				source[offset - 1] !== "$" &&
+				(/^\{[A-Za-z_][A-Za-z0-9_]*(?:(?::[-+?]|[-+?])[^}]*)?\}/.test(suffix) ||
+					/^[A-Za-z_][A-Za-z0-9_]*/.test(suffix));
+			return isVariableReference ? composeReferenceMarker : match;
+		},
+	);
+	const envVars = prepareEnvironmentVariablesInternal(
+		protectedServiceEnv,
 		projectEnv,
 		environmentEnv,
+		composeReferenceMarker,
 	);
 
 	return envVars.map((pair) => {
@@ -548,16 +581,8 @@ export const prepareEnvironmentVariablesForFile = (
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')
-			.replace(/\$/g, (match, offset: number, source: string) => {
-				const suffix = source.slice(offset + 1);
-				const isVariableReference =
-					source[offset - 1] !== "$" &&
-					(/^\{[A-Za-z_][A-Za-z0-9_]*(?:(?::[-+?]|[-+?])[^}]*)?\}/.test(
-						suffix,
-					) ||
-						/^[A-Za-z_][A-Za-z0-9_]*/.test(suffix));
-				return isVariableReference ? match : `\\${match}`;
-			});
+			.replace(/\$/g, "\\$")
+			.replaceAll(composeReferenceMarker, "$");
 		return `${key}="${escapedValue}"`;
 	});
 };


### PR DESCRIPTION
## What is this PR about?

Preserve valid Docker Compose `${VAR}` and `$VAR` references when writing deployment environment files, while continuing to escape literal dollar signs such as `pa$$word`. Regression coverage checks both forms through the existing environment-file path.

## Checklist

- [x] Created a dedicated branch based on `canary`.
- [x] Read the pull request guidance in `CONTRIBUTING.md`.
- [x] Tested the change locally.

## Issues related

Closes #5151

## Validation

- Focused Vitest regression
- Docker Compose config interpolation check
- Dokploy and server TypeScript checks
- Biome and `git diff --check`




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves direct Docker Compose `$VAR` and `${VAR}` interpolation references while continuing to escape literal dollar signs and values introduced through Dokploy placeholders.
- Adds reference-aware environment-file serialization.
- Keeps resolved project, environment, and service placeholder values literal.
- Adds focused unit and Compose integration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported resolved-value interpolation issue is addressed by restoring protected markers only for direct service-environment references while escaping dollar signs introduced through placeholder resolution.

<sub>Reviews (2): Last reviewed commit: ["fix(compose): escape resolved placeholde..."](https://github.com/dokploy/dokploy/commit/49306e379ef5de2ee14dcff6fa0fadd91dc6ec5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55784190)</sub>

**Context used:**

- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)

<!-- /greptile_comment -->