### PR TITLE
fix/docker-context-path-default: Placeholder with name attribute "doc…

### DIFF
--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -26,11 +26,7 @@ export const getDockerCommand = (application: ApplicationNested) => {
 	try {
 		const image = `${appName}`;
 
-		const defaultContextPath =
-			dockerFilePath.substring(0, dockerFilePath.lastIndexOf("/") + 1) || ".";
-
-		const dockerContextPath =
-			getDockerContextPath(application) || defaultContextPath;
+		const dockerContextPath = getDockerContextPath(application);
 
 		const commandArgs = ["build", "-t", image, "-f", dockerFilePath, "."];
 

--- a/packages/server/src/utils/filesystem/directory.ts
+++ b/packages/server/src/utils/filesystem/directory.ts
@@ -138,8 +138,10 @@ export const getDockerContextPath = (application: Application) => {
 	const { APPLICATIONS_PATH } = paths(!!application.serverId);
 	const { appName, dockerContextPath } = application;
 
-	if (!dockerContextPath) {
-		return null;
-	}
-	return path.join(APPLICATIONS_PATH, appName, "code", dockerContextPath);
+	return path.join(
+		APPLICATIONS_PATH,
+		appName,
+		"code",
+		dockerContextPath || ".",
+	);
 };


### PR DESCRIPTION
…kerContextPath" lied that the default path is ".", while being the Dockerfile directory.

## What is this PR about?
Docker context path input UI lies.

Please describe in a short paragraph what this PR is about.
<img width="668" height="135" alt="image" src="https://github.com/user-attachments/assets/0e6b06c8-487b-434e-bc43-771a2ecfe8ac" />
while it's actually the Dockerfile directory as context by default.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

## Screenshots (if applicable)
It's my first PR here :)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the Dockerfile build behavior with the Docker context input’s documented default by resolving an unset context path to the application’s code root.

- Makes `getDockerContextPath` always return an absolute workspace path, defaulting to `.` beneath the code directory.
- Removes the Dockerfile-directory fallback from Docker command generation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The changed resolver and Docker command remain aligned: an unset context now resolves to the application code root, while explicitly configured context paths continue to resolve beneath the same workspace.

<sub>Reviews (1): Last reviewed commit: ["fix/docker-context-path-default: Placeho..."](https://github.com/dokploy/dokploy/commit/f1e2467bb9454f1689431022b9da968f92413748) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58532732)</sub>

<!-- /greptile_comment -->