### PR TITLE
fix: File Mount update fails silently on nested paths

### DIFF
--- a/packages/server/src/services/mount.ts
+++ b/packages/server/src/services/mount.ts
@@ -262,18 +262,28 @@ export const updateFileMount = async (mountId: string) => {
 	if (!mount || !mount.filePath) return;
 	const basePath = await getBaseFilesPath(mountId);
 	const fullPath = path.join(basePath, mount.filePath);
+	const directory = path.dirname(fullPath);
 
 	try {
 		const serverId = await getServerId(mount);
 		const encodedContent = encodeBase64(mount.content || "");
-		const command = `echo "${encodedContent}" | base64 -d > ${quote([fullPath])}`;
+		const command = `
+			mkdir -p ${quote([directory])};
+			if [ -d ${quote([fullPath])} ]; then rm -rf ${quote([fullPath])}; fi;
+			echo "${encodedContent}" | base64 -d > ${quote([fullPath])};
+		`;
 		if (serverId) {
 			await execAsyncRemote(serverId, command);
 		} else {
 			await execAsync(command);
 		}
-	} catch {
-		console.log("Error updating file mount");
+	} catch (error) {
+		console.log(`Error updating the file mount: ${error}`);
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: `Error updating the mount ${error instanceof Error ? error.message : error}`,
+			cause: error,
+		});
 	}
 };
 


### PR DESCRIPTION
Fixes #5152

## Problem

`updateFileMount` wrote directly to the target path (`echo ... > path`) without ensuring the parent directory existed, and caught any error with a bare `console.log`, never surfacing it. If the path already existed as a directory — e.g. Docker pre-creating an empty directory for a bind mount declared elsewhere in the compose — the write silently failed, leaving the empty directory in place while the UI reported success.

`createFileMount` already did `mkdir -p` correctly; only the update path was missing it.

## Fix

`updateFileMount` now creates the parent directory, removes the target if it's already a directory, and throws a `TRPCError` on failure instead of swallowing it.

## Verification

Reproduced against a real Dokploy instance:
1. Created a File Mount with a nested path (`nginx/nginx.conf.template`) — worked fine on create.
2. Replaced the file with an empty directory at that path (simulating Docker pre-creating it).
3. Edited the mount's content from the UI — before the fix, the path stayed a directory and the content was silently dropped; after the fix, it correctly became a regular file with the updated content.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes file-mount updates create nested parent directories, replace an existing directory at the file target, and surface execution failures as tRPC errors.
- Adds parent-directory creation before writing updated mount content.
- Replaces directory-shaped targets before writing the file.
- Converts execution failures into caller-visible errors.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until recursive replacement is constrained to paths inside the managed service files directory.

An authorized mount updater can persist a traversing filePath, causing the newly added rm -rf command to delete an unintended directory under the local or remote server account.

**Files Needing Attention:** packages/server/src/services/mount.ts

<details open><summary><h3>Security Review</h3></summary>

The new recursive deletion is applied to a path derived from an unrestricted filePath. Parent traversal can escape the managed files directory and delete another directory under the local or remote execution account.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: mkdir parent dir before writing fil..."](https://github.com/dokploy/dokploy/commit/3a8fad57e6104872b3c63217632dd737f0a09ce3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57577296)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Managed databases and storage](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/managed-databases-and-storage.md)

<!-- /greptile_comment -->