### PR TITLE
fix(notifications): add missing serverThreshold for gotify/ntfy and f…

### DIFF
--- a/apps/dokploy/__test__/notifications/persistence.test.ts
+++ b/apps/dokploy/__test__/notifications/persistence.test.ts
@@ -1,0 +1,175 @@
+import { vi, describe, expect, it, beforeEach } from "vitest";
+
+/**
+ * Regression test for PR #5176:
+ * Gotify and Ntfy create/update must persist `serverThreshold` to the
+ * notifications table.  Before the fix, `serverThreshold` was omitted from
+ * the Gotify and Ntfy insert/update calls, so enabling it in the UI had
+ * no effect.
+ *
+ * Strategy: mock the DB layer so we can spy on the values passed to
+ * `insert().values()` and `update().set()`, then assert that
+ * `serverThreshold: true` is present.
+ */
+
+// ── hoisted mocks (available inside vi.mock factories) ──────────────
+const { mockInsertValues, mockUpdateSet } = vi.hoisted(() => {
+	const insertValues = vi.fn(() => ({
+		returning: () => ({
+			then: (cb: any) =>
+				cb([
+					{
+						gotifyId: "test-gotify-id",
+						ntfyId: "test-ntfy-id",
+						notificationId: "test-notification-id",
+					},
+				]),
+		}),
+	}));
+
+	const updateSet = vi.fn(() => ({
+		where: () => ({
+			returning: () => ({
+				then: (cb: any) => cb([{}]),
+			}),
+			then: (cb: any) => cb([{}]),
+		}),
+	}));
+
+	return { mockInsertValues: insertValues, mockUpdateSet: updateSet };
+});
+
+// ── module mocks ────────────────────────────────────────────────────
+vi.mock("@dokploy/server/db", () => {
+	const mockDb: any = {
+		insert: vi.fn(() => ({ values: mockInsertValues })),
+		update: vi.fn(() => ({ set: mockUpdateSet })),
+		transaction: vi.fn(async (cb: any) => cb(mockDb)),
+		query: {
+			notifications: {
+				findFirst: vi.fn(() =>
+					Promise.resolve({
+						organizationId: "org-1",
+						notificationId: "test-notification-id",
+					}),
+				),
+			},
+		},
+	};
+	return { db: mockDb };
+});
+
+// ── imports (resolved after mocks are hoisted) ──────────────────────
+import {
+	createGotifyNotification,
+	updateGotifyNotification,
+	createNtfyNotification,
+	updateNtfyNotification,
+} from "@dokploy/server/services/notification";
+
+// ── tests ───────────────────────────────────────────────────────────
+describe("Notification Persistence Regression (PR #5176)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ── Gotify ────────────────────────────────────────────────────────
+	it("createGotifyNotification passes serverThreshold to the db", async () => {
+		await createGotifyNotification(
+			{
+				name: "Gotify Test",
+				serverUrl: "http://gotify.test",
+				appToken: "token",
+				priority: 5,
+				serverThreshold: true,
+				appDeploy: false,
+				appBuildError: false,
+				databaseBackup: false,
+				dokployBackup: false,
+				volumeBackup: false,
+				dokployRestart: false,
+				dockerCleanup: false,
+			},
+			"org-1",
+		);
+
+		// First insert = gotify row, second insert = notifications row
+		expect(mockInsertValues).toHaveBeenCalledTimes(2);
+		const notificationInsertArgs = mockInsertValues.mock.calls[1][0];
+		expect(notificationInsertArgs).toHaveProperty("serverThreshold", true);
+	});
+
+	it("updateGotifyNotification passes serverThreshold to the db", async () => {
+		await updateGotifyNotification({
+			notificationId: "test-notification-id",
+			gotifyId: "test-gotify-id",
+			name: "Gotify Test Update",
+			serverUrl: "http://gotify.test",
+			appToken: "token",
+			priority: 5,
+			serverThreshold: true,
+			appDeploy: false,
+			appBuildError: false,
+			databaseBackup: false,
+			dokployBackup: false,
+			volumeBackup: false,
+			dokployRestart: false,
+			dockerCleanup: false,
+			organizationId: "org-1",
+		});
+
+		// First set = notifications row, second set = gotify row
+		expect(mockUpdateSet).toHaveBeenCalledTimes(2);
+		const notificationUpdateArgs = mockUpdateSet.mock.calls[0][0];
+		expect(notificationUpdateArgs).toHaveProperty("serverThreshold", true);
+	});
+
+	// ── Ntfy ─────────────────────────────────────────────────────────
+	it("createNtfyNotification passes serverThreshold to the db", async () => {
+		await createNtfyNotification(
+			{
+				name: "Ntfy Test",
+				serverUrl: "http://ntfy.test",
+				topic: "test-topic",
+				priority: 5,
+				serverThreshold: true,
+				appDeploy: false,
+				appBuildError: false,
+				databaseBackup: false,
+				dokployBackup: false,
+				volumeBackup: false,
+				dokployRestart: false,
+				dockerCleanup: false,
+			},
+			"org-1",
+		);
+
+		expect(mockInsertValues).toHaveBeenCalledTimes(2);
+		const notificationInsertArgs = mockInsertValues.mock.calls[1][0];
+		expect(notificationInsertArgs).toHaveProperty("serverThreshold", true);
+	});
+
+	it("updateNtfyNotification passes serverThreshold to the db", async () => {
+		await updateNtfyNotification({
+			notificationId: "test-notification-id",
+			ntfyId: "test-ntfy-id",
+			name: "Ntfy Test Update",
+			serverUrl: "http://ntfy.test",
+			topic: "test-topic",
+			priority: 5,
+			serverThreshold: true,
+			appDeploy: false,
+			appBuildError: false,
+			databaseBackup: false,
+			dokployBackup: false,
+			volumeBackup: false,
+			dokployRestart: false,
+			dockerCleanup: false,
+			organizationId: "org-1",
+		});
+
+		expect(mockUpdateSet).toHaveBeenCalledTimes(2);
+		const notificationUpdateArgs = mockUpdateSet.mock.calls[0][0];
+		expect(notificationUpdateArgs).toHaveProperty("serverThreshold", true);
+	});
+});

--- a/apps/dokploy/__test__/notifications/server-threshold.test.ts
+++ b/apps/dokploy/__test__/notifications/server-threshold.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Regression test for PR #5176:
+ * Teams notification failures must not escape the try/catch inside
+ * `sendServerThresholdNotifications`.  Before the fix, Teams was called
+ * outside the try/catch, so a rejection would propagate up and abort the
+ * entire notification loop — preventing subsequent providers (Gotify,
+ * Slack, etc.) from being notified.
+ *
+ * Strategy: mock the DB to return one notification record with both
+ * Teams and Gotify configured, make Teams reject, and assert that:
+ *   1. The function resolves without throwing.
+ *   2. Gotify is still called despite the Teams failure.
+ */
+
+// ── hoisted mocks ───────────────────────────────────────────────────
+const { mockFindMany } = vi.hoisted(() => ({
+	mockFindMany: vi.fn(),
+}));
+
+// ── module mocks ────────────────────────────────────────────────────
+vi.mock("@dokploy/server/utils/notifications/utils", () => ({
+	sendDiscordNotification: vi.fn(),
+	sendEmailNotification: vi.fn(),
+	sendGotifyNotification: vi.fn(),
+	sendSlackNotification: vi.fn(),
+	sendTelegramNotification: vi.fn(),
+	sendResendNotification: vi.fn(),
+	sendNtfyNotification: vi.fn(),
+	sendMattermostNotification: vi.fn(),
+	sendCustomNotification: vi.fn(),
+	sendLarkNotification: vi.fn(),
+	sendPushoverNotification: vi.fn(),
+	sendTeamsNotification: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			notifications: {
+				findMany: mockFindMany,
+			},
+		},
+	},
+}));
+
+// Mock react-email render used by the email template in server-threshold.ts
+vi.mock("@react-email/components", async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		render: vi.fn(() => Promise.resolve("mocked-html")),
+	};
+});
+
+// ── imports (resolved after mocks are hoisted) ──────────────────────
+import { sendServerThresholdNotifications } from "@dokploy/server/utils/notifications/server-threshold";
+import {
+	sendGotifyNotification,
+	sendTeamsNotification,
+} from "@dokploy/server/utils/notifications/utils";
+
+// ── tests ───────────────────────────────────────────────────────────
+describe("sendServerThresholdNotifications (PR #5176)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("catches Teams notification errors and still calls Gotify", async () => {
+		// DB returns one notification config with both Teams and Gotify
+		mockFindMany.mockResolvedValueOnce([
+			{
+				teams: { webhookUrl: "https://teams.test" },
+				gotify: {
+					serverUrl: "https://gotify.test",
+					appToken: "token",
+				},
+				// All other providers are null/undefined
+				slack: null,
+				discord: null,
+				telegram: null,
+				email: null,
+				resend: null,
+				ntfy: null,
+				mattermost: null,
+				custom: null,
+				lark: null,
+				pushover: null,
+			},
+		]);
+
+		// Teams rejects — this must be caught inside the loop
+		vi.mocked(sendTeamsNotification).mockRejectedValueOnce(
+			new Error("Teams webhook failed"),
+		);
+		vi.mocked(sendGotifyNotification).mockResolvedValueOnce(undefined);
+
+		// The function must resolve cleanly despite the Teams failure
+		await expect(
+			sendServerThresholdNotifications("org-1", {
+				Type: "CPU",
+				Value: 95,
+				Threshold: 90,
+				Message: "High CPU",
+				Timestamp: new Date().toISOString(),
+				Token: "token",
+				ServerName: "TestServer",
+			}),
+		).resolves.not.toThrow();
+
+		// Both providers were attempted
+		expect(sendTeamsNotification).toHaveBeenCalledTimes(1);
+		expect(sendGotifyNotification).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -446,6 +446,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 					serverUrl: notification.gotify?.serverUrl,
 					name: notification.name,
 					dockerCleanup: notification.dockerCleanup,
+					serverThreshold: notification.serverThreshold,
 				});
 			} else if (notification.notificationType === "ntfy") {
 				form.reset({
@@ -683,6 +684,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 				decoration: data.decoration,
 				notificationId: notificationId || "",
 				gotifyId: notification?.gotifyId || "",
+				serverThreshold: serverThreshold,
 			});
 		} else if (data.type === "ntfy") {
 			promise = ntfyMutation.mutateAsync({
@@ -700,6 +702,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 				dockerCleanup: dockerCleanup,
 				notificationId: notificationId || "",
 				ntfyId: notification?.ntfyId || "",
+				serverThreshold: serverThreshold,
 			});
 		} else if (data.type === "mattermost") {
 			promise = mattermostMutation.mutateAsync({

--- a/packages/server/src/db/schema/notification.ts
+++ b/packages/server/src/db/schema/notification.ts
@@ -433,6 +433,7 @@ export const apiCreateGotify = notificationsSchema
 		name: true,
 		appDeploy: true,
 		dockerCleanup: true,
+		serverThreshold: true,
 	})
 	.extend({
 		serverUrl: z.string().min(1),
@@ -468,6 +469,7 @@ export const apiCreateNtfy = notificationsSchema
 		name: true,
 		appDeploy: true,
 		dockerCleanup: true,
+		serverThreshold: true,
 	})
 	.extend({
 		serverUrl: z.string().min(1),

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -563,6 +563,7 @@ export const createGotifyNotification = async (
 				dockerCleanup: input.dockerCleanup,
 				notificationType: "gotify",
 				organizationId: organizationId,
+				serverThreshold: input.serverThreshold,
 			})
 			.returning()
 			.then((value) => value[0]);
@@ -594,6 +595,7 @@ export const updateGotifyNotification = async (
 				dokployRestart: input.dokployRestart,
 				dockerCleanup: input.dockerCleanup,
 				organizationId: input.organizationId,
+				serverThreshold: input.serverThreshold,
 			})
 			.where(eq(notifications.notificationId, input.notificationId))
 			.returning()
@@ -657,6 +659,7 @@ export const createNtfyNotification = async (
 				dockerCleanup: input.dockerCleanup,
 				notificationType: "ntfy",
 				organizationId: organizationId,
+				serverThreshold: input.serverThreshold,
 			})
 			.returning()
 			.then((value) => value[0]);
@@ -688,6 +691,7 @@ export const updateNtfyNotification = async (
 				dokployRestart: input.dokployRestart,
 				dockerCleanup: input.dockerCleanup,
 				organizationId: input.organizationId,
+				serverThreshold: input.serverThreshold,
 			})
 			.where(eq(notifications.notificationId, input.notificationId))
 			.returning()

--- a/packages/server/src/utils/notifications/server-threshold.ts
+++ b/packages/server/src/utils/notifications/server-threshold.ts
@@ -369,22 +369,22 @@ export const sendServerThresholdNotifications = async (
 					`Server: ${payload.ServerName}\nType: ${payload.Type}\nCurrent: ${payload.Value.toFixed(2)}%\nThreshold: ${payload.Threshold.toFixed(2)}%\nMessage: ${payload.Message}\nTime: ${date.toLocaleString()}`,
 				);
 			}
+
+			if (teams) {
+				await sendTeamsNotification(teams, {
+					title: `⚠️ Server ${payload.Type} Alert`,
+					facts: [
+						{ name: "Server Name", value: payload.ServerName },
+						{ name: "Type", value: payload.Type },
+						{ name: "Current Value", value: `${payload.Value.toFixed(2)}%` },
+						{ name: "Threshold", value: `${payload.Threshold.toFixed(2)}%` },
+						{ name: "Time", value: date.toLocaleString() },
+						{ name: "Message", value: payload.Message },
+					],
+				});
+			}
 		} catch (error) {
 			console.log(error);
-		}
-
-		if (teams) {
-			await sendTeamsNotification(teams, {
-				title: `⚠️ Server ${payload.Type} Alert`,
-				facts: [
-					{ name: "Server Name", value: payload.ServerName },
-					{ name: "Type", value: payload.Type },
-					{ name: "Current Value", value: `${payload.Value.toFixed(2)}%` },
-					{ name: "Threshold", value: `${payload.Threshold.toFixed(2)}%` },
-					{ name: "Time", value: date.toLocaleString() },
-					{ name: "Message", value: payload.Message },
-				],
-			});
 		}
 	}
 };


### PR DESCRIPTION
## What is this PR about?

This PR fixes two separate issues with the server threshold notification system. First, it adds the missing `serverThreshold` property to the Gotify and Ntfy schemas, service insert/update functions, and frontend UI forms so the preference correctly persists to the database. Second, it moves the Teams notification dispatch in `server-threshold.ts` inside the `try/catch` error boundary to prevent an unhandled rejection from aborting the entire notification processing loop.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file
https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #5175

## Screenshots (if applicable)

(No visual UI changes, just backend persistence/error boundary fixes)






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes Gotify and Ntfy server-threshold persistence across the UI, API schema, and notification services, and moves Teams delivery inside the notification loop’s error boundary.

- Passes `serverThreshold` through Gotify and Ntfy form initialization and mutation payloads.
- Accepts and persists the flag in Gotify and Ntfy create/update paths.
- Contains Teams delivery failures within the existing per-notification error handler.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;Dokploy:canary&#39; into fix/g..."](https://github.com/dokploy/dokploy/commit/1a4420e1083f51340b1b366912d25b8dbaf96053) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56180176)</sub>

<!-- /greptile_comment -->