### PR TITLE
fix: correct network monitoring chart labels and units

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/paid/servers/network-chart.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/paid/servers/network-chart.tsx
@@ -19,6 +19,11 @@ interface NetworkChartProps {
 	data: any[];
 }
 
+function formatNetworkGB(valueInMB: number) {
+	if (Number.isNaN(valueInMB)) return "0";
+	return (valueInMB / 1024).toFixed(1);
+}
+
 const chartConfig = {
 	networkIn: {
 		label: "Network In",
@@ -38,8 +43,8 @@ export function NetworkChart({ data }: NetworkChartProps) {
 			<CardHeader className="border-b py-5">
 				<CardTitle>Network</CardTitle>
 				<CardDescription>
-					Network Traffic: ↑ {latestData.networkOut} KB/s ↓{" "}
-					{latestData.networkIn} KB/s
+					Network Total: ↑ {formatNetworkGB(latestData.networkOut)} GB ↓{" "}
+					{formatNetworkGB(latestData.networkIn)} GB (since Boot)
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
@@ -83,7 +88,7 @@ export function NetworkChart({ data }: NetworkChartProps) {
 							minTickGap={32}
 							tickFormatter={(value) => formatTimestamp(value)}
 						/>
-						<YAxis tickFormatter={(value) => `${value} KB/s`} />
+						<YAxis tickFormatter={(value) => `${formatNetworkGB(value)} GB`} />
 						<ChartTooltip
 							cursor={false}
 							content={({ active, payload, label }) => {
@@ -105,8 +110,8 @@ export function NetworkChart({ data }: NetworkChartProps) {
 														Network
 													</span>
 													<span className="font-bold">
-														↑ {data.networkOut} KB/s
-														<br />↓ {data.networkIn} KB/s
+														↑ {formatNetworkGB(data.networkOut)} GB
+														<br />↓ {formatNetworkGB(data.networkIn)} GB
 													</span>
 												</div>
 											</div>


### PR DESCRIPTION
Fixes #5115

The network chart showed values labeled as KB/s, but the underlying data (`networkIn`/`networkOut`) is MB totals accumulated since boot, not a per-second rate.

- Relabel card description from "Network Traffic: ↑ X KB/s ↓ X KB/s" to "Network Total: ↑ X GB ↓ X GB (since Boot)"
- Convert MB → GB for card description, Y-axis, and tooltip

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects the server network chart to present cumulative traffic rather than a per-second rate.
- Converts the monitoring service's cumulative MB values to GB.
- Updates the card, Y-axis, and tooltip labels consistently.
- Clarifies that the totals represent traffic accumulated since boot.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the conversion and cumulative-total labels match the monitoring producer's metric semantics.

The monitoring service records cumulative byte counters as MB, and the changed component consistently divides those values by 1024 before displaying them as GB across the summary, axis, and tooltip.

<sub>Reviews (1): Last reviewed commit: ["fix: correct network monitoring chart la..."](https://github.com/dokploy/dokploy/commit/a822db59676ad6c91db1a15358d113e27b08a4d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57417755)</sub>

**Context used:**

- Knowledge Base — [Servers, clusters, and monitoring](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/servers-clusters-and-monitoring.md)

<!-- /greptile_comment -->