### PR TITLE
fix(compose): attach all services to dokploy-network

### DIFF
--- a/apps/dokploy/__test__/compose/network/service-networks.test.ts
+++ b/apps/dokploy/__test__/compose/network/service-networks.test.ts
@@ -1,10 +1,12 @@
 import type { Compose, ComposeSpecification } from "@dokploy/server";
 import {
+	addDomainToCompose,
 	applyServiceNetworks,
 	declareUsedNetworksInRoot,
 	resolveServiceNetworks,
 } from "@dokploy/server";
 import { db } from "@dokploy/server/db";
+import type { Domain } from "@dokploy/server/services/domain";
 import { beforeEach, expect, test, type vi } from "vitest";
 import { parse } from "yaml";
 
@@ -23,6 +25,77 @@ const baseCompose = {
 const withServiceNetworks = (
 	serviceNetworks: Compose["serviceNetworks"],
 ): Compose => ({ ...baseCompose, serviceNetworks });
+
+test("addDomainToCompose: attaches every compose service to dokploy-network by default", async () => {
+	const compose = {
+		...baseCompose,
+		appName: "test-app",
+		composeType: "docker-compose",
+		sourceType: "raw",
+		randomize: false,
+		suffix: "",
+		serviceNetworks: [],
+		composeFile: `
+services:
+  api:
+    image: example/app:latest
+  worker:
+    image: example/app:latest
+  cache:
+    image: redis:7
+`,
+	} as unknown as Compose;
+
+	const result = await addDomainToCompose(compose, [
+		{
+			host: "app.example.com",
+			serviceName: "api",
+			port: 3000,
+			https: false,
+			enabled: true,
+			uniqueConfigKey: 1,
+		} as Domain,
+	]);
+
+	for (const serviceName of ["api", "worker", "cache"]) {
+		expect(result?.services?.[serviceName]?.networks).toContain(
+			"dokploy-network",
+		);
+	}
+	expect(result?.networks).toHaveProperty("dokploy-network", {
+		external: true,
+	});
+});
+
+test("addDomainToCompose: preserves an explicit per-service detachment", async () => {
+	const compose = {
+		...baseCompose,
+		appName: "test-app",
+		composeType: "docker-compose",
+		sourceType: "raw",
+		randomize: false,
+		suffix: "",
+		serviceNetworks: [
+			{
+				serviceName: "worker",
+				networkIds: [],
+				detachDokployNetwork: true,
+			},
+		],
+		composeFile: `
+services:
+  api:
+    image: example/app:latest
+  worker:
+    image: example/app:latest
+`,
+	} as unknown as Compose;
+
+	const result = await addDomainToCompose(compose, []);
+
+	expect(result?.services?.api?.networks).toContain("dokploy-network");
+	expect(result?.services?.worker?.networks).not.toContain("dokploy-network");
+});
 
 test("applyServiceNetworks: no-op when serviceNetworks is empty", async () => {
 	const result = parse(`

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -321,7 +321,9 @@ export const addDomainToCompose = async (
 
 	if (!compose.isolatedDeployment) {
 		for (const service of Object.values(result.services ?? {})) {
-			service.networks = addDokployNetworkToService(service.networks);
+			if (!service.network_mode) {
+				service.networks = addDokployNetworkToService(service.networks);
+			}
 		}
 	}
 

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -317,12 +317,11 @@ export const addDomainToCompose = async (
 				);
 			}
 		}
+	}
 
-		if (!compose.isolatedDeployment) {
-			// Add the dokploy-network to the service
-			result.services[serviceName].networks = addDokployNetworkToService(
-				result.services[serviceName].networks,
-			);
+	if (!compose.isolatedDeployment) {
+		for (const service of Object.values(result.services ?? {})) {
+			service.networks = addDokployNetworkToService(service.networks);
 		}
 	}
 


### PR DESCRIPTION
## What is this PR about?

The PR ensures that every service in a non-isolated Docker Compose deployment joins `dokploy-network` .

Previously, the network attachment happened inside the enabled-domain loop and as a result, only services with a domain attached joined `dokploy-network`, while workers, databases, caches, and other supporting services are  disconnected.

The default attachment now runs across all Compose services. Isolated deployments remain unchanged, and an explicit per-service `Detach dokploy-network` configuration still takes precedence.

Regression tests cover both the multi-service default behavior and explicit service detachment.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A

## Screenshots (if applicable)

<img width="934" height="822" alt="image" src="https://github.com/user-attachments/assets/4aba6a3d-d1f3-4b9a-91b0-09c27cddc978" />





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes non-isolated Compose deployments attach every eligible service to the shared `dokploy-network`, rather than only services with enabled domains.
- Skips automatic attachment for services using `network_mode`.
- Preserves explicit per-service detachment.
- Adds regression coverage for multi-service attachment and detachment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported mutual-exclusion failure is fixed by skipping automatic network attachment for services that define `network_mode`, and no blocking failure remains.

<sub>Reviews (2): Last reviewed commit: ["Update packages/server/src/utils/docker/..."](https://github.com/dokploy/dokploy/commit/af4f087d4c4848f406ebe18635aadb0c17aa9a71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55868741)</sub>

**Context used:**

- Knowledge Base — [Docker networking and Traefik](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/docker-networking-and-traefik.md)

<!-- /greptile_comment -->