### PR TITLE
fix: typecheck errors in traefik config test

### DIFF
--- a/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
+++ b/apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts
@@ -60,7 +60,12 @@ describe("writeAppTraefikConfig", () => {
 		await writeAppTraefikConfig(
 			{
 				http: {
-					routers: { [`${appName}-router-1`]: { rule: "Host(`x`)" } },
+					routers: {
+						[`${appName}-router-1`]: {
+							rule: "Host(`x`)",
+							service: `${appName}-service`,
+						},
+					},
 					services: {},
 				},
 			},
@@ -80,7 +85,7 @@ describe("writeAppTraefikConfig", () => {
 		);
 
 		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
-		const [, command] = mocks.execAsyncRemote.mock.calls[0];
+		const [, command] = mocks.execAsyncRemote.mock.calls[0] ?? [];
 		expect(command).toMatch(/^rm -f /);
 		expect(command).toContain("no-domain-app.yml");
 	});
@@ -91,7 +96,12 @@ describe("writeAppTraefikConfig", () => {
 		await writeAppTraefikConfig(
 			{
 				http: {
-					routers: { "with-domain-app-router-1": { rule: "Host(`x`)" } },
+					routers: {
+						"with-domain-app-router-1": {
+							rule: "Host(`x`)",
+							service: "with-domain-app-service",
+						},
+					},
 					services: {},
 				},
 			},
@@ -100,7 +110,7 @@ describe("writeAppTraefikConfig", () => {
 		);
 
 		expect(mocks.execAsyncRemote).toHaveBeenCalledOnce();
-		const [, command] = mocks.execAsyncRemote.mock.calls[0];
+		const [, command] = mocks.execAsyncRemote.mock.calls[0] ?? [];
 		expect(command).toMatch(/^echo /);
 	});
 });


### PR DESCRIPTION
Fixes a pre-existing typecheck failure on `canary` in `apps/dokploy/__test__/traefik/write-app-traefik-config.test.ts` (unrelated to #4658):

- Test router objects were missing the required `service` field of `HttpRouter`.
- `mocks.execAsyncRemote.mock.calls[0]` destructuring failed under `noUncheckedIndexedAccess` since `.calls[0]` is typed as possibly `undefined`.

No behavior change — tests still pass (4/4).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves type-checking errors in the Traefik configuration tests without changing production behavior.
- Adds the required `service` property to two `HttpRouter` fixtures.
- Safely handles TypeScript’s possibly-undefined first mock call under `noUncheckedIndexedAccess`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the changes only correct test typing and preserve the existing behavioral checks.

The required router fields do not affect branch selection, and the mock-call fallback cannot make the tests pass when the call or command is missing.

<sub>Reviews (1): Last reviewed commit: ["fix: satisfy HttpRouter type in traefik ..."](https://github.com/dokploy/dokploy/commit/22450abc4b4a6633c7f3fd1922ac8c3862f2a905) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58095623)</sub>

<!-- /greptile_comment -->