### PR TITLE
feat: named resource profiles reusable across applications, databases and compose services

### DIFF
--- a/apps/dokploy/__test__/drop/drop.test.ts
+++ b/apps/dokploy/__test__/drop/drop.test.ts
@@ -155,6 +155,7 @@ const baseApp: ApplicationNested = {
 	rollbackActive: false,
 	stopGracePeriodSwarm: null,
 	ulimitsSwarm: null,
+	resourceProfileId: null,
 };
 
 /**

--- a/apps/dokploy/__test__/permissions/enterprise-only-resources.test.ts
+++ b/apps/dokploy/__test__/permissions/enterprise-only-resources.test.ts
@@ -18,6 +18,7 @@ const FREE_TIER_RESOURCES = [
 	"gitProviders",
 	"traefikFiles",
 	"api",
+	"resourceProfiles",
 ];
 
 const ENTERPRISE_RESOURCES = [

--- a/apps/dokploy/__test__/traefik/traefik.test.ts
+++ b/apps/dokploy/__test__/traefik/traefik.test.ts
@@ -129,6 +129,7 @@ const baseApp: ApplicationNested = {
 	dockerContextPath: null,
 	stopGracePeriodSwarm: null,
 	ulimitsSwarm: null,
+	resourceProfileId: null,
 };
 
 const baseDomain: Domain = {

--- a/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
@@ -1,6 +1,6 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { InfoIcon, Plus, Trash2 } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -155,6 +155,16 @@ export const ShowResources = ({ id, type }: Props) => {
 	const selectedGroupId = form.watch("resourceGroupId");
 	const selectedProfileId = form.watch("resourceProfileId");
 
+	const prevGroupIdRef = useRef<string>("");
+	useEffect(() => {
+		if (prevGroupIdRef.current !== selectedGroupId) {
+			if (prevGroupIdRef.current !== "") {
+				form.setValue("resourceProfileId", "");
+			}
+			prevGroupIdRef.current = selectedGroupId;
+		}
+	}, [selectedGroupId, form]);
+
 	const selectedGroup = groups?.find(
 		(group) => group.groupId === selectedGroupId,
 	);
@@ -255,7 +265,6 @@ export const ShowResources = ({ id, type }: Props) => {
 										<Select
 											onValueChange={(value) => {
 												field.onChange(value);
-												form.setValue("resourceProfileId", "");
 											}}
 											value={field.value || undefined}
 										>
@@ -283,9 +292,10 @@ export const ShowResources = ({ id, type }: Props) => {
 									<FormItem>
 										<FormLabel>Profile</FormLabel>
 										<Select
-											onValueChange={(value) =>
-												field.onChange(value === "none" ? null : value)
-											}
+											onValueChange={(value) => {
+												if (value === "") return;
+												field.onChange(value === "none" ? null : value);
+											}}
 											value={field.value || undefined}
 										>
 											<FormControl>

--- a/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-resources.tsx
@@ -65,6 +65,8 @@ const ulimitSchema = z.object({
 });
 
 const addResourcesSchema = z.object({
+	resourceGroupId: z.string().optional(),
+	resourceProfileId: z.string().nullable().optional(),
 	memoryReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
 	memoryLimit: z.string().optional(),
@@ -105,6 +107,8 @@ interface Props {
 type AddResources = z.infer<typeof addResourcesSchema>;
 
 export const ShowResources = ({ id, type }: Props) => {
+	const { data: groups } = api.resourceProfile.all.useQuery();
+
 	const queryMap = {
 		application: () =>
 			api.application.one.useQuery({ applicationId: id }, { enabled: !!id }),
@@ -137,6 +141,8 @@ export const ShowResources = ({ id, type }: Props) => {
 
 	const form = useForm({
 		defaultValues: {
+			resourceGroupId: "",
+			resourceProfileId: "",
 			cpuLimit: "",
 			cpuReservation: "",
 			memoryLimit: "",
@@ -146,14 +152,42 @@ export const ShowResources = ({ id, type }: Props) => {
 		resolver: zodResolver(addResourcesSchema),
 	});
 
+	const selectedGroupId = form.watch("resourceGroupId");
+	const selectedProfileId = form.watch("resourceProfileId");
+
+	const selectedGroup = groups?.find(
+		(group) => group.groupId === selectedGroupId,
+	);
+
+	const selectedProfile = groups
+		?.flatMap((group) => group.profiles)
+		.find((profile) => profile.profileId === selectedProfileId);
+
+	const groupProfiles =
+		groups?.find((group) => group.groupId === selectedGroupId)?.profiles ?? [];
+
+	const inherited = {
+		memoryLimit: selectedProfile?.memoryLimit || undefined,
+		memoryReservation: selectedProfile?.memoryReservation || undefined,
+		cpuLimit: selectedProfile?.cpuLimit || undefined,
+		cpuReservation: selectedProfile?.cpuReservation || undefined,
+	};
+
 	const { fields, append, remove } = useFieldArray({
 		control: form.control,
 		name: "ulimitsSwarm",
 	});
 
 	useEffect(() => {
-		if (data) {
+		if (data && groups) {
+			const profileId = (data as { resourceProfileId?: string | null })
+				?.resourceProfileId;
+			const group = groups.find((g) =>
+				g.profiles.some((p) => p.profileId === profileId),
+			);
 			form.reset({
+				resourceGroupId: group?.groupId || "",
+				resourceProfileId: profileId || "",
 				cpuLimit: data?.cpuLimit || undefined,
 				cpuReservation: data?.cpuReservation || undefined,
 				memoryLimit: data?.memoryLimit || undefined,
@@ -161,7 +195,7 @@ export const ShowResources = ({ id, type }: Props) => {
 				ulimitsSwarm: (data as any)?.ulimitsSwarm || [],
 			});
 		}
-	}, [data, form, form.reset]);
+	}, [data, groups, form, form.reset]);
 
 	const onSubmit = async (formData: AddResources) => {
 		await mutateAsync({
@@ -172,6 +206,7 @@ export const ShowResources = ({ id, type }: Props) => {
 			mysqlId: id || "",
 			postgresId: id || "",
 			redisId: id || "",
+			resourceProfileId: formData.resourceProfileId || null,
 			cpuLimit: formData.cpuLimit || null,
 			cpuReservation: formData.cpuReservation || null,
 			memoryLimit: formData.memoryLimit || null,
@@ -213,6 +248,83 @@ export const ShowResources = ({ id, type }: Props) => {
 						<div className="grid w-full md:grid-cols-2 gap-4">
 							<FormField
 								control={form.control}
+								name="resourceGroupId"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Profile Group</FormLabel>
+										<Select
+											onValueChange={(value) => {
+												field.onChange(value);
+												form.setValue("resourceProfileId", "");
+											}}
+											value={field.value || undefined}
+										>
+											<FormControl>
+												<SelectTrigger>
+													<SelectValue placeholder="None (custom values)" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												{groups?.map((group) => (
+													<SelectItem key={group.groupId} value={group.groupId}>
+														{group.name}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="resourceProfileId"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Profile</FormLabel>
+										<Select
+											onValueChange={(value) =>
+												field.onChange(value === "none" ? null : value)
+											}
+											value={field.value || undefined}
+										>
+											<FormControl>
+												<SelectTrigger disabled={!selectedGroupId}>
+													<SelectValue placeholder="Select a profile" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value="none">
+													None (custom values)
+												</SelectItem>
+												{groupProfiles.map((profile) => (
+													<SelectItem
+														key={profile.profileId}
+														value={profile.profileId}
+													>
+														{profile.name}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						{selectedProfile && selectedGroup && (
+							<div className="text-xs text-muted-foreground">
+								Inherited from profile{" "}
+								<span className="font-medium text-foreground">
+									{selectedGroup.name} / {selectedProfile.name}
+								</span>
+								: leave a field empty to inherit its value; any filled field
+								overrides the profile.
+							</div>
+						)}
+						<div className="grid w-full md:grid-cols-2 gap-4">
+							<FormField
+								control={form.control}
 								name="memoryLimit"
 								render={({ field }) => {
 									return (
@@ -241,7 +353,11 @@ export const ShowResources = ({ id, type }: Props) => {
 												<NumberInputWithSteps
 													value={field.value}
 													onChange={field.onChange}
-													placeholder="1073741824 (1GB in bytes)"
+													placeholder={
+														inherited.memoryLimit
+															? `${inherited.memoryLimit} (from profile)`
+															: "1073741824 (1GB in bytes)"
+													}
 													step={MEMORY_STEP_MB}
 													converter={memoryConverter}
 												/>
@@ -280,7 +396,11 @@ export const ShowResources = ({ id, type }: Props) => {
 											<NumberInputWithSteps
 												value={field.value}
 												onChange={field.onChange}
-												placeholder="268435456 (256MB in bytes)"
+												placeholder={
+													inherited.memoryReservation
+														? `${inherited.memoryReservation} (from profile)`
+														: "268435456 (256MB in bytes)"
+												}
 												step={MEMORY_STEP_MB}
 												converter={memoryConverter}
 											/>
@@ -320,7 +440,11 @@ export const ShowResources = ({ id, type }: Props) => {
 												<NumberInputWithSteps
 													value={field.value}
 													onChange={field.onChange}
-													placeholder="2000000000 (2 CPUs)"
+													placeholder={
+														inherited.cpuLimit
+															? `${inherited.cpuLimit} (from profile)`
+															: "2000000000 (2 CPUs)"
+													}
 													step={CPU_STEP}
 													converter={cpuConverter}
 												/>
@@ -360,7 +484,11 @@ export const ShowResources = ({ id, type }: Props) => {
 												<NumberInputWithSteps
 													value={field.value}
 													onChange={field.onChange}
-													placeholder="1000000000 (1 CPU)"
+													placeholder={
+														inherited.cpuReservation
+															? `${inherited.cpuReservation} (from profile)`
+															: "1000000000 (1 CPU)"
+													}
 													step={CPU_STEP}
 													converter={cpuConverter}
 												/>

--- a/apps/dokploy/components/dashboard/compose/advanced/assign-compose-resource-profiles.tsx
+++ b/apps/dokploy/components/dashboard/compose/advanced/assign-compose-resource-profiles.tsx
@@ -1,0 +1,408 @@
+import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { Loader2, RefreshCw, TriangleAlert } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import {
+	createConverter,
+	NumberInputWithSteps,
+} from "@/components/ui/number-input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/utils/api";
+
+const CPU_STEP = 0.25;
+const MEMORY_STEP_MB = 256;
+
+const formatNumber = (value: number, decimals = 2): string =>
+	Number.isInteger(value) ? String(value) : value.toFixed(decimals);
+
+const cpuConverter = createConverter(1_000_000_000, (cpu) =>
+	cpu <= 0 ? "" : `${formatNumber(cpu)} CPU`,
+);
+
+const memoryConverter = createConverter(1024 * 1024, (mb) => {
+	if (mb <= 0) return "";
+	return mb >= 1024
+		? `${formatNumber(mb / 1024)} GB`
+		: `${formatNumber(mb)} MB`;
+});
+
+const assignmentSchema = z.object({
+	services: z.array(
+		z.object({
+			serviceName: z.string(),
+			resourceGroupId: z.string().optional(),
+			profileId: z.string().nullable().optional(),
+			memoryReservation: z.string().optional(),
+			memoryLimit: z.string().optional(),
+			cpuReservation: z.string().optional(),
+			cpuLimit: z.string().optional(),
+		}),
+	),
+});
+
+type AssignmentForm = z.infer<typeof assignmentSchema>;
+
+interface Props {
+	composeId: string;
+}
+
+export const AssignComposeResourceProfiles = ({ composeId }: Props) => {
+	const [cacheType, setCacheType] = useState<"cache" | "fetch">("cache");
+	const utils = api.useUtils();
+
+	const {
+		data: services,
+		isLoading: isLoadingServices,
+		error: servicesError,
+		refetch: refetchServices,
+	} = api.compose.loadServicesWithResources.useQuery(
+		{ composeId, type: cacheType },
+		{ retry: false },
+	);
+
+	const { data: groups } = api.resourceProfile.all.useQuery();
+	const { data: assignments } = api.resourceProfile.composeAssignments.useQuery(
+		{ composeId },
+	);
+
+	const { mutateAsync, isPending } =
+		api.resourceProfile.saveComposeAssignments.useMutation();
+
+	const form = useForm<AssignmentForm>({
+		defaultValues: { services: [] },
+		resolver: zodResolver(assignmentSchema),
+	});
+
+	const { fields, replace } = useFieldArray({
+		control: form.control,
+		name: "services",
+		keyName: "fieldId",
+	});
+
+	useEffect(() => {
+		if (services && assignments) {
+			replace(
+				services.map((service) => {
+					const assignment = assignments.find(
+						(a) => a.serviceName === service.serviceName,
+					);
+					return {
+						serviceName: service.serviceName,
+						resourceGroupId: "",
+						profileId: assignment?.profileId || "",
+						memoryReservation: assignment?.memoryReservation || "",
+						memoryLimit: assignment?.memoryLimit || "",
+						cpuReservation: assignment?.cpuReservation || "",
+						cpuLimit: assignment?.cpuLimit || "",
+					};
+				}),
+			);
+		}
+	}, [services, assignments, replace]);
+
+	const onFetchServices = () => {
+		setCacheType("fetch");
+		setTimeout(() => refetchServices(), 0);
+	};
+
+	const onSubmit = async (formData: AssignmentForm) => {
+		await mutateAsync({
+			composeId,
+			services: formData.services.map((service) => ({
+				serviceName: service.serviceName,
+				profileId: service.profileId || null,
+				memoryReservation: service.memoryReservation || null,
+				memoryLimit: service.memoryLimit || null,
+				cpuReservation: service.cpuReservation || null,
+				cpuLimit: service.cpuLimit || null,
+			})),
+		})
+			.then(() => {
+				toast.success("Resource profiles saved");
+				utils.resourceProfile.composeAssignments.invalidate({ composeId });
+			})
+			.catch(() => {
+				toast.error("Error saving the resource profiles");
+			});
+	};
+
+	return (
+		<Card className="bg-background">
+			<CardHeader>
+				<CardTitle className="text-xl">Resource Profiles</CardTitle>
+				<CardDescription>
+					Assign a resource profile to each compose service. At deploy time
+					Dokploy injects <code>deploy.resources</code> into the generated stack
+					file. If the compose file already defines resources for a service, the
+					Dokploy assignment wins.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="flex flex-col gap-4">
+				{isLoadingServices ? (
+					<div className="flex flex-row gap-2 items-center justify-center text-sm text-muted-foreground min-h-[10vh]">
+						<span>Loading...</span>
+						<Loader2 className="animate-spin size-4" />
+					</div>
+				) : servicesError ? (
+					<div className="flex flex-col gap-4">
+						<AlertBlock type="warning">{servicesError.message}</AlertBlock>
+						<div className="flex justify-end">
+							<Button variant="outline" onClick={onFetchServices}>
+								<RefreshCw className="size-4 mr-1" />
+								Fetch Services
+							</Button>
+						</div>
+					</div>
+				) : (
+					<Form {...form}>
+						<form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+							{fields.length === 0 ? (
+								<p className="text-sm text-muted-foreground">
+									No services detected in the compose file.
+								</p>
+							) : (
+								fields.map((field, index) => {
+									const service = services?.find(
+										(s) => s.serviceName === field.serviceName,
+									);
+									const groupId = form.watch(
+										`services.${index}.resourceGroupId`,
+									);
+									const profileId = form.watch(`services.${index}.profileId`);
+									const groupProfiles =
+										groups?.find((g) => g.groupId === groupId)?.profiles ?? [];
+									return (
+										<div
+											key={field.fieldId}
+											className="flex flex-col gap-3 p-3 border rounded-lg bg-muted/30"
+										>
+											<div className="flex items-center justify-between gap-4 flex-wrap">
+												<div className="flex items-center gap-2">
+													<span className="text-sm font-medium">
+														{field.serviceName}
+													</span>
+													{service?.hasDeployResources && (
+														<Badge
+															variant="secondary"
+															className="gap-1 text-amber-600"
+														>
+															<TriangleAlert className="size-3" />
+															defines its own resources (will be overridden)
+														</Badge>
+													)}
+												</div>
+												<div className="grid grid-cols-2 gap-2 w-full sm:w-auto sm:min-w-[380px]">
+													<FormField
+														control={form.control}
+														name={`services.${index}.resourceGroupId`}
+														render={({ field: groupField }) => (
+															<FormItem>
+																<FormLabel>Group</FormLabel>
+																<Select
+																	onValueChange={(value) => {
+																		groupField.onChange(value);
+																		form.setValue(
+																			`services.${index}.profileId`,
+																			"",
+																		);
+																	}}
+																	value={groupField.value || undefined}
+																>
+																	<FormControl>
+																		<SelectTrigger>
+																			<SelectValue placeholder="None" />
+																		</SelectTrigger>
+																	</FormControl>
+																	<SelectContent>
+																		{groups?.map((group) => (
+																			<SelectItem
+																				key={group.groupId}
+																				value={group.groupId}
+																			>
+																				{group.name}
+																			</SelectItem>
+																		))}
+																	</SelectContent>
+																</Select>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name={`services.${index}.profileId`}
+														render={({ field: profileField }) => (
+															<FormItem>
+																<FormLabel>Profile</FormLabel>
+																<Select
+																	onValueChange={(value) =>
+																		profileField.onChange(
+																			value === "none" ? null : value,
+																		)
+																	}
+																	value={profileField.value || undefined}
+																>
+																	<FormControl>
+																		<SelectTrigger disabled={!groupId}>
+																			<SelectValue placeholder="Select" />
+																		</SelectTrigger>
+																	</FormControl>
+																	<SelectContent>
+																		<SelectItem value="none">None</SelectItem>
+																		{groupProfiles.map((profile) => (
+																			<SelectItem
+																				key={profile.profileId}
+																				value={profile.profileId}
+																			>
+																				{profile.name}
+																			</SelectItem>
+																		))}
+																	</SelectContent>
+																</Select>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+												</div>
+											</div>
+											<details>
+												<summary className="text-xs text-muted-foreground cursor-pointer select-none">
+													Advanced overrides
+												</summary>
+												<div className="grid grid-cols-1 md:grid-cols-4 gap-3 pt-3">
+													<FormField
+														control={form.control}
+														name={`services.${index}.memoryLimit`}
+														render={({ field: overrideField }) => (
+															<FormItem>
+																<FormLabel>Memory Limit</FormLabel>
+																<FormControl>
+																	<NumberInputWithSteps
+																		value={overrideField.value ?? ""}
+																		onChange={overrideField.onChange}
+																		placeholder="Bytes"
+																		step={MEMORY_STEP_MB}
+																		converter={memoryConverter}
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name={`services.${index}.memoryReservation`}
+														render={({ field: overrideField }) => (
+															<FormItem>
+																<FormLabel>Memory Reservation</FormLabel>
+																<FormControl>
+																	<NumberInputWithSteps
+																		value={overrideField.value ?? ""}
+																		onChange={overrideField.onChange}
+																		placeholder="Bytes"
+																		step={MEMORY_STEP_MB}
+																		converter={memoryConverter}
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name={`services.${index}.cpuLimit`}
+														render={({ field: overrideField }) => (
+															<FormItem>
+																<FormLabel>CPU Limit</FormLabel>
+																<FormControl>
+																	<NumberInputWithSteps
+																		value={overrideField.value ?? ""}
+																		onChange={overrideField.onChange}
+																		placeholder="CPUs"
+																		step={CPU_STEP}
+																		converter={cpuConverter}
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name={`services.${index}.cpuReservation`}
+														render={({ field: overrideField }) => (
+															<FormItem>
+																<FormLabel>CPU Reservation</FormLabel>
+																<FormControl>
+																	<NumberInputWithSteps
+																		value={overrideField.value ?? ""}
+																		onChange={overrideField.onChange}
+																		placeholder="CPUs"
+																		step={CPU_STEP}
+																		converter={cpuConverter}
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+												</div>
+											</details>
+											{profileId && groupId && (
+												<span className="text-xs text-muted-foreground">
+													Inherits values from the selected profile; fill an
+													override to win over the profile.
+												</span>
+											)}
+										</div>
+									);
+								})
+							)}
+							{fields.length > 0 && (
+								<div className="flex justify-end gap-2">
+									<Button
+										type="button"
+										variant="outline"
+										onClick={onFetchServices}
+									>
+										<RefreshCw className="size-4 mr-1" />
+										Refresh Services
+									</Button>
+									<Button isLoading={isPending} type="submit">
+										Save
+									</Button>
+								</div>
+							)}
+						</form>
+					</Form>
+				)}
+			</CardContent>
+		</Card>
+	);
+};

--- a/apps/dokploy/components/dashboard/settings/resource-profile/handle-resource-group.tsx
+++ b/apps/dokploy/components/dashboard/settings/resource-profile/handle-resource-group.tsx
@@ -1,0 +1,187 @@
+import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { PenBoxIcon, PlusIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { api } from "@/utils/api";
+
+const groupSchema = z.object({
+	name: z.string().min(1, "Name is required"),
+	description: z.string().optional(),
+});
+
+type GroupForm = z.infer<typeof groupSchema>;
+
+interface Props {
+	groupId?: string;
+}
+
+export const HandleResourceGroup = ({ groupId }: Props) => {
+	const [open, setOpen] = useState(false);
+	const utils = api.useUtils();
+
+	const {
+		mutateAsync: createMutateAsync,
+		isError,
+		error,
+		isPending,
+	} = api.resourceProfile.createGroup.useMutation();
+	const { mutateAsync: updateMutateAsync } =
+		api.resourceProfile.updateGroup.useMutation();
+
+	const { data: group } = api.resourceProfile.oneGroup.useQuery(
+		{ groupId: groupId || "" },
+		{
+			enabled: !!groupId,
+			refetchOnWindowFocus: false,
+		},
+	);
+
+	const form = useForm<GroupForm>({
+		defaultValues: { name: "", description: "" },
+		resolver: zodResolver(groupSchema),
+	});
+
+	useEffect(() => {
+		if (group) {
+			form.reset({
+				name: group.name,
+				description: group.description || "",
+			});
+		}
+	}, [group, form]);
+
+	useEffect(() => {
+		if (!open) {
+			form.reset({ name: "", description: "" });
+		}
+	}, [open, form]);
+
+	const onSubmit = async (data: GroupForm) => {
+		if (groupId) {
+			await updateMutateAsync({
+				groupId,
+				name: data.name,
+				description: data.description,
+			})
+				.then(() => {
+					toast.success("Group updated");
+					utils.resourceProfile.all.invalidate();
+					setOpen(false);
+				})
+				.catch(() => {
+					toast.error("Error saving the group");
+				});
+		} else {
+			await createMutateAsync({
+				name: data.name,
+				description: data.description,
+			})
+				.then(() => {
+					toast.success("Group created");
+					utils.resourceProfile.all.invalidate();
+					setOpen(false);
+				})
+				.catch(() => {
+					toast.error("Error creating the group");
+				});
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button
+					variant={groupId ? "ghost" : "default"}
+					size={groupId ? "icon" : "default"}
+				>
+					{groupId ? (
+						<PenBoxIcon className="size-4 text-primary" />
+					) : (
+						<>
+							<PlusIcon className="size-4 mr-1" />
+							Create Group
+						</>
+					)}
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>
+						{groupId ? "Edit" : "Create"} Resource Group
+					</DialogTitle>
+					<DialogDescription>
+						A group represents a set of named resource profiles, like a server
+						tier (for example KVM-2 or KVM-4).
+					</DialogDescription>
+				</DialogHeader>
+				<Form {...form}>
+					<form
+						id="resource-group-form"
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="grid w-full gap-4"
+					>
+						{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
+						<FormField
+							control={form.control}
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name</FormLabel>
+									<FormControl>
+										<Input placeholder="KVM-2" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="description"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Description (optional)</FormLabel>
+									<FormControl>
+										<Textarea
+											placeholder="Sizing for small VPS instances"
+											{...field}
+											value={field.value ?? ""}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<DialogFooter>
+							<Button isLoading={isPending} type="submit">
+								Save
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/settings/resource-profile/handle-resource-profile.tsx
+++ b/apps/dokploy/components/dashboard/settings/resource-profile/handle-resource-profile.tsx
@@ -1,0 +1,288 @@
+import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { PenBoxIcon, PlusIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+	createConverter,
+	NumberInputWithSteps,
+} from "@/components/ui/number-input";
+import { api } from "@/utils/api";
+
+const CPU_STEP = 0.25;
+const MEMORY_STEP_MB = 256;
+
+const formatNumber = (value: number, decimals = 2): string =>
+	Number.isInteger(value) ? String(value) : value.toFixed(decimals);
+
+const cpuConverter = createConverter(1_000_000_000, (cpu) =>
+	cpu <= 0 ? "" : `${formatNumber(cpu)} CPU`,
+);
+
+const memoryConverter = createConverter(1024 * 1024, (mb) => {
+	if (mb <= 0) return "";
+	return mb >= 1024
+		? `${formatNumber(mb / 1024)} GB`
+		: `${formatNumber(mb)} MB`;
+});
+
+const profileSchema = z.object({
+	name: z.string().min(1, "Name is required"),
+	memoryReservation: z.string().optional(),
+	memoryLimit: z.string().optional(),
+	cpuReservation: z.string().optional(),
+	cpuLimit: z.string().optional(),
+});
+
+type ProfileForm = z.infer<typeof profileSchema>;
+
+interface Props {
+	groupId: string;
+	profileId?: string;
+}
+
+export const HandleResourceProfile = ({ groupId, profileId }: Props) => {
+	const [open, setOpen] = useState(false);
+	const utils = api.useUtils();
+
+	const {
+		mutateAsync: createMutateAsync,
+		isError,
+		error,
+		isPending,
+	} = api.resourceProfile.createProfile.useMutation();
+	const { mutateAsync: updateMutateAsync } =
+		api.resourceProfile.updateProfile.useMutation();
+
+	const { data: profile } = api.resourceProfile.oneProfile.useQuery(
+		{ profileId: profileId || "" },
+		{
+			enabled: !!profileId && open,
+			refetchOnWindowFocus: false,
+		},
+	);
+
+	const form = useForm<ProfileForm>({
+		defaultValues: {
+			name: "",
+			memoryReservation: "",
+			memoryLimit: "",
+			cpuReservation: "",
+			cpuLimit: "",
+		},
+		resolver: zodResolver(profileSchema),
+	});
+
+	useEffect(() => {
+		if (profile && open) {
+			form.reset({
+				name: profile.name,
+				memoryReservation: profile.memoryReservation || "",
+				memoryLimit: profile.memoryLimit || "",
+				cpuReservation: profile.cpuReservation || "",
+				cpuLimit: profile.cpuLimit || "",
+			});
+		}
+	}, [profile, open, form]);
+
+	useEffect(() => {
+		if (!open) {
+			form.reset({
+				name: "",
+				memoryReservation: "",
+				memoryLimit: "",
+				cpuReservation: "",
+				cpuLimit: "",
+			});
+		}
+	}, [open, form]);
+
+	const onSubmit = async (data: ProfileForm) => {
+		const values = {
+			name: data.name,
+			memoryReservation: data.memoryReservation || null,
+			memoryLimit: data.memoryLimit || null,
+			cpuReservation: data.cpuReservation || null,
+			cpuLimit: data.cpuLimit || null,
+		};
+
+		if (profileId) {
+			await updateMutateAsync({ profileId, ...values })
+				.then(() => {
+					toast.success("Profile updated");
+					utils.resourceProfile.all.invalidate();
+					setOpen(false);
+				})
+				.catch(() => {
+					toast.error("Error updating the profile");
+				});
+		} else {
+			await createMutateAsync({ groupId, ...values })
+				.then(() => {
+					toast.success("Profile created");
+					utils.resourceProfile.all.invalidate();
+					setOpen(false);
+				})
+				.catch(() => {
+					toast.error("Error creating the profile");
+				});
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button
+					variant={profileId ? "ghost" : "outline"}
+					size={profileId ? "icon" : "sm"}
+				>
+					{profileId ? (
+						<PenBoxIcon className="size-4 text-primary" />
+					) : (
+						<>
+							<PlusIcon className="size-4 mr-1" />
+							Add Profile
+						</>
+					)}
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-xl">
+				<DialogHeader>
+					<DialogTitle>
+						{profileId ? "Edit" : "Create"} Resource Profile
+					</DialogTitle>
+					<DialogDescription>
+						A profile holds the resource limits and reservations that services
+						can inherit. Values use the same format as service resources.
+					</DialogDescription>
+				</DialogHeader>
+				<Form {...form}>
+					<form
+						id="resource-profile-form"
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="grid w-full gap-4"
+					>
+						{isError && <AlertBlock type="error">{error?.message}</AlertBlock>}
+						<FormField
+							control={form.control}
+							name="name"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Name</FormLabel>
+									<FormControl>
+										<Input placeholder="API" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+							<FormField
+								control={form.control}
+								name="memoryLimit"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Memory Limit</FormLabel>
+										<FormControl>
+											<NumberInputWithSteps
+												value={field.value ?? ""}
+												onChange={field.onChange}
+												placeholder="1073741824 (1GB in bytes)"
+												step={MEMORY_STEP_MB}
+												converter={memoryConverter}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="memoryReservation"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Memory Reservation</FormLabel>
+										<FormControl>
+											<NumberInputWithSteps
+												value={field.value ?? ""}
+												onChange={field.onChange}
+												placeholder="268435456 (256MB in bytes)"
+												step={MEMORY_STEP_MB}
+												converter={memoryConverter}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="cpuLimit"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>CPU Limit</FormLabel>
+										<FormControl>
+											<NumberInputWithSteps
+												value={field.value ?? ""}
+												onChange={field.onChange}
+												placeholder="2000000000 (2 CPUs)"
+												step={CPU_STEP}
+												converter={cpuConverter}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="cpuReservation"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>CPU Reservation</FormLabel>
+										<FormControl>
+											<NumberInputWithSteps
+												value={field.value ?? ""}
+												onChange={field.onChange}
+												placeholder="1000000000 (1 CPU)"
+												step={CPU_STEP}
+												converter={cpuConverter}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+						<DialogFooter>
+							<Button isLoading={isPending} type="submit">
+								Save
+							</Button>
+						</DialogFooter>
+					</form>
+				</Form>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/dokploy/components/dashboard/settings/resource-profile/show-resource-profiles.tsx
+++ b/apps/dokploy/components/dashboard/settings/resource-profile/show-resource-profiles.tsx
@@ -1,0 +1,216 @@
+import { Layers, Loader2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { DialogAction } from "@/components/shared/dialog-action";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { api } from "@/utils/api";
+import { HandleResourceGroup } from "./handle-resource-group";
+import { HandleResourceProfile } from "./handle-resource-profile";
+
+const formatMemory = (value: string | null): string => {
+	if (!value) return "-";
+	const bytes = Number.parseInt(value, 10);
+	if (!bytes) return value;
+	return bytes >= 1024 * 1024 * 1024
+		? `${(bytes / (1024 * 1024 * 1024)).toFixed(2).replace(/\.?0+$/, "")} GB`
+		: `${(bytes / (1024 * 1024)).toFixed(2).replace(/\.?0+$/, "")} MB`;
+};
+
+const formatCpu = (value: string | null): string => {
+	if (!value) return "-";
+	const nano = Number.parseInt(value, 10);
+	if (!nano) return value;
+	return `${(nano / 1_000_000_000).toFixed(2).replace(/\.?0+$/, "")} CPU`;
+};
+
+interface ProfileRowProps {
+	profile: {
+		profileId: string;
+		name: string;
+		memoryReservation: string | null;
+		memoryLimit: string | null;
+		cpuReservation: string | null;
+		cpuLimit: string | null;
+		usageCount: number;
+	};
+	groupId: string;
+}
+
+const ProfileRow = ({ profile, groupId }: ProfileRowProps) => {
+	const utils = api.useUtils();
+	const { mutateAsync, isPending } =
+		api.resourceProfile.removeProfile.useMutation();
+
+	return (
+		<div className="flex items-center justify-between gap-4 p-3 rounded-lg border bg-sidebar">
+			<div className="flex flex-col gap-1 min-w-0">
+				<div className="flex items-center gap-2">
+					<span className="text-sm font-medium">{profile.name}</span>
+					<Badge variant={profile.usageCount > 0 ? "default" : "secondary"}>
+						{profile.usageCount === 0
+							? "Unused"
+							: `${profile.usageCount} service${profile.usageCount > 1 ? "s" : ""}`}
+					</Badge>
+				</div>
+				<span className="text-xs text-muted-foreground truncate">
+					Memory Limit: {formatMemory(profile.memoryLimit)} · Memory
+					Reservation: {formatMemory(profile.memoryReservation)} · CPU Limit:{" "}
+					{formatCpu(profile.cpuLimit)} · CPU Reservation:{" "}
+					{formatCpu(profile.cpuReservation)}
+				</span>
+			</div>
+			<div className="flex items-center gap-1 shrink-0">
+				<HandleResourceProfile
+					groupId={groupId}
+					profileId={profile.profileId}
+				/>
+				<DialogAction
+					title="Delete Resource Profile"
+					description={`Are you sure you want to delete the profile "${profile.name}"? Profiles assigned to services cannot be deleted.`}
+					type="destructive"
+					onClick={async () => {
+						await mutateAsync({ profileId: profile.profileId })
+							.then(() => {
+								toast.success("Profile deleted successfully");
+								utils.resourceProfile.all.invalidate();
+							})
+							.catch((error) => {
+								toast.error(error?.message || "Error deleting the profile");
+							});
+					}}
+				>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="group hover:bg-red-500/10"
+						isLoading={isPending}
+					>
+						<Trash2 className="size-4 text-primary group-hover:text-red-500" />
+					</Button>
+				</DialogAction>
+			</div>
+		</div>
+	);
+};
+
+export const ShowResourceProfiles = () => {
+	const { data, isPending, refetch } = api.resourceProfile.all.useQuery();
+	const { mutateAsync, isPending: isRemoving } =
+		api.resourceProfile.removeGroup.useMutation();
+
+	return (
+		<div className="w-full">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto">
+				<div className="rounded-xl bg-background shadow-md">
+					<CardHeader>
+						<CardTitle className="text-xl flex flex-row gap-2">
+							<Layers className="size-6 text-muted-foreground self-center" />
+							Resource Profiles
+						</CardTitle>
+						<CardDescription>
+							Create groups of named resource profiles (for example one group
+							per server tier) and reuse them across your applications,
+							databases and compose services. Editing a profile updates the
+							effective resources of every linked service on the next deploy.
+						</CardDescription>
+					</CardHeader>
+					<CardContent className="space-y-4 py-8 border-t">
+						{isPending ? (
+							<div className="flex flex-row gap-2 items-center justify-center text-sm text-muted-foreground min-h-[25vh]">
+								<span>Loading...</span>
+								<Loader2 className="animate-spin size-4" />
+							</div>
+						) : !data || data.length === 0 ? (
+							<div className="flex flex-col items-center gap-3 min-h-[25vh] justify-center">
+								<Layers className="size-8 self-center text-muted-foreground" />
+								<span className="text-base text-muted-foreground">
+									Create a group to start organizing your resource profiles.
+								</span>
+								<HandleResourceGroup />
+							</div>
+						) : (
+							<div className="flex flex-col gap-6">
+								{data.map((group) => (
+									<div
+										key={group.groupId}
+										className="flex flex-col gap-3 p-4 rounded-lg border"
+									>
+										<div className="flex items-start justify-between gap-4">
+											<div className="flex flex-col gap-1">
+												<span className="text-base font-semibold">
+													{group.name}
+												</span>
+												{group.description && (
+													<span className="text-xs text-muted-foreground">
+														{group.description}
+													</span>
+												)}
+											</div>
+											<div className="flex items-center gap-1">
+												<HandleResourceGroup groupId={group.groupId} />
+												<DialogAction
+													title="Delete Resource Group"
+													description={`Are you sure you want to delete the group "${group.name}" and all its profiles? Groups whose profiles are still in use cannot be deleted.`}
+													type="destructive"
+													onClick={async () => {
+														await mutateAsync({ groupId: group.groupId })
+															.then(() => {
+																toast.success("Group deleted successfully");
+																refetch();
+															})
+															.catch((error) => {
+																toast.error(
+																	error?.message || "Error deleting the group",
+																);
+															});
+													}}
+												>
+													<Button
+														variant="ghost"
+														size="icon"
+														className="group hover:bg-red-500/10"
+														isLoading={isRemoving}
+													>
+														<Trash2 className="size-4 text-primary group-hover:text-red-500" />
+													</Button>
+												</DialogAction>
+											</div>
+										</div>
+										<div className="flex flex-col gap-2">
+											{group.profiles.length === 0 ? (
+												<span className="text-xs text-muted-foreground">
+													No profiles in this group yet.
+												</span>
+											) : (
+												group.profiles.map((profile) => (
+													<ProfileRow
+														key={profile.profileId}
+														profile={profile}
+														groupId={group.groupId}
+													/>
+												))
+											)}
+										</div>
+										<div className="flex justify-end">
+											<HandleResourceProfile groupId={group.groupId} />
+										</div>
+									</div>
+								))}
+								<div className="flex justify-end">
+									<HandleResourceGroup />
+								</div>
+							</div>
+						)}
+					</CardContent>
+				</div>
+			</Card>
+		</div>
+	);
+};

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -24,6 +24,7 @@ import {
 	Key,
 	KeyRound,
 	LayoutGrid,
+	Layers,
 	Loader2,
 	LogIn,
 	type LucideIcon,
@@ -392,6 +393,13 @@ const MENU: Menu = {
 			url: "/dashboard/settings/destinations",
 			icon: HardDrive,
 			isEnabled: ({ permissions }) => !!permissions?.destination.read,
+		},
+		{
+			isSingle: true,
+			title: "Resource Profiles",
+			url: "/dashboard/settings/resource-profiles",
+			icon: Layers,
+			isEnabled: ({ permissions }) => !!permissions?.resourceProfiles.read,
 		},
 
 		{

--- a/apps/dokploy/drizzle/0186_useful_union_jack.sql
+++ b/apps/dokploy/drizzle/0186_useful_union_jack.sql
@@ -1,0 +1,53 @@
+CREATE TABLE "compose_service_resource_profile" (
+	"composeServiceId" text PRIMARY KEY NOT NULL,
+	"composeId" text NOT NULL,
+	"serviceName" text NOT NULL,
+	"profileId" text,
+	"memoryReservation" text,
+	"memoryLimit" text,
+	"cpuReservation" text,
+	"cpuLimit" text,
+	CONSTRAINT "compose_service_unique" UNIQUE("composeId","serviceName")
+);
+--> statement-breakpoint
+CREATE TABLE "resource_group" (
+	"groupId" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"organizationId" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "resource_group_org_name_unique" UNIQUE("organizationId","name")
+);
+--> statement-breakpoint
+CREATE TABLE "resource_profile" (
+	"profileId" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"memoryReservation" text,
+	"memoryLimit" text,
+	"cpuReservation" text,
+	"cpuLimit" text,
+	"groupId" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "resource_profile_group_name_unique" UNIQUE("groupId","name")
+);
+--> statement-breakpoint
+ALTER TABLE "application" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "libsql" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "mariadb" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "mongo" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "mysql" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "postgres" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "redis" ADD COLUMN "resourceProfileId" text;--> statement-breakpoint
+ALTER TABLE "compose_service_resource_profile" ADD CONSTRAINT "compose_service_resource_profile_composeId_compose_composeId_fk" FOREIGN KEY ("composeId") REFERENCES "public"."compose"("composeId") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "compose_service_resource_profile" ADD CONSTRAINT "compose_service_resource_profile_profileId_resource_profile_profileId_fk" FOREIGN KEY ("profileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "resource_group" ADD CONSTRAINT "resource_group_organizationId_organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "resource_profile" ADD CONSTRAINT "resource_profile_groupId_resource_group_groupId_fk" FOREIGN KEY ("groupId") REFERENCES "public"."resource_group"("groupId") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "composeServiceProfile_profileId_idx" ON "compose_service_resource_profile" USING btree ("profileId");--> statement-breakpoint
+CREATE INDEX "resourceProfile_groupId_idx" ON "resource_profile" USING btree ("groupId");--> statement-breakpoint
+ALTER TABLE "application" ADD CONSTRAINT "application_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "libsql" ADD CONSTRAINT "libsql_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mariadb" ADD CONSTRAINT "mariadb_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mongo" ADD CONSTRAINT "mongo_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mysql" ADD CONSTRAINT "mysql_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "postgres" ADD CONSTRAINT "postgres_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "redis" ADD CONSTRAINT "redis_resourceProfileId_resource_profile_profileId_fk" FOREIGN KEY ("resourceProfileId") REFERENCES "public"."resource_profile"("profileId") ON DELETE set null ON UPDATE no action;

--- a/apps/dokploy/drizzle/meta/0186_snapshot.json
+++ b/apps/dokploy/drizzle/meta/0186_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "c9bd795e-2581-48e8-b8ff-c7a2a5d96dd1",
+  "id": "ccbcfb66-ba47-4ae4-8913-a9ac6700046a",
   "prevId": "8e851600-c994-4d52-a9d0-a8257e22a073",
   "version": "7",
   "dialect": "postgresql",
@@ -1257,6 +1257,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "title": {
           "name": "title",
           "type": "text",
@@ -1731,6 +1737,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "application_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "application_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "application",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "application_customGitSSHKeyId_ssh-key_sshKeyId_fk": {
           "name": "application_customGitSSHKeyId_ssh-key_sshKeyId_fk",
           "tableFrom": "application",
@@ -4134,6 +4153,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "externalPort": {
           "name": "externalPort",
           "type": "integer",
@@ -4262,6 +4287,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "libsql_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "libsql_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "libsql",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "libsql_environmentId_environment_environmentId_fk": {
           "name": "libsql_environmentId_environment_environmentId_fk",
           "tableFrom": "libsql",
@@ -4403,6 +4441,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "externalPort": {
           "name": "externalPort",
           "type": "integer",
@@ -4525,6 +4569,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "mariadb_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "mariadb_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "mariadb",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "mariadb_environmentId_environment_environmentId_fk": {
           "name": "mariadb_environmentId_environment_environmentId_fk",
           "tableFrom": "mariadb",
@@ -4651,6 +4708,12 @@
         },
         "cpuLimit": {
           "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -4784,6 +4847,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "mongo_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "mongo_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "mongo",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "mongo_environmentId_environment_environmentId_fk": {
           "name": "mongo_environmentId_environment_environmentId_fk",
           "tableFrom": "mongo",
@@ -5142,6 +5218,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "externalPort": {
           "name": "externalPort",
           "type": "integer",
@@ -5264,6 +5346,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "mysql_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "mysql_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "mysql",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "mysql_environmentId_environment_environmentId_fk": {
           "name": "mysql_environmentId_environment_environmentId_fk",
           "tableFrom": "mysql",
@@ -5320,12 +5415,6 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
-        },
-        "dockerId": {
-          "name": "dockerId",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "driver": {
           "name": "driver",
@@ -6499,6 +6588,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "applicationStatus": {
           "name": "applicationStatus",
           "type": "applicationStatus",
@@ -6615,6 +6710,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "postgres_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "postgres_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "postgres",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "postgres_environmentId_environment_environmentId_fk": {
           "name": "postgres_environmentId_environment_environmentId_fk",
           "tableFrom": "postgres",
@@ -7000,6 +7108,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "resourceProfileId": {
+          "name": "resourceProfileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "externalPort": {
           "name": "externalPort",
           "type": "integer",
@@ -7122,6 +7236,19 @@
       },
       "indexes": {},
       "foreignKeys": {
+        "redis_resourceProfileId_resource_profile_profileId_fk": {
+          "name": "redis_resourceProfileId_resource_profile_profileId_fk",
+          "tableFrom": "redis",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "resourceProfileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "redis_environmentId_environment_environmentId_fk": {
           "name": "redis_environmentId_environment_environmentId_fk",
           "tableFrom": "redis",
@@ -7243,6 +7370,287 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_service_resource_profile": {
+      "name": "compose_service_resource_profile",
+      "schema": "",
+      "columns": {
+        "composeServiceId": {
+          "name": "composeServiceId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serviceName": {
+          "name": "serviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profileId": {
+          "name": "profileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "composeServiceProfile_profileId_idx": {
+          "name": "composeServiceProfile_profileId_idx",
+          "columns": [
+            {
+              "expression": "profileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compose_service_resource_profile_composeId_compose_composeId_fk": {
+          "name": "compose_service_resource_profile_composeId_compose_composeId_fk",
+          "tableFrom": "compose_service_resource_profile",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compose_service_resource_profile_profileId_resource_profile_profileId_fk": {
+          "name": "compose_service_resource_profile_profileId_resource_profile_profileId_fk",
+          "tableFrom": "compose_service_resource_profile",
+          "tableTo": "resource_profile",
+          "columnsFrom": [
+            "profileId"
+          ],
+          "columnsTo": [
+            "profileId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compose_service_unique": {
+          "name": "compose_service_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "composeId",
+            "serviceName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_group": {
+      "name": "resource_group",
+      "schema": "",
+      "columns": {
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_group_organizationId_organization_id_fk": {
+          "name": "resource_group_organizationId_organization_id_fk",
+          "tableFrom": "resource_group",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_group_org_name_unique": {
+          "name": "resource_group_org_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organizationId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_profile": {
+      "name": "resource_profile",
+      "schema": "",
+      "columns": {
+        "profileId": {
+          "name": "profileId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resourceProfile_groupId_idx": {
+          "name": "resourceProfile_groupId_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_profile_groupId_resource_group_groupId_fk": {
+          "name": "resource_profile_groupId_resource_group_groupId_fk",
+          "tableFrom": "resource_profile",
+          "tableTo": "resource_group",
+          "columnsFrom": [
+            "groupId"
+          ],
+          "columnsTo": [
+            "groupId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_profile_group_name_unique": {
+          "name": "resource_profile_group_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "groupId",
+            "name"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/apps/dokploy/drizzle/meta/_journal.json
+++ b/apps/dokploy/drizzle/meta/_journal.json
@@ -1307,8 +1307,8 @@
     {
       "idx": 186,
       "version": "7",
-      "when": 1787813846067,
-      "tag": "0186_tearful_dragon_man",
+      "when": 1787676712095,
+      "tag": "0186_useful_union_jack",
       "breakpoints": true
     }
   ]

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/compose/[composeId].tsx
@@ -23,6 +23,7 @@ import { ShowSchedules } from "@/components/dashboard/application/schedules/show
 import { ShowVolumeBackups } from "@/components/dashboard/application/volume-backups/show-volume-backups";
 import { AddCommandCompose } from "@/components/dashboard/compose/advanced/add-command";
 import { IsolatedDeploymentTab } from "@/components/dashboard/compose/advanced/add-isolation";
+import { AssignComposeResourceProfiles } from "@/components/dashboard/compose/advanced/assign-compose-resource-profiles";
 import { ShowComposeContainers } from "@/components/dashboard/compose/containers/show-compose-containers";
 import { DeleteService } from "@/components/dashboard/compose/delete-service";
 import { ShowGeneralCompose } from "@/components/dashboard/compose/general/show";
@@ -433,6 +434,7 @@ const Service = (
 												<ShowVolumes id={composeId} type="compose" />
 												<ShowImport composeId={composeId} />
 												<AssignComposeNetworks composeId={composeId} />
+												<AssignComposeResourceProfiles composeId={composeId} />
 												<IsolatedDeploymentTab composeId={composeId} />
 											</div>
 										</TabsContent>

--- a/apps/dokploy/pages/dashboard/settings/resource-profiles.tsx
+++ b/apps/dokploy/pages/dashboard/settings/resource-profiles.tsx
@@ -1,0 +1,56 @@
+import { validateRequest } from "@dokploy/server";
+import { createServerSideHelpers } from "@trpc/react-query/server";
+import type { GetServerSidePropsContext } from "next";
+import type { ReactElement } from "react";
+import superjson from "superjson";
+import { ShowResourceProfiles } from "@/components/dashboard/settings/resource-profile/show-resource-profiles";
+import { DashboardLayout } from "@/components/layouts/dashboard-layout";
+import { appRouter } from "@/server/api/root";
+
+const Page = () => {
+	return (
+		<div className="flex flex-col gap-4 w-full">
+			<ShowResourceProfiles />
+		</div>
+	);
+};
+
+export default Page;
+
+Page.getLayout = (page: ReactElement) => {
+	return <DashboardLayout metaName="Resource Profiles">{page}</DashboardLayout>;
+};
+export async function getServerSideProps(
+	ctx: GetServerSidePropsContext<{ serviceId: string }>,
+) {
+	const { req, res } = ctx;
+	const { user, session } = await validateRequest(req);
+	if (!user || user.role === "member") {
+		return {
+			redirect: {
+				permanent: false,
+				destination: "/",
+			},
+		};
+	}
+
+	const helpers = createServerSideHelpers({
+		router: appRouter,
+		ctx: {
+			req: req as any,
+			res: res as any,
+			db: null as any,
+			session: session as any,
+			user: user as any,
+		},
+		transformer: superjson,
+	});
+	await helpers.user.get.prefetch();
+	await helpers.settings.isCloud.prefetch();
+
+	return {
+		props: {
+			trpcState: helpers.dehydrate(),
+		},
+	};
+}

--- a/apps/dokploy/server/api/root.ts
+++ b/apps/dokploy/server/api/root.ts
@@ -44,6 +44,7 @@ import { whitelabelingRouter } from "./routers/proprietary/whitelabeling";
 import { redirectsRouter } from "./routers/redirects";
 import { redisRouter } from "./routers/redis";
 import { registryRouter } from "./routers/registry";
+import { resourceProfileRouter } from "./routers/resource-profile";
 import { rollbackRouter } from "./routers/rollbacks";
 import { scheduleRouter } from "./routers/schedule";
 import { securityRouter } from "./routers/security";
@@ -96,6 +97,7 @@ export const appRouter = createTRPCRouter({
 	redirects: redirectsRouter,
 	redis: redisRouter,
 	registry: registryRouter,
+	resourceProfile: resourceProfileRouter,
 	security: securityRouter,
 	server: serverRouter,
 	settings: settingsRouter,

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -22,6 +22,7 @@ import {
 	getWebServerSettings,
 	IS_CLOUD,
 	loadServices,
+	loadServicesWithResources,
 	randomizeComposeFile,
 	randomizeIsolatedDeploymentComposeFile,
 	removeCompose,
@@ -319,6 +320,14 @@ export const composeRouter = createTRPCRouter({
 				service: ["read"],
 			});
 			return await loadServices(input.composeId, input.type);
+		}),
+	loadServicesWithResources: protectedProcedure
+		.input(apiFetchServices)
+		.query(async ({ input, ctx }) => {
+			await checkServicePermissionAndAccess(ctx, input.composeId, {
+				service: ["read"],
+			});
+			return await loadServicesWithResources(input.composeId, input.type);
 		}),
 	loadMountsByService: protectedProcedure
 		.input(

--- a/apps/dokploy/server/api/routers/resource-profile.ts
+++ b/apps/dokploy/server/api/routers/resource-profile.ts
@@ -1,0 +1,243 @@
+import {
+	createResourceGroup,
+	createResourceProfile,
+	findComposeServiceAssignments,
+	findResourceGroupsByOrganization,
+	findResourceProfileById,
+	getProfilesUsageCounts,
+	removeComposeServiceAssignment,
+	removeResourceGroupById,
+	removeResourceProfileById,
+	saveComposeServiceAssignment,
+	updateResourceGroupById,
+	updateResourceProfileById,
+} from "@dokploy/server";
+import { TRPCError } from "@trpc/server";
+import {
+	apiAssignComposeServiceProfile,
+	apiCreateResourceGroup,
+	apiCreateResourceProfile,
+	apiFindOneResourceGroup,
+	apiFindOneResourceProfile,
+	apiRemoveComposeServiceProfile,
+	apiRemoveResourceGroup,
+	apiRemoveResourceProfile,
+	apiUpdateResourceGroup,
+	apiUpdateResourceProfile,
+	resourceGroup,
+} from "@dokploy/server/db/schema";
+import { db } from "@dokploy/server/db";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import {
+	createTRPCRouter,
+	protectedProcedure,
+	withPermission,
+} from "@/server/api/trpc";
+import { audit } from "@/server/api/utils/audit";
+
+const apiSaveComposeServices = z.object({
+	composeId: z.string().min(1),
+	services: z.array(apiAssignComposeServiceProfile.omit({ composeId: true })),
+});
+
+export const resourceProfileRouter = createTRPCRouter({
+	all: withPermission("resourceProfiles", "read").query(async ({ ctx }) => {
+		const organizationId = ctx.session.activeOrganizationId;
+		const groups = await findResourceGroupsByOrganization(organizationId);
+		const profileIds = groups.flatMap((g) =>
+			g.profiles.map((p) => p.profileId),
+		);
+		const usageCounts = await getProfilesUsageCounts(profileIds);
+		return groups.map((group) => ({
+			...group,
+			profiles: group.profiles.map((profile) => ({
+				...profile,
+				usageCount: usageCounts.get(profile.profileId) || 0,
+			})),
+		}));
+	}),
+	oneGroup: withPermission("resourceProfiles", "read")
+		.input(apiFindOneResourceGroup)
+		.query(async ({ input, ctx }) => {
+			const group = await db.query.resourceGroup.findFirst({
+				where: eq(resourceGroup.groupId, input.groupId),
+				with: { profiles: true },
+			});
+			if (!group || group.organizationId !== ctx.session.activeOrganizationId) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Resource group not found",
+				});
+			}
+			return group;
+		}),
+	oneProfile: withPermission("resourceProfiles", "read")
+		.input(apiFindOneResourceProfile)
+		.query(async ({ input }) => {
+			const profile = await findResourceProfileById(input.profileId);
+			if (!profile) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Resource profile not found",
+				});
+			}
+			return profile;
+		}),
+	createGroup: withPermission("resourceProfiles", "create")
+		.input(apiCreateResourceGroup)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const result = await createResourceGroup(
+					input,
+					ctx.session.activeOrganizationId,
+				);
+				await audit(ctx, {
+					action: "create",
+					resourceType: "resourceProfile",
+					resourceId: result.groupId,
+					resourceName: input.name,
+				});
+				return result;
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error creating the resource group",
+					cause: error,
+				});
+			}
+		}),
+	updateGroup: withPermission("resourceProfiles", "update")
+		.input(apiUpdateResourceGroup)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const result = await updateResourceGroupById(input);
+				await audit(ctx, {
+					action: "update",
+					resourceType: "resourceProfile",
+					resourceId: input.groupId,
+					resourceName: input.name,
+				});
+				return result;
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error updating the resource group",
+					cause: error,
+				});
+			}
+		}),
+	removeGroup: withPermission("resourceProfiles", "delete")
+		.input(apiRemoveResourceGroup)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const result = await removeResourceGroupById(
+					input.groupId,
+					ctx.session.activeOrganizationId,
+				);
+				await audit(ctx, {
+					action: "delete",
+					resourceType: "resourceProfile",
+					resourceId: input.groupId,
+					resourceName: result?.name ?? "",
+				});
+				return result;
+			} catch (error) {
+				if (error instanceof TRPCError && error.code === "CONFLICT") {
+					throw error;
+				}
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error deleting the resource group",
+					cause: error,
+				});
+			}
+		}),
+	createProfile: withPermission("resourceProfiles", "create")
+		.input(apiCreateResourceProfile)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const result = await createResourceProfile(input);
+				await audit(ctx, {
+					action: "create",
+					resourceType: "resourceProfile",
+					resourceId: result.profileId,
+					resourceName: input.name,
+				});
+				return result;
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error creating the resource profile",
+					cause: error,
+				});
+			}
+		}),
+	updateProfile: withPermission("resourceProfiles", "update")
+		.input(apiUpdateResourceProfile)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const result = await updateResourceProfileById(input);
+				await audit(ctx, {
+					action: "update",
+					resourceType: "resourceProfile",
+					resourceId: input.profileId,
+					resourceName: input.name ?? "",
+				});
+				return result;
+			} catch (error) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error updating the resource profile",
+					cause: error,
+				});
+			}
+		}),
+	removeProfile: withPermission("resourceProfiles", "delete")
+		.input(apiRemoveResourceProfile)
+		.mutation(async ({ input, ctx }) => {
+			try {
+				const result = await removeResourceProfileById(
+					input.profileId,
+					ctx.session.activeOrganizationId,
+				);
+				await audit(ctx, {
+					action: "delete",
+					resourceType: "resourceProfile",
+					resourceId: input.profileId,
+					resourceName: result?.name ?? "",
+				});
+				return result;
+			} catch (error) {
+				if (error instanceof TRPCError && error.code === "CONFLICT") {
+					throw error;
+				}
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Error deleting the resource profile",
+					cause: error,
+				});
+			}
+		}),
+	composeAssignments: protectedProcedure
+		.input(z.object({ composeId: z.string().min(1) }))
+		.query(async ({ input }) => {
+			return await findComposeServiceAssignments(input.composeId);
+		}),
+	saveComposeAssignments: protectedProcedure
+		.input(apiSaveComposeServices)
+		.mutation(async ({ input }) => {
+			for (const service of input.services) {
+				await saveComposeServiceAssignment({
+					...service,
+					composeId: input.composeId,
+				});
+			}
+			return true;
+		}),
+	removeComposeAssignment: protectedProcedure
+		.input(apiRemoveComposeServiceProfile)
+		.mutation(async ({ input }) => {
+			return await removeComposeServiceAssignment(input.composeServiceId);
+		}),
+});

--- a/apps/dokploy/server/api/routers/resource-profile.ts
+++ b/apps/dokploy/server/api/routers/resource-profile.ts
@@ -1,7 +1,9 @@
 import {
 	createResourceGroup,
 	createResourceProfile,
+	findComposeServiceAssignmentById,
 	findComposeServiceAssignments,
+	findComposeById,
 	findResourceGroupsByOrganization,
 	findResourceProfileById,
 	getProfilesUsageCounts,
@@ -12,6 +14,7 @@ import {
 	updateResourceGroupById,
 	updateResourceProfileById,
 } from "@dokploy/server";
+import { checkServicePermissionAndAccess } from "@dokploy/server/services/permission";
 import { TRPCError } from "@trpc/server";
 import {
 	apiAssignComposeServiceProfile,
@@ -40,6 +43,53 @@ const apiSaveComposeServices = z.object({
 	composeId: z.string().min(1),
 	services: z.array(apiAssignComposeServiceProfile.omit({ composeId: true })),
 });
+
+const verifyGroupOwnership = async (groupId: string, organizationId: string) => {
+	const group = await db.query.resourceGroup.findFirst({
+		where: eq(resourceGroup.groupId, groupId),
+	});
+	if (!group || group.organizationId !== organizationId) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Resource group not found",
+		});
+	}
+	return group;
+};
+
+const verifyProfileOwnership = async (
+	profileId: string,
+	organizationId: string,
+) => {
+	const profile = await findResourceProfileById(profileId);
+	if (!profile || profile.group.organizationId !== organizationId) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Resource profile not found",
+		});
+	}
+	return profile;
+};
+
+const verifyComposeAccess = async (
+	ctx: { user: { id: string }; session: { activeOrganizationId: string } },
+	composeId: string,
+) => {
+	const compose = await findComposeById(composeId);
+	if (
+		compose.environment.project.organizationId !==
+		ctx.session.activeOrganizationId
+	) {
+		throw new TRPCError({
+			code: "UNAUTHORIZED",
+			message: "You are not authorized to access this compose",
+		});
+	}
+	await checkServicePermissionAndAccess(ctx, composeId, {
+		service: ["read"],
+	});
+	return compose;
+};
 
 export const resourceProfileRouter = createTRPCRouter({
 	all: withPermission("resourceProfiles", "read").query(async ({ ctx }) => {
@@ -74,15 +124,11 @@ export const resourceProfileRouter = createTRPCRouter({
 		}),
 	oneProfile: withPermission("resourceProfiles", "read")
 		.input(apiFindOneResourceProfile)
-		.query(async ({ input }) => {
-			const profile = await findResourceProfileById(input.profileId);
-			if (!profile) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Resource profile not found",
-				});
-			}
-			return profile;
+		.query(async ({ input, ctx }) => {
+			return await verifyProfileOwnership(
+				input.profileId,
+				ctx.session.activeOrganizationId,
+			);
 		}),
 	createGroup: withPermission("resourceProfiles", "create")
 		.input(apiCreateResourceGroup)
@@ -111,6 +157,10 @@ export const resourceProfileRouter = createTRPCRouter({
 		.input(apiUpdateResourceGroup)
 		.mutation(async ({ input, ctx }) => {
 			try {
+				await verifyGroupOwnership(
+					input.groupId,
+					ctx.session.activeOrganizationId,
+				);
 				const result = await updateResourceGroupById(input);
 				await audit(ctx, {
 					action: "update",
@@ -157,6 +207,10 @@ export const resourceProfileRouter = createTRPCRouter({
 		.input(apiCreateResourceProfile)
 		.mutation(async ({ input, ctx }) => {
 			try {
+				await verifyGroupOwnership(
+					input.groupId,
+					ctx.session.activeOrganizationId,
+				);
 				const result = await createResourceProfile(input);
 				await audit(ctx, {
 					action: "create",
@@ -177,6 +231,10 @@ export const resourceProfileRouter = createTRPCRouter({
 		.input(apiUpdateResourceProfile)
 		.mutation(async ({ input, ctx }) => {
 			try {
+				await verifyProfileOwnership(
+					input.profileId,
+					ctx.session.activeOrganizationId,
+				);
 				const result = await updateResourceProfileById(input);
 				await audit(ctx, {
 					action: "update",
@@ -221,12 +279,14 @@ export const resourceProfileRouter = createTRPCRouter({
 		}),
 	composeAssignments: protectedProcedure
 		.input(z.object({ composeId: z.string().min(1) }))
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			await verifyComposeAccess(ctx, input.composeId);
 			return await findComposeServiceAssignments(input.composeId);
 		}),
 	saveComposeAssignments: protectedProcedure
 		.input(apiSaveComposeServices)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
+			await verifyComposeAccess(ctx, input.composeId);
 			for (const service of input.services) {
 				await saveComposeServiceAssignment({
 					...service,
@@ -237,7 +297,17 @@ export const resourceProfileRouter = createTRPCRouter({
 		}),
 	removeComposeAssignment: protectedProcedure
 		.input(apiRemoveComposeServiceProfile)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
+			const assignment = await findComposeServiceAssignmentById(
+				input.composeServiceId,
+			);
+			if (!assignment) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Assignment not found",
+				});
+			}
+			await verifyComposeAccess(ctx, assignment.composeId);
 			return await removeComposeServiceAssignment(input.composeServiceId);
 		}),
 });

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -22,6 +22,7 @@ import { gitlab } from "./gitlab";
 import { mounts } from "./mount";
 import { patch } from "./patch";
 import { ports } from "./port";
+import { resourceProfile } from "./resource-profile";
 import { previewDeployments } from "./preview-deployments";
 import { redirects } from "./redirects";
 import { registry } from "./registry";
@@ -116,6 +117,10 @@ export const applications = pgTable("application", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	title: text("title"),
 	enabled: boolean("enabled"),
 	subtitle: text("subtitle"),
@@ -246,6 +251,10 @@ export const applicationsRelations = relations(
 			fields: [applications.environmentId],
 			references: [environments.environmentId],
 		}),
+		resourceProfile: one(resourceProfile, {
+			fields: [applications.resourceProfileId],
+			references: [resourceProfile.profileId],
+		}),
 		deployments: many(deployments),
 		customGitSSHKey: one(sshKeys, {
 			fields: [applications.customGitSSHKeyId],
@@ -321,6 +330,7 @@ const createSchema = createInsertSchema(applications, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	title: z.string().optional(),
 	enabled: z.boolean().optional(),
 	subtitle: z.string().optional(),

--- a/packages/server/src/db/schema/audit-log.ts
+++ b/packages/server/src/db/schema/audit-log.ts
@@ -94,4 +94,5 @@ export type AuditResourceType =
 	| "compose"
 	| "network"
 	| "vaultProvider"
-	| "dnsProvider";
+	| "dnsProvider"
+	| "resourceProfile";

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -31,6 +31,7 @@ export * from "./project";
 export * from "./redirects";
 export * from "./redis";
 export * from "./registry";
+export * from "./resource-profile";
 export * from "./rollbacks";
 export * from "./schedule";
 export * from "./scim";

--- a/packages/server/src/db/schema/libsql.ts
+++ b/packages/server/src/db/schema/libsql.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { backups } from "./backups";
 import { environments } from "./environment";
 import { mounts } from "./mount";
+import { resourceProfile } from "./resource-profile";
 import { server } from "./server";
 import {
 	applicationStatus,
@@ -65,6 +66,10 @@ export const libsql = pgTable("libsql", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	//
 	externalPort: integer("externalPort"),
 	externalGRPCPort: integer("externalGRPCPort"),
@@ -104,6 +109,10 @@ export const libsqlRelations = relations(libsql, ({ one, many }) => ({
 		fields: [libsql.environmentId],
 		references: [environments.environmentId],
 	}),
+	resourceProfile: one(resourceProfile, {
+		fields: [libsql.resourceProfileId],
+		references: [resourceProfile.profileId],
+	}),
 	backups: many(backups),
 	mounts: many(mounts),
 	server: one(server, {
@@ -133,6 +142,7 @@ const createSchema = createInsertSchema(libsql, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	environmentId: z.string(),
 	applicationStatus: z.enum(["idle", "running", "done", "error"]),
 	externalPort: z.number(),

--- a/packages/server/src/db/schema/mariadb.ts
+++ b/packages/server/src/db/schema/mariadb.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { backups } from "./backups";
 import { environments } from "./environment";
 import { mounts } from "./mount";
+import { resourceProfile } from "./resource-profile";
 import { server } from "./server";
 import {
 	applicationStatus,
@@ -68,6 +69,10 @@ export const mariadb = pgTable("mariadb", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	//
 	externalPort: integer("externalPort"),
 	applicationStatus: applicationStatus("applicationStatus")
@@ -106,6 +111,10 @@ export const mariadbRelations = relations(mariadb, ({ one, many }) => ({
 		fields: [mariadb.environmentId],
 		references: [environments.environmentId],
 	}),
+	resourceProfile: one(resourceProfile, {
+		fields: [mariadb.resourceProfileId],
+		references: [resourceProfile.profileId],
+	}),
 	backups: many(backups),
 	mounts: many(mounts),
 	server: one(server, {
@@ -143,6 +152,7 @@ const createSchema = createInsertSchema(mariadb, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	environmentId: z.string(),
 	applicationStatus: z.enum(["idle", "running", "done", "error"]),
 	externalPort: z.number(),

--- a/packages/server/src/db/schema/mongo.ts
+++ b/packages/server/src/db/schema/mongo.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { backups } from "./backups";
 import { environments } from "./environment";
 import { mounts } from "./mount";
+import { resourceProfile } from "./resource-profile";
 import { server } from "./server";
 import {
 	applicationStatus,
@@ -65,6 +66,10 @@ export const mongo = pgTable("mongo", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	externalPort: integer("externalPort"),
 	applicationStatus: applicationStatus("applicationStatus")
 		.notNull()
@@ -103,6 +108,10 @@ export const mongoRelations = relations(mongo, ({ one, many }) => ({
 		fields: [mongo.environmentId],
 		references: [environments.environmentId],
 	}),
+	resourceProfile: one(resourceProfile, {
+		fields: [mongo.resourceProfileId],
+		references: [resourceProfile.profileId],
+	}),
 	backups: many(backups),
 	mounts: many(mounts),
 	server: one(server, {
@@ -133,6 +142,7 @@ const createSchema = createInsertSchema(mongo, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	environmentId: z.string(),
 	applicationStatus: z.enum(["idle", "running", "done", "error"]),
 	externalPort: z.number(),

--- a/packages/server/src/db/schema/mysql.ts
+++ b/packages/server/src/db/schema/mysql.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { backups } from "./backups";
 import { environments } from "./environment";
 import { mounts } from "./mount";
+import { resourceProfile } from "./resource-profile";
 import { server } from "./server";
 import {
 	applicationStatus,
@@ -67,6 +68,10 @@ export const mysql = pgTable("mysql", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	externalPort: integer("externalPort"),
 	applicationStatus: applicationStatus("applicationStatus")
 		.notNull()
@@ -103,6 +108,10 @@ export const mysqlRelations = relations(mysql, ({ one, many }) => ({
 	environment: one(environments, {
 		fields: [mysql.environmentId],
 		references: [environments.environmentId],
+	}),
+	resourceProfile: one(resourceProfile, {
+		fields: [mysql.resourceProfileId],
+		references: [resourceProfile.profileId],
 	}),
 	backups: many(backups),
 	mounts: many(mounts),
@@ -141,6 +150,7 @@ const createSchema = createInsertSchema(mysql, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	applicationStatus: z.enum(["idle", "running", "done", "error"]),
 	externalPort: z.number(),
 	description: z.string().optional(),

--- a/packages/server/src/db/schema/postgres.ts
+++ b/packages/server/src/db/schema/postgres.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { backups } from "./backups";
 import { environments } from "./environment";
 import { mounts } from "./mount";
+import { resourceProfile } from "./resource-profile";
 import { server } from "./server";
 import {
 	applicationStatus,
@@ -67,6 +68,10 @@ export const postgres = pgTable("postgres", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	applicationStatus: applicationStatus("applicationStatus")
 		.notNull()
 		.default("idle"),
@@ -104,6 +109,10 @@ export const postgresRelations = relations(postgres, ({ one, many }) => ({
 		fields: [postgres.environmentId],
 		references: [environments.environmentId],
 	}),
+	resourceProfile: one(resourceProfile, {
+		fields: [postgres.resourceProfileId],
+		references: [resourceProfile.profileId],
+	}),
 	backups: many(backups),
 	mounts: many(mounts),
 	server: one(server, {
@@ -134,6 +143,7 @@ const createSchema = createInsertSchema(postgres, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	environmentId: z.string(),
 	applicationStatus: z.enum(["idle", "running", "done", "error"]),
 	externalPort: z.number(),

--- a/packages/server/src/db/schema/redis.ts
+++ b/packages/server/src/db/schema/redis.ts
@@ -12,6 +12,7 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { environments } from "./environment";
 import { mounts } from "./mount";
+import { resourceProfile } from "./resource-profile";
 import { server } from "./server";
 import {
 	applicationStatus,
@@ -61,6 +62,10 @@ export const redis = pgTable("redis", {
 	memoryLimit: text("memoryLimit"),
 	cpuReservation: text("cpuReservation"),
 	cpuLimit: text("cpuLimit"),
+	resourceProfileId: text("resourceProfileId").references(
+		() => resourceProfile.profileId,
+		{ onDelete: "set null" },
+	),
 	externalPort: integer("externalPort"),
 	createdAt: text("createdAt")
 		.notNull()
@@ -98,6 +103,10 @@ export const redisRelations = relations(redis, ({ one, many }) => ({
 		fields: [redis.environmentId],
 		references: [environments.environmentId],
 	}),
+	resourceProfile: one(resourceProfile, {
+		fields: [redis.resourceProfileId],
+		references: [resourceProfile.profileId],
+	}),
 	mounts: many(mounts),
 	server: one(server, {
 		fields: [redis.serverId],
@@ -124,6 +133,7 @@ const createSchema = createInsertSchema(redis, {
 	memoryLimit: z.string().optional(),
 	cpuReservation: z.string().optional(),
 	cpuLimit: z.string().optional(),
+	resourceProfileId: z.string().nullish(),
 	environmentId: z.string(),
 	applicationStatus: z.enum(["idle", "running", "done", "error"]),
 	externalPort: z.number(),

--- a/packages/server/src/db/schema/resource-profile.ts
+++ b/packages/server/src/db/schema/resource-profile.ts
@@ -1,0 +1,170 @@
+import { relations } from "drizzle-orm";
+import { index, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { organization } from "./account";
+import { compose } from "./compose";
+
+export const resourceGroup = pgTable(
+	"resource_group",
+	{
+		groupId: text("groupId")
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => nanoid()),
+		name: text("name").notNull(),
+		description: text("description"),
+		organizationId: text("organizationId")
+			.notNull()
+			.references(() => organization.id, { onDelete: "cascade" }),
+		createdAt: timestamp("createdAt").notNull().defaultNow(),
+	},
+	(table) => [
+		unique("resource_group_org_name_unique").on(
+			table.organizationId,
+			table.name,
+		),
+	],
+);
+
+export const resourceProfile = pgTable(
+	"resource_profile",
+	{
+		profileId: text("profileId")
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => nanoid()),
+		name: text("name").notNull(),
+		memoryReservation: text("memoryReservation"),
+		memoryLimit: text("memoryLimit"),
+		cpuReservation: text("cpuReservation"),
+		cpuLimit: text("cpuLimit"),
+		groupId: text("groupId")
+			.notNull()
+			.references(() => resourceGroup.groupId, { onDelete: "cascade" }),
+		createdAt: timestamp("createdAt").notNull().defaultNow(),
+	},
+	(table) => [
+		index("resourceProfile_groupId_idx").on(table.groupId),
+		unique("resource_profile_group_name_unique").on(table.groupId, table.name),
+	],
+);
+
+export const composeServiceResourceProfile = pgTable(
+	"compose_service_resource_profile",
+	{
+		composeServiceId: text("composeServiceId")
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => nanoid()),
+		composeId: text("composeId")
+			.notNull()
+			.references(() => compose.composeId, { onDelete: "cascade" }),
+		serviceName: text("serviceName").notNull(),
+		profileId: text("profileId").references(() => resourceProfile.profileId, {
+			onDelete: "set null",
+		}),
+		memoryReservation: text("memoryReservation"),
+		memoryLimit: text("memoryLimit"),
+		cpuReservation: text("cpuReservation"),
+		cpuLimit: text("cpuLimit"),
+	},
+	(table) => [
+		unique("compose_service_unique").on(table.composeId, table.serviceName),
+		index("composeServiceProfile_profileId_idx").on(table.profileId),
+	],
+);
+
+export const resourceGroupRelations = relations(
+	resourceGroup,
+	({ many, one }) => ({
+		profiles: many(resourceProfile),
+		organization: one(organization, {
+			fields: [resourceGroup.organizationId],
+			references: [organization.id],
+		}),
+	}),
+);
+
+export const resourceProfileRelations = relations(
+	resourceProfile,
+	({ one }) => ({
+		group: one(resourceGroup, {
+			fields: [resourceProfile.groupId],
+			references: [resourceGroup.groupId],
+		}),
+	}),
+);
+
+const resourceFields = {
+	memoryReservation: z
+		.string()
+		.optional()
+		.nullable()
+		.transform((v) => (v === "" ? null : v)),
+	memoryLimit: z
+		.string()
+		.optional()
+		.nullable()
+		.transform((v) => (v === "" ? null : v)),
+	cpuReservation: z
+		.string()
+		.optional()
+		.nullable()
+		.transform((v) => (v === "" ? null : v)),
+	cpuLimit: z
+		.string()
+		.optional()
+		.nullable()
+		.transform((v) => (v === "" ? null : v)),
+};
+
+export const apiCreateResourceGroup = z.object({
+	name: z.string().min(1),
+	description: z.string().optional(),
+});
+
+export const apiUpdateResourceGroup = z.object({
+	groupId: z.string().min(1),
+	name: z.string().min(1),
+	description: z.string().optional(),
+});
+
+export const apiFindOneResourceGroup = z.object({
+	groupId: z.string().min(1),
+});
+
+export const apiRemoveResourceGroup = z.object({
+	groupId: z.string().min(1),
+});
+
+export const apiCreateResourceProfile = z.object({
+	name: z.string().min(1),
+	groupId: z.string().min(1),
+	...resourceFields,
+});
+
+export const apiUpdateResourceProfile = z.object({
+	profileId: z.string().min(1),
+	name: z.string().optional(),
+	...resourceFields,
+});
+
+export const apiFindOneResourceProfile = z.object({
+	profileId: z.string().min(1),
+});
+
+export const apiRemoveResourceProfile = z.object({
+	profileId: z.string().min(1),
+});
+
+export const apiAssignComposeServiceProfile = z.object({
+	composeId: z.string().min(1),
+	serviceName: z.string().min(1),
+	profileId: z.string().nullable().optional(),
+	...resourceFields,
+});
+
+export const apiRemoveComposeServiceProfile = z.object({
+	composeServiceId: z.string().min(1),
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -47,6 +47,7 @@ export * from "./services/proprietary/whitelabeling";
 export * from "./services/redirect";
 export * from "./services/redis";
 export * from "./services/registry";
+export * from "./services/resource-profile";
 export * from "./services/rollbacks";
 export * from "./services/schedule";
 export * from "./services/security";

--- a/packages/server/src/lib/access-control.ts
+++ b/packages/server/src/lib/access-control.ts
@@ -28,6 +28,7 @@ export const statements = {
 	gitProviders: ["read", "create", "delete"],
 	traefikFiles: ["read", "write"],
 	api: ["read"],
+	resourceProfiles: ["read", "create", "update", "delete"],
 
 	// Enterprise-only resources (custom roles only)
 	volume: ["read", "create", "delete"],
@@ -99,6 +100,7 @@ export const ownerRole = ac.newRole({
 	gitProviders: ["read", "create", "delete"],
 	traefikFiles: ["read", "write"],
 	api: ["read"],
+	resourceProfiles: ["read", "create", "update", "delete"],
 	volume: ["read", "create", "delete"],
 	deployment: ["read", "create", "cancel"],
 	envVars: ["read", "write"],
@@ -138,6 +140,7 @@ export const adminRole = ac.newRole({
 	gitProviders: ["read", "create", "delete"],
 	traefikFiles: ["read", "write"],
 	api: ["read"],
+	resourceProfiles: ["read", "create", "update", "delete"],
 	volume: ["read", "create", "delete"],
 	deployment: ["read", "create", "cancel"],
 	envVars: ["read", "write"],
@@ -180,6 +183,7 @@ export const memberRole = ac.newRole({
 	gitProviders: [],
 	traefikFiles: [],
 	api: [],
+	resourceProfiles: [],
 	// Service-level enterprise resources — member can do everything within services they have access to
 	volume: ["read", "create", "delete"],
 	deployment: ["read", "create", "cancel"],

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -156,6 +156,43 @@ export const loadServices = async (
 	composeId: string,
 	type: "fetch" | "cache" = "fetch",
 ) => {
+	const composeData = await loadComposeSpecification(composeId, type);
+
+	if (!composeData?.services) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Services not found",
+		});
+	}
+
+	const services = Object.keys(composeData.services);
+
+	return [...services];
+};
+
+export const loadServicesWithResources = async (
+	composeId: string,
+	type: "fetch" | "cache" = "fetch",
+) => {
+	const composeData = await loadComposeSpecification(composeId, type);
+
+	if (!composeData?.services) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Services not found",
+		});
+	}
+
+	return Object.entries(composeData.services).map(([serviceName, service]) => ({
+		serviceName,
+		hasDeployResources: !!service.deploy?.resources,
+	}));
+};
+
+export const loadComposeSpecification = async (
+	composeId: string,
+	type: "fetch" | "cache" = "fetch",
+) => {
 	const compose = await findComposeById(composeId);
 
 	if (type === "fetch") {
@@ -183,16 +220,7 @@ export const loadServices = async (
 		composeData = randomizedCompose;
 	}
 
-	if (!composeData?.services) {
-		throw new TRPCError({
-			code: "NOT_FOUND",
-			message: "Services not found",
-		});
-	}
-
-	const services = Object.keys(composeData.services);
-
-	return [...services];
+	return composeData;
 };
 
 export const updateCompose = async (
@@ -319,7 +347,7 @@ export const deployCompose = async ({
 			projectName: compose.environment.project.name,
 			applicationName: compose.name,
 			applicationType: "compose",
-			// @ts-ignore
+			// @ts-expect-error
 			errorMessage: error?.message || "Error building",
 			buildLink,
 			organizationId: compose.environment.project.organizationId,

--- a/packages/server/src/services/resource-profile.ts
+++ b/packages/server/src/services/resource-profile.ts
@@ -1,0 +1,443 @@
+import { db } from "@dokploy/server/db";
+import {
+	type apiAssignComposeServiceProfile,
+	type apiCreateResourceGroup,
+	type apiCreateResourceProfile,
+	applications,
+	composeServiceResourceProfile,
+	type apiUpdateResourceGroup,
+	type apiUpdateResourceProfile,
+	libsql,
+	mariadb,
+	mongo,
+	mysql,
+	postgres,
+	redis,
+	resourceGroup,
+	resourceProfile,
+} from "@dokploy/server/db/schema";
+import type { ResourceRequirements } from "dockerode";
+import { TRPCError } from "@trpc/server";
+import { and, asc, eq, inArray } from "drizzle-orm";
+import type { z } from "zod";
+import type { ComposeSpecification } from "../utils/docker/types";
+import { calculateResources } from "../utils/docker/utils";
+
+export type ResourceGroup = typeof resourceGroup.$inferSelect;
+export type ResourceProfile = typeof resourceProfile.$inferSelect;
+
+type ResourceValues = {
+	memoryReservation: string | null;
+	memoryLimit: string | null;
+	cpuReservation: string | null;
+	cpuLimit: string | null;
+};
+
+export const createResourceGroup = async (
+	input: z.infer<typeof apiCreateResourceGroup>,
+	organizationId: string,
+) => {
+	const newGroup = await db
+		.insert(resourceGroup)
+		.values({
+			name: input.name,
+			description: input.description,
+			organizationId,
+		})
+		.returning()
+		.then((value) => value[0]);
+
+	if (!newGroup) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Error input: Inserting resource group",
+		});
+	}
+
+	return newGroup;
+};
+
+export const updateResourceGroupById = async (
+	input: z.infer<typeof apiUpdateResourceGroup>,
+) => {
+	const result = await db
+		.update(resourceGroup)
+		.set({
+			name: input.name,
+			description: input.description,
+		})
+		.where(eq(resourceGroup.groupId, input.groupId))
+		.returning();
+
+	return result[0];
+};
+
+export const removeResourceGroupById = async (
+	groupId: string,
+	organizationId: string,
+) => {
+	const group = await db.query.resourceGroup.findFirst({
+		where: and(
+			eq(resourceGroup.groupId, groupId),
+			eq(resourceGroup.organizationId, organizationId),
+		),
+		with: {
+			profiles: true,
+		},
+	});
+
+	if (!group) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Resource group not found",
+		});
+	}
+
+	if (group.profiles.length > 0) {
+		const usage = await getProfilesUsageCounts(
+			group.profiles.map((p) => p.profileId),
+		);
+		const totalUsage = [...usage.values()].reduce((a, b) => a + b, 0);
+		if (totalUsage > 0) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message:
+					"Cannot delete this group because one or more profiles are still assigned to services. Unassign them first.",
+			});
+		}
+	}
+
+	const result = await db
+		.delete(resourceGroup)
+		.where(
+			and(
+				eq(resourceGroup.groupId, groupId),
+				eq(resourceGroup.organizationId, organizationId),
+			),
+		)
+		.returning();
+
+	return result[0];
+};
+
+export const createResourceProfile = async (
+	input: z.infer<typeof apiCreateResourceProfile>,
+) => {
+	const newProfile = await db
+		.insert(resourceProfile)
+		.values({
+			name: input.name,
+			groupId: input.groupId,
+			memoryReservation: input.memoryReservation ?? null,
+			memoryLimit: input.memoryLimit ?? null,
+			cpuReservation: input.cpuReservation ?? null,
+			cpuLimit: input.cpuLimit ?? null,
+		})
+		.returning()
+		.then((value) => value[0]);
+
+	if (!newProfile) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "Error input: Inserting resource profile",
+		});
+	}
+
+	return newProfile;
+};
+
+export const updateResourceProfileById = async (
+	input: z.infer<typeof apiUpdateResourceProfile>,
+) => {
+	const result = await db
+		.update(resourceProfile)
+		.set({
+			...(input.name !== undefined && { name: input.name }),
+			...(input.memoryReservation !== undefined && {
+				memoryReservation: input.memoryReservation,
+			}),
+			...(input.memoryLimit !== undefined && {
+				memoryLimit: input.memoryLimit,
+			}),
+			...(input.cpuReservation !== undefined && {
+				cpuReservation: input.cpuReservation,
+			}),
+			...(input.cpuLimit !== undefined && { cpuLimit: input.cpuLimit }),
+		})
+		.where(eq(resourceProfile.profileId, input.profileId))
+		.returning();
+
+	return result[0];
+};
+
+export const findResourceProfileById = async (profileId: string) => {
+	const profile = await db.query.resourceProfile.findFirst({
+		where: eq(resourceProfile.profileId, profileId),
+	});
+	return profile;
+};
+
+export const removeResourceProfileById = async (
+	profileId: string,
+	organizationId: string,
+) => {
+	const profile = await db.query.resourceProfile.findFirst({
+		where: eq(resourceProfile.profileId, profileId),
+		with: {
+			group: true,
+		},
+	});
+
+	if (!profile || profile.group.organizationId !== organizationId) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Resource profile not found",
+		});
+	}
+
+	const usage = await getProfilesUsageCounts([profileId]);
+	if ((usage.get(profileId) || 0) > 0) {
+		throw new TRPCError({
+			code: "CONFLICT",
+			message:
+				"Cannot delete this profile because it is still assigned to services. Unassign it first.",
+		});
+	}
+
+	const result = await db
+		.delete(resourceProfile)
+		.where(eq(resourceProfile.profileId, profileId))
+		.returning();
+
+	return result[0];
+};
+
+export const findResourceGroupsByOrganization = (organizationId: string) => {
+	return db.query.resourceGroup.findMany({
+		where: eq(resourceGroup.organizationId, organizationId),
+		with: {
+			profiles: {
+				orderBy: [asc(resourceProfile.name)],
+			},
+		},
+		orderBy: [asc(resourceGroup.name)],
+	});
+};
+
+export const getProfilesUsageCounts = async (profileIds: string[]) => {
+	const counts = new Map<string, number>();
+	if (profileIds.length === 0) {
+		return counts;
+	}
+
+	const increment = (rows: Array<{ resourceProfileId: string | null }>) => {
+		for (const row of rows) {
+			if (row.resourceProfileId) {
+				counts.set(
+					row.resourceProfileId,
+					(counts.get(row.resourceProfileId) || 0) + 1,
+				);
+			}
+		}
+	};
+
+	increment(
+		await db
+			.select({ resourceProfileId: applications.resourceProfileId })
+			.from(applications)
+			.where(inArray(applications.resourceProfileId, profileIds)),
+	);
+	increment(
+		await db
+			.select({ resourceProfileId: postgres.resourceProfileId })
+			.from(postgres)
+			.where(inArray(postgres.resourceProfileId, profileIds)),
+	);
+	increment(
+		await db
+			.select({ resourceProfileId: mysql.resourceProfileId })
+			.from(mysql)
+			.where(inArray(mysql.resourceProfileId, profileIds)),
+	);
+	increment(
+		await db
+			.select({ resourceProfileId: mariadb.resourceProfileId })
+			.from(mariadb)
+			.where(inArray(mariadb.resourceProfileId, profileIds)),
+	);
+	increment(
+		await db
+			.select({ resourceProfileId: mongo.resourceProfileId })
+			.from(mongo)
+			.where(inArray(mongo.resourceProfileId, profileIds)),
+	);
+	increment(
+		await db
+			.select({ resourceProfileId: redis.resourceProfileId })
+			.from(redis)
+			.where(inArray(redis.resourceProfileId, profileIds)),
+	);
+	increment(
+		await db
+			.select({ resourceProfileId: libsql.resourceProfileId })
+			.from(libsql)
+			.where(inArray(libsql.resourceProfileId, profileIds)),
+	);
+
+	const composeAssignments = await db
+		.select({ resourceProfileId: composeServiceResourceProfile.profileId })
+		.from(composeServiceResourceProfile)
+		.where(inArray(composeServiceResourceProfile.profileId, profileIds));
+	increment(composeAssignments);
+
+	return counts;
+};
+
+/**
+ * Resolves the effective resources of a service: explicit values on the
+ * service act as overrides of the values inherited from its resource profile.
+ */
+export const resolveEffectiveResources = async (
+	service: Partial<ResourceValues> & { resourceProfileId?: string | null },
+): Promise<ResourceRequirements> => {
+	let { memoryLimit, memoryReservation, cpuLimit, cpuReservation } = service;
+
+	if (service.resourceProfileId) {
+		const profile = await findResourceProfileById(service.resourceProfileId);
+		if (profile) {
+			memoryLimit ??= profile.memoryLimit;
+			memoryReservation ??= profile.memoryReservation;
+			cpuLimit ??= profile.cpuLimit;
+			cpuReservation ??= profile.cpuReservation;
+		}
+	}
+
+	return calculateResources({
+		memoryLimit: memoryLimit ?? null,
+		memoryReservation: memoryReservation ?? null,
+		cpuLimit: cpuLimit ?? null,
+		cpuReservation: cpuReservation ?? null,
+	});
+};
+
+export const findComposeServiceAssignments = (composeId: string) => {
+	return db
+		.select()
+		.from(composeServiceResourceProfile)
+		.where(eq(composeServiceResourceProfile.composeId, composeId));
+};
+
+export const saveComposeServiceAssignment = async (
+	input: z.infer<typeof apiAssignComposeServiceProfile>,
+) => {
+	const result = await db
+		.insert(composeServiceResourceProfile)
+		.values({
+			composeId: input.composeId,
+			serviceName: input.serviceName,
+			profileId: input.profileId ?? null,
+			memoryReservation: input.memoryReservation ?? null,
+			memoryLimit: input.memoryLimit ?? null,
+			cpuReservation: input.cpuReservation ?? null,
+			cpuLimit: input.cpuLimit ?? null,
+		})
+		.onConflictDoUpdate({
+			target: [
+				composeServiceResourceProfile.composeId,
+				composeServiceResourceProfile.serviceName,
+			],
+			set: {
+				profileId: input.profileId ?? null,
+				memoryReservation: input.memoryReservation ?? null,
+				memoryLimit: input.memoryLimit ?? null,
+				cpuReservation: input.cpuReservation ?? null,
+				cpuLimit: input.cpuLimit ?? null,
+			},
+		})
+		.returning();
+
+	return result[0];
+};
+
+export const removeComposeServiceAssignment = async (
+	composeServiceId: string,
+) => {
+	const result = await db
+		.delete(composeServiceResourceProfile)
+		.where(eq(composeServiceResourceProfile.composeServiceId, composeServiceId))
+		.returning();
+
+	return result[0];
+};
+
+/**
+ * Injects `deploy.resources.limits/reservations` into the compose services
+ * that have a resource profile assignment. Dokploy assignments win over any
+ * `deploy.resources` already defined in the compose file for that service.
+ */
+export const applyResourceProfilesToSpecification = async (
+	composeId: string,
+	spec: ComposeSpecification,
+): Promise<ComposeSpecification> => {
+	const assignments = await findComposeServiceAssignments(composeId);
+	if (!assignments.length || !spec.services) {
+		return spec;
+	}
+
+	const profileIds = assignments
+		.map((a) => a.profileId)
+		.filter((id): id is string => !!id);
+	const profiles = new Map<string, ResourceProfile>();
+	if (profileIds.length > 0) {
+		const rows = await db
+			.select()
+			.from(resourceProfile)
+			.where(inArray(resourceProfile.profileId, profileIds));
+		for (const row of rows) {
+			profiles.set(row.profileId, row);
+		}
+	}
+
+	for (const assignment of assignments) {
+		const service = spec.services[assignment.serviceName];
+		if (!service) {
+			continue;
+		}
+		const profile = assignment.profileId
+			? profiles.get(assignment.profileId)
+			: undefined;
+
+		const memoryLimit = assignment.memoryLimit ?? profile?.memoryLimit ?? null;
+		const memoryReservation =
+			assignment.memoryReservation ?? profile?.memoryReservation ?? null;
+		const cpuLimit = assignment.cpuLimit ?? profile?.cpuLimit ?? null;
+		const cpuReservation =
+			assignment.cpuReservation ?? profile?.cpuReservation ?? null;
+
+		const existingLimits = service.deploy?.resources?.limits ?? {};
+		const existingReservations = service.deploy?.resources?.reservations ?? {};
+
+		const limits = {
+			...existingLimits,
+			...(memoryLimit && { memory: String(memoryLimit) }),
+			...(cpuLimit && { cpus: String(Number(cpuLimit) / 1_000_000_000) }),
+		};
+		const reservations = {
+			...existingReservations,
+			...(memoryReservation && { memory: String(memoryReservation) }),
+			...(cpuReservation && {
+				cpus: String(Number(cpuReservation) / 1_000_000_000),
+			}),
+		};
+
+		service.deploy = {
+			...service.deploy,
+			resources: {
+				...(Object.keys(limits).length > 0 && { limits }),
+				...(Object.keys(reservations).length > 0 && { reservations }),
+			},
+		};
+	}
+
+	return spec;
+};

--- a/packages/server/src/services/resource-profile.ts
+++ b/packages/server/src/services/resource-profile.ts
@@ -173,6 +173,9 @@ export const updateResourceProfileById = async (
 export const findResourceProfileById = async (profileId: string) => {
 	const profile = await db.query.resourceProfile.findFirst({
 		where: eq(resourceProfile.profileId, profileId),
+		with: {
+			group: true,
+		},
 	});
 	return profile;
 };
@@ -325,6 +328,17 @@ export const findComposeServiceAssignments = (composeId: string) => {
 		.select()
 		.from(composeServiceResourceProfile)
 		.where(eq(composeServiceResourceProfile.composeId, composeId));
+};
+
+export const findComposeServiceAssignmentById = async (
+	composeServiceId: string,
+) => {
+	return db.query.composeServiceResourceProfile.findFirst({
+		where: eq(
+			composeServiceResourceProfile.composeServiceId,
+			composeServiceId,
+		),
+	});
 };
 
 export const saveComposeServiceAssignment = async (

--- a/packages/server/src/services/rollbacks.ts
+++ b/packages/server/src/services/rollbacks.ts
@@ -9,7 +9,6 @@ import {
 } from "../db/schema";
 import { getRegistryTag } from "../utils/cluster/upload";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateVolumeMounts,
@@ -23,6 +22,7 @@ import { findDeploymentById } from "./deployment";
 import type { Environment } from "./environment";
 import type { Mount } from "./mount";
 import { resolveServiceNetworks } from "./network";
+import { resolveEffectiveResources } from "./resource-profile";
 import type { Port } from "./port";
 import type { Project } from "./project";
 import {
@@ -230,23 +230,9 @@ const rollbackApplication = async (
 
 	const docker = await getRemoteDocker(serverId);
 
-	const {
-		env,
-		mounts,
-		cpuLimit,
-		memoryLimit,
-		memoryReservation,
-		cpuReservation,
-		command,
-		ports,
-	} = resolvedContext;
+	const { env, mounts, command, ports } = resolvedContext;
 
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(resolvedContext);
 
 	const volumesMount = generateVolumeMounts(mounts);
 

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -1,10 +1,10 @@
 import { resolveServiceNetworks } from "@dokploy/server/services/network";
 import { findRegistryByIdWithCredentials } from "@dokploy/server/services/registry";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { getRegistryTag, uploadImageRemoteCommand } from "../cluster/upload";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
@@ -82,25 +82,9 @@ export const mechanizeDockerContainer = async (
 	rawApplication: ApplicationNested,
 ) => {
 	const application = await withResolvedVaultRefs(rawApplication);
-	const {
-		appName,
-		env,
-		mounts,
-		cpuLimit,
-		memoryLimit,
-		memoryReservation,
-		cpuReservation,
-		command,
-		args,
-		ports,
-	} = application;
+	const { appName, env, mounts, command, args, ports } = application;
 
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(application);
 
 	const volumesMount = generateVolumeMounts(mounts);
 

--- a/packages/server/src/utils/databases/libsql.ts
+++ b/packages/server/src/utils/databases/libsql.ts
@@ -2,13 +2,13 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions, PortConfig } from "dockerode";
 import { resolveServiceNetworks } from "../../services/network";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
 	prepareEnvironmentVariables,
 } from "../docker/utils";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
 
@@ -27,14 +27,10 @@ export const buildLibsql = async (rawLibsql: LibsqlNested) => {
 		externalPort,
 		externalGRPCPort,
 		externalAdminPort,
-		memoryLimit,
-		memoryReservation,
 		databaseUser,
 		databasePassword,
 		sqldNode,
 		sqldPrimaryUrl,
-		cpuLimit,
-		cpuReservation,
 		command,
 		mounts,
 		enableNamespaces,
@@ -60,12 +56,7 @@ export const buildLibsql = async (rawLibsql: LibsqlNested) => {
 		RollbackConfig,
 		UpdateConfig,
 	} = generateConfigContainer(libsql);
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(libsql);
 	const envVariables = prepareEnvironmentVariables(
 		defaultLibsqlEnv,
 		libsql.environment.project.env,

--- a/packages/server/src/utils/databases/mariadb.ts
+++ b/packages/server/src/utils/databases/mariadb.ts
@@ -2,13 +2,13 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { resolveServiceNetworks } from "../../services/network";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
 	prepareEnvironmentVariables,
 } from "../docker/utils";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
 
@@ -23,14 +23,10 @@ export const buildMariadb = async (rawMariadb: MariadbNested) => {
 		env,
 		externalPort,
 		dockerImage,
-		memoryLimit,
-		memoryReservation,
 		databaseName,
 		databaseUser,
 		databasePassword,
 		databaseRootPassword,
-		cpuLimit,
-		cpuReservation,
 		command,
 		args,
 		mounts,
@@ -54,12 +50,7 @@ export const buildMariadb = async (rawMariadb: MariadbNested) => {
 		EndpointSpec,
 		Ulimits,
 	} = generateConfigContainer(mariadb);
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(mariadb);
 	const envVariables = prepareEnvironmentVariables(
 		defaultMariadbEnv,
 		mariadb.environment.project.env,

--- a/packages/server/src/utils/databases/mongo.ts
+++ b/packages/server/src/utils/databases/mongo.ts
@@ -2,13 +2,13 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { resolveServiceNetworks } from "../../services/network";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
 	prepareEnvironmentVariables,
 } from "../docker/utils";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
 
@@ -24,10 +24,6 @@ export const buildMongo = async (rawMongo: MongoNested) => {
 		env,
 		externalPort,
 		dockerImage,
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
 		databaseUser,
 		databasePassword,
 		command,
@@ -101,12 +97,7 @@ ${command ?? "wait $MONGOD_PID"}`;
 		Ulimits,
 	} = generateConfigContainer(mongo);
 
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(mongo);
 
 	const envVariables = prepareEnvironmentVariables(
 		defaultMongoEnv,

--- a/packages/server/src/utils/databases/mysql.ts
+++ b/packages/server/src/utils/databases/mysql.ts
@@ -2,13 +2,13 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { resolveServiceNetworks } from "../../services/network";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
 	prepareEnvironmentVariables,
 } from "../docker/utils";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
 
@@ -24,14 +24,10 @@ export const buildMysql = async (rawMysql: MysqlNested) => {
 		env,
 		externalPort,
 		dockerImage,
-		memoryLimit,
-		memoryReservation,
 		databaseName,
 		databaseUser,
 		databasePassword,
 		databaseRootPassword,
-		cpuLimit,
-		cpuReservation,
 		command,
 		args,
 		mounts,
@@ -60,12 +56,7 @@ export const buildMysql = async (rawMysql: MysqlNested) => {
 		EndpointSpec,
 		Ulimits,
 	} = generateConfigContainer(mysql);
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(mysql);
 	const envVariables = prepareEnvironmentVariables(
 		defaultMysqlEnv,
 		mysql.environment.project.env,

--- a/packages/server/src/utils/databases/postgres.ts
+++ b/packages/server/src/utils/databases/postgres.ts
@@ -2,13 +2,13 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { resolveServiceNetworks } from "../../services/network";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
 	prepareEnvironmentVariables,
 } from "../docker/utils";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
 
@@ -23,10 +23,6 @@ export const buildPostgres = async (rawPostgres: PostgresNested) => {
 		env,
 		externalPort,
 		dockerImage,
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
 		databaseName,
 		databaseUser,
 		databasePassword,
@@ -53,12 +49,7 @@ export const buildPostgres = async (rawPostgres: PostgresNested) => {
 		EndpointSpec,
 		Ulimits,
 	} = generateConfigContainer(postgres);
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(postgres);
 	const envVariables = prepareEnvironmentVariables(
 		defaultPostgresEnv,
 		postgres.environment.project.env,

--- a/packages/server/src/utils/databases/redis.ts
+++ b/packages/server/src/utils/databases/redis.ts
@@ -2,13 +2,13 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { resolveServiceNetworks } from "../../services/network";
 import {
-	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
 	prepareEnvironmentVariables,
 } from "../docker/utils";
+import { resolveEffectiveResources } from "../../services/resource-profile";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
 
@@ -23,11 +23,7 @@ export const buildRedis = async (rawRedis: RedisNested) => {
 		env,
 		externalPort,
 		dockerImage,
-		memoryLimit,
-		memoryReservation,
 		databasePassword,
-		cpuLimit,
-		cpuReservation,
 		command,
 		args,
 		mounts,
@@ -51,12 +47,7 @@ export const buildRedis = async (rawRedis: RedisNested) => {
 		EndpointSpec,
 		Ulimits,
 	} = generateConfigContainer(redis);
-	const resources = calculateResources({
-		memoryLimit,
-		memoryReservation,
-		cpuLimit,
-		cpuReservation,
-	});
+	const resources = await resolveEffectiveResources(redis);
 	const envVariables = prepareEnvironmentVariables(
 		defaultRedisEnv,
 		redis.environment.project.env,

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -15,6 +15,7 @@ import { cloneGiteaRepository } from "../providers/gitea";
 import { cloneGithubRepository } from "../providers/github";
 import { cloneGitlabRepository } from "../providers/gitlab";
 import { getCreateComposeFileCommand } from "../providers/raw";
+import { applyResourceProfilesToSpecification } from "../../services/resource-profile";
 import { randomizeDeployableSpecificationFile } from "./collision";
 import { randomizeSpecificationFile } from "./compose";
 import type {
@@ -219,6 +220,11 @@ export const addDomainToCompose = async (
 	}
 
 	result = (await applyComposeFilePatch(compose)) ?? result;
+
+	result = await applyResourceProfilesToSpecification(
+		compose.composeId,
+		result,
+	);
 
 	if (compose.isolatedDeployment) {
 		const randomized = randomizeDeployableSpecificationFile(


### PR DESCRIPTION
Fixes #5106

## Description

Adds organization-level **Resource Groups** containing named **Resource Profiles** (the same 4 values already used by services today, in the same units/format), so resource sizing no longer has to be copy-pasted on every service and can be changed in one place.

### What's included

**Schema (migration 0186)**
- `resource_group` (org-scoped, unique name per org)
- `resource_profile` (belongs to a group; holds memoryReservation / memoryLimit / cpuReservation / cpuLimit, unique name per group)
- `compose_service_resource_profile` (per compose service assignment with per-field overrides)

**Applications & databases**
- New nullable `resourceProfileId` column on `application`, `postgres`, `mysql`, `mariadb`, `mongo`, `redis`, `libsql`
- The existing 4 resource fields act as per-field overrides — effective value = override ?? profile value
- Resolution happens at deploy time in the existing path (`builders`, database builders, rollbacks), applied on the next deploy/redeploy with no implicit restarts
- Services without a profile behave exactly as before

**Docker Compose**
- Compose settings (Advanced tab) list the services parsed from the file and allow assigning a profile (+ overrides) per service
- At deploy time Dokploy injects `deploy.resources.limits/reservations` into the generated stack file; if the service already defines `deploy.resources`, the Dokploy assignment wins and the UI shows a warning badge

**Settings UI**
- New "Resource Profiles" section (same pattern as S3 Destinations): CRUD for groups/profiles, usage counts shown per profile, deleting a group/profile still in use is blocked with a clear error
- Resources tab now has a Group → Profile selector; inherited values show as placeholders and each field remains individually overridable

## Screenshots

| | |
|---|---|
| ![Settings — empty state](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/01-resource-profiles-empty.png) | ![Create group dialog](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/02-create-group-dialog.png) |
| ![Create profile dialog](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/03-create-profile-dialog.png) | ![Profiles list with usage badges](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/04-resource-profiles-list.png) |
| ![Application Resources tab](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/05-app-resources-tab.png) | ![Profile dropdown expanded](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/06-app-resources-profile-dropdown.png) |

![Compose Advanced — per-service profile assignment](https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/07-compose-resource-profiles.png)

## Demo

https://github.com/gkissel/dokploy/releases/download/resource-profiles-screenshots/resource-profiles-demo.webm

## Testing

Verified locally against a running dev instance:
- ✅ tRPC CRUD for groups/profiles via live API
- ✅ Deleting an in-use profile returns CONFLICT with a clear message; unused profiles delete fine
- ✅ `resolveEffectiveResources`: profile inheritance verified live (profile 1GB/0.5CPU → effective limits), override precedence verified (app-level 2GB memory wins over profile, remaining fields inherit)
- ✅ Compose injection: parsed YAML with assigned service gets `deploy.resources.limits.memory=1073741824` + override `cpus=0.75`; unassigned service untouched
- ✅ Migration 0186 applies cleanly to Postgres
- ✅ `pnpm run typecheck`, Biome lint/format clean, unit tests pass (the only failing tests are the pre-existing network-dependent `application.real.test.ts` clone tests, which fail identically on a clean canary checkout in this environment)
- ✅ Profile select correctly displays linked profile on load (Radix Select controlled-value race fixed)
- ✅ Org-boundary authorization: cross-org profile access returns 404/CONFLICT
