### PR TITLE
feat(volume-backups): add gzip compression to volume backups

### DIFF
--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
 	const actual =
-		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
+		await importOriginal<
+			typeof import("@dokploy/server/utils/process/execAsync")
+		>();
 	return {
 		...actual,
 		execAsyncRemote: mocks.execAsyncRemote,

--- a/packages/server/src/utils/volume-backups/backup.ts
+++ b/packages/server/src/utils/volume-backups/backup.ts
@@ -74,7 +74,7 @@ export const backupVolume = async (
 		volumeBackup.application?.serverId || volumeBackup.compose?.serverId;
 	const { VOLUME_BACKUPS_PATH, VOLUME_BACKUP_LOCK_PATH } = paths(!!serverId);
 	const s3AppName = getVolumeServiceAppName(volumeBackup);
-	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar`;
+	const backupFileName = `${volumeName}-${getBackupTimestamp()}.tar.gz`;
 	const bucketDestination = `${s3AppName}/${normalizeS3Path(prefix || "")}${backupFileName}`;
 	const rcloneFlags = getS3Credentials(destination);
 	const rcloneDestination = `:s3:${destination.bucket}/${bucketDestination}`;
@@ -93,7 +93,7 @@ export const backupVolume = async (
   -v ${volumeName}:/volume_data \
   -v ${volumeBackupPath}:/backup \
   ubuntu \
-  bash -c "cd /volume_data && tar cvf /backup/${backupFileName} ."
+  bash -c "cd /volume_data && tar czf /backup/${backupFileName} ."
   echo "Volume backup done ✅"
   `;
 

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -87,7 +87,7 @@ const cleanupOldVolumeBackups = async (
 		const rcloneFlags = getS3Credentials(destination);
 		const s3AppName = getVolumeServiceAppName(volumeBackup);
 		const backupFilesPath = `:s3:${destination.bucket}/${s3AppName}/${normalizeS3Path(prefix || "")}`;
-		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar\" ${backupFilesPath}`;
+		const listCommand = `rclone lsf ${rcloneFlags.join(" ")} --include \"${volumeName}-*.tar.gz\" ${backupFilesPath}`;
 		const sortAndPick = `sort -r | tail -n +$((${keepLatestCount}+1)) | xargs -I{}`;
 		const deleteCommand = `rclone delete ${rcloneFlags.join(" ")} ${backupFilesPath}{}`;
 		const fullCommand = `${listCommand} | ${sortAndPick} ${deleteCommand}`;
@@ -156,8 +156,8 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 			VOLUME_BACKUPS_PATH,
 			volumeBackup.appName,
 		);
-		// delete all the .tar files
-		const command = `rm -rf ${volumeBackupPath}/*.tar`;
+		// delete all the .tar.gz files
+		const command = `rm -rf ${volumeBackupPath}/*.tar.gz`;
 		if (serverId) {
 			await execAsyncRemote(serverId, command);
 		} else {

--- a/packages/server/src/utils/volume-backups/utils.ts
+++ b/packages/server/src/utils/volume-backups/utils.ts
@@ -156,8 +156,8 @@ export const runVolumeBackup = async (volumeBackupId: string) => {
 			VOLUME_BACKUPS_PATH,
 			volumeBackup.appName,
 		);
-		// delete all the .tar.gz files
-		const command = `rm -rf ${volumeBackupPath}/*.tar.gz`;
+		// delete all the .tar and .tar.gz files (including legacy .tar from pre-upgrade)
+		const command = `rm -rf ${volumeBackupPath}/*.tar*`;
 		if (serverId) {
 			await execAsyncRemote(serverId, command);
 		} else {


### PR DESCRIPTION
## What is this PR about?

Volume backups currently create uncompressed `.tar` archives using `tar cvf`. This means that for data that compresses well (SQLite databases, JSON, text logs, configuration files), the backup stored in S3 is the same size as the original volume — wasting storage space and increasing S3 costs.

This PR changes to `tar czf` (gzip compression), producing `.tar.gz` files that are significantly smaller for compressible data, reducing S3 storage costs and transfer time.

## Changes

- **`backup.ts`**: Changed `tar cvf` → `tar czf` and extension `.tar` → `.tar.gz`
- **`utils.ts`**: Updated retention filter `--include "*.tar"` → `--include "*.tar.gz"` and error cleanup `*.tar` → `*.tar.gz`

## Compatibility

- **gzip is pre-installed** in the `ubuntu` Docker image used for volume backups — no additional dependencies or runtime package installation needed
- **Restore is backward compatible**: `tar xvf` in `restore.ts` auto-detects gzip compression, so existing restore logic continues to work for both old `.tar` and new `.tar.gz` files without any changes
- **Old `.tar` files** already in S3 are not affected by the new retention policy (which now filters `*.tar.gz`); they will need manual cleanup

## Testing

Tested locally with a full development stack (Dokploy dev server + MinIO as local S3 destination + Docker Swarm):

- [x] Verified `gzip` is available in the `ubuntu` Docker image
- [x] Created volume backup with gzip compression
- [x] Verified `.tar.gz` file appears in S3 destination (MinIO)
- [x] Verified `file` command reports `gzip compressed data, from Unix`
- [x] Restored from `.tar.gz` backup successfully
- [x] Verified `keepLatestCount` retention works with `.tar.gz` extension
- [x] Verified backward compatibility: `tar xvf` restores both `.tar` and `.tar.gz`

**Compression results (13.4MB of text/JSON/SQL data):**

| | Size |
|---|---|
| Volume (uncompressed) | 13.4 MB |
| Backup in S3 (.tar.gz) | 884 KB |
| Compression ratio | ~15:1 |

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers time reviewing code that has not been verified by you.

## Known limitations

- Overlapping backup schedules for the same service (`appName`) share a directory, and the error cleanup uses a broad `*.tar*` glob that may delete another run's in-progress archive. A follow-up should clean up only the specific archive created by the failing run.

## Issues related (if applicable)

Closes #3566

## Screenshots (if applicable)

**Backup log showing `tar czf` and `.tar.gz`:**

```
Backup file name: gzip-test-vol-2026-08-28T15-31-31-553Z.tar.gz
Turning off volume backup: Yes
Starting volume backup
Volume backup done ✅
Starting upload to S3...
Upload to S3 done ✅
Local backup file cleaned up ✅
```





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=57954051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because failure cleanup can delete a concurrent backup run's in-progress archive.

<h3>Summary</h3>

- Changes volume archive creation from uncompressed tar to gzip-compressed tar.
- Restricts remote retention matching to `.tar.gz` files.
- Expands local failure cleanup to cover both current and legacy archive extensions.

<sub>Reviews (3) · Last reviewed commit: ["fix(volume-backups): clean up legacy .ta..."](https://github.com/dokploy/dokploy/commit/eb8fde384265399e6fc7e77a6d2a6229de466ef6)</sub>

<!-- /greptile_comment -->