### PR TITLE
fix(server): keep ${VAR} self-references interpolatable in .env

### DIFF
--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -120,7 +120,16 @@ describe("getCreateEnvFileCommand", () => {
 
 		const out = execFileSync(
 			"docker",
-			["compose", "run", "--rm", "-T", "test", "sh", "-c", "printf '%s' \"$ASSET_URL\""],
+			[
+				"compose",
+				"run",
+				"--rm",
+				"-T",
+				"test",
+				"sh",
+				"-c",
+				"printf '%s' \"$ASSET_URL\"",
+			],
 			{ cwd: codePath, encoding: "utf8" },
 		);
 

--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -93,4 +93,37 @@ describe("getCreateEnvFileCommand", () => {
 			expect(actual[key], key).toBe(value);
 		}
 	}, 60000);
+
+	it("still interpolates a ${VAR} self-reference in the .env file", () => {
+		mkdirSync(codePath, { recursive: true });
+
+		const serviceEnv = [
+			"APP_URL=https://example.com",
+			'ASSET_URL="${APP_URL}"',
+		].join("\n");
+
+		const command = getCreateEnvFileCommand({
+			appName,
+			composePath: "docker-compose.yml",
+			env: serviceEnv,
+			randomize: false,
+			suffix: "",
+			serverId: null,
+			environment: { project: { env: "" }, env: "" },
+		} as Parameters<typeof getCreateEnvFileCommand>[0]);
+
+		execFileSync("bash", ["-c", command]);
+
+		const composeFile =
+			"services:\n  test:\n    image: busybox\n    environment:\n      - ASSET_URL=${ASSET_URL}\n";
+		writeFileSync(join(codePath, "docker-compose.yml"), composeFile);
+
+		const out = execFileSync(
+			"docker",
+			["compose", "run", "--rm", "-T", "test", "sh", "-c", "printf '%s' \"$ASSET_URL\""],
+			{ cwd: codePath, encoding: "utf8" },
+		);
+
+		expect(out).toBe("https://example.com");
+	}, 60000);
 });

--- a/apps/dokploy/__test__/env/environment.test.ts
+++ b/apps/dokploy/__test__/env/environment.test.ts
@@ -1,5 +1,6 @@
 import {
 	prepareEnvironmentVariables,
+	prepareEnvironmentVariablesForFile,
 	prepareEnvironmentVariablesForShell,
 } from "@dokploy/server/index";
 import { describe, expect, it } from "vitest";
@@ -640,5 +641,55 @@ SPECIAL=café résumé naïve
 		expect(resolved[0]).toContain("🌍");
 		expect(resolved[1]).toContain("你好");
 		expect(resolved[2]).toContain("café");
+	});
+});
+
+describe("prepareEnvironmentVariablesForFile (.env file escaping)", () => {
+	it("keeps a well-formed ${VAR} self-reference interpolatable", () => {
+		const serviceEnv = `
+APP_URL=https://example.com
+ASSET_URL=\${APP_URL}
+`;
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+
+		expect(resolved).toEqual([
+			`APP_URL="https://example.com"`,
+			`ASSET_URL="\${APP_URL}"`,
+		]);
+	});
+
+	it("keeps a ${VAR:-default} self-reference with a modifier interpolatable", () => {
+		const serviceEnv = `ASSET_URL=\${APP_URL:-https://default.com}`;
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+
+		expect(resolved).toEqual([`ASSET_URL="\${APP_URL:-https://default.com}"`]);
+	});
+
+	it("escapes a literal dollar sign followed by a word so it isn't interpolated", () => {
+		const serviceEnv = "PASSWORD=pa$word";
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+
+		expect(resolved).toEqual([`PASSWORD="pa\\$word"`]);
+	});
+
+	it("escapes a trailing dollar sign", () => {
+		const serviceEnv = "PRICE=100$";
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+
+		expect(resolved).toEqual([`PRICE="100\\$"`]);
+	});
+
+	it("still escapes double quotes and backslashes", () => {
+		const serviceEnv = String.raw`MESSAGE=say "hi" and \backslash`;
+
+		const resolved = prepareEnvironmentVariablesForFile(serviceEnv, "", "");
+
+		expect(resolved).toEqual([
+			String.raw`MESSAGE="say \"hi\" and \\backslash"`,
+		]);
 	});
 });

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -548,10 +548,7 @@ export const prepareEnvironmentVariablesForFile = (
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')
-			.replace(
-				/\$(?!\{[A-Za-z_][A-Za-z0-9_]*(?::?[-+?][^}]*)?\})/g,
-				"\\$",
-			);
+			.replace(/\$(?!\{[A-Za-z_][A-Za-z0-9_]*(?::?[-+?][^}]*)?\})/g, "\\$");
 		return `${key}="${escapedValue}"`;
 	});
 };

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -548,7 +548,10 @@ export const prepareEnvironmentVariablesForFile = (
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')
-			.replace(/\$/g, "\\$");
+			.replace(
+				/\$(?!\{[A-Za-z_][A-Za-z0-9_]*(?::?[-+?][^}]*)?\})/g,
+				"\\$",
+			);
 		return `${key}="${escapedValue}"`;
 	});
 };


### PR DESCRIPTION
## What is this PR about?

`prepareEnvironmentVariablesForFile` was escaping every `$` before writing a service's `.env` file, which broke Docker Compose's documented `${VAR}` interpolation feature (e.g. `ASSET_URL="${APP_URL}"`) — the $4962 fix for literal-dollar-sign passwords was too broad. This PR narrows the escaping so only $-signs that aren't part of a well-formed ${VAR} reference get escaped, keeping both the literal-dollar-sign fix and legitimate self-references working. Verified with unit tests and an end-to-end test that runs real `docker compose` against the generated `.env` file.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #5151

## Screenshots (if applicable)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows `.env` dollar escaping so Docker Compose can interpolate well-formed `${VAR}` references while continuing to escape other dollar signs.
- Replaces unconditional dollar escaping with a negative-lookahead expression.
- Adds unit coverage for references, modifiers, literal dollars, quotes, and backslashes.
- Adds a Docker Compose integration test for generated `.env` interpolation.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until generated `.env` values retain an explicit way to represent literal `${VAR}` text without Compose expansion.

The new regex fixes intended self-references but unconditionally reinterprets valid `${VAR}` sequences in passwords and template strings, corrupting those deployed values.

**Files Needing Attention:** packages/server/src/utils/docker/utils.ts

<sub>Reviews (1): Last reviewed commit: ["fix(server): keep ${VAR} self-references..."](https://github.com/dokploy/dokploy/commit/2d8dfee9f34dc731f53552a1ab82af86fc8a273f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57404314)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)

<!-- /greptile_comment -->