### PR TITLE
feat(compose): transactional deployments with automatic rollback to last good release

### DIFF
--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -90,6 +90,10 @@ const Service = (
 		},
 		{ refetchInterval: 5000 },
 	);
+	const { data: serviceDomains } = api.domain.byComposeId.useQuery(
+		{ composeId },
+		{ refetchInterval: 10000 },
+	);
 	const latestLiveDeployment = deployments
 		?.filter((d) => d.status === "done")
 		.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))[0];
@@ -147,28 +151,44 @@ const Service = (
 									<span className="text-sm text-muted-foreground">
 										{data?.appName}
 									</span>
-									<div className="flex flex-wrap gap-2 items-center mt-1">
-										<Badge
-											variant="secondary"
-											className={
-												latestLiveDeployment
-													? "bg-green-500/15 text-green-600"
-													: "text-muted-foreground"
-											}
-										>
-											<span
-												className={`mr-1 size-1.5 rounded-full ${
-													latestLiveDeployment
-														? "bg-green-500"
-														: "bg-muted-foreground/40"
-												}`}
-											/>
-											Live:{" "}
-											{latestLiveDeployment?.title ||
-												"No successful deployment yet"}
-										</Badge>
+									{(serviceDomains?.length ?? 0) > 0 && (
+										<div className="flex flex-wrap gap-2 mt-2">
+											{serviceDomains?.map((domain) => (
+												<a
+													key={domain.domainId}
+													href={`http${domain.https ? "s" : ""}://${domain.host}`}
+													target="_blank"
+													rel="noreferrer"
+													className={`text-xs font-medium rounded-md px-2 py-0.5 border transition-colors ${
+														domain.enabled
+															? "border-green-500/30 bg-green-500/10 text-green-600"
+															: "border-muted bg-muted/40 text-muted-foreground line-through"
+													}`}
+												>
+													{domain.enabled ? "🔗 " : "🔒 "}
+													{domain.host}
+												</a>
+											))}
+										</div>
+									)}
+								</div>
+								<div className="flex flex-col h-fit w-fit gap-2">
+									<div className="flex flex-row gap-2 justify-end flex-wrap">
+										{latestLiveDeployment && (
+											<Badge
+												variant="secondary"
+												className="bg-green-500/15 text-green-600"
+												title={`Live since ${latestLiveDeployment?.createdAt}`}
+											>
+												<span className="mr-1 size-1.5 rounded-full bg-green-500" />
+												Live ✓
+											</Badge>
+										)}
 										{isDeploying && (
-											<Badge variant="secondary" className="bg-amber-500/15 text-amber-600">
+											<Badge
+												variant="secondary"
+												className="bg-amber-500/15 text-amber-600"
+											>
 												<Loader2 className="size-3 animate-spin mr-1" />
 												Deploying...
 											</Badge>
@@ -178,14 +198,18 @@ const Service = (
 												<Badge
 													variant="secondary"
 													className="bg-red-500/15 text-red-600"
+													title="The last deployment failed; the previous successful one is still serving traffic"
 												>
 													<AlertTriangle className="size-3 mr-1" />
-													Last deploy failed — live kept
+													Last deploy failed
 												</Badge>
 											)}
+										{!latestLiveDeployment && (
+											<Badge variant="secondary" className="text-muted-foreground">
+												No deployments yet
+											</Badge>
+										)}
 									</div>
-								</div>
-								<div className="flex flex-col h-fit w-fit gap-2">
 									<div className="flex flex-row h-fit w-fit gap-2">
 										<Badge
 											className="cursor-pointer"

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -1,7 +1,16 @@
 import { validateRequest } from "@dokploy/server/lib/auth";
 import { createServerSideHelpers } from "@trpc/react-query/server";
 import copy from "copy-to-clipboard";
-import { AlertTriangle, HelpCircle, Loader2, ServerOff } from "lucide-react";
+import {
+	AlertTriangle,
+	ArrowUpRight,
+	Check,
+	Copy,
+	Globe,
+	HelpCircle,
+	Loader2,
+	ServerOff,
+} from "lucide-react";
 import type {
 	GetServerSidePropsContext,
 	InferGetServerSidePropsType,
@@ -100,6 +109,7 @@ const Service = (
 	const latestDeployment = deployments
 		?.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))[0];
 	const isDeploying = ["running", "queued"].includes(latestDeployment?.status || "");
+	const [appNameCopied, setAppNameCopied] = useState(false);
 
 	const { data: auth } = api.user.get.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();
@@ -129,79 +139,79 @@ const Service = (
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 					<div className="rounded-xl bg-background shadow-md ">
 						<div className="flex flex-col gap-4">
-							<CardHeader className="flex flex-row justify-between items-center">
-								<div className="flex flex-col">
-									<CardTitle className="text-xl flex flex-row gap-2 items-center">
-										<div className="relative flex flex-row gap-4 items-center">
-											<ShowIconSettings
-												serviceId={composeId}
-												serviceType="compose"
-												icon={data?.icon}
-											/>
-											<div className="absolute -right-1 -top-2 z-10">
-												<StatusTooltip status={data?.composeStatus} />
-											</div>
+							<CardHeader className="flex flex-row justify-between items-start gap-6">
+								<div className="flex flex-row gap-4 items-center min-w-0">
+									<div className="relative shrink-0">
+										<ShowIconSettings
+											serviceId={composeId}
+											serviceType="compose"
+											icon={data?.icon}
+										/>
+										<div className="absolute -right-1 -top-2 z-10">
+											<StatusTooltip status={data?.composeStatus} />
 										</div>
-										{data?.name}
-									</CardTitle>
-									{data?.description && (
-										<CardDescription>{data?.description}</CardDescription>
-									)}
-
-									<span className="text-sm text-muted-foreground">
-										{data?.appName}
-									</span>
-									{(serviceDomains?.length ?? 0) > 0 && (
-										<div className="flex flex-wrap gap-2 mt-2">
-											{serviceDomains?.map((domain) => (
-												<a
-													key={domain.domainId}
-													href={`http${domain.https ? "s" : ""}://${domain.host}`}
-													target="_blank"
-													rel="noreferrer"
-													className={`text-xs font-medium rounded-md px-2 py-0.5 border transition-colors ${
-														domain.enabled
-															? "border-green-500/30 bg-green-500/10 text-green-600"
-															: "border-muted bg-muted/40 text-muted-foreground line-through"
-													}`}
-												>
-													{domain.enabled ? "🔗 " : "🔒 "}
-													{domain.host}
-												</a>
-											))}
-										</div>
-									)}
+									</div>
+									<div className="flex flex-col gap-1 min-w-0">
+										<CardTitle className="text-xl leading-tight truncate">
+											{data?.name}
+										</CardTitle>
+										<button
+											type="button"
+											className="flex w-fit flex-row items-center gap-1.5 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+											title="Copy compose project name"
+											onClick={() => {
+												copy(data?.appName || "");
+												setAppNameCopied(true);
+												setTimeout(() => setAppNameCopied(false), 1500);
+											}}
+										>
+											{data?.appName}
+											{appNameCopied ? (
+												<Check className="size-3 text-green-600" />
+											) : (
+												<Copy className="size-3 opacity-50" />
+											)}
+										</button>
+										{data?.description && (
+											<CardDescription className="truncate">
+												{data?.description}
+											</CardDescription>
+										)}
+									</div>
 								</div>
 								<div className="flex flex-col h-fit w-fit gap-2">
 									<div className="flex flex-row gap-2 justify-end flex-wrap">
 										{latestLiveDeployment && (
 											<Badge
 												variant="secondary"
-												className="bg-green-500/15 text-green-600"
-												title={`Live since ${latestLiveDeployment?.createdAt}`}
+												className="gap-1.5 border border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+												title={`Last successful deploy: ${latestLiveDeployment?.createdAt}`}
 											>
-												<span className="mr-1 size-1.5 rounded-full bg-green-500" />
-												Live ✓
+												<span className="relative flex size-2">
+													<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-60" />
+													<span className="relative inline-flex size-2 rounded-full bg-emerald-500" />
+												</span>
+												Live
 											</Badge>
 										)}
 										{isDeploying && (
 											<Badge
 												variant="secondary"
-												className="bg-amber-500/15 text-amber-600"
+												className="gap-1.5 border border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400"
 											>
-												<Loader2 className="size-3 animate-spin mr-1" />
-												Deploying...
+												<Loader2 className="size-3 animate-spin" />
+												Deploying
 											</Badge>
 										)}
 										{latestDeployment?.status === "error" &&
 											latestLiveDeployment && (
 												<Badge
 													variant="secondary"
-													className="bg-red-500/15 text-red-600"
-													title="The last deployment failed; the previous successful one is still serving traffic"
+													className="gap-1.5 border border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400"
+													title="The last deployment failed. The previous successful deployment is still serving traffic."
 												>
-													<AlertTriangle className="size-3 mr-1" />
-													Last deploy failed
+													<AlertTriangle className="size-3" />
+													Deploy failed
 												</Badge>
 											)}
 										{!latestLiveDeployment && (
@@ -210,7 +220,7 @@ const Service = (
 											</Badge>
 										)}
 									</div>
-									<div className="flex flex-row h-fit w-fit gap-2">
+									<div className="flex flex-row h-fit w-fit gap-2 items-center">
 										<Badge
 											className="cursor-pointer"
 											onClick={() => {
@@ -252,18 +262,36 @@ const Service = (
 												</Tooltip>
 											</TooltipProvider>
 										)}
-									</div>
-									<div className="flex flex-row gap-2 justify-end">
 										{permissions?.service.create && (
 											<UpdateCompose composeId={composeId} />
 										)}
-
 										{permissions?.service.delete && (
 											<DeleteService id={composeId} type="compose" />
 										)}
 									</div>
 								</div>
 							</CardHeader>
+							{(serviceDomains?.length ?? 0) > 0 && (
+								<div className="flex flex-wrap items-center gap-2 px-6 pb-5">
+									<Globe className="size-3.5 text-muted-foreground" />
+									{serviceDomains?.map((domain) => (
+										<a
+											key={domain.domainId}
+											href={`http${domain.https ? "s" : ""}://${domain.host}`}
+											target="_blank"
+											rel="noreferrer"
+											className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${
+												domain.enabled
+													? "border-border bg-accent hover:border-primary/40 hover:bg-primary/10"
+													: "border-border bg-muted/40 text-muted-foreground line-through opacity-70"
+											}`}
+										>
+											<ArrowUpRight className="size-3" />
+											{domain.host}
+										</a>
+									))}
+								</div>
+							)}
 						</div>
 						<CardContent className="space-y-2 py-8 border-t">
 							{data?.server?.serverStatus === "inactive" ? (

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -1,7 +1,7 @@
 import { validateRequest } from "@dokploy/server/lib/auth";
 import { createServerSideHelpers } from "@trpc/react-query/server";
 import copy from "copy-to-clipboard";
-import { HelpCircle, ServerOff } from "lucide-react";
+import { AlertTriangle, HelpCircle, Loader2, ServerOff } from "lucide-react";
 import type {
 	GetServerSidePropsContext,
 	InferGetServerSidePropsType,
@@ -84,6 +84,19 @@ const Service = (
 
 	const { data } = api.compose.one.useQuery({ composeId });
 
+	const { data: deployments } = api.deployment.allByCompose.useQuery(
+		{
+			composeId,
+		},
+		{ refetchInterval: 5000 },
+	);
+	const latestLiveDeployment = deployments
+		?.filter((d) => d.status === "done")
+		.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))[0];
+	const latestDeployment = deployments
+		?.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))[0];
+	const isDeploying = ["running", "queued"].includes(latestDeployment?.status || "");
+
 	const { data: auth } = api.user.get.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const { data: isCloud } = api.settings.isCloud.useQuery();
@@ -134,6 +147,43 @@ const Service = (
 									<span className="text-sm text-muted-foreground">
 										{data?.appName}
 									</span>
+									<div className="flex flex-wrap gap-2 items-center mt-1">
+										<Badge
+											variant="secondary"
+											className={
+												latestLiveDeployment
+													? "bg-green-500/15 text-green-600"
+													: "text-muted-foreground"
+											}
+										>
+											<span
+												className={`mr-1 size-1.5 rounded-full ${
+													latestLiveDeployment
+														? "bg-green-500"
+														: "bg-muted-foreground/40"
+												}`}
+											/>
+											Live:{" "}
+											{latestLiveDeployment?.title ||
+												"No successful deployment yet"}
+										</Badge>
+										{isDeploying && (
+											<Badge variant="secondary" className="bg-amber-500/15 text-amber-600">
+												<Loader2 className="size-3 animate-spin mr-1" />
+												Deploying...
+											</Badge>
+										)}
+										{latestDeployment?.status === "error" &&
+											latestLiveDeployment && (
+												<Badge
+													variant="secondary"
+													className="bg-red-500/15 text-red-600"
+												>
+													<AlertTriangle className="size-3 mr-1" />
+													Last deploy failed — live kept
+												</Badge>
+											)}
+									</div>
 								</div>
 								<div className="flex flex-col h-fit w-fit gap-2">
 									<div className="flex flex-row h-fit w-fit gap-2">

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -93,26 +93,38 @@ const Service = (
 
 	const { data } = api.compose.one.useQuery({ composeId });
 
+	const { data: permissions } = api.user.getPermissions.useQuery();
+	const canReadDeployments = !!permissions?.deployment.read;
+	const canReadDomains = !!permissions?.domain.read;
+
 	const { data: deployments } = api.deployment.allByCompose.useQuery(
 		{
 			composeId,
 		},
-		{ refetchInterval: 5000 },
+		{
+			enabled: canReadDeployments,
+			refetchInterval: canReadDeployments ? 5000 : false,
+		},
 	);
 	const { data: serviceDomains } = api.domain.byComposeId.useQuery(
 		{ composeId },
-		{ refetchInterval: 10000 },
+		{
+			enabled: canReadDomains,
+			refetchInterval: canReadDomains ? 10000 : false,
+		},
 	);
 	const latestLiveDeployment = deployments
 		?.filter((d) => d.status === "done")
 		.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))[0];
-	const latestDeployment = deployments
-		?.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))[0];
-	const isDeploying = ["running", "queued"].includes(latestDeployment?.status || "");
+	const latestDeployment = deployments?.sort((a, b) =>
+		(b.createdAt || "").localeCompare(a.createdAt || ""),
+	)[0];
+	const isDeploying = ["running", "queued"].includes(
+		latestDeployment?.status || "",
+	);
 	const [appNameCopied, setAppNameCopied] = useState(false);
 
 	const { data: auth } = api.user.get.useQuery();
-	const { data: permissions } = api.user.getPermissions.useQuery();
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data: serverIp } = api.settings.getIp.useQuery();
 	const { data: environments } = api.environment.byProjectId.useQuery({
@@ -215,7 +227,10 @@ const Service = (
 												</Badge>
 											)}
 										{!latestLiveDeployment && (
-											<Badge variant="secondary" className="text-muted-foreground">
+											<Badge
+												variant="secondary"
+												className="text-muted-foreground"
+											>
 												No deployments yet
 											</Badge>
 										)}

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -7,7 +7,10 @@ import {
 	cleanAppName,
 	compose,
 } from "@dokploy/server/db/schema";
-import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
+import {
+	getBuildComposeCommand,
+	ROLLBACK_OK_MARKER,
+} from "@dokploy/server/utils/builders/compose";
 import { randomizeSpecificationFile } from "@dokploy/server/utils/docker/compose";
 import {
 	cloneCompose,
@@ -212,10 +215,8 @@ export const updateCompose = async (
 	return composeResult[0];
 };
 
-const ROLLBACK_OK_MARKER = "__DOKPLOY_ROLLBACK_OK__";
-
 export const didRollbackSucceed = async (compose: Compose, logPath: string) => {
-	const command = `if grep -q "${ROLLBACK_OK_MARKER}" "${logPath}" 2>/dev/null; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
+	const command = `if grep -q '^${ROLLBACK_OK_MARKER}$' "${logPath}" 2>/dev/null; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
 	try {
 		if (compose.serverId) {
 			const { stdout } = await execAsyncRemote(compose.serverId, command);

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -215,14 +215,7 @@ export const updateCompose = async (
 const ROLLBACK_OK_MARKER = "__DOKPLOY_ROLLBACK_OK__";
 
 export const didRollbackSucceed = async (compose: Compose, logPath: string) => {
-	const { COMPOSE_PATH } = paths(!!compose.serverId);
-	const lastGoodFile = join(
-		COMPOSE_PATH,
-		compose.appName,
-		".deploy-backup",
-		"last-good-docker-compose.yml.bak",
-	);
-	const command = `if grep -q "${ROLLBACK_OK_MARKER}" "${logPath}" 2>/dev/null || [ -f "${lastGoodFile}" ]; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
+	const command = `if grep -q "${ROLLBACK_OK_MARKER}" "${logPath}" 2>/dev/null; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
 	try {
 		if (compose.serverId) {
 			const { stdout } = await execAsyncRemote(compose.serverId, command);
@@ -360,7 +353,10 @@ export const deployCompose = async ({
 			await execAsync(command);
 		}
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		const rollbackSucceeded = await didRollbackSucceed(compose, deployment.logPath);
+		const rollbackSucceeded = await didRollbackSucceed(
+			compose,
+			deployment.logPath,
+		);
 		await updateCompose(composeId, {
 			composeStatus: rollbackSucceeded ? "done" : "error",
 		});
@@ -368,7 +364,7 @@ export const deployCompose = async ({
 			projectName: compose.environment.project.name,
 			applicationName: compose.name,
 			applicationType: "compose",
-			// @ts-ignore
+			// @ts-expect-error
 			errorMessage: error?.message || "Error building",
 			buildLink,
 			organizationId: compose.environment.project.organizationId,
@@ -408,6 +404,7 @@ export const rebuildCompose = async ({
 	});
 
 	try {
+		await backupCurrentDeployment(compose, deployment.logPath);
 		let command = "set -e;";
 		if (compose.sourceType === "raw") {
 			command += getCreateComposeFileCommand(compose);
@@ -465,7 +462,10 @@ export const rebuildCompose = async ({
 			await execAsync(command);
 		}
 		await updateDeploymentStatus(deployment.deploymentId, "error");
-		const rollbackSucceeded = await didRollbackSucceed(compose, deployment.logPath);
+		const rollbackSucceeded = await didRollbackSucceed(
+			compose,
+			deployment.logPath,
+		);
 		await updateCompose(composeId, {
 			composeStatus: rollbackSucceeded ? "done" : "error",
 		});

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -212,6 +212,22 @@ export const updateCompose = async (
 	return composeResult[0];
 };
 
+const ROLLBACK_OK_MARKER = "__DOKPLOY_ROLLBACK_OK__";
+
+export const didRollbackSucceed = async (compose: Compose, logPath: string) => {
+	const command = `grep -q "${ROLLBACK_OK_MARKER}" "${logPath}" && echo "ROLLBACK_OK" || echo "ROLLBACK_FAILED"`;
+	try {
+		if (compose.serverId) {
+			const { stdout } = await execAsyncRemote(compose.serverId, command);
+			return stdout.trim() === "ROLLBACK_OK";
+		}
+		const { stdout } = await execAsync(command);
+		return stdout.trim() === "ROLLBACK_OK";
+	} catch {
+		return false;
+	}
+};
+
 export const backupCurrentDeployment = async (
 	compose: Compose,
 	logPath: string,
@@ -337,8 +353,9 @@ export const deployCompose = async ({
 			await execAsync(command);
 		}
 		await updateDeploymentStatus(deployment.deploymentId, "error");
+		const rollbackSucceeded = await didRollbackSucceed(compose, deployment.logPath);
 		await updateCompose(composeId, {
-			composeStatus: "error",
+			composeStatus: rollbackSucceeded ? "done" : "error",
 		});
 		await sendBuildErrorNotifications({
 			projectName: compose.environment.project.name,
@@ -441,8 +458,9 @@ export const rebuildCompose = async ({
 			await execAsync(command);
 		}
 		await updateDeploymentStatus(deployment.deploymentId, "error");
+		const rollbackSucceeded = await didRollbackSucceed(compose, deployment.logPath);
 		await updateCompose(composeId, {
-			composeStatus: "error",
+			composeStatus: rollbackSucceeded ? "done" : "error",
 		});
 		throw error;
 	}

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -243,9 +243,9 @@ export const backupCurrentDeployment = async (
 	const envFilePath = join(dirname(composeFilePath), ".env");
 
 	const backupCommand = `
-mkdir -p ${quote([backupDir])};
-cp ${quote([composeFilePath])} ${quote([join(backupDir, "docker-compose.yml.bak")])} 2>/dev/null || echo "No previous compose file found";
-cp ${quote([envFilePath])} ${quote([join(backupDir, "env.bak")])} 2>/dev/null || echo "No previous env file found";
+mkdir -p ${quote([backupDir])} 2>/dev/null || exit 1;
+if [ -f ${quote([composeFilePath])} ]; then cp ${quote([composeFilePath])} ${quote([join(backupDir, "docker-compose.yml.bak")])} || exit 1; else echo "No previous compose file found"; fi
+if [ -f ${quote([envFilePath])} ]; then cp ${quote([envFilePath])} ${quote([join(backupDir, "env.bak")])} || exit 1; else echo "No previous env file found"; fi
 	`;
 
 	const command = `(${backupCommand}) >> ${logPath} 2>&1`;

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -215,14 +215,21 @@ export const updateCompose = async (
 const ROLLBACK_OK_MARKER = "__DOKPLOY_ROLLBACK_OK__";
 
 export const didRollbackSucceed = async (compose: Compose, logPath: string) => {
-	const command = `grep -q "${ROLLBACK_OK_MARKER}" "${logPath}" && echo "ROLLBACK_OK" || echo "ROLLBACK_FAILED"`;
+	const { COMPOSE_PATH } = paths(!!compose.serverId);
+	const lastGoodFile = join(
+		COMPOSE_PATH,
+		compose.appName,
+		".deploy-backup",
+		"last-good-docker-compose.yml.bak",
+	);
+	const command = `if grep -q "${ROLLBACK_OK_MARKER}" "${logPath}" 2>/dev/null || [ -f "${lastGoodFile}" ]; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
 	try {
 		if (compose.serverId) {
 			const { stdout } = await execAsyncRemote(compose.serverId, command);
-			return stdout.trim() === "ROLLBACK_OK";
+			return stdout.trim() === "LIVE_OK";
 		}
 		const { stdout } = await execAsync(command);
-		return stdout.trim() === "ROLLBACK_OK";
+		return stdout.trim() === "LIVE_OK";
 	} catch {
 		return false;
 	}

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -215,8 +215,12 @@ export const updateCompose = async (
 	return composeResult[0];
 };
 
-export const didRollbackSucceed = async (compose: Compose, logPath: string) => {
-	const command = `if grep -q '^${ROLLBACK_OK_MARKER}$' "${logPath}" 2>/dev/null; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
+export const didRollbackSucceed = async (
+	compose: Compose,
+	logPath: string,
+	deploymentId: string,
+) => {
+	const command = `if grep -q '^${ROLLBACK_OK_MARKER}:${deploymentId}$' "${logPath}" 2>/dev/null; then echo "LIVE_OK"; else echo "LIVE_FAILED"; fi`;
 	try {
 		if (compose.serverId) {
 			const { stdout } = await execAsyncRemote(compose.serverId, command);
@@ -315,7 +319,7 @@ export const deployCompose = async ({
 		}
 
 		command = "set -e;";
-		command += await getBuildComposeCommand(entity);
+		command += await getBuildComposeCommand(entity, deployment.deploymentId);
 		commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (compose.serverId) {
 			await execAsyncRemote(compose.serverId, commandWithLog);
@@ -357,6 +361,7 @@ export const deployCompose = async ({
 		const rollbackSucceeded = await didRollbackSucceed(
 			compose,
 			deployment.logPath,
+			deployment.deploymentId,
 		);
 		await updateCompose(composeId, {
 			composeStatus: rollbackSucceeded ? "done" : "error",
@@ -434,7 +439,7 @@ export const rebuildCompose = async ({
 		}
 
 		command = "set -e;";
-		command += await getBuildComposeCommand(compose);
+		command += await getBuildComposeCommand(compose, deployment.deploymentId);
 		commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (compose.serverId) {
 			await execAsyncRemote(compose.serverId, commandWithLog);
@@ -466,6 +471,7 @@ export const rebuildCompose = async ({
 		const rollbackSucceeded = await didRollbackSucceed(
 			compose,
 			deployment.logPath,
+			deployment.deploymentId,
 		);
 		await updateCompose(composeId, {
 			composeStatus: rollbackSucceeded ? "done" : "error",

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { paths } from "@dokploy/server/constants";
 import { db } from "@dokploy/server/db";
 import {
@@ -11,6 +11,7 @@ import { getBuildComposeCommand } from "@dokploy/server/utils/builders/compose";
 import { randomizeSpecificationFile } from "@dokploy/server/utils/docker/compose";
 import {
 	cloneCompose,
+	getComposePath,
 	loadDockerCompose,
 	loadDockerComposeRemote,
 } from "@dokploy/server/utils/docker/domain";
@@ -211,6 +212,29 @@ export const updateCompose = async (
 	return composeResult[0];
 };
 
+export const backupCurrentDeployment = async (
+	compose: Compose,
+	logPath: string,
+) => {
+	const { COMPOSE_PATH } = paths(!!compose.serverId);
+	const backupDir = join(COMPOSE_PATH, compose.appName, ".deploy-backup");
+	const composeFilePath = getComposePath(compose);
+	const envFilePath = join(dirname(composeFilePath), ".env");
+
+	const backupCommand = `
+mkdir -p ${quote([backupDir])};
+cp ${quote([composeFilePath])} ${quote([join(backupDir, "docker-compose.yml.bak")])} 2>/dev/null || echo "No previous compose file found";
+cp ${quote([envFilePath])} ${quote([join(backupDir, "env.bak")])} 2>/dev/null || echo "No previous env file found";
+	`;
+
+	const command = `(${backupCommand}) >> ${logPath} 2>&1`;
+	if (compose.serverId) {
+		await execAsyncRemote(compose.serverId, command);
+	} else {
+		await execAsync(command);
+	}
+};
+
 export const deployCompose = async ({
 	composeId,
 	titleLog = "Manual deployment",
@@ -232,6 +256,7 @@ export const deployCompose = async ({
 	});
 
 	try {
+		await backupCurrentDeployment(compose, deployment.logPath);
 		const entity = {
 			...compose,
 			type: "compose" as const,

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -3,7 +3,7 @@ import { paths } from "@dokploy/server/constants";
 import type { InferResultType } from "@dokploy/server/types/with";
 import boxen from "boxen";
 import { quote } from "shell-quote";
-import { writeDomainsToCompose } from "../docker/domain";
+import { getComposePath, writeDomainsToCompose } from "../docker/domain";
 import {
 	encodeBase64,
 	getEnvironmentVariablesObject,
@@ -47,10 +47,40 @@ Compose Type: ${composeType} ✅`;
 		borderStyle: "double",
 	});
 
+	const backupDir = join(COMPOSE_PATH, compose.appName, ".deploy-backup");
+	const composeFilePath = getComposePath(compose);
+	const envFilePath = join(dirname(composeFilePath), ".env");
+	const isTransactional = composeType === "docker-compose";
+	const restoreCommand = command
+		.split(" ")
+		.join(" ")
+		.replace(/ --build/g, "");
+
+	const backupCommands = isTransactional
+		? `
+		mkdir -p "${backupDir}";
+		cp "${composeFilePath}" "${backupDir}/docker-compose.yml.bak" 2>/dev/null || true;
+		cp "${envFilePath}" "${backupDir}/env.bak" 2>/dev/null || true;
+		`
+		: "";
+
+	const restoreCommands = isTransactional
+		? `
+		echo "Restoring previous working deployment... ⏪";
+		cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || true;
+		cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
+		`
+		: "";
+
+	const cleanupBackup = isTransactional ? `rm -rf "${backupDir}";` : "";
+
 	const bashCommand = `
 	set -e
 	{
 		echo "${logBox}";
+
+		${backupCommands}
 
 		${newCompose}
 
@@ -59,8 +89,10 @@ Compose Type: ${composeType} ✅`;
 		cd "${projectPath}";
 
 		${compose.isolatedDeployment ? `docker network inspect ${compose.appName} >/dev/null 2>&1 || docker network create ${compose.composeType === "stack" ? "--driver overlay" : ""} --attachable ${compose.appName}` : ""}
-		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${command.split(" ").join(" ")} 2>&1 || { echo "Error: ❌ Docker command failed"; exit 1; }
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${command.split(" ").join(" ")} 2>&1 || { echo "Error: ❌ Docker command failed"; ${restoreCommands} exit 1; }
 		${compose.isolatedDeployment ? `docker network connect ${compose.appName} $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1` : ""}
+
+		${cleanupBackup}
 
 		echo "Docker Compose Deployed: ✅";
 	} || {

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -12,6 +12,8 @@ import {
 } from "../docker/utils";
 import { withResolvedVaultRefs } from "../vault";
 
+export const ROLLBACK_OK_MARKER = "__DOKPLOY_ROLLBACK_OK__";
+
 export type ComposeNested = InferResultType<
 	"compose",
 	{ environment: { with: { project: true } }; mounts: true; domains: true }
@@ -61,8 +63,8 @@ Compose Type: ${composeType} ✅`;
 		echo "Restoring previous working deployment... ⏪";
 		RESTORE_FILES_OK=1;
 		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || RESTORE_FILES_OK=0;
-		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || RESTORE_FILES_OK=0;
-		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && [ "$RESTORE_FILES_OK" = "1" ] && echo "__DOKPLOY_ROLLBACK_OK__" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
+		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && [ "$RESTORE_FILES_OK" = "1" ] && echo "${ROLLBACK_OK_MARKER}" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
 		`
 		: "";
 

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -59,9 +59,10 @@ Compose Type: ${composeType} ✅`;
 	const restoreCommands = isTransactional
 		? `
 		echo "Restoring previous working deployment... ⏪";
-		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || true;
-		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
-		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && echo "__DOKPLOY_ROLLBACK_OK__" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
+		RESTORE_FILES_OK=1;
+		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || RESTORE_FILES_OK=0;
+		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || RESTORE_FILES_OK=0;
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && [ "$RESTORE_FILES_OK" = "1" ] && echo "__DOKPLOY_ROLLBACK_OK__" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
 		`
 		: "";
 

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -63,6 +63,7 @@ Compose Type: ${composeType} ✅`;
 	const rollbackMarkerLine = deploymentId
 		? `${ROLLBACK_OK_MARKER}:${deploymentId}`
 		: ROLLBACK_OK_MARKER;
+	const isEnvRequired = compose.createEnvFile ? "1" : "0";
 
 	const restoreCommands = isTransactional
 		? `
@@ -71,7 +72,7 @@ Compose Type: ${composeType} ✅`;
 		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || RESTORE_FILES_OK=0;
 		RESTORE_ENV_OK=1;
 		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || RESTORE_ENV_OK=0;
-		if [ "$RESTORE_ENV_OK" = "0" ] && [ -f "${backupDir}/last-good-env.bak" -o -f "${backupDir}/env.bak" ]; then RESTORE_FILES_OK=0; echo "Warning: ⚠️ Previous .env could not be restored"; fi
+		if [ "$RESTORE_ENV_OK" = "0" ] && { [ "${isEnvRequired}" = "1" ] || [ -f "${backupDir}/last-good-env.bak" -o -f "${backupDir}/env.bak" ]; }; then RESTORE_FILES_OK=0; echo "Warning: ⚠️ Previous .env could not be restored"; fi
 		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && [ "$RESTORE_FILES_OK" = "1" ] && echo "${rollbackMarkerLine}" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
 		`
 		: "";

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -80,8 +80,8 @@ Compose Type: ${composeType} ✅`;
 	const persistLastGood = isTransactional
 		? `
 		mkdir -p "${backupDir}";
-		cp "${composeFilePath}" "${backupDir}/last-good-docker-compose.yml.bak" 2>/dev/null || true;
-		cp "${envFilePath}" "${backupDir}/last-good-env.bak" 2>/dev/null || true;
+		cp "${composeFilePath}" "${backupDir}/last-good-docker-compose.yml.bak" 2>/dev/null || rm -f "${backupDir}/last-good-docker-compose.yml.bak";
+		cp "${envFilePath}" "${backupDir}/last-good-env.bak" 2>/dev/null || rm -f "${backupDir}/last-good-env.bak";
 		`
 		: "";
 

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -19,7 +19,10 @@ export type ComposeNested = InferResultType<
 	{ environment: { with: { project: true } }; mounts: true; domains: true }
 >;
 
-export const getBuildComposeCommand = async (rawCompose: ComposeNested) => {
+export const getBuildComposeCommand = async (
+	rawCompose: ComposeNested,
+	deploymentId?: string,
+) => {
 	const compose = await withResolvedVaultRefs(rawCompose);
 	const { COMPOSE_PATH } = paths(!!compose.serverId);
 	const { sourceType, appName, mounts, composeType, domains } = compose;
@@ -57,14 +60,19 @@ Compose Type: ${composeType} ✅`;
 		.split(" ")
 		.join(" ")
 		.replace(/ --build/g, "");
+	const rollbackMarkerLine = deploymentId
+		? `${ROLLBACK_OK_MARKER}:${deploymentId}`
+		: ROLLBACK_OK_MARKER;
 
 	const restoreCommands = isTransactional
 		? `
 		echo "Restoring previous working deployment... ⏪";
 		RESTORE_FILES_OK=1;
 		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || RESTORE_FILES_OK=0;
-		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
-		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && [ "$RESTORE_FILES_OK" = "1" ] && echo "${ROLLBACK_OK_MARKER}" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
+		RESTORE_ENV_OK=1;
+		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || RESTORE_ENV_OK=0;
+		if [ "$RESTORE_ENV_OK" = "0" ] && [ -f "${backupDir}/last-good-env.bak" -o -f "${backupDir}/env.bak" ]; then RESTORE_FILES_OK=0; echo "Warning: ⚠️ Previous .env could not be restored"; fi
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && [ "$RESTORE_FILES_OK" = "1" ] && echo "${rollbackMarkerLine}" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
 		`
 		: "";
 

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -56,31 +56,27 @@ Compose Type: ${composeType} ✅`;
 		.join(" ")
 		.replace(/ --build/g, "");
 
-	const backupCommands = isTransactional
-		? `
-		mkdir -p "${backupDir}";
-		cp "${composeFilePath}" "${backupDir}/docker-compose.yml.bak" 2>/dev/null || true;
-		cp "${envFilePath}" "${backupDir}/env.bak" 2>/dev/null || true;
-		`
-		: "";
-
 	const restoreCommands = isTransactional
 		? `
 		echo "Restoring previous working deployment... ⏪";
-		cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || true;
-		cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
+		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || true;
+		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
 		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
 		`
 		: "";
 
-	const cleanupBackup = isTransactional ? `rm -rf "${backupDir}";` : "";
+	const persistLastGood = isTransactional
+		? `
+		mkdir -p "${backupDir}";
+		cp "${composeFilePath}" "${backupDir}/last-good-docker-compose.yml.bak" 2>/dev/null || true;
+		cp "${envFilePath}" "${backupDir}/last-good-env.bak" 2>/dev/null || true;
+		`
+		: "";
 
 	const bashCommand = `
 	set -e
 	{
 		echo "${logBox}";
-
-		${backupCommands}
 
 		${newCompose}
 
@@ -92,7 +88,7 @@ Compose Type: ${composeType} ✅`;
 		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${command.split(" ").join(" ")} 2>&1 || { echo "Error: ❌ Docker command failed"; ${restoreCommands} exit 1; }
 		${compose.isolatedDeployment ? `docker network connect ${compose.appName} $(docker ps --filter "name=dokploy-traefik" -q) >/dev/null 2>&1` : ""}
 
-		${cleanupBackup}
+		${persistLastGood}
 
 		echo "Docker Compose Deployed: ✅";
 	} || {

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -61,7 +61,7 @@ Compose Type: ${composeType} ✅`;
 		echo "Restoring previous working deployment... ⏪";
 		cp "${backupDir}/last-good-docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || cp "${backupDir}/docker-compose.yml.bak" "${composeFilePath}" 2>/dev/null || true;
 		cp "${backupDir}/last-good-env.bak" "${envFilePath}" 2>/dev/null || cp "${backupDir}/env.bak" "${envFilePath}" 2>/dev/null || true;
-		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
+		env -i PATH="$PATH" HOME="$HOME" ${exportEnvCommand} docker ${restoreCommand} 2>&1 && echo "__DOKPLOY_ROLLBACK_OK__" || echo "Warning: ⚠️ Automatic restore failed, manual intervention may be required";
 		`
 		: "";
 


### PR DESCRIPTION
## What is this PR about?

Today, if a Docker Compose deployment fails (wrong image name, broken compose file, failed build), Dokploy can leave your **running services down** until you notice and manually redeploy. This PR fixes that: **a failed deploy now rolls back automatically and your last working release keeps serving traffic**, Vercel-style.

| | Before | After |
|---|---|---|
| Deploy fails | Services stop / run from broken files | Last good release keeps running |
| Service status in UI | Turns red on rollback success | Stays green, only the deployment shows the error |
| Recovery | Manual intervention needed | Automatic, logged in the deploy log |

## How it works

1. **Snapshot first** - before anything is touched, the current compose file and `.env` are backed up.
2. **Restore on failure** - if any step fails, the backup is restored and `docker compose up -d` brings the previous release back up. Each step is visible in the deployment log.
3. **Remember the last good release** - every successful deploy saves its compose file and env as a known-good snapshot. Rollbacks always prefer this snapshot.
4. **Honest status** - after a successful rollback the service stays marked as live; only the failed *deployment* entry shows the error.

## UI improvements included

- Status badges in the service header: pulsing green **Live**, amber **Deploying**, red **Deploy failed**.
- Clickable domain chips under the service name (disabled domains are shown struck-through).
- Compose project name with click-to-copy.

Scope: applies to `docker-compose` type only. Stack type deployments keep their current behavior.

## Testing

Verified end-to-end on a local instance:

1. Deploy a working service - succeeds, known-good snapshot saved.
2. Push a deploy with a broken image reference - deploy fails, log shows the restore steps, old containers keep answering HTTP requests during the whole process, service stays green.
3. Fix the compose and redeploy - succeeds again and refreshes the snapshot.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.
















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds transactional Docker Compose deployments that preserve the current deployment, restore it after failed updates, and retain known-good artifacts for later recovery. It also adds permission-aware deployment and domain status information to the Compose service header.

- Backs up the active Compose definition and environment before deployment and rebuild mutations.
- Restores the previous release after Docker Compose failures and keeps workload status live only when rollback succeeds.
- Refreshes or removes known-good snapshots after successful deployments so stale artifacts are not preferred.
- Adds live, deploying, and failed-deployment badges, domain links, and project-name copying to the Compose dashboard.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<sub>Reviews (8): Last reviewed commit: ["fix(compose): drop stale last-good snaps..."](https://github.com/dokploy/dokploy/commit/390d5f9260e7e629f2d71c167e75900b544931e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56452040)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Deployment lifecycle](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/deployment-lifecycle.md)
- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)
- Knowledge Base — [Dashboard and client state](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dashboard-and-client-state.md)
</details>


<!-- /greptile_comment -->