### PR TITLE
fix: treat recovered instances with users as initialized

### DIFF
--- a/apps/dokploy/__test__/services/admin-present.test.ts
+++ b/apps/dokploy/__test__/services/admin-present.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDb = vi.hoisted(() => ({
+	query: {
+		member: {
+			findFirst: vi.fn(),
+		},
+		organization: {
+			findFirst: vi.fn(),
+		},
+		user: {
+			findFirst: vi.fn(),
+		},
+	},
+}));
+
+vi.mock("@dokploy/server/db", () => ({ db: mockDb }));
+
+import { isAdminPresent } from "@dokploy/server/services/admin";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockDb.query.member.findFirst.mockResolvedValue(undefined);
+	mockDb.query.organization.findFirst.mockResolvedValue(undefined);
+	mockDb.query.user.findFirst.mockResolvedValue(undefined);
+});
+
+describe("isAdminPresent", () => {
+	it("returns false on a truly uninitialized instance", async () => {
+		await expect(isAdminPresent()).resolves.toBe(false);
+	});
+
+	it("returns true when an owner membership exists", async () => {
+		mockDb.query.member.findFirst.mockResolvedValue({
+			id: "member-1",
+			role: "owner",
+			userId: "user-1",
+			organizationId: "org-1",
+		});
+
+		await expect(isAdminPresent()).resolves.toBe(true);
+	});
+
+	it("returns true when member.owner is missing but an organization owner exists", async () => {
+		mockDb.query.organization.findFirst.mockResolvedValue({
+			id: "org-1",
+			ownerId: "user-1",
+			owner: { id: "user-1", email: "admin@example.com" },
+		});
+
+		await expect(isAdminPresent()).resolves.toBe(true);
+	});
+
+	it("returns true when users exist even if owner membership and organizations are missing", async () => {
+		mockDb.query.user.findFirst.mockResolvedValue({
+			id: "user-1",
+			email: "admin@example.com",
+		});
+
+		await expect(isAdminPresent()).resolves.toBe(true);
+	});
+});

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -16,6 +16,7 @@ import {
 	getTrustedOrigins,
 	getTrustedProviders,
 	getUserByToken,
+	isAdminPresent,
 } from "../services/admin";
 import { createAuditLog } from "../services/proprietary/audit-log";
 import { resolveOrganizationDefaultRole } from "../services/proprietary/license-key";
@@ -206,10 +207,7 @@ const createBetterAuth = () =>
 								if (isSSORequest) {
 									return;
 								}
-								const isAdminPresent = await db.query.member.findFirst({
-									where: eq(schema.member.role, "owner"),
-								});
-								if (isAdminPresent) {
+								if (await isAdminPresent()) {
 									throw new APIError("BAD_REQUEST", {
 										message: "Admin is already created",
 									});
@@ -220,11 +218,11 @@ const createBetterAuth = () =>
 					after: async (user, context) => {
 						const isSSORequest = context?.path.includes("/sso");
 						const isSCIMRequest = context?.path.includes("/scim");
-						const isAdminPresent = await db.query.member.findFirst({
+						const ownerMember = await db.query.member.findFirst({
 							where: eq(schema.member.role, "owner"),
 						});
 
-						if (!IS_CLOUD && !isAdminPresent) {
+						if (!IS_CLOUD && !ownerMember) {
 							await updateWebServerSettings({
 								serverIp: await getPublicIpWithFallback(),
 							});
@@ -273,7 +271,7 @@ const createBetterAuth = () =>
 							return;
 						}
 
-						if (IS_CLOUD || !isAdminPresent) {
+						if (IS_CLOUD || !ownerMember) {
 							await db.transaction(async (tx) => {
 								const organization = await tx
 									.insert(schema.organization)

--- a/packages/server/src/services/admin.ts
+++ b/packages/server/src/services/admin.ts
@@ -41,10 +41,24 @@ export const isAdminPresent = async () => {
 		where: eq(member.role, "owner"),
 	});
 
-	if (!admin) {
-		return false;
+	if (admin) {
+		return true;
 	}
-	return true;
+
+	// Partial DB restore can drop member.owner while user/org rows remain.
+	// Those instances are initialized, not a fresh Setup.
+	const org = await db.query.organization.findFirst({
+		with: {
+			owner: true,
+		},
+	});
+
+	if (org?.owner) {
+		return true;
+	}
+
+	const existingUser = await db.query.user.findFirst();
+	return Boolean(existingUser);
 };
 
 export const findOwner = async () => {


### PR DESCRIPTION
## Summary
After a partial DB restore, user / organization rows can survive while the member.role = owner row is gone. isAdminPresent() only checked owner membership, so / treated the instance as a fresh install and redirected to Setup.

## Changes
- isAdminPresent() returns true when an owner membership exists, or an organization has a real owner user, or any user exists.
- Self-hosted first-admin signup uses that same check so a recovered instance cannot create a second first admin.
- The post-create hook still keys off owner membership only, so a real first install still creates the organization.

## Test plan
- [x] admin-present vitest (4 passed)
- [ ] Recovered instance with users but no owner membership stays off Setup / register
- [ ] Fresh empty install still reaches Setup and creates the first admin + org

Fixes #5192


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR broadens initialized-instance detection so partially restored installations with surviving users cannot re-enter first-admin setup.
- Treats owner memberships, live organization owners, or any user as evidence of initialization.
- Reuses the shared initialization check for self-hosted local signup.
- Preserves owner-membership-only behavior in the post-create organization hook.
- Adds focused initialization-state tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge; the only identified issue is a non-blocking redundant database query in initialization detection.

The changed checks prevent recovered instances from reopening first-admin registration as intended, while the organization-owner lookup adds avoidable work because the following user lookup already covers every successful owner relation.

**Files Needing Attention:** packages/server/src/services/admin.ts

<sub>Reviews (1): Last reviewed commit: ["fix: treat recovered instances with user..."](https://github.com/dokploy/dokploy/commit/c70cbe1a90f10e08b0e900e17495dc25aae462e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58187749)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->