### PR TITLE
fix: apply watch path negations as a pattern set

### DIFF
--- a/apps/dokploy/__test__/deploy/should-deploy.test.ts
+++ b/apps/dokploy/__test__/deploy/should-deploy.test.ts
@@ -16,6 +16,30 @@ describe("shouldDeploy", () => {
 		expect(shouldDeploy(["src/**"], ["docs/readme.md"])).toBe(false);
 	});
 
+	it("should apply multiple negated watch paths as one pattern set", () => {
+		const watchPaths = ["!CHANGELOG.md", "!VERSION", "!tests/**"];
+
+		expect(shouldDeploy(watchPaths, ["CHANGELOG.md"])).toBe(false);
+		expect(shouldDeploy(watchPaths, ["VERSION"])).toBe(false);
+		expect(shouldDeploy(watchPaths, ["tests/unit/example.test.ts"])).toBe(
+			false,
+		);
+	});
+
+	it("should deploy when a changed file remains after exclusions", () => {
+		const watchPaths = ["!CHANGELOG.md", "!VERSION", "!tests/**"];
+
+		expect(shouldDeploy(watchPaths, ["VERSION", "src/index.ts"])).toBe(true);
+	});
+
+	it("should combine positive and negated watch paths", () => {
+		const watchPaths = ["src/**", "!src/**/*.test.ts"];
+
+		expect(shouldDeploy(watchPaths, ["src/index.ts"])).toBe(true);
+		expect(shouldDeploy(watchPaths, ["src/index.test.ts"])).toBe(false);
+		expect(shouldDeploy(watchPaths, ["docs/readme.md"])).toBe(false);
+	});
+
 	it("should not throw when modified files contain non-string values", () => {
 		expect(() =>
 			shouldDeploy(["src/**"], ["src/index.ts", undefined, null] as any),

--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -10,9 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
 	const actual =
-		await importOriginal<
-			typeof import("@dokploy/server/utils/process/execAsync")
-		>();
+		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
 	return {
 		...actual,
 		execAsyncRemote: mocks.execAsyncRemote,

--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
 	const actual =
-		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
+		await importOriginal<
+			typeof import("@dokploy/server/utils/process/execAsync")
+		>();
 	return {
 		...actual,
 		execAsyncRemote: mocks.execAsyncRemote,

--- a/packages/server/src/utils/watch-paths/should-deploy.ts
+++ b/packages/server/src/utils/watch-paths/should-deploy.ts
@@ -8,5 +8,5 @@ export const shouldDeploy = (
 	const files = (modifiedFiles ?? []).filter(
 		(file): file is string => typeof file === "string",
 	);
-	return micromatch.some(files, watchPaths);
+	return micromatch(files, watchPaths).length > 0;
 };


### PR DESCRIPTION
## Summary

- evaluate all configured watch paths as one micromatch pattern set
- prevent one negated pattern from re-including a file excluded by another
- add regressions for multiple exclusions and mixed include/exclude patterns

Fixes #5207.

## Test plan

- `pnpm --filter=dokploy exec vitest --config __test__/vitest.config.ts __test__/deploy/should-deploy.test.ts` (9 tests passed)
- `pnpm --filter=@dokploy/server run typecheck`
- `pnpm exec biome check packages/server/src/utils/watch-paths/should-deploy.ts apps/dokploy/__test__/deploy/should-deploy.test.ts`

All commands ran with Node 24.4.0 and pnpm 10.22.0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes watched-path evaluation to apply all micromatch patterns as a single set, fixing interactions between multiple exclusions and mixed include/exclude rules.

- Replaces independent any-pattern matching with whole-set file filtering.
- Adds regression coverage for multiple negations, surviving files, and combined positive/negative patterns.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The implementation now evaluates changed files against the complete pattern set, and the added tests cover the failure modes targeted by the fix without revealing a broken deployment-filtering contract.

<sub>Reviews (1): Last reviewed commit: ["fix: apply watch path negations as a pat..."](https://github.com/dokploy/dokploy/commit/abc2439ec49d2ec3048aa010441c33a0a3d74cd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57997035)</sub>

**Context used:**

- Knowledge Base — [Source providers and operational automation](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/source-providers-and-automation.md)

<!-- /greptile_comment -->