### PR TITLE
fix: domain validation false negative on servers with multiple IPs

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -191,8 +191,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 		try {
 			const result = await validateDomain({
 				domain: host,
-				serverIp:
-					application?.server?.ipAddress?.toString() || ip?.toString() || "",
+				serverId: application?.serverId ?? undefined,
 			});
 
 			setValidationStates((prev) => ({

--- a/apps/dokploy/server/api/routers/domain.ts
+++ b/apps/dokploy/server/api/routers/domain.ts
@@ -7,6 +7,7 @@ import {
 	findPreviewDeploymentById,
 	findServerById,
 	generateTraefikMeDomain,
+	getServerIpCandidates,
 	getWebServerSettings,
 	manageDomain,
 	removeDomain,
@@ -248,10 +249,11 @@ export const domainRouter = createTRPCRouter({
 		.input(
 			z.object({
 				domain: z.string(),
-				serverIp: z.string().optional(),
+				serverId: z.string().optional(),
 			}),
 		)
 		.mutation(async ({ input }) => {
-			return validateDomain(input.domain, input.serverIp);
+			const expectedIps = await getServerIpCandidates(input.serverId);
+			return validateDomain(input.domain, expectedIps);
 		}),
 });

--- a/apps/dokploy/server/api/routers/domain.ts
+++ b/apps/dokploy/server/api/routers/domain.ts
@@ -252,7 +252,17 @@ export const domainRouter = createTRPCRouter({
 				serverId: z.string().optional(),
 			}),
 		)
-		.mutation(async ({ input }) => {
+		.mutation(async ({ input, ctx }) => {
+			if (input.serverId) {
+				const server = await findServerById(input.serverId);
+				if (server.organizationId !== ctx.session.activeOrganizationId) {
+					throw new TRPCError({
+						code: "UNAUTHORIZED",
+						message: "You are not authorized to access this server",
+					});
+				}
+			}
+
 			const expectedIps = await getServerIpCandidates(input.serverId);
 			return validateDomain(input.domain, expectedIps);
 		}),

--- a/packages/server/src/services/domain.ts
+++ b/packages/server/src/services/domain.ts
@@ -3,7 +3,9 @@ import { promisify } from "node:util";
 import { db } from "@dokploy/server/db";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
 import { generateRandomDomain } from "@dokploy/server/templates";
+import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { manageDomain } from "@dokploy/server/utils/traefik/domain";
+import { getPublicIpWithFallback } from "@dokploy/server/wss/utils";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import type { z } from "zod";
@@ -154,7 +156,7 @@ const resolveDns = promisify(dns.resolve4);
 
 export const validateDomain = async (
 	domain: string,
-	expectedIp?: string,
+	expectedIps?: string[],
 ): Promise<{
 	isValid: boolean;
 	resolvedIp?: string;
@@ -186,13 +188,13 @@ export const validateDomain = async (
 			};
 		}
 
-		// If we have an expected IP, validate against it
-		if (expectedIp) {
+		if (expectedIps && expectedIps.length > 0) {
+			const isValid = resolvedIps.some((ip) => expectedIps.includes(ip));
 			return {
-				isValid: resolvedIps.includes(expectedIp),
+				isValid,
 				resolvedIp: resolvedIps.join(", "),
-				error: !resolvedIps.includes(expectedIp)
-					? `Domain resolves to ${resolvedIps.join(", ")} but should point to ${expectedIp}`
+				error: !isValid
+					? `Domain resolves to ${resolvedIps.join(", ")} but should point to ${expectedIps.join(" or ")}`
 					: undefined,
 			};
 		}
@@ -209,4 +211,48 @@ export const validateDomain = async (
 				error instanceof Error ? error.message : "Failed to resolve domain",
 		};
 	}
+};
+
+export const getServerIpCandidates = async (
+	serverId?: string | null,
+): Promise<string[]> => {
+	const candidates = new Set<string>();
+
+	if (serverId) {
+		const server = await findServerById(serverId);
+		if (server.ipAddress) {
+			candidates.add(server.ipAddress);
+		}
+
+		const publicIp = await withTimeout(
+			execAsyncRemote(
+				serverId,
+				"curl -s -m 5 https://ifconfig.me || curl -s -m 5 https://icanhazip.com",
+			),
+			7000,
+		);
+		const detectedIp = publicIp?.stdout?.trim();
+		if (detectedIp) {
+			candidates.add(detectedIp);
+		}
+	} else {
+		const settings = await getWebServerSettings();
+		if (settings?.serverIp) {
+			candidates.add(settings.serverIp);
+		}
+
+		const publicIp = await withTimeout(getPublicIpWithFallback(), 7000);
+		if (publicIp) {
+			candidates.add(publicIp);
+		}
+	}
+
+	return Array.from(candidates);
+};
+
+const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T | null> => {
+	return Promise.race([
+		promise,
+		new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
+	]).catch(() => null);
 };


### PR DESCRIPTION
Fixes #4658

Domain validation only checked the resolved DNS IP against the server's stored SSH `ipAddress`. Servers commonly sit behind NAT or have separate SSH/public IPs, so a domain correctly pointing at the server's real public IP was reported as invalid.

Now `validateDomain` accepts a list of expected IPs and passes if the domain resolves to any of them. The candidate list is built server-side from the stored `ipAddress` plus the server's detected public egress IP (via SSH `curl` for remote servers, or the host's own outbound IP for the local Dokploy server).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes domain validation to compare DNS results against multiple candidate server addresses, including a dynamically detected public address.
- Replaces the client-supplied server IP with a server identifier.
- Builds candidate addresses locally or through an SSH public-IP lookup.
- Updates validation to accept any matching candidate address.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until domain validation verifies access to the supplied server, because the current mutation crosses organization boundaries and exposes server addresses.

The new caller-controlled serverId reaches an unrestricted server lookup and SSH execution path, and mismatch responses disclose the resulting candidate addresses; the timeout implementation also leaves timed-out operations running in the background.

**Files Needing Attention:** apps/dokploy/server/api/routers/domain.ts and packages/server/src/services/domain.ts

<details open><summary><h3>Security Review</h3></summary>

The new `serverId` input is not scoped to the active organization. A caller with domain read permission can select another organization’s server, trigger a fixed outbound lookup over SSH, and obtain its stored and detected IP addresses through the mismatch response.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: domain validation false negative on..."](https://github.com/dokploy/dokploy/commit/976161647ff30dbec0399d533f64b324f175dc95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58094614)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [API boundary](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/api-boundary.md)
- Knowledge Base — [Servers, clusters, and monitoring](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/servers-clusters-and-monitoring.md)
- Knowledge Base — [Docker networking and Traefik](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/docker-networking-and-traefik.md)
</details>


<!-- /greptile_comment -->