### PR TITLE
fix: close terminal websocket when local container shell exits

### DIFF
--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -182,6 +182,10 @@ export const setupDockerContainerTerminalWebSocketServer = (
 				ptyProcess.onData((data) => {
 					ws.send(data);
 				});
+				ptyProcess.onExit(({ exitCode }) => {
+					ws.send(`\nContainer closed with code: ${exitCode}\n`);
+					ws.close();
+				});
 				ws.on("close", () => {
 					ptyProcess.kill();
 				});


### PR DESCRIPTION
Closes #5172

The local branch (no `serverId`) of `/docker-container-terminal` spawned a `node-pty` but never handled `ptyProcess.onExit`, so the WebSocket stayed open indefinitely after the shell exited (`exit`, or the exec process failing to start). The SSH branch already closed on `stream.on('close')`.

Mirrors the SSH branch: on pty exit, send the exit code and close the socket.

Verified with Playwright: before the fix, `readyState` stayed `OPEN` after `exit`; after the fix, the client receives `Container closed with code: N` and the socket closes (`readyState: CLOSED`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds local container-terminal lifecycle handling so the WebSocket reports the PTY exit code and closes when the shell exits.
- Registers an exit handler on the local `node-pty` process.
- Sends the container shell’s exit code to the connected client.
- Closes the WebSocket after the terminal process exits.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and resolves the lingering local container-terminal WebSocket.

The new exit handler closes the socket when the local PTY ends, while client-first disconnects remain safe because repeated socket and PTY cleanup operations are harmless with the pinned dependencies.

<sub>Reviews (1): Last reviewed commit: ["fix: close terminal websocket when local..."](https://github.com/dokploy/dokploy/commit/1053743a1c87d8b67b37e8ae4d451bc3874cbb61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58079660)</sub>

<!-- /greptile_comment -->