### PR TITLE
fix(server): allow '+' and '@' in readValidDirectory path validation

### DIFF
--- a/apps/dokploy/__test__/wss/readValidDirectory.test.ts
+++ b/apps/dokploy/__test__/wss/readValidDirectory.test.ts
@@ -94,4 +94,32 @@ describe("readValidDirectory (path traversal)", () => {
 			),
 		).toBe(true);
 	});
+
+	it("returns true for SvelteKit routes with + prefix and @ symbols", () => {
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/src/routes/+page.svelte`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/src/routes/+layout.svelte`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/src/routes/+server.ts`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/src/routes/+error.svelte`,
+			),
+		).toBe(true);
+		expect(
+			readValidDirectory(
+				`${BASE}/applications/myapp/code/node_modules/@types/node/index.d.ts`,
+			),
+		).toBe(true);
+	});
 });

--- a/packages/server/src/wss/utils.ts
+++ b/packages/server/src/wss/utils.ts
@@ -40,7 +40,7 @@ export const readValidDirectory = (
 	directory: string,
 	serverId?: string | null,
 ) => {
-	if (!/^[\w/. :[\]-]{1,500}$/.test(directory)) {
+	if (!/^[\w/. :[\]+@~(),=%-]{1,500}$/.test(directory)) {
 		return false;
 	}
 

--- a/scripts/find-free-port.mjs
+++ b/scripts/find-free-port.mjs
@@ -18,6 +18,9 @@ async function findFreePort(start) {
 	return port;
 }
 
-const start = Number.parseInt(process.argv[2] || process.env.PORT || "3000", 10);
+const start = Number.parseInt(
+	process.argv[2] || process.env.PORT || "3000",
+	10,
+);
 const port = await findFreePort(start);
 process.stdout.write(String(port));


### PR DESCRIPTION
### Summary
Allows valid filename/path characters such as `+` (standard SvelteKit files like `+page.svelte`, `+layout.svelte`, `+server.ts`) and `@` (scoped `@types` / npm modules) in `readValidDirectory`.

### Problem
Previously, `readValidDirectory` used `/^[\w/. :[\]-]{1,500}$/` which rejected paths containing `+` or `@`, falsely reporting them as path traversal during ZIP drops and deployment.

### Changes
1. Updated regex in `packages/server/src/wss/utils.ts` to include `+`, `@`, `~`, `(`, `)`, `,`, `=`, `%`.
2. Added unit tests in `apps/dokploy/__test__/wss/readValidDirectory.test.ts` verifying SvelteKit route files and scoped module paths.

Closes #5185

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands `readValidDirectory`’s filename allowlist so valid SvelteKit and scoped-package paths are accepted while retaining resolved-path containment checks.
- Allows `+`, `@`, `~`, parentheses, comma, equals, and percent in validated paths.
- Adds coverage for SvelteKit route files and scoped `@types` module paths.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security failures identified.

The newly permitted characters remain subject to the existing base-directory containment check and are handled safely by all current filesystem and command consumers.

<sub>Reviews (1): Last reviewed commit: ["fix(server): allow plus, at, and valid p..."](https://github.com/dokploy/dokploy/commit/bd8ba128cd0cbf0c8ff934822047d362b23547ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56882028)</sub>

<!-- /greptile_comment -->