### PR TITLE
fix: don't write invalid empty traefik config for apps without domains

### DIFF
--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeAppTraefikConfig } from "@dokploy/server/utils/traefik/application";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	execAsyncRemote: vi.fn(),
+}));
+
+vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
+	return {
+		...actual,
+		execAsyncRemote: mocks.execAsyncRemote,
+	};
+});
+
+describe("writeAppTraefikConfig", () => {
+	let cwd: string;
+	let dynamicPath: string;
+
+	beforeEach(() => {
+		cwd = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-traefik-"));
+		dynamicPath = path.join(cwd, ".docker", "traefik", "dynamic");
+		fs.mkdirSync(dynamicPath, { recursive: true });
+		vi.spyOn(process, "cwd").mockReturnValue(cwd);
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fs.rmSync(cwd, { recursive: true, force: true });
+	});
+
+	// Regression test for #5189: Traefik's file provider rejects a standalone
+	// `routers: {}` / `services: {}` map and aborts its watcher for every
+	// dynamic config once it hits one, so an app with no domains must never
+	// get an on-disk config file at all.
+	it("removes the file instead of writing empty routers/services", async () => {
+		const appName = "no-domain-app";
+		const configPath = path.join(dynamicPath, `${appName}.yml`);
+		fs.writeFileSync(configPath, "stale content", "utf8");
+
+		await writeAppTraefikConfig(
+			{ http: { routers: {}, services: {} } },
+			appName,
+		);
+
+		expect(fs.existsSync(configPath)).toBe(false);
+	});
+
+	it("writes the file when routers/services are present", async () => {
+		const appName = "with-domain-app";
+		const configPath = path.join(dynamicPath, `${appName}.yml`);
+
+		await writeAppTraefikConfig(
+			{
+				http: {
+					routers: { [`${appName}-router-1`]: { rule: "Host(`x`)" } },
+					services: {},
+				},
+			},
+			appName,
+		);
+
+		expect(fs.existsSync(configPath)).toBe(true);
+	});
+
+	it("removes the remote file instead of writing empty routers/services", async () => {
+		mocks.execAsyncRemote.mockResolvedValue({ stdout: "", stderr: "" });
+
+		await writeAppTraefikConfig(
+			{ http: { routers: {}, services: {} } },
+			"no-domain-app",
+			"server-id",
+		);
+
+		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
+		const [, command] = mocks.execAsyncRemote.mock.calls[0];
+		expect(command).toMatch(/^rm -f /);
+		expect(command).toContain("no-domain-app.yml");
+	});
+
+	it("writes the remote file when routers/services are present", async () => {
+		mocks.execAsyncRemote.mockResolvedValue({ stdout: "", stderr: "" });
+
+		await writeAppTraefikConfig(
+			{
+				http: {
+					routers: { "with-domain-app-router-1": { rule: "Host(`x`)" } },
+					services: {},
+				},
+			},
+			"with-domain-app",
+			"server-id",
+		);
+
+		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
+		const [, command] = mocks.execAsyncRemote.mock.calls[0];
+		expect(command).toMatch(/^echo /);
+	});
+});

--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
 	const actual =
-		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
+		await importOriginal<
+			typeof import("@dokploy/server/utils/process/execAsync")
+		>();
 	return {
 		...actual,
 		execAsyncRemote: mocks.execAsyncRemote,

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -292,6 +292,26 @@ export const writeTraefikConfigRemote = async (
 	}
 };
 
+const isEmptyHttpRoutersAndServices = (traefikConfig: FileConfig) =>
+	Object.keys(traefikConfig.http?.routers || {}).length === 0 &&
+	Object.keys(traefikConfig.http?.services || {}).length === 0;
+
+export const writeAppTraefikConfig = async (
+	traefikConfig: FileConfig,
+	appName: string,
+	serverId?: string | null,
+) => {
+	if (isEmptyHttpRoutersAndServices(traefikConfig)) {
+		await removeTraefikConfig(appName, serverId);
+		return;
+	}
+	if (serverId) {
+		await writeTraefikConfigRemote(traefikConfig, appName, serverId);
+	} else {
+		writeTraefikConfig(traefikConfig, appName);
+	}
+};
+
 export const createServiceConfig = (
 	appName: string,
 	domain: Domain,

--- a/packages/server/src/utils/traefik/redirect.ts
+++ b/packages/server/src/utils/traefik/redirect.ts
@@ -3,7 +3,7 @@ import type { ApplicationNested } from "../builders";
 import {
 	loadOrCreateConfig,
 	loadOrCreateConfigRemote,
-	writeTraefikConfig,
+	writeAppTraefikConfig,
 	writeTraefikConfigRemote,
 } from "./application";
 import type { FileConfig } from "./file-types";
@@ -89,11 +89,10 @@ export const createRedirectMiddleware = async (
 
 	if (serverId) {
 		await writeTraefikConfigRemote(config, "middlewares", serverId);
-		await writeTraefikConfigRemote(appConfig, appName, serverId);
 	} else {
 		writeMiddleware(config);
-		writeTraefikConfig(appConfig, appName);
 	}
+	await writeAppTraefikConfig(appConfig, appName, serverId);
 };
 
 export const removeRedirectMiddleware = async (
@@ -124,9 +123,8 @@ export const removeRedirectMiddleware = async (
 
 	if (serverId) {
 		await writeTraefikConfigRemote(config, "middlewares", serverId);
-		await writeTraefikConfigRemote(appConfig, appName, serverId);
 	} else {
-		writeTraefikConfig(appConfig, appName);
 		writeMiddleware(config);
 	}
+	await writeAppTraefikConfig(appConfig, appName, serverId);
 };

--- a/packages/server/src/utils/traefik/security.ts
+++ b/packages/server/src/utils/traefik/security.ts
@@ -4,7 +4,7 @@ import type { ApplicationNested } from "../builders";
 import {
 	loadOrCreateConfig,
 	loadOrCreateConfigRemote,
-	writeTraefikConfig,
+	writeAppTraefikConfig,
 	writeTraefikConfigRemote,
 } from "./application";
 import type {
@@ -62,11 +62,10 @@ export const createSecurityMiddleware = async (
 	addMiddleware(appConfig, middlewareName);
 	if (serverId) {
 		await writeTraefikConfigRemote(config, "middlewares", serverId);
-		await writeTraefikConfigRemote(appConfig, appName, serverId);
 	} else {
-		writeTraefikConfig(appConfig, appName);
 		writeMiddleware(config);
 	}
+	await writeAppTraefikConfig(appConfig, appName, serverId);
 };
 
 export const removeSecurityMiddleware = async (
@@ -89,6 +88,7 @@ export const removeSecurityMiddleware = async (
 		appConfig = loadOrCreateConfig(appName);
 	}
 	const middlewareName = `auth-${appName}`;
+	let removedLastUser = false;
 
 	if (config.http?.middlewares) {
 		const currentMiddleware = config.http.middlewares[middlewareName];
@@ -106,11 +106,7 @@ export const removeSecurityMiddleware = async (
 					delete config.http.middlewares[middlewareName];
 				}
 				deleteMiddleware(appConfig, middlewareName);
-				if (serverId) {
-					await writeTraefikConfigRemote(appConfig, appName, serverId);
-				} else {
-					writeTraefikConfig(appConfig, appName);
-				}
+				removedLastUser = true;
 			}
 		}
 	}
@@ -119,6 +115,9 @@ export const removeSecurityMiddleware = async (
 		await writeTraefikConfigRemote(config, "middlewares", serverId);
 	} else {
 		writeMiddleware(config);
+	}
+	if (removedLastUser) {
+		await writeAppTraefikConfig(appConfig, appName, serverId);
 	}
 };
 


### PR DESCRIPTION
Fixes #5189

Attaching Basic Auth or a Redirect to an application with no domains yet writes the app's dynamic config file with empty `routers: {}` / `services: {}`. Traefik's file provider rejects that as invalid and aborts its watcher, blocking config reloads for every other application on the same instance.

## Fix

Added `writeAppTraefikConfig(config, appName, serverId?)`, which removes the app's dynamic config file instead of writing an empty one (mirrors the guard `removeDomain` already had for the last-router case). Wired into `security.ts` and `redirect.ts`, the two call sites that could write an empty config before any domain exists.

`writeTraefikConfig`/`writeTraefikConfigRemote` were left untouched since they're also used to write the shared `middlewares.yml`, which legitimately has no `routers`/`services` keys.

## Repro

Before the fix, adding Basic Auth to a domainless app wrote:
```yaml
http:
  routers: {}
  services: {}
```
— the exact invalid config from the issue. After the fix, no file is written.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an application-specific Traefik writer that removes empty per-application configuration files rather than writing invalid empty router/service maps, and routes Basic Auth and redirect updates through it.
- Adds local and remote regression coverage for deleting empty app configs and retaining non-empty configs.
- Uses the new helper in security and redirect middleware lifecycle operations.
- Changes middleware-removal persistence ordering, leaving a transient missing-definition state for routed applications.

<h3>Confidence Score: 4/5</h3>

The empty-config fix is sound, but the middleware-removal ordering should be corrected before merging because Traefik can observe routers that temporarily reference missing middleware.

Security and local redirect removal now persist deletion of shared middleware definitions before removing their router references, exposing an invalid intermediate dynamic-configuration state.

**Files Needing Attention:** packages/server/src/utils/traefik/security.ts, packages/server/src/utils/traefik/redirect.ts

<sub>Reviews (1): Last reviewed commit: ["fix: remove empty routers/services traef..."](https://github.com/dokploy/dokploy/commit/032e80411472d5a8b31ad61ba1176b94744b5803) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57548664)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Docker networking and Traefik](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/docker-networking-and-traefik.md)

<!-- /greptile_comment -->