### PR TITLE
fix: remove stopped containers referencing a volume before restore

### DIFF
--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -66,14 +66,16 @@ export const restoreVolume = async (
 			docker volume rm ${volumeName} --force
 			${baseRestoreCommand}
 		else
-			RUNNING_CONTAINERS=$(echo "$CONTAINERS_USING_VOLUME" | awk -F'|' '$3 == "running"')
-			STOPPED_CONTAINERS=$(echo "$CONTAINERS_USING_VOLUME" | awk -F'|' '$3 != "running"')
+			# Only "exited", "created" and "dead" are safe to remove. Anything else
+			# (running, restarting, paused, removing) is treated as still in use.
+			RUNNING_CONTAINERS=$(echo "$CONTAINERS_USING_VOLUME" | awk -F'|' '$3 != "exited" && $3 != "created" && $3 != "dead"')
+			STOPPED_CONTAINERS=$(echo "$CONTAINERS_USING_VOLUME" | awk -F'|' '$3 == "exited" || $3 == "created" || $3 == "dead"')
 
 			if [ -n "$RUNNING_CONTAINERS" ]; then
 				echo ""
 				echo "⚠️  WARNING: Cannot restore volume as it is currently in use!"
 				echo ""
-				echo "📋 The following running containers are using volume '${volumeName}':"
+				echo "📋 The following containers are using volume '${volumeName}':"
 				echo ""
 
 				echo "$RUNNING_CONTAINERS" | while IFS='|' read container_id container_name container_state labels; do
@@ -104,17 +106,49 @@ export const restoreVolume = async (
 				exit 1
 			fi
 
+			# Re-check each container's live state right before removing it: it may have
+			# started running again since the "docker ps -a" snapshot above.
+			ACTIVE_AGAIN=""
+			while IFS='|' read -r container_id container_name container_state labels; do
+				CURRENT_STATE=$(docker inspect -f '{{.State.Status}}' "$container_id" 2>/dev/null || echo "gone")
+				case "$CURRENT_STATE" in
+					running|restarting|paused|removing)
+						ACTIVE_AGAIN="$ACTIVE_AGAIN $container_name"
+						;;
+				esac
+			done < <(printf '%s\\n' "$STOPPED_CONTAINERS")
+
+			if [ -n "$ACTIVE_AGAIN" ]; then
+				echo ""
+				echo "⚠️  WARNING: Container(s)$ACTIVE_AGAIN became active again, aborting restore"
+				echo "❌ Volume restore aborted - volume is in use"
+				exit 1
+			fi
+
 			echo "Volume exists but is only referenced by stopped containers, removing them..."
 			echo ""
 
-			echo "$STOPPED_CONTAINERS" | while IFS='|' read container_id container_name container_state labels; do
+			REMOVE_FAILED=""
+			while IFS='|' read -r container_id container_name container_state labels; do
 				echo "   🗑  Removing stopped container: $container_name ($container_id) [status: $container_state]"
-				docker rm -f "$container_id" >/dev/null 2>&1 || true
-			done
+				if ! docker rm -f "$container_id" >/dev/null 2>&1; then
+					REMOVE_FAILED="$REMOVE_FAILED $container_name"
+				fi
+			done < <(printf '%s\\n' "$STOPPED_CONTAINERS")
+
+			if [ -n "$REMOVE_FAILED" ]; then
+				echo ""
+				echo "❌ Failed to remove container(s):$REMOVE_FAILED"
+				echo "❌ Volume restore aborted - could not free the volume"
+				exit 1
+			fi
 
 			echo ""
 			echo "Removing existing volume and proceeding with restore"
-			docker volume rm ${volumeName} --force
+			if ! docker volume rm ${volumeName} --force; then
+				echo "❌ Volume restore aborted - failed to remove existing volume"
+				exit 1
+			fi
 			${baseRestoreCommand}
 		fi
 	fi

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -66,38 +66,56 @@ export const restoreVolume = async (
 			docker volume rm ${volumeName} --force
 			${baseRestoreCommand}
 		else
-			echo ""
-			echo "⚠️  WARNING: Cannot restore volume as it is currently in use!"
-			echo ""
-			echo "📋 The following containers are using volume '${volumeName}':"
-			echo ""
-			
-			echo "$CONTAINERS_USING_VOLUME" | while IFS='|' read container_id container_name container_state labels; do
-				echo "   🐳 Container: $container_name ($container_id)"
-				echo "      Status: $container_state"
-				
-				# Determine container type
-				if echo "$labels" | grep -q "com.docker.swarm.service.name="; then
-					SERVICE_NAME=$(echo "$labels" | grep -o "com.docker.swarm.service.name=[^,]*" | cut -d'=' -f2)
-					echo "      Type: Docker Swarm Service ($SERVICE_NAME)"
-				elif echo "$labels" | grep -q "com.docker.compose.project="; then
-					PROJECT_NAME=$(echo "$labels" | grep -o "com.docker.compose.project=[^,]*" | cut -d'=' -f2)
-					echo "      Type: Docker Compose ($PROJECT_NAME)"
-				else
-					echo "      Type: Regular Container"
-				fi
+			RUNNING_CONTAINERS=$(echo "$CONTAINERS_USING_VOLUME" | awk -F'|' '$3 == "running"')
+			STOPPED_CONTAINERS=$(echo "$CONTAINERS_USING_VOLUME" | awk -F'|' '$3 != "running"')
+
+			if [ -n "$RUNNING_CONTAINERS" ]; then
 				echo ""
+				echo "⚠️  WARNING: Cannot restore volume as it is currently in use!"
+				echo ""
+				echo "📋 The following running containers are using volume '${volumeName}':"
+				echo ""
+
+				echo "$RUNNING_CONTAINERS" | while IFS='|' read container_id container_name container_state labels; do
+					echo "   🐳 Container: $container_name ($container_id)"
+					echo "      Status: $container_state"
+
+					# Determine container type
+					if echo "$labels" | grep -q "com.docker.swarm.service.name="; then
+						SERVICE_NAME=$(echo "$labels" | grep -o "com.docker.swarm.service.name=[^,]*" | cut -d'=' -f2)
+						echo "      Type: Docker Swarm Service ($SERVICE_NAME)"
+					elif echo "$labels" | grep -q "com.docker.compose.project="; then
+						PROJECT_NAME=$(echo "$labels" | grep -o "com.docker.compose.project=[^,]*" | cut -d'=' -f2)
+						echo "      Type: Docker Compose ($PROJECT_NAME)"
+					else
+						echo "      Type: Regular Container"
+					fi
+					echo ""
+				done
+
+				echo ""
+				echo "🔧 To restore this volume, please:"
+				echo "   1. Stop all containers/services using this volume"
+				echo "   2. Remove the existing volume: docker volume rm ${volumeName}"
+				echo "   3. Run the restore operation again"
+				echo ""
+				echo "❌ Volume restore aborted - volume is in use"
+
+				exit 1
+			fi
+
+			echo "Volume exists but is only referenced by stopped containers, removing them..."
+			echo ""
+
+			echo "$STOPPED_CONTAINERS" | while IFS='|' read container_id container_name container_state labels; do
+				echo "   🗑  Removing stopped container: $container_name ($container_id) [status: $container_state]"
+				docker rm -f "$container_id" >/dev/null 2>&1 || true
 			done
-			
+
 			echo ""
-			echo "🔧 To restore this volume, please:"
-			echo "   1. Stop all containers/services using this volume"
-			echo "   2. Remove the existing volume: docker volume rm ${volumeName}"
-			echo "   3. Run the restore operation again"
-			echo ""
-			echo "❌ Volume restore aborted - volume is in use"
-			
-			exit 1
+			echo "Removing existing volume and proceeding with restore"
+			docker volume rm ${volumeName} --force
+			${baseRestoreCommand}
 		fi
 	fi
 	`;

--- a/packages/server/src/utils/volume-backups/restore.ts
+++ b/packages/server/src/utils/volume-backups/restore.ts
@@ -106,6 +106,11 @@ export const restoreVolume = async (
 				exit 1
 			fi
 
+			# Use a temp file instead of process substitution ("< <(...)") so this
+			# still works under a plain POSIX /bin/sh, not just bash.
+			STOPPED_CONTAINERS_FILE=$(mktemp)
+			printf '%s\\n' "$STOPPED_CONTAINERS" > "$STOPPED_CONTAINERS_FILE"
+
 			# Re-check each container's live state right before removing it: it may have
 			# started running again since the "docker ps -a" snapshot above.
 			ACTIVE_AGAIN=""
@@ -116,9 +121,10 @@ export const restoreVolume = async (
 						ACTIVE_AGAIN="$ACTIVE_AGAIN $container_name"
 						;;
 				esac
-			done < <(printf '%s\\n' "$STOPPED_CONTAINERS")
+			done < "$STOPPED_CONTAINERS_FILE"
 
 			if [ -n "$ACTIVE_AGAIN" ]; then
+				rm -f "$STOPPED_CONTAINERS_FILE"
 				echo ""
 				echo "⚠️  WARNING: Container(s)$ACTIVE_AGAIN became active again, aborting restore"
 				echo "❌ Volume restore aborted - volume is in use"
@@ -134,7 +140,9 @@ export const restoreVolume = async (
 				if ! docker rm -f "$container_id" >/dev/null 2>&1; then
 					REMOVE_FAILED="$REMOVE_FAILED $container_name"
 				fi
-			done < <(printf '%s\\n' "$STOPPED_CONTAINERS")
+			done < "$STOPPED_CONTAINERS_FILE"
+
+			rm -f "$STOPPED_CONTAINERS_FILE"
 
 			if [ -n "$REMOVE_FAILED" ]; then
 				echo ""


### PR DESCRIPTION
Fixes #3995

Volume restore aborted with "volume is in use" whenever a stopped/exited container still referenced the target volume, forcing users to SSH in and manually remove the container before restoring. This is common after stopping a compose service from the UI — Docker keeps the exited container attached to the volume.

## Change

In `restoreVolume`'s in-use check, containers referencing the volume are now split into running vs stopped:
- **Running** containers still abort the restore with the existing warning (unchanged, safe behavior).
- **Stopped** containers are removed automatically (`docker rm -f`) before the volume is recreated and the restore proceeds.

## Verified

Reproduced end-to-end against a local Dokploy instance (Playwright UI + real Docker):
1. Deployed a compose service with a named volume, took a manual volume backup.
2. Stopped the service — container went `exited` but kept referencing the volume.
3. Confirmed the bug: restore aborted with the "volume is in use" error.
4. Applied the fix and reran the restore: log showed the stopped container being removed, then the volume was recreated and restored successfully, with no manual SSH step.
5. Confirmed via Docker that the old container was gone and the volume contained the restored backup files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows volume restores to remove containers considered stopped before recreating the target volume.

- Splits attached containers into running and non-running groups.
- Preserves the abort path for containers reported as running.
- Force-removes non-running containers and then restores the volume from backup.

<h3>Confidence Score: 2/5</h3>

The PR is not safe to merge until automatic removal is restricted to confirmed stopped containers and all destructive preconditions are revalidated and enforced.

The changed restore path can force-delete paused, restarting, or concurrently started containers, and ignored cleanup failures can make an overlay extraction into the old volume appear successful.

**Files Needing Attention:** packages/server/src/utils/volume-backups/restore.ts

<sub>Reviews (1): Last reviewed commit: ["fix: remove stopped containers referenci..."](https://github.com/dokploy/dokploy/commit/931fa4a3c4326deefe14691313a5becedf79a0b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58449137)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Backups and restore](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/backups-and-restore.md)
- Knowledge Base — [Managed data services](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/managed-data-services.md)

<!-- /greptile_comment -->