### PR TITLE
fix: keep native log container id in sync when Swarm/compose replaces it

### DIFF
--- a/apps/dokploy/components/dashboard/compose/logs/show-stack.tsx
+++ b/apps/dokploy/components/dashboard/compose/logs/show-stack.tsx
@@ -55,6 +55,7 @@ export const ShowDockerLogsStack = ({
 			},
 			{
 				enabled: !!appName && option === "swarm",
+				refetchInterval: 5000,
 			},
 		);
 
@@ -67,6 +68,7 @@ export const ShowDockerLogsStack = ({
 			},
 			{
 				enabled: !!appName && option === "native",
+				refetchInterval: 5000,
 			},
 		);
 

--- a/apps/dokploy/components/dashboard/compose/logs/show.tsx
+++ b/apps/dokploy/components/dashboard/compose/logs/show.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { badgeStateColor } from "@/components/dashboard/application/logs/show";
+import { resolveContainerSelection } from "@/components/dashboard/docker/logs/utils";
 import { Badge } from "@/components/ui/badge";
 import {
 	Card,
@@ -52,14 +53,15 @@ export const ShowDockerLogsCompose = ({
 		},
 		{
 			enabled: !!appName,
+			refetchInterval: 5000,
 		},
 	);
 	const [containerId, setContainerId] = useState<string | undefined>();
 
 	useEffect(() => {
-		if (data && data?.length > 0) {
-			setContainerId(data[0]?.containerId);
-		}
+		setContainerId((currentContainerId) =>
+			resolveContainerSelection(currentContainerId, data),
+		);
 	}, [data]);
 
 	return (


### PR DESCRIPTION
Fixes #5134

The Logs tab resolved the container id for Native logging once on mount and never re-checked it. If the underlying container got replaced while the page stayed open (Swarm task reschedule/restart, compose recreate), the WebSocket kept streaming from the now-gone id and either froze or failed with `No such container`.

Both container-list queries (`show-stack.tsx` for Stack mode, `show.tsx` for regular compose) now poll every 5s (same interval used elsewhere for container status) and reconcile the selected id via `resolveContainerSelection` — it keeps the current selection if still valid, otherwise falls back to the first available container. This is the same mechanism `show-stack.tsx` already used for the initial pick, just re-run on an interval instead of once.

Verified locally against a real single-node swarm: force-removed the running container behind an open Native log stream (both Stack and plain compose) and confirmed the UI picks up the new container id and resumes streaming within one poll cycle, with no manual refresh.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR periodically refreshes Compose and Swarm container lists and reconciles the selected native-log container so streams can follow runtime replacements.
- Adds five-second polling to the relevant container-list queries.
- Reuses resolveContainerSelection in the regular Compose logs view.
- The new polling path also treats transient query failures as confirmed empty lists, which can unnecessarily disconnect or redirect an active stream.

<h3>Confidence Score: 4/5</h3>

The transient-empty-result handling should be fixed before merging because a routine polling failure can disconnect an active log stream and later redirect it to a different container.

The container-list services collapse command failures into empty arrays, while the newly periodic reconciliation interprets an empty array as authoritative removal and clears the container ID that owns the active WebSocket.

**Files Needing Attention:** apps/dokploy/components/dashboard/compose/logs/show.tsx; apps/dokploy/components/dashboard/compose/logs/show-stack.tsx

<sub>Reviews (1): Last reviewed commit: ["fix: keep native log container id in syn..."](https://github.com/dokploy/dokploy/commit/cf0e8d236cef8962796b465e9c468d57dbbed445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58075488)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->