### PR TITLE
fix: only pin --project-directory when compose has mounts

### DIFF
--- a/apps/dokploy/__test__/compose/compose-project-directory.test.ts
+++ b/apps/dokploy/__test__/compose/compose-project-directory.test.ts
@@ -55,4 +55,69 @@ describe("compose createCommand --project-directory", () => {
 		);
 		expect(cmd).toContain("-f docker-compose.yml");
 	});
+
+	it("resolves build.context against the compose file's own directory when there are no mounts", () => {
+		const cmd = createCommand({
+			...base,
+			composePath: "./backend/docker-compose.yml",
+		} as any);
+
+		expect(cmd).not.toContain("--project-directory");
+		expect(cmd).toContain("-f ./backend/docker-compose.yml");
+	});
+});
+
+describe("compose createCommand --env-file", () => {
+	it("points --env-file at the generated .env next to a nested compose file", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				composePath: "./deploy/docker-compose.yml",
+				createEnvFile: true,
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).toContain("--env-file deploy/.env");
+		expect(cmd).toContain(
+			"--project-directory /etc/dokploy/compose/compose-app/code",
+		);
+	});
+
+	it("omits --env-file when createEnvFile is disabled", () => {
+		const cmd = createCommand(
+			{ ...base, composePath: "./deploy/docker-compose.yml" } as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).not.toContain("--env-file");
+	});
+
+	it("uses the code-root .env for raw sourceType", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				sourceType: "raw",
+				composePath: "docker-compose.yml",
+				createEnvFile: true,
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).toContain("--env-file .env");
+	});
+
+	it("does not add --env-file to stack deploy (unsupported flag)", () => {
+		const cmd = createCommand(
+			{
+				...base,
+				composeType: "stack",
+				composePath: "./deploy/docker-compose.yml",
+				createEnvFile: true,
+			} as any,
+			"/etc/dokploy/compose/compose-app/code",
+		);
+
+		expect(cmd).not.toContain("--env-file");
+	});
 });

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -551,7 +551,10 @@ export const composeRouter = createTRPCRouter({
 			const compose = await findComposeById(input.composeId);
 			const { COMPOSE_PATH } = paths(!!compose.serverId);
 			const projectPath = join(COMPOSE_PATH, compose.appName, "code");
-			const command = createCommand(compose, projectPath);
+			const command = createCommand(
+				compose,
+				compose.mounts.length > 0 ? projectPath : undefined,
+			);
 			return `docker ${command}`;
 		}),
 	refreshToken: protectedProcedure

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -22,7 +22,10 @@ export const getBuildComposeCommand = async (rawCompose: ComposeNested) => {
 	const { COMPOSE_PATH } = paths(!!compose.serverId);
 	const { sourceType, appName, mounts, composeType, domains } = compose;
 	const projectPath = join(COMPOSE_PATH, compose.appName, "code");
-	const command = createCommand(compose, projectPath);
+	const command = createCommand(
+		compose,
+		mounts.length > 0 ? projectPath : undefined,
+	);
 	const envCommand = compose.createEnvFile
 		? getCreateEnvFileCommand(compose)
 		: "";
@@ -133,7 +136,10 @@ export const createCommand = (compose: ComposeNested, projectPath?: string) => {
 		const projectDirectoryFlag = projectPath
 			? `--project-directory ${quote([projectPath])} `
 			: "";
-		command = `compose -p ${quote([appName])} ${projectDirectoryFlag}-f ${quote([path])} up -d --build --remove-orphans`;
+		const envFileFlag = compose.createEnvFile
+			? `--env-file ${quote([join(dirname(compose.composePath || "docker-compose.yml"), ".env")])} `
+			: "";
+		command = `compose -p ${quote([appName])} ${projectDirectoryFlag}${envFileFlag}-f ${quote([path])} up -d --build --remove-orphans`;
 	} else if (composeType === "stack") {
 		command = `stack deploy -c ${quote([path])} ${quote([appName])} --prune --with-registry-auth`;
 	}


### PR DESCRIPTION
## What is this PR about?

`--project-directory` was added unconditionally in 87b914996 to fix relative bind mount resolution for git-based compose deploys with a nested `composePath` (#5181). It also changes where `build.context` and the generated `.env` resolve — breaking any compose file in a subdirectory that has `context: .` alongside its Dockerfile (#5230), or that interpolates env vars via the Environment tab (#5242).

Fix:
- Only pin `--project-directory` when the compose actually has mounts configured. Otherwise `build.context` resolves against the compose file's own directory, same as plain `docker compose`.
- Pass `--env-file` explicitly pointing at the generated `.env` next to the compose file, so it's found even when `--project-directory` is pinned (credit: @tonnenpinguin, #5235).

Known gap: this gates on "does the compose have any mount configured", not "does the compose file actually reference one in volumes" (can't parse arbitrary user YAML for that). A mount created but unused on a git-based compose with a nested `composePath` and a relative `build.context` can still hit the original issue. Narrow edge case, tracked separately.

Verified locally end to end (real deploys, not just unit tests): reproduced #5230's exact failure (`failed to read dockerfile: open Dockerfile: no such file or directory`) and #5242's env interpolation failure, then confirmed both are fixed, including the case where a mount is also present (so both --project-directory and --env-file are active together).

Fixes #5230
Fixes #5242

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR conditionally pins Docker Compose's project directory only when Dokploy mounts are configured and explicitly points Compose at the generated environment file.
- Preserves compose-file-relative build contexts for nested Compose files without mounts.
- Keeps project-root resolution when managed mounts require it.
- Adds coverage for nested Compose paths, generated environment files, raw sources, and Swarm stack commands.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The deployment and command-preview paths apply the same mount-based project-directory rule, while the generated environment-file path remains aligned with the Compose workspace and stack deployments avoid the unsupported flag.

<sub>Reviews (1): Last reviewed commit: ["fix: only pin --project-directory when c..."](https://github.com/dokploy/dokploy/commit/ec8e6457581117cad5d0ad28ce1f7d3abbadd424) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58941339)</sub>

**Context used:**

- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)

<!-- /greptile_comment -->