### PR TITLE
fix: pass --env-file so the generated .env is found with --project-directory

### DIFF
--- a/apps/dokploy/__test__/compose/compose-project-directory.test.ts
+++ b/apps/dokploy/__test__/compose/compose-project-directory.test.ts
@@ -56,3 +56,58 @@ describe("compose createCommand --project-directory", () => {
 		expect(cmd).toContain("-f docker-compose.yml");
 	});
 });
+
+describe("compose createCommand --env-file", () => {
+	it("points --env-file at the generated .env next to a nested compose file", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				composePath: "./deploy/docker-compose.yml",
+				createEnvFile: true,
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).toContain("--env-file deploy/.env");
+		expect(cmd).toContain(
+			"--project-directory /etc/dokploy/compose/compose-app/code",
+		);
+	});
+
+	it("omits --env-file when createEnvFile is disabled", () => {
+		const cmd = createCommand(
+			{ ...base, composePath: "./deploy/docker-compose.yml" } as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).not.toContain("--env-file");
+	});
+
+	it("uses the code-root .env for raw sourceType", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				sourceType: "raw",
+				composePath: "docker-compose.yml",
+				createEnvFile: true,
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).toContain("--env-file .env");
+	});
+
+	it("does not add --env-file to stack deploy (unsupported flag)", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				composeType: "stack",
+				composePath: "./deploy/docker-compose.yml",
+				createEnvFile: true,
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).not.toContain("--env-file");
+	});
+});

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -133,7 +133,14 @@ export const createCommand = (compose: ComposeNested, projectPath?: string) => {
 		const projectDirectoryFlag = projectPath
 			? `--project-directory ${quote([projectPath])} `
 			: "";
-		command = `compose -p ${quote([appName])} ${projectDirectoryFlag}-f ${quote([path])} up -d --build --remove-orphans`;
+		// The generated .env lives next to the compose file (see
+		// getCreateEnvFileCommand), while --project-directory makes compose look
+		// it up in the project directory — pass it explicitly so interpolation
+		// works for nested compose paths.
+		const envFileFlag = compose.createEnvFile
+			? `--env-file ${quote([join(dirname(compose.composePath || "docker-compose.yml"), ".env")])} `
+			: "";
+		command = `compose -p ${quote([appName])} ${projectDirectoryFlag}${envFileFlag}-f ${quote([path])} up -d --build --remove-orphans`;
 	} else if (composeType === "stack") {
 		command = `stack deploy -c ${quote([path])} ${quote([appName])} --prune --with-registry-auth`;
 	}


### PR DESCRIPTION
## What is this PR about?

Since 87b914996, compose deploys run with `--project-directory <code>`, so docker compose looks for `.env` in the code root — but `getCreateEnvFileCommand` writes the Environment-tab `.env` next to the compose file. For nested compose paths (e.g. `./docker/docker-compose.yml`) every `${VAR}` silently interpolates to a blank string:

```
The "INFLUXDB_INIT_ADMIN_TOKEN" variable is not set. Defaulting to a blank string.
```

Fix: `createCommand` passes `--env-file <dirname(composePath)>/.env` (only when **Create Environment File** is enabled; docker-compose type only — stack already uses env export).

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

Tested via:
- 4 new unit tests in `compose-project-directory.test.ts` (nested path, disabled flag, raw, stack); full compose suite passes except the pre-existing docker-dependent `env-file-literals` integration test
- Full local dev instance (`pnpm dokploy:dev`, v0.30.3 canary): custom-git compose app with `composePath: ./docker/docker-compose.yml`, Environment-tab var, Create Environment File on
  - unpatched: `The "TESTVAR" variable is not set. Defaulting to a blank string.`, container env empty
  - patched: command gains `--env-file docker/.env`, no warning, container receives the value

## Issues related (if applicable)

Same root cause as #5230 (different symptom: that one is `build.context`, this one is `.env` interpolation). Hit in production upgrading v0.30.2 → v0.30.3.
