### PR TITLE
fix(traefik): skip empty service reconnect

### DIFF
--- a/apps/dokploy/__test__/traefik/reconnect-services.test.ts
+++ b/apps/dokploy/__test__/traefik/reconnect-services.test.ts
@@ -1,0 +1,71 @@
+import { reconnectServicesToTraefik } from "@dokploy/server/services/settings";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	findMany: vi.fn(),
+	execAsync: vi.fn(),
+	execAsyncRemote: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			compose: {
+				findMany: mocks.findMany,
+			},
+		},
+	},
+}));
+
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsync: mocks.execAsync,
+	execAsyncRemote: mocks.execAsyncRemote,
+}));
+
+describe("reconnectServicesToTraefik", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.findMany.mockResolvedValue([]);
+	});
+
+	it("does not execute an empty local command when no isolated deployments exist", async () => {
+		await reconnectServicesToTraefik();
+
+		expect(mocks.execAsync).not.toHaveBeenCalled();
+	});
+
+	it("does not execute an empty remote command when no isolated deployments exist", async () => {
+		await reconnectServicesToTraefik("server-id");
+
+		expect(mocks.execAsyncRemote).not.toHaveBeenCalled();
+	});
+
+	it("reconnects isolated deployments to the local Traefik network", async () => {
+		mocks.findMany.mockResolvedValue([
+			{ appName: "first-compose" },
+			{ appName: "second-compose" },
+		]);
+
+		await reconnectServicesToTraefik();
+
+		expect(mocks.execAsync).toHaveBeenCalledOnce();
+		expect(mocks.execAsync).toHaveBeenCalledWith(
+			'docker network connect first-compose $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1\n' +
+				'docker network connect second-compose $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1\n',
+		);
+		expect(mocks.execAsyncRemote).not.toHaveBeenCalled();
+	});
+
+	it("reconnects isolated deployments on a remote server", async () => {
+		mocks.findMany.mockResolvedValue([{ appName: "remote-compose" }]);
+
+		await reconnectServicesToTraefik("server-id");
+
+		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
+		expect(mocks.execAsyncRemote).toHaveBeenCalledWith(
+			"server-id",
+			'docker network connect remote-compose $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1\n',
+		);
+		expect(mocks.execAsync).not.toHaveBeenCalled();
+	});
+});

--- a/packages/server/src/services/settings.ts
+++ b/packages/server/src/services/settings.ts
@@ -485,7 +485,7 @@ export const reconnectServicesToTraefik = async (serverId?: string) => {
 		),
 	});
 
-	if (!composeResult) {
+	if (composeResult.length === 0) {
 		return;
 	}
 	let commands = "";


### PR DESCRIPTION
## Summary

- return early when Traefik reconnect finds no isolated Compose deployments
- avoid calling the local or remote command executor with an empty command
- add regression coverage for empty and non-empty local/remote reconnect paths

## Before

When the Compose query returned `[]`, the existing truthiness guard did not return. The function built an empty command and called:

```text
execAsync("")
execAsyncRemote("server-id", "")
```

In the Docker regression run, both empty-deployment tests failed and showed those exact calls. In production this surfaces as `The argument 'file' cannot be empty` while updating the Traefik environment.

## After

The function now returns when `composeResult.length === 0`. Existing local and remote reconnect commands are unchanged when isolated deployments exist.

```text
Test Files  1 passed (1)
Tests       4 passed (4)
```

## Validation

- Docker focused regression tests: 4 passed
- Docker unit/integration suite: 98 files, 884 tests passed (the external real-deployment test file was excluded)
- monorepo TypeScript check: passed
- Biome check on changed files: passed
- official Dockerfile `build` target on Node 24.4.0: passed

Fixes #5145


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents Traefik reconnection from invoking local or remote command executors when no isolated Compose deployments exist.

- Replaces an ineffective array truthiness check with an explicit empty-result check.
- Adds regression coverage for empty and populated local and remote reconnect paths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the empty-result failure corrected while preserving populated local and remote reconnect behavior.

The relational query returns an array, and the new explicit length check prevents empty command execution without changing command generation or executor selection when isolated deployments exist.

<sub>Reviews (1): Last reviewed commit: ["fix(traefik): skip empty service reconne..."](https://github.com/dokploy/dokploy/commit/ede46263965d55ef6453dba4e5e974d1ab2540a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55823090)</sub>

<!-- /greptile_comment -->