### PR TITLE
fix(swarm): report failed service rollouts

### DIFF
--- a/apps/dokploy/__test__/server/mechanizeDockerContainer.test.ts
+++ b/apps/dokploy/__test__/server/mechanizeDockerContainer.test.ts
@@ -12,27 +12,52 @@ type MockCreateServiceOptions = {
 	[key: string]: unknown;
 };
 
-const { inspectMock, getServiceMock, createServiceMock, getRemoteDockerMock } =
-	vi.hoisted(() => {
-		const inspect = vi.fn<() => Promise<never>>();
-		const getService = vi.fn(() => ({ inspect }));
-		const createService = vi.fn<
-			(opts: MockCreateServiceOptions) => Promise<void>
-		>(async () => undefined);
-		const getRemoteDocker = vi.fn(async () => ({
-			getService,
-			createService,
-		}));
-		return {
-			inspectMock: inspect,
-			getServiceMock: getService,
-			createServiceMock: createService,
-			getRemoteDockerMock: getRemoteDocker,
-		};
-	});
+type MockServiceInspect = {
+	Version: { Index: number };
+	Spec: { TaskTemplate: { ForceUpdate?: number } };
+	ServiceStatus?: { DesiredTasks: number };
+};
+
+const {
+	inspectMock,
+	updateMock,
+	serviceMock,
+	getServiceMock,
+	createServiceMock,
+	getRemoteDockerMock,
+	waitForSwarmServiceUpdateMock,
+	getSwarmServiceUpdateTimeoutMsMock,
+} = vi.hoisted(() => {
+	const inspect = vi.fn<() => Promise<MockServiceInspect>>();
+	const update = vi.fn(async () => undefined);
+	const service = { id: "test-app", inspect, update };
+	const getService = vi.fn(() => service);
+	const createService = vi.fn<
+		(opts: MockCreateServiceOptions) => Promise<void>
+	>(async () => undefined);
+	const getRemoteDocker = vi.fn(async () => ({
+		getService,
+		createService,
+	}));
+	return {
+		inspectMock: inspect,
+		updateMock: update,
+		serviceMock: service,
+		getServiceMock: getService,
+		createServiceMock: createService,
+		getRemoteDockerMock: getRemoteDocker,
+		waitForSwarmServiceUpdateMock: vi.fn(async () => undefined),
+		getSwarmServiceUpdateTimeoutMsMock: vi.fn(() => 120_000),
+	};
+});
 
 vi.mock("@dokploy/server/utils/servers/remote-docker", () => ({
 	getRemoteDocker: getRemoteDockerMock,
+}));
+
+vi.mock("@dokploy/server/utils/docker/swarm-update", () => ({
+	getSwarmServiceUpdateTimeoutMs: getSwarmServiceUpdateTimeoutMsMock,
+	waitForSwarmServiceUpdate: waitForSwarmServiceUpdateMock,
 }));
 
 const createApplication = (
@@ -67,9 +92,14 @@ describe("mechanizeDockerContainer", () => {
 	beforeEach(() => {
 		inspectMock.mockReset();
 		inspectMock.mockRejectedValue(new Error("service not found"));
+		updateMock.mockReset();
+		updateMock.mockResolvedValue(undefined);
 		getServiceMock.mockClear();
 		createServiceMock.mockClear();
 		getRemoteDockerMock.mockClear();
+		waitForSwarmServiceUpdateMock.mockClear();
+		getSwarmServiceUpdateTimeoutMsMock.mockClear();
+		getSwarmServiceUpdateTimeoutMsMock.mockReturnValue(120_000);
 		getRemoteDockerMock.mockResolvedValue({
 			getService: getServiceMock,
 			createService: createServiceMock,
@@ -157,5 +187,86 @@ describe("mechanizeDockerContainer", () => {
 		}
 		const [settings] = call;
 		expect(settings.TaskTemplate?.ContainerSpec).not.toHaveProperty("Ulimits");
+	});
+
+	it("waits for an existing service update to finish", async () => {
+		inspectMock.mockReset();
+		inspectMock.mockResolvedValue({
+			Version: { Index: 7 },
+			Spec: { TaskTemplate: { ForceUpdate: 2 } },
+			ServiceStatus: { DesiredTasks: 1 },
+		});
+
+		await mechanizeDockerContainer(createApplication());
+
+		expect(updateMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				version: 7,
+				TaskTemplate: expect.objectContaining({ ForceUpdate: 3 }),
+			}),
+		);
+		expect(getSwarmServiceUpdateTimeoutMsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ replicas: 1 }),
+		);
+		expect(waitForSwarmServiceUpdateMock).toHaveBeenCalledWith(
+			expect.anything(),
+			serviceMock,
+			{
+				expectedForceUpdate: 3,
+				previousVersion: 7,
+				timeoutMs: 120_000,
+			},
+		);
+		expect(createServiceMock).not.toHaveBeenCalled();
+	});
+
+	it("does not create a replacement service when an update fails", async () => {
+		inspectMock.mockReset();
+		inspectMock.mockResolvedValue({
+			Version: { Index: 7 },
+			Spec: { TaskTemplate: { ForceUpdate: 2 } },
+		});
+		updateMock.mockRejectedValue(new Error("update failed"));
+
+		await expect(mechanizeDockerContainer(createApplication())).rejects.toThrow(
+			"update failed",
+		);
+
+		expect(createServiceMock).not.toHaveBeenCalled();
+		expect(waitForSwarmServiceUpdateMock).not.toHaveBeenCalled();
+	});
+
+	it("propagates a failed rollout without creating a replacement service", async () => {
+		inspectMock.mockReset();
+		inspectMock.mockResolvedValue({
+			Version: { Index: 7 },
+			Spec: { TaskTemplate: { ForceUpdate: 2 } },
+		});
+		waitForSwarmServiceUpdateMock.mockRejectedValue(
+			new Error("Swarm service update rolled back"),
+		);
+
+		await expect(mechanizeDockerContainer(createApplication())).rejects.toThrow(
+			"Swarm service update rolled back",
+		);
+
+		expect(createServiceMock).not.toHaveBeenCalled();
+	});
+
+	it("does not wait for job-mode service updates", async () => {
+		inspectMock.mockReset();
+		inspectMock.mockResolvedValue({
+			Version: { Index: 7 },
+			Spec: { TaskTemplate: { ForceUpdate: 2 } },
+		});
+
+		await mechanizeDockerContainer(
+			createApplication({
+				modeSwarm: { ReplicatedJob: { TotalCompletions: 1 } },
+			}),
+		);
+
+		expect(updateMock).toHaveBeenCalledOnce();
+		expect(waitForSwarmServiceUpdateMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/dokploy/__test__/server/swarm-update.test.ts
+++ b/apps/dokploy/__test__/server/swarm-update.test.ts
@@ -1,0 +1,177 @@
+import {
+	getSwarmServiceUpdateTimeoutMs,
+	waitForSwarmServiceUpdate,
+} from "@dokploy/server/utils/docker/swarm-update";
+import { describe, expect, it, vi } from "vitest";
+
+type DockerClient = Parameters<typeof waitForSwarmServiceUpdate>[0];
+type DockerService = Parameters<typeof waitForSwarmServiceUpdate>[1];
+
+const createService = (
+	inspects: Array<Record<string, unknown>>,
+	serviceName = "test-service",
+) => {
+	const inspect = vi.fn();
+	for (const value of inspects) inspect.mockResolvedValueOnce(value);
+
+	return {
+		id: serviceName,
+		inspect,
+	} as unknown as DockerService;
+};
+
+describe("waitForSwarmServiceUpdate", () => {
+	it("waits for the current update to complete", async () => {
+		const service = createService([
+			{ Version: { Index: 11 }, UpdateStatus: { State: "updating" } },
+			{ Version: { Index: 11 }, UpdateStatus: { State: "completed" } },
+		]);
+		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
+		const sleepFn = vi.fn(async () => undefined);
+
+		await waitForSwarmServiceUpdate(docker, service, {
+			expectedForceUpdate: 4,
+			pollIntervalMs: 1,
+			previousVersion: 10,
+			sleepFn,
+			timeoutMs: 1_000,
+		});
+
+		expect(service.inspect).toHaveBeenCalledTimes(2);
+		expect(sleepFn).toHaveBeenCalledOnce();
+		expect(docker.listTasks).not.toHaveBeenCalled();
+	});
+
+	it("ignores a stale completed status from the previous service version", async () => {
+		const service = createService([
+			{ Version: { Index: 10 }, UpdateStatus: { State: "completed" } },
+			{ Version: { Index: 11 }, UpdateStatus: { State: "completed" } },
+		]);
+		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
+		const sleepFn = vi.fn(async () => undefined);
+
+		await waitForSwarmServiceUpdate(docker, service, {
+			expectedForceUpdate: 4,
+			pollIntervalMs: 1,
+			previousVersion: 10,
+			sleepFn,
+			timeoutMs: 1_000,
+		});
+
+		expect(service.inspect).toHaveBeenCalledTimes(2);
+		expect(sleepFn).toHaveBeenCalledOnce();
+	});
+
+	it("reports an automatic rollback with the failed task reason", async () => {
+		const service = createService([
+			{
+				Version: { Index: 11 },
+				UpdateStatus: {
+					State: "rollback_completed",
+					Message: "rollback completed",
+				},
+			},
+		]);
+		const docker = {
+			listTasks: vi.fn(async () => [
+				{
+					Version: { Index: 20 },
+					Spec: { ForceUpdate: 4 },
+					Status: {
+						State: "failed",
+						Err: "task: unhealthy container",
+						ContainerStatus: { ExitCode: 137 },
+					},
+				},
+				{
+					Version: { Index: 21 },
+					Spec: { ForceUpdate: 3 },
+					Status: { State: "failed", Err: "older failure" },
+				},
+			]),
+		} as unknown as DockerClient;
+
+		await expect(
+			waitForSwarmServiceUpdate(docker, service, {
+				expectedForceUpdate: 4,
+				previousVersion: 10,
+				timeoutMs: 1_000,
+			}),
+		).rejects.toThrow(
+			"Swarm service update rolled back: rollback completed. Latest task failure: task: unhealthy container, exit code 137",
+		);
+	});
+
+	it("reports a paused update even when task lookup fails", async () => {
+		const service = createService([
+			{
+				Version: { Index: 11 },
+				UpdateStatus: { State: "paused", Message: "update paused" },
+			},
+		]);
+		const docker = {
+			listTasks: vi.fn(async () => {
+				throw new Error("task lookup failed");
+			}),
+		} as unknown as DockerClient;
+
+		await expect(
+			waitForSwarmServiceUpdate(docker, service, {
+				expectedForceUpdate: 4,
+				previousVersion: 10,
+				timeoutMs: 1_000,
+			}),
+		).rejects.toThrow("Swarm service update paused: update paused");
+	});
+
+	it("times out instead of waiting forever", async () => {
+		const service = {
+			id: "test-service",
+			inspect: vi.fn(async () => ({
+				Version: { Index: 11 },
+				UpdateStatus: { State: "updating" },
+			})),
+		} as unknown as DockerService;
+		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
+		let now = 0;
+
+		await expect(
+			waitForSwarmServiceUpdate(docker, service, {
+				expectedForceUpdate: 4,
+				nowFn: () => now,
+				pollIntervalMs: 1_000,
+				previousVersion: 10,
+				sleepFn: async (milliseconds) => {
+					now += milliseconds;
+				},
+				timeoutMs: 2_000,
+			}),
+		).rejects.toThrow(
+			"Swarm service update did not finish within 2 seconds (last state: updating)",
+		);
+	});
+});
+
+describe("getSwarmServiceUpdateTimeoutMs", () => {
+	it("accounts for update and rollback batches", () => {
+		expect(
+			getSwarmServiceUpdateTimeoutMs({
+				replicas: 10,
+				updateConfig: {
+					Parallelism: 1,
+					Monitor: 30_000_000_000,
+					Delay: 10_000_000_000,
+				},
+				rollbackConfig: {
+					Parallelism: 1,
+					Monitor: 30_000_000_000,
+					Delay: 10_000_000_000,
+				},
+			}),
+		).toBe(840_000);
+	});
+
+	it("keeps small updates above a safe minimum", () => {
+		expect(getSwarmServiceUpdateTimeoutMs({ replicas: 1 })).toBe(120_000);
+	});
+});

--- a/apps/dokploy/__test__/server/swarm-update.test.ts
+++ b/apps/dokploy/__test__/server/swarm-update.test.ts
@@ -23,8 +23,16 @@ const createService = (
 describe("waitForSwarmServiceUpdate", () => {
 	it("waits for the current update to complete", async () => {
 		const service = createService([
-			{ Version: { Index: 11 }, UpdateStatus: { State: "updating" } },
-			{ Version: { Index: 11 }, UpdateStatus: { State: "completed" } },
+			{
+				Version: { Index: 11 },
+				Spec: { TaskTemplate: { ForceUpdate: 4 } },
+				UpdateStatus: { State: "updating", StartedAt: "operation-1" },
+			},
+			{
+				Version: { Index: 11 },
+				Spec: { TaskTemplate: { ForceUpdate: 4 } },
+				UpdateStatus: { State: "completed", StartedAt: "operation-1" },
+			},
 		]);
 		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
 		const sleepFn = vi.fn(async () => undefined);
@@ -45,7 +53,11 @@ describe("waitForSwarmServiceUpdate", () => {
 	it("ignores a stale completed status from the previous service version", async () => {
 		const service = createService([
 			{ Version: { Index: 10 }, UpdateStatus: { State: "completed" } },
-			{ Version: { Index: 11 }, UpdateStatus: { State: "completed" } },
+			{
+				Version: { Index: 11 },
+				Spec: { TaskTemplate: { ForceUpdate: 4 } },
+				UpdateStatus: { State: "completed", StartedAt: "operation-1" },
+			},
 		]);
 		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
 		const sleepFn = vi.fn(async () => undefined);
@@ -65,10 +77,12 @@ describe("waitForSwarmServiceUpdate", () => {
 	it("reports an automatic rollback with the failed task reason", async () => {
 		const service = createService([
 			{
-				Version: { Index: 11 },
+				Version: { Index: 12 },
+				Spec: { TaskTemplate: { ForceUpdate: 3 } },
 				UpdateStatus: {
 					State: "rollback_completed",
 					Message: "rollback completed",
+					StartedAt: "operation-1",
 				},
 			},
 		]);
@@ -106,7 +120,12 @@ describe("waitForSwarmServiceUpdate", () => {
 		const service = createService([
 			{
 				Version: { Index: 11 },
-				UpdateStatus: { State: "paused", Message: "update paused" },
+				Spec: { TaskTemplate: { ForceUpdate: 4 } },
+				UpdateStatus: {
+					State: "paused",
+					Message: "update paused",
+					StartedAt: "operation-1",
+				},
 			},
 		]);
 		const docker = {
@@ -124,12 +143,62 @@ describe("waitForSwarmServiceUpdate", () => {
 		).rejects.toThrow("Swarm service update paused: update paused");
 	});
 
+	it("rejects a terminal state from a concurrent service update", async () => {
+		const service = createService([
+			{
+				Version: { Index: 11 },
+				Spec: { TaskTemplate: { ForceUpdate: 4 } },
+				UpdateStatus: { State: "updating", StartedAt: "operation-1" },
+			},
+			{
+				Version: { Index: 12 },
+				Spec: { TaskTemplate: { ForceUpdate: 5 } },
+				UpdateStatus: { State: "completed", StartedAt: "operation-2" },
+			},
+		]);
+		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
+
+		await expect(
+			waitForSwarmServiceUpdate(docker, service, {
+				expectedForceUpdate: 4,
+				pollIntervalMs: 1,
+				previousVersion: 10,
+				sleepFn: async () => undefined,
+				timeoutMs: 1_000,
+			}),
+		).rejects.toThrow(
+			"Swarm service update was superseded by another operation",
+		);
+	});
+
+	it("rejects a concurrent update observed before the expected operation", async () => {
+		const service = createService([
+			{
+				Version: { Index: 12 },
+				Spec: { TaskTemplate: { ForceUpdate: 5 } },
+				UpdateStatus: { State: "completed", StartedAt: "operation-2" },
+			},
+		]);
+		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
+
+		await expect(
+			waitForSwarmServiceUpdate(docker, service, {
+				expectedForceUpdate: 4,
+				previousVersion: 10,
+				timeoutMs: 1_000,
+			}),
+		).rejects.toThrow(
+			"Swarm service update was superseded by another operation",
+		);
+	});
+
 	it("times out instead of waiting forever", async () => {
 		const service = {
 			id: "test-service",
 			inspect: vi.fn(async () => ({
 				Version: { Index: 11 },
-				UpdateStatus: { State: "updating" },
+				Spec: { TaskTemplate: { ForceUpdate: 4 } },
+				UpdateStatus: { State: "updating", StartedAt: "operation-1" },
 			})),
 		} as unknown as DockerService;
 		const docker = { listTasks: vi.fn() } as unknown as DockerClient;
@@ -173,5 +242,9 @@ describe("getSwarmServiceUpdateTimeoutMs", () => {
 
 	it("keeps small updates above a safe minimum", () => {
 		expect(getSwarmServiceUpdateTimeoutMs({ replicas: 1 })).toBe(120_000);
+	});
+
+	it("does not truncate a valid rollout window", () => {
+		expect(getSwarmServiceUpdateTimeoutMs({ replicas: 100 })).toBe(6_060_000);
 	});
 });

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -4,6 +4,10 @@ import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
 import { getRegistryTag, uploadImageRemoteCommand } from "../cluster/upload";
 import {
+	getSwarmServiceUpdateTimeoutMs,
+	waitForSwarmServiceUpdate,
+} from "../docker/swarm-update";
+import {
 	calculateResources,
 	generateBindMounts,
 	generateConfigContainer,
@@ -174,18 +178,10 @@ export const mechanizeDockerContainer = async (
 		UpdateConfig,
 	};
 
+	const service = docker.getService(appName);
+	let inspect: Awaited<ReturnType<typeof service.inspect>>;
 	try {
-		const service = docker.getService(appName);
-		const inspect = await service.inspect();
-
-		await service.update({
-			version: Number.parseInt(inspect.Version.Index),
-			...settings,
-			TaskTemplate: {
-				...settings.TaskTemplate,
-				ForceUpdate: inspect.Spec.TaskTemplate.ForceUpdate + 1,
-			},
-		});
+		inspect = await service.inspect();
 	} catch (error) {
 		console.log(error);
 		if (authConfig) {
@@ -193,7 +189,36 @@ export const mechanizeDockerContainer = async (
 		} else {
 			await docker.createService(settings);
 		}
+		return;
 	}
+
+	const previousVersion = Number(inspect.Version.Index);
+	const expectedForceUpdate =
+		Number(inspect.Spec.TaskTemplate.ForceUpdate ?? 0) + 1;
+	await service.update({
+		version: previousVersion,
+		...settings,
+		TaskTemplate: {
+			...settings.TaskTemplate,
+			ForceUpdate: expectedForceUpdate,
+		},
+	});
+
+	if (settings.Mode?.ReplicatedJob || settings.Mode?.GlobalJob) return;
+
+	const replicas =
+		settings.Mode?.Replicated?.Replicas ??
+		inspect.ServiceStatus?.DesiredTasks ??
+		1;
+	await waitForSwarmServiceUpdate(docker, service, {
+		expectedForceUpdate,
+		previousVersion,
+		timeoutMs: getSwarmServiceUpdateTimeoutMs({
+			replicas,
+			rollbackConfig: settings.RollbackConfig,
+			updateConfig: settings.UpdateConfig,
+		}),
+	});
 };
 
 const getImageName = async (application: ApplicationNested) => {

--- a/packages/server/src/utils/docker/swarm-update.ts
+++ b/packages/server/src/utils/docker/swarm-update.ts
@@ -1,0 +1,188 @@
+import type Dockerode from "dockerode";
+import { sleep } from "../process/execAsync";
+
+const DEFAULT_MONITOR_NS = 30_000_000_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const MIN_UPDATE_TIMEOUT_MS = 2 * 60 * 1_000;
+const MAX_UPDATE_TIMEOUT_MS = 60 * 60 * 1_000;
+const UPDATE_TIMEOUT_BUFFER_MS = 60 * 1_000;
+
+type SwarmUpdateConfig = {
+	Parallelism?: number;
+	Delay?: number;
+	Monitor?: number;
+};
+
+type SwarmServiceInfo = {
+	Version?: { Index?: number };
+	UpdateStatus?: {
+		State?: string;
+		Message?: string;
+	};
+};
+
+type SwarmTask = {
+	Version?: { Index?: number };
+	Spec?: { ForceUpdate?: number };
+	Status?: {
+		State?: string;
+		Err?: string;
+		Message?: string;
+		ContainerStatus?: { ExitCode?: number };
+	};
+};
+
+type WaitForSwarmServiceUpdateOptions = {
+	expectedForceUpdate: number;
+	pollIntervalMs?: number;
+	previousVersion: number;
+	sleepFn?: (milliseconds: number) => Promise<unknown>;
+	timeoutMs: number;
+	nowFn?: () => number;
+};
+
+const failedUpdateStates = new Set([
+	"paused",
+	"rollback_paused",
+	"rollback_completed",
+]);
+
+const failedTaskStates = new Set(["failed", "rejected", "orphaned"]);
+
+const nanosecondsToMilliseconds = (value: number | undefined) =>
+	(value ?? DEFAULT_MONITOR_NS) / 1_000_000;
+
+const getPhaseTimeoutMs = (
+	config: SwarmUpdateConfig | undefined,
+	replicas: number,
+) => {
+	const parallelism = Math.max(0, config?.Parallelism ?? 1);
+	const batches =
+		parallelism === 0
+			? 1
+			: Math.max(1, Math.ceil(Math.max(1, replicas) / parallelism));
+	const monitorMs = nanosecondsToMilliseconds(config?.Monitor);
+	const delayMs = (config?.Delay ?? 0) / 1_000_000;
+
+	return batches * monitorMs + Math.max(0, batches - 1) * delayMs;
+};
+
+export const getSwarmServiceUpdateTimeoutMs = ({
+	replicas,
+	rollbackConfig,
+	updateConfig,
+}: {
+	replicas: number;
+	rollbackConfig?: SwarmUpdateConfig;
+	updateConfig?: SwarmUpdateConfig;
+}) => {
+	const calculatedTimeout =
+		getPhaseTimeoutMs(updateConfig, replicas) +
+		getPhaseTimeoutMs(rollbackConfig, replicas) +
+		UPDATE_TIMEOUT_BUFFER_MS;
+
+	return Math.min(
+		MAX_UPDATE_TIMEOUT_MS,
+		Math.max(MIN_UPDATE_TIMEOUT_MS, calculatedTimeout),
+	);
+};
+
+const getLatestTaskFailure = async (
+	docker: Dockerode,
+	serviceName: string,
+	expectedForceUpdate: number,
+) => {
+	try {
+		const tasks = (await docker.listTasks({
+			filters: JSON.stringify({ service: [serviceName] }),
+		})) as SwarmTask[];
+		const failedTask = tasks
+			.filter(
+				(task) =>
+					task.Spec?.ForceUpdate === expectedForceUpdate &&
+					failedTaskStates.has(task.Status?.State ?? ""),
+			)
+			.sort(
+				(left, right) =>
+					(right.Version?.Index ?? 0) - (left.Version?.Index ?? 0),
+			)[0];
+
+		if (!failedTask) return;
+
+		const detail = failedTask.Status?.Err || failedTask.Status?.Message;
+		const exitCode = failedTask.Status?.ContainerStatus?.ExitCode;
+		return [
+			detail,
+			exitCode !== undefined ? `exit code ${exitCode}` : undefined,
+		]
+			.filter(Boolean)
+			.join(", ");
+	} catch {
+		return;
+	}
+};
+
+const getUpdateFailureMessage = async (
+	docker: Dockerode,
+	serviceName: string,
+	state: string,
+	message: string | undefined,
+	expectedForceUpdate: number,
+) => {
+	const summary =
+		state === "rollback_completed"
+			? "Swarm service update rolled back"
+			: state === "rollback_paused"
+				? "Swarm service rollback paused"
+				: "Swarm service update paused";
+	const taskFailure = await getLatestTaskFailure(
+		docker,
+		serviceName,
+		expectedForceUpdate,
+	);
+
+	return `${summary}${message ? `: ${message}` : ""}${
+		taskFailure ? `. Latest task failure: ${taskFailure}` : ""
+	}`;
+};
+
+export const waitForSwarmServiceUpdate = async (
+	docker: Dockerode,
+	service: Dockerode.Service,
+	options: WaitForSwarmServiceUpdateOptions,
+) => {
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const sleepFn = options.sleepFn ?? sleep;
+	const nowFn = options.nowFn ?? Date.now;
+	const startedAt = nowFn();
+	let lastState = "pending";
+
+	while (nowFn() - startedAt < options.timeoutMs) {
+		const inspect = (await service.inspect()) as SwarmServiceInfo;
+		const version = inspect.Version?.Index ?? 0;
+
+		if (version > options.previousVersion) {
+			const state = inspect.UpdateStatus?.State;
+			lastState = state ?? "pending";
+
+			if (state === "completed") return;
+			if (state && failedUpdateStates.has(state)) {
+				throw new Error(
+					await getUpdateFailureMessage(
+						docker,
+						service.id,
+						state,
+						inspect.UpdateStatus?.Message,
+						options.expectedForceUpdate,
+					),
+				);
+			}
+		}
+
+		await sleepFn(pollIntervalMs);
+	}
+
+	throw new Error(
+		`Swarm service update did not finish within ${Math.round(options.timeoutMs / 1_000)} seconds (last state: ${lastState})`,
+	);
+};

--- a/packages/server/src/utils/docker/swarm-update.ts
+++ b/packages/server/src/utils/docker/swarm-update.ts
@@ -4,7 +4,6 @@ import { sleep } from "../process/execAsync";
 const DEFAULT_MONITOR_NS = 30_000_000_000;
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const MIN_UPDATE_TIMEOUT_MS = 2 * 60 * 1_000;
-const MAX_UPDATE_TIMEOUT_MS = 60 * 60 * 1_000;
 const UPDATE_TIMEOUT_BUFFER_MS = 60 * 1_000;
 
 type SwarmUpdateConfig = {
@@ -18,7 +17,9 @@ type SwarmServiceInfo = {
 	UpdateStatus?: {
 		State?: string;
 		Message?: string;
+		StartedAt?: string;
 	};
+	Spec?: { TaskTemplate?: { ForceUpdate?: number } };
 };
 
 type SwarmTask = {
@@ -50,7 +51,7 @@ const failedUpdateStates = new Set([
 const failedTaskStates = new Set(["failed", "rejected", "orphaned"]);
 
 const nanosecondsToMilliseconds = (value: number | undefined) =>
-	(value ?? DEFAULT_MONITOR_NS) / 1_000_000;
+	Math.max(0, value ?? DEFAULT_MONITOR_NS) / 1_000_000;
 
 const getPhaseTimeoutMs = (
 	config: SwarmUpdateConfig | undefined,
@@ -62,7 +63,7 @@ const getPhaseTimeoutMs = (
 			? 1
 			: Math.max(1, Math.ceil(Math.max(1, replicas) / parallelism));
 	const monitorMs = nanosecondsToMilliseconds(config?.Monitor);
-	const delayMs = (config?.Delay ?? 0) / 1_000_000;
+	const delayMs = Math.max(0, config?.Delay ?? 0) / 1_000_000;
 
 	return batches * monitorMs + Math.max(0, batches - 1) * delayMs;
 };
@@ -81,10 +82,7 @@ export const getSwarmServiceUpdateTimeoutMs = ({
 		getPhaseTimeoutMs(rollbackConfig, replicas) +
 		UPDATE_TIMEOUT_BUFFER_MS;
 
-	return Math.min(
-		MAX_UPDATE_TIMEOUT_MS,
-		Math.max(MIN_UPDATE_TIMEOUT_MS, calculatedTimeout),
-	);
+	return Math.max(MIN_UPDATE_TIMEOUT_MS, calculatedTimeout);
 };
 
 const getLatestTaskFailure = async (
@@ -156,6 +154,7 @@ export const waitForSwarmServiceUpdate = async (
 	const nowFn = options.nowFn ?? Date.now;
 	const startedAt = nowFn();
 	let lastState = "pending";
+	let operationStartedAt: string | undefined;
 
 	while (nowFn() - startedAt < options.timeoutMs) {
 		const inspect = (await service.inspect()) as SwarmServiceInfo;
@@ -164,6 +163,34 @@ export const waitForSwarmServiceUpdate = async (
 		if (version > options.previousVersion) {
 			const state = inspect.UpdateStatus?.State;
 			lastState = state ?? "pending";
+			const currentForceUpdate = inspect.Spec?.TaskTemplate?.ForceUpdate;
+			const currentOperationStartedAt = inspect.UpdateStatus?.StartedAt;
+
+			if (!operationStartedAt) {
+				const isExpectedUpdate =
+					currentForceUpdate === options.expectedForceUpdate;
+				const isExpectedRollback =
+					state?.startsWith("rollback_") &&
+					Boolean(
+						await getLatestTaskFailure(
+							docker,
+							service.id,
+							options.expectedForceUpdate,
+						),
+					);
+
+				if (!isExpectedUpdate && !isExpectedRollback) {
+					throw new Error(
+						"Swarm service update was superseded by another operation",
+					);
+				}
+
+				operationStartedAt = currentOperationStartedAt;
+			} else if (currentOperationStartedAt !== operationStartedAt) {
+				throw new Error(
+					"Swarm service update was superseded by another operation",
+				);
+			}
 
 			if (state === "completed") return;
 			if (state && failedUpdateStates.has(state)) {


### PR DESCRIPTION
## Summary

- Wait for an existing Swarm service update to reach its terminal state before marking the deployment complete.
- Treat paused and rolled-back updates as deployment failures, including the latest failed task reason and exit code when available.
- Bound the wait using the configured update and rollback timings, while preserving the existing create path and job-mode behavior.

## Testing

- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter dokploy exec vitest run --config __test__/vitest.config.ts __test__/server/swarm-update.test.ts __test__/server/mechanizeDockerContainer.test.ts` (16 tests passed)
- Biome check on all changed files
- Real local Swarm verification: a healthy update reached `completed`, while an unhealthy update automatically rolled back and surfaced the failed task reason

Fixes #3987

Happy to adjust the polling states or failure details if you would prefer a different approach.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR waits for existing Swarm application-service updates to reach a terminal state and reports paused or rolled-back rollouts with task failure details.

- Adds bounded polling and failure-detail helpers for Swarm updates.
- Integrates rollout waiting into existing non-job service updates while preserving service creation and job-mode behavior.
- Adds unit coverage for successful updates, stale status handling, rollback failures, timeouts, and builder integration.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until rollout waits are correlated to the initiating update and valid configured rollouts cannot be prematurely failed by the fixed one-hour cap.

Concurrent direct service mutations can make the waiter attribute another update’s terminal state to the current deployment, while accepted long-duration Swarm settings can exceed the capped wait and produce false deployment failures.

**Files Needing Attention:** packages/server/src/utils/docker/swarm-update.ts and packages/server/src/utils/builders/index.ts

<sub>Reviews (1): Last reviewed commit: ["fix(swarm): report failed service rollou..."](https://github.com/dokploy/dokploy/commit/b1b74f7a8beb31e7343a32c840f04e63103819e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58232633)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Deployment lifecycle](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/deployment-lifecycle.md)
- Knowledge Base — [Applications and deployments](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/applications-and-deployments.md)
- Knowledge Base — [Infrastructure runtime](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/infrastructure-runtime.md)
</details>


<!-- /greptile_comment -->