### PR TITLE
feat(organization): add ownership transfer

### DIFF
--- a/apps/dokploy/__test__/api/organization-transfer-ownership.test.ts
+++ b/apps/dokploy/__test__/api/organization-transfer-ownership.test.ts
@@ -1,0 +1,216 @@
+import { db } from "@dokploy/server/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { organizationRouter } from "@/server/api/routers/organization";
+import { member, organization } from "@/server/db/schema";
+
+type CallerCtx = {
+	session: { id: string; userId: string; activeOrganizationId: string } | null;
+	user: { id: string; email: string; role: string } | null;
+	db: typeof db;
+	req: unknown;
+	res: unknown;
+};
+
+const createCtx = (overrides: Partial<CallerCtx> = {}): CallerCtx => ({
+	session: {
+		id: "session-1",
+		userId: "owner-user",
+		activeOrganizationId: "org-1",
+	},
+	user: { id: "owner-user", email: "owner@example.com", role: "owner" },
+	db,
+	req: {},
+	res: {},
+	...overrides,
+});
+
+const createCaller = (ctx: CallerCtx) =>
+	organizationRouter.createCaller(ctx as never);
+
+const orgFixture: any = {
+	id: "org-1",
+	name: "Acme",
+	ownerId: "owner-user",
+	slug: "acme",
+	createdAt: new Date(),
+};
+
+const ownerMemberFixture: any = {
+	id: "m-owner",
+	organizationId: "org-1",
+	userId: "owner-user",
+	role: "owner",
+	createdAt: new Date(),
+};
+
+const targetFixture: any = {
+	id: "m-target",
+	organizationId: "org-1",
+	userId: "user-2",
+	role: "admin",
+	createdAt: new Date(),
+	user: { id: "user-2", email: "target@example.com" },
+};
+
+const findFirstMock = vi.mocked(db.query.member.findFirst);
+
+let transactionCalls: unknown[][] = [];
+
+const createTx = () => {
+	const updateMock = vi.fn((_table: unknown) => ({
+		set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([])) })),
+	}));
+	return { tx: { update: updateMock, query: db.query }, updateMock };
+};
+
+beforeEach(() => {
+	findFirstMock.mockReset();
+	transactionCalls = [];
+	(db as unknown as { transaction: unknown }).transaction = vi.fn(
+		async (cb: (tx: unknown) => Promise<unknown>) => {
+			const { tx, updateMock } = createTx();
+			const result = await cb(tx);
+			transactionCalls.push(updateMock.mock.calls.map((call) => call[0]));
+			return result;
+		},
+	);
+});
+
+describe("organization.transferOwnership input validation", () => {
+	it("rejects a missing memberId", async () => {
+		findFirstMock.mockResolvedValueOnce(ownerMemberFixture);
+		const caller = createCaller(createCtx());
+		await expect(
+			// @ts-expect-error testing invalid input
+			caller.transferOwnership({}),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+	});
+
+	it("rejects an empty memberId", async () => {
+		findFirstMock.mockResolvedValueOnce(ownerMemberFixture);
+		const caller = createCaller(createCtx());
+		await expect(
+			caller.transferOwnership({ memberId: "" }),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+	});
+});
+
+describe("organization.transferOwnership authorization", () => {
+	it("rejects unauthenticated calls", async () => {
+		const caller = createCaller(createCtx({ session: null, user: null }));
+		await expect(
+			caller.transferOwnership({ memberId: "m-target" }),
+		).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+	});
+
+	it("rejects callers that are not the organization owner", async () => {
+		findFirstMock
+			.mockResolvedValueOnce({ ...ownerMemberFixture, role: "admin" })
+			.mockResolvedValueOnce({ ...orgFixture, ownerId: "someone-else" })
+			.mockResolvedValueOnce({ ...ownerMemberFixture, role: "admin" });
+
+		const caller = createCaller(
+			createCtx({
+				user: { id: "admin-user", email: "admin@example.com", role: "admin" },
+			}),
+		);
+
+		await expect(
+			caller.transferOwnership({ memberId: "m-target" }),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	it("rejects when the organization does not exist", async () => {
+		findFirstMock
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(undefined);
+
+		const caller = createCaller(createCtx());
+
+		await expect(
+			caller.transferOwnership({ memberId: "m-target" }),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+	});
+});
+
+describe("organization.transferOwnership target validation", () => {
+	it("rejects when the target member does not exist", async () => {
+		findFirstMock
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(orgFixture)
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(undefined);
+
+		const caller = createCaller(createCtx());
+
+		await expect(
+			caller.transferOwnership({ memberId: "missing" }),
+		).rejects.toMatchObject({ code: "NOT_FOUND" });
+	});
+
+	it("rejects a target from another organization", async () => {
+		findFirstMock
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(orgFixture)
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce({ ...targetFixture, organizationId: "org-2" });
+
+		const caller = createCaller(createCtx());
+
+		await expect(
+			caller.transferOwnership({ memberId: "m-target" }),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	it("rejects transferring ownership to the caller", async () => {
+		findFirstMock
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(orgFixture)
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce({ ...targetFixture, userId: "owner-user" });
+
+		const caller = createCaller(createCtx());
+
+		await expect(
+			caller.transferOwnership({ memberId: "m-target" }),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+	});
+
+	it("rejects when the target is already the owner", async () => {
+		findFirstMock
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(orgFixture)
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce({ ...targetFixture, role: "owner" });
+
+		const caller = createCaller(createCtx());
+
+		await expect(
+			caller.transferOwnership({ memberId: "m-target" }),
+		).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+	});
+});
+
+describe("organization.transferOwnership success path", () => {
+	it("swaps roles and organization owner in a single transaction", async () => {
+		findFirstMock
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(orgFixture)
+			.mockResolvedValueOnce(ownerMemberFixture)
+			.mockResolvedValueOnce(targetFixture);
+
+		const caller = createCaller(createCtx());
+		const result = await caller.transferOwnership({
+			memberId: "m-target",
+		});
+
+		expect(result).toBe(true);
+
+		const transactionMock = vi.mocked(
+			(db as unknown as { transaction: (cb: unknown) => unknown }).transaction,
+		);
+		expect(transactionMock).toHaveBeenCalledTimes(1);
+		expect(transactionCalls).toHaveLength(1);
+		expect(transactionCalls[0]).toEqual([member, member, organization]);
+	});
+});

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -36,6 +36,8 @@ export const ShowUsers = () => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data, isPending, refetch } = api.user.all.useQuery();
 	const { mutateAsync, isPending: isRemoving } = api.user.remove.useMutation();
+	const { mutateAsync: transferOwnership, isPending: isTransferring } =
+		api.organization.transferOwnership.useMutation();
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const { data: hasValidLicense } =
 		api.licenseKey.haveValidLicenseKey.useQuery();
@@ -131,6 +133,11 @@ export const ShowUsers = () => {
 															(currentUserRole === "admin" &&
 																member.role !== "admin"));
 
+													const canTransferOwnership =
+														currentUserRole === "owner" &&
+														member.role !== "owner" &&
+														member.user.id !== session?.user?.id;
+
 													const canDeleteMember =
 														permissions?.member.delete ?? false;
 
@@ -150,6 +157,7 @@ export const ShowUsers = () => {
 													const hasAnyAction =
 														canEditPermissions ||
 														canChangeRole ||
+														canTransferOwnership ||
 														canDelete ||
 														canUnlink;
 
@@ -223,6 +231,40 @@ export const ShowUsers = () => {
 																					currentRole={member.role}
 																					userEmail={member.user.email}
 																				/>
+																			)}
+
+																			{canTransferOwnership && (
+																				<DialogAction
+																					title="Transfer Ownership"
+																					description={`Transfer organization ownership to ${member.user.email}? You will become an admin. This cannot be undone.`}
+																					type="destructive"
+																					disabled={isTransferring}
+																					onClick={async () => {
+																						await transferOwnership({
+																							memberId: member.id,
+																						})
+																							.then(() => {
+																								toast.success(
+																									"Ownership transferred successfully",
+																								);
+																								refetch();
+																								utils.user.session.invalidate();
+																							})
+																							.catch((err) => {
+																								toast.error(
+																									err?.message ||
+																										"Error transferring ownership",
+																								);
+																							});
+																					}}
+																				>
+																					<DropdownMenuItem
+																						className="w-full cursor-pointer"
+																						onSelect={(e) => e.preventDefault()}
+																					>
+																						Transfer Ownership
+																					</DropdownMenuItem>
+																				</DialogAction>
 																			)}
 
 																			{canEditPermissions && (

--- a/apps/dokploy/server/api/routers/organization.ts
+++ b/apps/dokploy/server/api/routers/organization.ts
@@ -542,6 +542,118 @@ export const organizationRouter = createTRPCRouter({
 			});
 			return true;
 		}),
+	transferOwnership: withPermission("member", "update")
+		.input(
+			z.object({
+				memberId: z.string().min(1),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const orgId = ctx.session.activeOrganizationId;
+
+			const org = await db.query.organization.findFirst({
+				where: eq(organization.id, orgId),
+			});
+
+			if (!org) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Organization not found",
+				});
+			}
+
+			const userMember = await db.query.member.findFirst({
+				where: and(
+					eq(member.organizationId, orgId),
+					eq(member.userId, ctx.user.id),
+				),
+			});
+
+			const isOwner =
+				org.ownerId === ctx.user.id || userMember?.role === "owner";
+
+			if (!isOwner) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "Only the organization owner can transfer ownership",
+				});
+			}
+
+			const target = await db.query.member.findFirst({
+				where: eq(member.id, input.memberId),
+				with: { user: true },
+			});
+
+			if (!target) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Member not found",
+				});
+			}
+
+			if (target.organizationId !== orgId) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You are not allowed to transfer ownership to this member",
+				});
+			}
+
+			if (target.userId === ctx.user.id) {
+				throw new TRPCError({
+					code: "FORBIDDEN",
+					message: "You cannot transfer ownership to yourself",
+				});
+			}
+
+			if (target.role === "owner") {
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: "This member is already the organization owner",
+				});
+			}
+
+			await db.transaction(async (tx) => {
+				await tx
+					.update(member)
+					.set({ role: "owner" })
+					.where(eq(member.id, target.id));
+
+				const previousOwner =
+					userMember ??
+					(await tx.query.member.findFirst({
+						where: and(
+							eq(member.organizationId, orgId),
+							eq(member.role, "owner"),
+						),
+					}));
+
+				if (previousOwner) {
+					await tx
+						.update(member)
+						.set({ role: "admin" })
+						.where(eq(member.id, previousOwner.id));
+				}
+
+				await tx
+					.update(organization)
+					.set({ ownerId: target.userId })
+					.where(eq(organization.id, orgId));
+			});
+
+			await audit(ctx, {
+				action: "update",
+				resourceType: "organization",
+				resourceId: orgId,
+				resourceName: org.name,
+				metadata: {
+					type: "transferOwnership",
+					from: ctx.user.id,
+					to: target.userId,
+					toEmail: target.user.email,
+				},
+			});
+			return true;
+		}),
 	setDefault: protectedProcedure
 		.input(
 			z.object({


### PR DESCRIPTION
# PR: feat(organization): add ownership transfer

Related issue: #1413 (checklist item "Add the ability to transfer ownership").
Slice announced in: https://github.com/Dokploy/dokploy/issues/1413#issuecomment-5479774027

## Description

Adds the ability to transfer organization ownership to an existing member. The
`owner` role was previously nontransferable by design (`updateMemberRole` rejects
any change to/from `owner`), so this introduces a dedicated, owner-only mutation
instead of relaxing that guard.

## Changes

### Backend — `apps/dokploy/server/api/routers/organization.ts`
- New `organization.transferOwnership` mutation (`memberId` input):
  - Caller must be the organization owner (`organization.ownerId` or a member
    record with `role === "owner"` in the active organization); admins/members
    get `FORBIDDEN`.
  - Target must exist, belong to the active organization, and not be the caller;
    transferring to a member who is already the owner is rejected.
  - Atomic swap in a single transaction: target member role → `owner`, previous
    owner member role → `admin`, `organization.ownerId` → target user. This
    guarantees exactly one owner before and after the transfer.
  - Audit log entry with `type: "transferOwnership"`, `from`/`to`/`toEmail`
    metadata (same audit pattern as the other organization mutations).

### Frontend — `apps/dokploy/components/dashboard/settings/users/show-users.tsx`
- "Transfer Ownership" action in the per-user dropdown, visible only to the
  organization owner, only for other members who are not owners.
- Confirmation dialog (`DialogAction`, destructive) explaining that the caller
  becomes an admin; success/error toasts; refetches the member list and
  invalidates the session query so role-gated UI updates immediately.

### Tests — `apps/dokploy/__test__/api/organization-transfer-ownership.test.ts`
10 focused tests using the existing mocked-DB harness:
- zod input validation (missing/empty `memberId`);
- unauthenticated calls rejected;
- non-owner callers rejected;
- missing organization / missing target member rejected;
- cross-org target rejected;
- self-transfer rejected;
- target already owner rejected;
- happy path asserts the transaction performs exactly three updates in order:
  member (new owner), member (previous owner demoted), organization (ownerId).

## Verification performed by the author
- `pnpm exec vitest run --config __test__/vitest.config.ts` (new file): 10/10 pass.
- Full app test suite: 913 passed; the 10 failing tests are pre-existing on
  `canary` without this change (`*.real.test.ts` requiring a Docker socket and
  a git clone over https) — verified by stashing this branch and re-running them.
- `pnpm --filter=dokploy run typecheck` (tsc --noEmit): pass.
- `pnpm exec biome check` on the changed files: clean.
- Note: a full local dev-environment walkthrough (`dokploy:setup`) was not run
  because this environment has no Docker daemon; the mutation is covered by the
  unit tests above and follows the exact patterns of the neighboring mutations.

## AI assistance disclosure
This implementation was produced with an AI coding agent under the supervision
of the account owner, who reviewed the diff and the test results. All claims in
"Verification performed" are from actual runs.

## Scope
Out of scope (separate slices of #1413): teams, view-only role, remote-server
assignment, team-based invitations.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an owner-only organization ownership-transfer mutation, a dashboard confirmation action, and focused API tests.

- Atomically updates the target role, previous-owner role, and organization owner identifier.
- Refreshes member-related client state after a successful transfer.
- Covers validation, authorization, organization scoping, and the sequential success path.

<h3>Confidence Score: 3/5</h3>

This PR should not merge until ownership transfers are serialized so concurrent requests cannot leave multiple users with owner privileges.

The new mutation checks ownership outside the transaction and has no database constraint or lock enforcing a single owner-role member, allowing concurrent transfers to persist multiple privileged owners.

**Files Needing Attention:** apps/dokploy/server/api/routers/organization.ts

<details open><summary><h3>Security Review</h3></summary>

Concurrent transfers are not serialized, so separate targets can retain owner-role authorization after `organization.ownerId` resolves to only one of them.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(organization): add ownership transf..."](https://github.com/dokploy/dokploy/commit/13255a944be45f8db2d0130da4a5cc0a67821739) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58655468)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [API boundary](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/api-boundary.md)
- Knowledge Base — [Dashboard and client state](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dashboard-and-client-state.md)

<!-- /greptile_comment -->