### PR TITLE
fix: report remote-node containers correctly in stack monitoring

### DIFF
--- a/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
+++ b/apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx
@@ -1,5 +1,6 @@
 import { formatMb } from "@dokploy/server/monitoring/units";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { api } from "@/utils/api";
@@ -167,6 +168,8 @@ export const ContainerFreeMonitoring = ({
 	}, [data]);
 
 	useEffect(() => {
+		if (!appName) return;
+
 		const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 		const wsUrl = `${protocol}//${window.location.host}/listen-docker-stats-monitoring?appName=${appName}&appType=${appType}`;
 		const ws = new WebSocket(wsUrl);
@@ -196,7 +199,9 @@ export const ContainerFreeMonitoring = ({
 		};
 
 		ws.onclose = (e) => {
-			console.log(e.reason);
+			if (e.reason) {
+				toast.error(e.reason);
+			}
 		};
 
 		return () => ws.close();

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -8,8 +8,56 @@ import {
 	recordAdvancedStats,
 	validateRequest,
 } from "@dokploy/server";
+import { quote } from "shell-quote";
 import { WebSocketServer } from "ws";
 import { canAccessDockerOverWss } from "./authorize";
+
+type AppType = "application" | "stack" | "docker-compose";
+
+// Swarm task names are "<service>.<slot>.<taskId>"; the manager's local
+// `docker ps` only sees containers scheduled on this host, so a task running
+// on another node looks identical to a stopped one. `docker service ps` is
+// swarm-aggregated and answers from the manager regardless of which node the
+// task landed on, so we use it here to tell the two cases apart.
+const findRemoteSwarmNode = async (
+	appName: string,
+	appType: AppType,
+): Promise<string | null> => {
+	if (appType === "docker-compose") {
+		return null;
+	}
+
+	// `docker service ps --format {{.Name}}` only prints "<service>.<slot>",
+	// never the taskId, so we match on the task ID instead — the last segment
+	// of the stack task name — rather than trying to reconstruct the full name.
+	const [serviceName, taskId] =
+		appType === "stack"
+			? [appName.split(".").slice(0, -2).join("."), appName.split(".").pop()]
+			: [appName, null];
+
+	if (!serviceName) {
+		return null;
+	}
+
+	try {
+		const { stdout } = await execAsync(
+			`docker service ps ${quote([serviceName])} --filter "desired-state=running" --no-trunc --format '{"ID":"{{.ID}}","Node":"{{.Node}}","CurrentState":"{{.CurrentState}}"}'`,
+		);
+
+		for (const line of stdout.trim().split("\n")) {
+			if (!line) continue;
+			const task = JSON.parse(line);
+			const isMatch = taskId ? task.ID === taskId : true;
+			if (isMatch && task.CurrentState?.startsWith("Running")) {
+				return task.Node;
+			}
+		}
+	} catch {
+		// Not a swarm service (or the swarm CLI isn't available) — fall back to "not running".
+	}
+
+	return null;
+};
 
 export const setupDockerStatsMonitoringSocketServer = (
 	server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>,
@@ -98,7 +146,13 @@ export const setupDockerStatsMonitoringSocketServer = (
 
 				const container = containers[0];
 				if (!container || container?.State !== "running") {
-					ws.close(4000, "Container not running");
+					const remoteNode = await findRemoteSwarmNode(appName, appType);
+					ws.close(
+						4000,
+						remoteNode
+							? `Container running on remote node "${remoteNode}"`.slice(0, 123)
+							: "Container not running",
+					);
 					return;
 				}
 				const { stdout, stderr } = await execAsync(


### PR DESCRIPTION
Closes #5133

Free monitoring resolved containers via a local Dockerode `listContainers()` call, which only sees containers scheduled on the host running Dokploy. For Stack services with tasks scheduled on other Swarm nodes, this always fell into the "Container not running" branch even when the task was healthy elsewhere — local `docker.listContainers()` can't see containers on remote nodes.

Now falls back to `docker service ps` (Swarm-aggregated, answers from any manager regardless of task placement) to tell a genuinely stopped container apart from one running on another node, and reports that distinction in the WS close reason instead of the misleading message.

Also fixes a client-side race where the stats websocket connected with an empty `appName` on first mount (before the container selector settled), and surfaces the WS close reason as a toast instead of only logging it to the console.

Note: this doesn't make live stats work *for* remote nodes — that would need an agent per node (which is what paid monitoring already does). It just stops the free monitoring from lying about container state when the task is actually healthy elsewhere in the cluster.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delays the free-monitoring websocket until a container is selected, surfaces websocket close reasons in the dashboard, and adds a Swarm-manager fallback intended to distinguish stopped containers from healthy tasks on remote nodes.

- Adds remote-node discovery through `docker service ps`.
- Avoids opening the stats websocket with an empty application name.
- Displays server close reasons as toast notifications.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the Stack service-name derivation is corrected, because its primary remote-node scenario still reports healthy tasks as stopped.

Stack monitoring supplies a task name with an additional task-ID suffix, while the new parser removes only two trailing segments and consequently invokes docker service ps with the slot still attached to the service name.

**Files Needing Attention:** apps/dokploy/server/wss/docker-stats.ts; apps/dokploy/components/dashboard/monitoring/free/container/show-free-container-monitoring.tsx

<sub>Reviews (1): Last reviewed commit: ["fix: report remote-node containers corre..."](https://github.com/dokploy/dokploy/commit/0efe7feaf586de24ad521bc4d7bd2e12f4e3532e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58087429)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->