### PR TITLE
fix: unsaved organization form fields reset on window visibility change

### DIFF
--- a/apps/dokploy/components/dashboard/organization/handle-organization.tsx
+++ b/apps/dokploy/components/dashboard/organization/handle-organization.tsx
@@ -48,6 +48,7 @@ export function AddOrganization({ organizationId }: Props) {
 		},
 		{
 			enabled: !!organizationId,
+			refetchOnWindowFocus: false,
 		},
 	);
 	const { mutateAsync, isPending } = organizationId


### PR DESCRIPTION
Fixes #5146

The organization edit form used `api.organization.one.useQuery` without disabling `refetchOnWindowFocus`. Switching tabs/windows and returning triggered a refetch; when it resolved with a new data reference, the `useEffect` that syncs the query result into the form called `form.reset(...)`, wiping any unsaved edits.

Fix: disable `refetchOnWindowFocus` on that query, matching the pattern already used elsewhere in the codebase.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disables window-focus refetching for the organization edit query so returning to the window does not reset unsaved form values.
- Adds `refetchOnWindowFocus: false` to the organization detail query.
- Aligns the form with existing editable-query patterns that preserve local draft state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The organization query no longer refetches on window focus, preventing its synchronization effect from replacing unsaved form values when the user returns to the window.

<sub>Reviews (1): Last reviewed commit: ["fix: prevent unsaved organization form f..."](https://github.com/dokploy/dokploy/commit/f46cd4601ca742bb747e542a8ef02113e94b1821) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57414190)</sub>

<!-- /greptile_comment -->