### PR TITLE
fix: resolve relative bind mounts against code dir for git-based compose deploys

### DIFF
--- a/apps/dokploy/__test__/compose/compose-project-directory.test.ts
+++ b/apps/dokploy/__test__/compose/compose-project-directory.test.ts
@@ -1,0 +1,58 @@
+import { createCommand } from "@dokploy/server/utils/builders/compose";
+import { describe, expect, it } from "vitest";
+
+const base = {
+	composeType: "docker-compose" as const,
+	appName: "compose-app",
+	sourceType: "github" as const,
+	command: "",
+};
+
+describe("compose createCommand --project-directory", () => {
+	it("pins --project-directory to the code dir when composePath is nested", () => {
+		const cmd = createCommand(
+			{ ...base, composePath: "./deploy/docker-compose.yml" } as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).toContain(
+			"--project-directory /etc/dokploy/compose/compose-app/code",
+		);
+		expect(cmd).toContain("-f ./deploy/docker-compose.yml");
+	});
+
+	it("omits --project-directory when no projectPath is passed", () => {
+		const cmd = createCommand({
+			...base,
+			composePath: "./deploy/docker-compose.yml",
+		} as any);
+
+		expect(cmd).not.toContain("--project-directory");
+	});
+
+	it("does not add --project-directory to stack deploy (unsupported flag)", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				composeType: "stack",
+				composePath: "./deploy/docker-compose.yml",
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).not.toContain("--project-directory");
+		expect(cmd.startsWith("stack deploy")).toBe(true);
+	});
+
+	it("keeps raw sourceType resolving from the code dir (root docker-compose.yml)", () => {
+		const cmd = createCommand(
+			{ ...base, sourceType: "raw", composePath: "docker-compose.yml" } as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).toContain(
+			"--project-directory /etc/dokploy/compose/compose-app/code",
+		);
+		expect(cmd).toContain("-f docker-compose.yml");
+	});
+});

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import {
 	addDomainToCompose,
 	clearOldDeployments,
@@ -32,6 +33,7 @@ import {
 	updateCompose,
 	updateDeploymentStatus,
 } from "@dokploy/server";
+import { paths } from "@dokploy/server/constants";
 import { db } from "@dokploy/server/db";
 import { canEditDeployGitSource } from "@dokploy/server/services/git-provider";
 import {
@@ -547,7 +549,9 @@ export const composeRouter = createTRPCRouter({
 				service: ["create"],
 			});
 			const compose = await findComposeById(input.composeId);
-			const command = createCommand(compose);
+			const { COMPOSE_PATH } = paths(!!compose.serverId);
+			const projectPath = join(COMPOSE_PATH, compose.appName, "code");
+			const command = createCommand(compose, projectPath);
 			return `docker ${command}`;
 		}),
 	refreshToken: protectedProcedure

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -21,11 +21,11 @@ export const getBuildComposeCommand = async (rawCompose: ComposeNested) => {
 	const compose = await withResolvedVaultRefs(rawCompose);
 	const { COMPOSE_PATH } = paths(!!compose.serverId);
 	const { sourceType, appName, mounts, composeType, domains } = compose;
-	const command = createCommand(compose);
+	const projectPath = join(COMPOSE_PATH, compose.appName, "code");
+	const command = createCommand(compose, projectPath);
 	const envCommand = compose.createEnvFile
 		? getCreateEnvFileCommand(compose)
 		: "";
-	const projectPath = join(COMPOSE_PATH, compose.appName, "code");
 	const exportEnvCommand = getExportEnvCommand(compose);
 
 	const newCompose = await writeDomainsToCompose(compose, domains);
@@ -119,7 +119,7 @@ const sanitizeCommand = (command: string) => {
 	return restCommand.join(" ");
 };
 
-export const createCommand = (compose: ComposeNested) => {
+export const createCommand = (compose: ComposeNested, projectPath?: string) => {
 	const { composeType, appName, sourceType } = compose;
 	if (compose.command) {
 		return `${sanitizeCommand(compose.command)}`;
@@ -130,7 +130,10 @@ export const createCommand = (compose: ComposeNested) => {
 	let command = "";
 
 	if (composeType === "docker-compose") {
-		command = `compose -p ${quote([appName])} -f ${quote([path])} up -d --build --remove-orphans`;
+		const projectDirectoryFlag = projectPath
+			? `--project-directory ${quote([projectPath])} `
+			: "";
+		command = `compose -p ${quote([appName])} ${projectDirectoryFlag}-f ${quote([path])} up -d --build --remove-orphans`;
 	} else if (composeType === "stack") {
 		command = `stack deploy -c ${quote([path])} ${quote([appName])} --prune --with-registry-auth`;
 	}


### PR DESCRIPTION
Fixes #5181

File mounts (bind mounts with relative paths, e.g. `../files/:/files/:ro`) don't get applied when a compose service uses a Git provider (GitHub/GitLab/Gitea/Bitbucket/custom Git) for auto-deploy, but work fine with the `raw` provider.

**Root cause:** Docker Compose resolves relative bind-mount paths against the directory of the compose file passed via `-f`, not against the shell's cwd. With `raw`, the synthesized compose file always lives flat in `code/docker-compose.yml`, so `../files` happens to resolve to `code/../files` — exactly where file mounts are written. With Git providers, the repo is cloned verbatim and `composePath` can point into a subdirectory (e.g. `deploy/docker-compose.yml`), which shifts where `../files` resolves to, silently binding an empty/missing directory instead of the configured mount content.

**Fix:** pass `--project-directory` pinned to the fixed `code/` dir when building the `docker compose` command, so relative mounts always resolve the same way raw deployments already do. Only applied to `docker-compose` mode (`docker stack deploy` doesn't support the flag).

Verified end-to-end against a real git clone + deploy + running container: before the fix the mount bound `code/files` (empty); after the fix it binds the correct `<appName>/files` dir with the configured content.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins generated Docker Compose commands to each service's code workspace so relative paths remain stable when the Compose file is nested.
- Passes the code workspace into Compose command construction for deploy, rebuild, and command display paths.
- Adds --project-directory only to Docker Compose mode, preserving Docker Stack syntax.
- Adds focused command-generation tests for nested, raw, omitted-path, and stack cases.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until nested generated .env handling and custom Compose commands are aligned with the new project-directory behavior.

The generated flag fixes default relative mount resolution, but it makes Docker Compose look for interpolation configuration in a different directory from the generated .env file and is skipped entirely by supported custom commands.

**Files Needing Attention:** packages/server/src/utils/builders/compose.ts

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/server/src/utils/builders/compose.ts`, line 124-126 ([link](https://github.com/dokploy/dokploy/blob/87b914996f37b2238dd09b362c0105d65b0465dc/packages/server/src/utils/builders/compose.ts#L124-L126)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Custom commands bypass rebasing**

   When a Git-based service with a nested Compose file uses a supported custom command such as `compose -f ./deploy/docker-compose.yml up -d`, this early return skips the new `--project-directory` flag, so relative bind mounts still resolve against the nested file directory and the reported missing or empty mount behavior remains.

   **Knowledge Base Used:** [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: resolve relative bind mounts agains..."](https://github.com/dokploy/dokploy/commit/87b914996f37b2238dd09b362c0105d65b0465dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57540699)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)

<!-- /greptile_comment -->