### PR TITLE
fix: preserve ${VAR} interpolation in .env values

### DIFF
--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -34,6 +34,7 @@ const cases: Record<string, string> = {
 	MULTILINE_PEM: "-----BEGIN KEY-----\nabc123\n-----END KEY-----",
 	APP_URL: "https://example.com",
 	ASSET_URL: "https://example.com",
+	DB_HOST: "localhost",
 };
 
 // How each value must be typed in the UI so the (unchanged) dotenv input
@@ -50,6 +51,7 @@ const inputEncoding: Record<string, string> = {
 	MULTILINE_PEM: '"-----BEGIN KEY-----\nabc123\n-----END KEY-----"',
 	APP_URL: "https://example.com",
 	ASSET_URL: '"${APP_URL}"',
+	DB_HOST: '"${UNDEFINED_HOST:-localhost}"',
 };
 
 describe("getCreateEnvFileCommand", () => {

--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -32,6 +32,8 @@ const cases: Record<string, string> = {
 	APOSTROPHE: "it's a test",
 	UNICODE: "héllo wörld 日本語 🚀",
 	MULTILINE_PEM: "-----BEGIN KEY-----\nabc123\n-----END KEY-----",
+	APP_URL: "https://example.com",
+	ASSET_URL: "https://example.com",
 };
 
 // How each value must be typed in the UI so the (unchanged) dotenv input
@@ -46,6 +48,8 @@ const inputEncoding: Record<string, string> = {
 	APOSTROPHE: "it's a test",
 	UNICODE: "héllo wörld 日本語 🚀",
 	MULTILINE_PEM: '"-----BEGIN KEY-----\nabc123\n-----END KEY-----"',
+	APP_URL: "https://example.com",
+	ASSET_URL: '"${APP_URL}"',
 };
 
 describe("getCreateEnvFileCommand", () => {

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -548,7 +548,7 @@ export const prepareEnvironmentVariablesForFile = (
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')
-			.replace(/\$/g, "\\$");
+			.replace(/\$(?!\{[A-Za-z_][A-Za-z0-9_]*\})/g, "\\$");
 		return `${key}="${escapedValue}"`;
 	});
 };

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -548,7 +548,7 @@ export const prepareEnvironmentVariablesForFile = (
 		const escapedValue = value
 			.replace(/\\/g, "\\\\")
 			.replace(/"/g, '\\"')
-			.replace(/\$(?!\{[A-Za-z_][A-Za-z0-9_]*\})/g, "\\$");
+			.replace(/\$(?!\{[A-Za-z_][A-Za-z0-9_]*(?::?[-+?][^{}]*)?\})/g, "\\$");
 		return `${key}="${escapedValue}"`;
 	});
 };


### PR DESCRIPTION
Fixes #5151

`prepareEnvironmentVariablesForFile` unconditionally escaped every `$` before writing `.env`, which broke Docker Compose's documented `.env` variable interpolation (`ASSET_URL="${APP_URL}"` never resolved). Now only escapes a `$` that isn't part of a `${IDENTIFIER}` reference, so braced variable references still interpolate while literal `$` (e.g. in passwords) stays escaped as before.

**Before**
```
APP_URL=https://example.com
ASSET_URL="${APP_URL}"
```
written to `.env` as `ASSET_URL="\${APP_URL}"` → app receives literal `${APP_URL}`.

**After**
`ASSET_URL="${APP_URL}"` is written unescaped → Compose interpolates it to `https://example.com`, matching plain `docker compose` behavior.

Added a regression case to `env-file-literals.test.ts` covering the `${VAR}` reference alongside the existing literal-`$` cases (e.g. `pa$$word`), confirming both keep working.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Compose `.env` serialization so simple `${VAR}` references remain available for Docker Compose interpolation while other dollar signs remain escaped.

- Adds a Docker Compose integration regression case for `${APP_URL}`.
- Replaces unconditional dollar escaping with an identifier-specific negative lookahead.
- The new rule omits Compose parameter-expansion forms and removes the prior ability to preserve literal `${VAR}` text.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until Compose parameter-expansion syntax and an explicit way to preserve literal `${VAR}` values are handled.

The new regex silently changes valid environment values in two reachable cases: supported Compose expressions containing operators remain escaped, while literal simple references become active interpolation.

**Files Needing Attention:** packages/server/src/utils/docker/utils.ts and apps/dokploy/__test__/compose/env-file-literals.test.ts

<sub>Reviews (1): Last reviewed commit: ["fix: preserve ${VAR} interpolation in .e..."](https://github.com/dokploy/dokploy/commit/452b7aa2f2a3e18f6ad80bfb185f2380b23d2013) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57405317)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)

<!-- /greptile_comment -->