### PR TITLE
test(traefik): fix config regression test types

### DIFF
--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
 	const actual =
-		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
+		await importOriginal<
+			typeof import("@dokploy/server/utils/process/execAsync")
+		>();
 	return {
 		...actual,
 		execAsyncRemote: mocks.execAsyncRemote,
@@ -58,7 +60,12 @@ describe("writeAppTraefikConfig", () => {
 		await writeAppTraefikConfig(
 			{
 				http: {
-					routers: { [`${appName}-router-1`]: { rule: "Host(`x`)" } },
+					routers: {
+						[`${appName}-router-1`]: {
+							rule: "Host(`x`)",
+							service: `${appName}-service-1`,
+						},
+					},
 					services: {},
 				},
 			},
@@ -78,7 +85,7 @@ describe("writeAppTraefikConfig", () => {
 		);
 
 		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
-		const [, command] = mocks.execAsyncRemote.mock.calls[0];
+		const command = mocks.execAsyncRemote.mock.calls[0]?.[1];
 		expect(command).toMatch(/^rm -f /);
 		expect(command).toContain("no-domain-app.yml");
 	});
@@ -89,7 +96,12 @@ describe("writeAppTraefikConfig", () => {
 		await writeAppTraefikConfig(
 			{
 				http: {
-					routers: { "with-domain-app-router-1": { rule: "Host(`x`)" } },
+					routers: {
+						"with-domain-app-router-1": {
+							rule: "Host(`x`)",
+							service: "with-domain-app-service-1",
+						},
+					},
 					services: {},
 				},
 			},
@@ -98,7 +110,7 @@ describe("writeAppTraefikConfig", () => {
 		);
 
 		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
-		const [, command] = mocks.execAsyncRemote.mock.calls[0];
+		const command = mocks.execAsyncRemote.mock.calls[0]?.[1];
 		expect(command).toMatch(/^echo /);
 	});
 });

--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -66,7 +66,14 @@ describe("writeAppTraefikConfig", () => {
 							service: `${appName}-service-1`,
 						},
 					},
-					services: {},
+					services: {
+						[`${appName}-service-1`]: {
+							loadBalancer: {
+								servers: [{ url: `http://${appName}:3000` }],
+								passHostHeader: true,
+							},
+						},
+					},
 				},
 			},
 			appName,
@@ -102,7 +109,14 @@ describe("writeAppTraefikConfig", () => {
 							service: "with-domain-app-service-1",
 						},
 					},
-					services: {},
+					services: {
+						"with-domain-app-service-1": {
+							loadBalancer: {
+								servers: [{ url: "http://with-domain-app:3000" }],
+								passHostHeader: true,
+							},
+						},
+					},
 				},
 			},
 			"with-domain-app",


### PR DESCRIPTION
## What is this PR about?

The Traefik regression tests added in #5202 currently fail the repository-wide typecheck on canary, which stops the remaining pull-request jobs early.

- Add the required service field to the router fixtures.
- Read mocked remote commands without destructuring a possibly missing call.
- Apply the repository formatting to the existing long import.

There is no production behavior change; this only corrects the test fixtures and assertions.

## Testing

- pnpm typecheck on Node 24.4.0: passed.
- Focused Traefik regression test: 4 tests passed.
- Biome check for the changed file: passed.

## Issues related

Follow-up to #5202

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs Traefik regression-test type errors without changing production behavior.
- Formats the mocked module import.
- Adds the required service property to router fixtures.
- Safely indexes mocked remote-command calls.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking fixture-fidelity issue in the Traefik regression tests.

The typecheck correction and optional mock-call access preserve the tested branches, but both updated fixtures serialize dangling router service references rather than production-representative configurations.

**Files Needing Attention:** apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts

<sub>Reviews (1): Last reviewed commit: ["test(traefik): fix config regression tes..."](https://github.com/dokploy/dokploy/commit/4b42338f06ae36750731c8b9768f1b7338319005) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58003397)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->