### PR TITLE
fix: disable delete/unlink user button while mutation is pending

### DIFF
--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@dokploy/server/utils/process/execAsync", async (importOriginal) => {
 	const actual =
-		await importOriginal<typeof import("@dokploy/server/utils/process/execAsync")>();
+		await importOriginal<
+			typeof import("@dokploy/server/utils/process/execAsync")
+		>();
 	return {
 		...actual,
 		execAsyncRemote: mocks.execAsyncRemote,

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -35,7 +35,7 @@ import { ChangeRole } from "./change-role";
 export const ShowUsers = () => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data, isPending, refetch } = api.user.all.useQuery();
-	const { mutateAsync } = api.user.remove.useMutation();
+	const { mutateAsync, isPending: isRemoving } = api.user.remove.useMutation();
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const { data: hasValidLicense } =
 		api.licenseKey.haveValidLicenseKey.useQuery();
@@ -237,6 +237,7 @@ export const ShowUsers = () => {
 																					title="Delete User"
 																					description="Are you sure you want to delete this user?"
 																					type="destructive"
+																					disabled={isRemoving}
 																					onClick={async () => {
 																						await mutateAsync({
 																							userId: member.user.id,
@@ -269,6 +270,7 @@ export const ShowUsers = () => {
 																					title="Unlink User"
 																					description="Are you sure you want to unlink this user?"
 																					type="destructive"
+																					disabled={isRemoving}
 																					onClick={async () => {
 																						if (!isCloud) {
 																							const orgCount =


### PR DESCRIPTION
Fixes #5063 (partial): the Confirm button on the Delete/Unlink User dialog had no disabled/loading state, so a double-click before the request resolved could fire the delete mutation twice.

Passes the mutation's `isPending` as `disabled` to the two `DialogAction` triggers (Delete User / Unlink User) in `show-users.tsx`.

Note: the other part of the issue (owner being removable) is already blocked both in the UI and in the self-hosted backend (`user.remove` procedure rejects `role === "owner"`), so it's not addressed here.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR connects the user-removal mutation's pending state to the Delete User and Unlink User confirmation controls to prevent repeated destructive requests.

- Adds an `isRemoving` alias for the `user.remove` mutation state.
- Disables both destructive confirmation buttons while that state is pending.

<h3>Confidence Score: 4/5</h3>

The unlink path should be fixed before merging because its confirmation button remains enabled while the actual unlink request is pending.

Cloud unlinking calls organization.removeMember directly, while the newly supplied disabled state tracks only user.remove, so repeated unlink submissions remain possible.

**Files Needing Attention:** apps/dokploy/components/dashboard/settings/users/show-users.tsx

<sub>Reviews (1): Last reviewed commit: ["fix: disable delete/unlink user button w..."](https://github.com/dokploy/dokploy/commit/fee0071223fe70216f4a9aefa010b327e2864e9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58078707)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->