### PR TITLE
chore: automate git worktree setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+	"worktree": {
+		"baseRef": "fresh",
+		"symlinkDirectories": ["node_modules"]
+	},
+	"hooks": {
+		"PostToolUse": [
+			{
+				"matcher": "EnterWorktree",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR/scripts/assign-worktree-port.sh\""
+					}
+				]
+			}
+		]
+	}
+}

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: fix-issue
+description: Implement a GitHub issue with reproduction and verification
+allowed-tools: Bash, Edit, Write, Read, Glob, Grep, mcp__playwright__*, mcp__dokploy__*
+---
+
+The issue number is passed as $1. An isolated instance is running at $DOKPLOY_BASE_URL.
+
+## Tools
+
+- `mcp__dokploy__*` — the Dokploy API of the running instance. Use it to set up
+  state (create a project, an app, an env var) and to verify backend behavior.
+  Search for the tool you need; they are not all loaded upfront.
+- `mcp__playwright__*` — the browser at $DOKPLOY_BASE_URL. Use it for anything
+  a user would see or click.
+
+Pick by where the bug lives, not by convenience:
+
+- Bug in the UI (rendering, forms, navigation, state) → reproduce in Playwright.
+  The API returning correct data proves nothing here.
+- Bug in the API, deploy logic, or data → reproduce with the Dokploy MCP.
+  A green screenshot proves nothing here.
+- Unclear → do both.
+
+Use the MCP to reach the state you need quickly, then verify in the UI. Do not
+click through ten screens to create a project the API can create in one call.
+
+## Steps
+
+1. Run `gh issue view $1` and read the full issue, including comments.
+2. Reproduce the bug with the appropriate tool. If you cannot reproduce it,
+   comment on the issue explaining what you tried and STOP.
+   Do not implement anything.
+3. Implement the fix. Keep the change minimal and scoped to the issue.
+4. Run `pnpm test`, then re-run the same reproduction from step 2.
+5. Only if both pass: commit and run `gh pr create`. The PR description must
+   include the before/after reproduction steps and reference the issue.
+
+Never skip step 2. A fix you cannot reproduce and then verify is not a fix.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+	"mcpServers": {
+		"dokploy": {
+			"type": "http",
+			"url": "${DOKPLOY_BASE_URL}/api/mcp",
+			"headers": { "Authorization": "Bearer ${DOKPLOY_TOKEN}" }
+		},
+		"playwright": {
+			"command": "npx",
+			"args": ["-y", "@playwright/mcp@latest", "--headless", "--isolated"]
+		}
+	}
+}

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env
+.env.local

--- a/scripts/assign-worktree-port.sh
+++ b/scripts/assign-worktree-port.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PAYLOAD=$(cat)
+WORKTREE_PATH=$(echo "$PAYLOAD" | jq -r '.tool_response.worktreePath // empty')
+
+if [ -z "$WORKTREE_PATH" ]; then
+	exit 0
+fi
+
+ENV_FILE="$WORKTREE_PATH/apps/dokploy/.env"
+if [ ! -f "$ENV_FILE" ]; then
+	exit 0
+fi
+
+FREE_PORT=$(node "$CLAUDE_PROJECT_DIR/scripts/find-free-port.mjs")
+
+sed -i.bak "s/^PORT=.*/PORT=$FREE_PORT/" "$ENV_FILE"
+sed -i.bak -E "s#^(BETTER_AUTH_URL=https?://[^:/]+):[0-9]+#\1:$FREE_PORT#" "$ENV_FILE"
+rm -f "$ENV_FILE.bak"
+
+echo "Worktree $WORKTREE_PATH -> dokploy dev PORT=$FREE_PORT"

--- a/scripts/find-free-port.mjs
+++ b/scripts/find-free-port.mjs
@@ -1,0 +1,23 @@
+import { createServer } from "node:net";
+
+function isFree(port) {
+	return new Promise((resolve) => {
+		const server = createServer();
+		server.once("error", () => resolve(false));
+		server.listen(port, "0.0.0.0", () => {
+			server.close(() => resolve(true));
+		});
+	});
+}
+
+async function findFreePort(start) {
+	let port = start;
+	while (!(await isFree(port))) {
+		port++;
+	}
+	return port;
+}
+
+const start = Number.parseInt(process.argv[2] || process.env.PORT || "3000", 10);
+const port = await findFreePort(start);
+process.stdout.write(String(port));


### PR DESCRIPTION
Automates git worktree creation for this repo:

- `worktree.baseRef: fresh` and `worktree.symlinkDirectories: ["node_modules"]` in `.claude/settings.json` — new worktrees branch clean from `origin/canary` and symlink `node_modules` instead of reinstalling.
- `.worktreeinclude` copies `.env`/`.env.local` into new worktrees.
- A `PostToolUse` hook on `EnterWorktree` runs `scripts/assign-worktree-port.sh`, which assigns each new worktree a free port and syncs `PORT`/`BETTER_AUTH_URL` in `apps/dokploy/.env` so `pnpm dokploy:dev` never collides across worktrees and auth still works.
- `.mcp.json` + `.claude/skills/fix-issue/SKILL.md` — registers the Dokploy and Playwright MCP servers and the `/fix-issue` skill so they're available inside worktrees too (git worktrees only include tracked files).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Claude worktree automation, development-port assignment, MCP server registration, and a guided issue-fixing skill.
- Creates fresh worktrees with shared node_modules and copied environment files.
- Adds a PostToolUse hook that updates Dokploy's development port and auth URL.
- Registers Dokploy and Playwright MCP servers for worktree sessions.
- Documents an issue reproduction, implementation, testing, and pull-request workflow.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until worktree port allocation prevents duplicate assignments between worktrees created before their development servers start.

The new allocator only probes and releases a port, so sequential or concurrent worktree creation can persist the same value in multiple worktrees and cause a later development server to fail binding.

**Files Needing Attention:** scripts/assign-worktree-port.sh, scripts/find-free-port.mjs

<sub>Reviews (1): Last reviewed commit: ["chore: add SKILL.md for issue reproducti..."](https://github.com/dokploy/dokploy/commit/1ccd633153538397f5e31b6fcf995ddac5552802) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56555065)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->