### PR TITLE
fix(test): wait for swarm convergence before idempotency re-check

### DIFF
--- a/apps/dokploy/__test__/setup/monitoring-setup.real.test.ts
+++ b/apps/dokploy/__test__/setup/monitoring-setup.real.test.ts
@@ -64,6 +64,21 @@ const serviceExists = async (name: string) => {
 	}
 };
 
+// Swarm keeps converging a service for a bit after it's created (scheduling
+// tasks, resolving endpoints), which bumps Version.Index on its own. Calling
+// setupMonitoring again before that settles races that internal bump, so wait
+// for two consecutive reads to agree before treating the service as stable.
+const waitForServiceConvergence = async (name: string, timeoutMs = 5000) => {
+	const deadline = Date.now() + timeoutMs;
+	let lastIndex: string | null = null;
+	while (Date.now() < deadline) {
+		const inspect = await docker.getService(name).inspect();
+		if (inspect.Version.Index === lastIndex) return;
+		lastIndex = inspect.Version.Index;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+};
+
 const swarmTaskNames = async () => {
 	const list = await docker.listContainers({ all: true });
 	return list
@@ -193,6 +208,7 @@ describe.skipIf(hasRealMonitoring())(
 				expect(await containerExists(SERVICE_NAME)).toBe(false);
 
 				await expect(setupMonitoring("test-server")).resolves.not.toThrow();
+				await waitForServiceConvergence(SERVICE_NAME);
 				await expect(setupMonitoring("test-server")).resolves.not.toThrow();
 
 				expect(await serviceExists(SERVICE_NAME)).toBe(true);


### PR DESCRIPTION
## Summary
- \`setupMonitoring\`'s idempotency test calls it twice back to back; Swarm keeps converging a freshly created service (scheduling tasks, resolving endpoints) which bumps `Version.Index` on its own right after creation.
- If that internal bump lands between the second call's `inspect()` and `update()`, Docker rejects it with `update out of sequence` — flaky in CI (saw it fail on PR #5014's CI, unrelated to that PR's own changes).
- This doesn't happen in production: `setupMonitoring` is only triggered by a UI button click or once during server setup, both far enough apart for Swarm to settle. So the fix stays in the test, not the production retry logic — wait for two consecutive `Version.Index` reads to agree before the second call.

## Test plan
- [x] Ran `monitoring-setup.real.test.ts` against local Docker Swarm 5x with the fix — all green.
- [x] Reverted the fix and ran 8x without it — could not reproduce locally (my machine's Docker converges faster than the CI runner), consistent with this being a CI-timing-sensitive race.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds test-side polling before repeating monitoring setup, aiming to avoid racing Docker Swarm's post-creation service-version updates.
- Adds a `waitForServiceConvergence` helper that polls `Version.Index`.
- Calls the helper between the two setup invocations in the real-Docker idempotency test.

<h3>Confidence Score: 4/5</h3>

The convergence check should be strengthened before merging because it can return during a brief quiet interval and leave the targeted CI race reachable.

The new test helper equates two inspections only 50 ms apart with completed Swarm convergence, even though later asynchronous service-version updates can still occur before the repeated setup call.

**Files Needing Attention:** apps/dokploy/__test__/setup/monitoring-setup.real.test.ts

<sub>Reviews (1): Last reviewed commit: ["fix(test): wait for swarm convergence be..."](https://github.com/dokploy/dokploy/commit/cee950b6c8f946fd042763335614a6740979d718) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58783798)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Servers, clusters, and monitoring](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/servers-clusters-and-monitoring.md)

<!-- /greptile_comment -->