### PR TITLE
fix: detect billing plan across all active Stripe subscriptions

### DIFF
--- a/apps/dokploy/server/api/routers/stripe.ts
+++ b/apps/dokploy/server/api/routers/stripe.ts
@@ -80,38 +80,52 @@ export const stripeRouter = createTRPCRouter({
 		let currentPlan: CurrentPlan = "legacy";
 		let isAnnualCurrent = false;
 		let currentPriceAmount: number | null = null;
-		const activeSub = subscriptions.data[0];
-		if (activeSub) {
-			const priceIds = activeSub.items.data.map(
-				(item) => (item.price as Stripe.Price).id,
+		if (subscriptions.data.length > 0) {
+			const matchedSub = subscriptions.data.find((sub) =>
+				sub.items.data.some(
+					(item) =>
+						(item.price as Stripe.Price).id === STARTUP_BASE_PRICE_MONTHLY_ID ||
+						(item.price as Stripe.Price).id === STARTUP_BASE_PRICE_ANNUAL_ID,
+				),
 			);
-			if (
-				priceIds.some(
-					(id) =>
-						id === STARTUP_BASE_PRICE_MONTHLY_ID ||
-						id === STARTUP_BASE_PRICE_ANNUAL_ID,
-				)
-			) {
+			const hobbySub = subscriptions.data.find((sub) =>
+				sub.items.data.some(
+					(item) =>
+						(item.price as Stripe.Price).id === HOBBY_PRICE_MONTHLY_ID ||
+						(item.price as Stripe.Price).id === HOBBY_PRICE_ANNUAL_ID,
+				),
+			);
+			const legacySub = subscriptions.data.find((sub) =>
+				sub.items.data.some((item) =>
+					LEGACY_PRICE_IDS.includes((item.price as Stripe.Price).id),
+				),
+			);
+
+			const activeSub = matchedSub ?? hobbySub ?? legacySub;
+			if (matchedSub) {
 				currentPlan = "startup";
-			} else if (
-				priceIds.some(
-					(id) => id === HOBBY_PRICE_MONTHLY_ID || id === HOBBY_PRICE_ANNUAL_ID,
-				)
-			) {
+			} else if (hobbySub) {
 				currentPlan = "hobby";
-			} else if (priceIds.some((id) => LEGACY_PRICE_IDS.includes(id))) {
+			} else if (legacySub) {
 				currentPlan = "legacy";
 			}
-			const firstPrice = activeSub.items.data[0]?.price as
+
+			const firstPrice = activeSub?.items.data[0]?.price as
 				| Stripe.Price
 				| undefined;
 			isAnnualCurrent = firstPrice?.recurring?.interval === "year";
-			const totalCents = activeSub.items.data.reduce((sum, item) => {
-				const price = item.price as Stripe.Price;
-				const amount = price.unit_amount ?? 0;
-				const qty = item.quantity ?? 1;
-				return sum + amount * qty;
-			}, 0);
+
+			const totalCents = subscriptions.data.reduce(
+				(subTotal, sub) =>
+					subTotal +
+					sub.items.data.reduce((sum, item) => {
+						const price = item.price as Stripe.Price;
+						const amount = price.unit_amount ?? 0;
+						const qty = item.quantity ?? 1;
+						return sum + amount * qty;
+					}, 0),
+				0,
+			);
 			currentPriceAmount = totalCents / 100;
 		}
 

--- a/apps/dokploy/server/api/routers/stripe.ts
+++ b/apps/dokploy/server/api/routers/stripe.ts
@@ -115,17 +115,12 @@ export const stripeRouter = createTRPCRouter({
 				| undefined;
 			isAnnualCurrent = firstPrice?.recurring?.interval === "year";
 
-			const totalCents = subscriptions.data.reduce(
-				(subTotal, sub) =>
-					subTotal +
-					sub.items.data.reduce((sum, item) => {
-						const price = item.price as Stripe.Price;
-						const amount = price.unit_amount ?? 0;
-						const qty = item.quantity ?? 1;
-						return sum + amount * qty;
-					}, 0),
-				0,
-			);
+			const totalCents = (activeSub?.items.data ?? []).reduce((sum, item) => {
+				const price = item.price as Stripe.Price;
+				const amount = price.unit_amount ?? 0;
+				const qty = item.quantity ?? 1;
+				return sum + amount * qty;
+			}, 0);
 			currentPriceAmount = totalCents / 100;
 		}
 

--- a/apps/dokploy/server/utils/billing.ts
+++ b/apps/dokploy/server/utils/billing.ts
@@ -27,11 +27,10 @@ export const getCurrentPlanForUser = async (
 		status: "active",
 		expand: ["data.items.data.price"],
 	});
-	const activeSub = subscriptions.data[0];
-	if (!activeSub) return null;
+	if (subscriptions.data.length === 0) return null;
 
-	const priceIds = activeSub.items.data.map(
-		(item) => (item.price as Stripe.Price).id,
+	const priceIds = subscriptions.data.flatMap((sub) =>
+		sub.items.data.map((item) => (item.price as Stripe.Price).id),
 	);
 
 	if (


### PR DESCRIPTION
Fixes the HubSpot chat bubble not showing for cloud users on the Startup plan.

`getCurrentPlanForUser` (billing.ts) and `getProducts` (stripe.ts) only looked at `subscriptions.data[0]`, the first active Stripe subscription returned. A customer with more than one active subscription (e.g. Startup plus a separately purchased additional server) could have the plan resolved from the wrong subscription, so `currentPlan` came back as `null`/wrong plan instead of `"startup"`, and the chat bubble (gated on `currentPlan === "startup"`) never rendered.

Both functions now scan price IDs across all active subscriptions instead of just the first one. `getProducts` also sums `currentPriceAmount` across all active subscriptions instead of only the first one's items.

Verified locally with Playwright against a cloud-mode instance: `stripe.getCurrentPlan` now returns `"startup"` and the HubSpot script loads correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates Stripe plan detection to inspect all active subscriptions instead of only the first and aggregates their charges for the billing view.
- Resolves Startup, Hobby, and Legacy prices across all returned active subscriptions.
- Selects the matching plan subscription for billing cadence.
- Sums prices and quantities across active subscriptions.

<h3>Confidence Score: 4/5</h3>

The mixed-interval price aggregation should be corrected before merging because it can show customers a materially incorrect billing amount and cadence.

getProducts labels a sum spanning every active subscription with the billing interval of only the selected plan subscription, so annual and monthly charges can be combined and presented as though they share one cadence.

**Files Needing Attention:** apps/dokploy/server/api/routers/stripe.ts

<sub>Reviews (1): Last reviewed commit: ["fix: detect billing plan across all acti..."](https://github.com/dokploy/dokploy/commit/e79239a100422c181fd92cbfa4f0fae3a610cd57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58470684)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing and enterprise features](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/billing-and-enterprise-features.md)

<!-- /greptile_comment -->