### PR TITLE
fix: persist serverThreshold for gotify/ntfy and guard teams dispatch

### DIFF
--- a/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/handle-notifications.tsx
@@ -446,6 +446,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 					serverUrl: notification.gotify?.serverUrl,
 					name: notification.name,
 					dockerCleanup: notification.dockerCleanup,
+					serverThreshold: notification.serverThreshold,
 				});
 			} else if (notification.notificationType === "ntfy") {
 				form.reset({
@@ -681,6 +682,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 				name: data.name,
 				dockerCleanup: dockerCleanup,
 				decoration: data.decoration,
+				serverThreshold: serverThreshold,
 				notificationId: notificationId || "",
 				gotifyId: notification?.gotifyId || "",
 			});
@@ -698,6 +700,7 @@ export const HandleNotifications = ({ notificationId }: Props) => {
 				priority: data.priority,
 				name: data.name,
 				dockerCleanup: dockerCleanup,
+				serverThreshold: serverThreshold,
 				notificationId: notificationId || "",
 				ntfyId: notification?.ntfyId || "",
 			});

--- a/packages/server/src/db/schema/notification.ts
+++ b/packages/server/src/db/schema/notification.ts
@@ -433,6 +433,7 @@ export const apiCreateGotify = notificationsSchema
 		name: true,
 		appDeploy: true,
 		dockerCleanup: true,
+		serverThreshold: true,
 	})
 	.extend({
 		serverUrl: z.string().min(1),
@@ -468,6 +469,7 @@ export const apiCreateNtfy = notificationsSchema
 		name: true,
 		appDeploy: true,
 		dockerCleanup: true,
+		serverThreshold: true,
 	})
 	.extend({
 		serverUrl: z.string().min(1),

--- a/packages/server/src/services/notification.ts
+++ b/packages/server/src/services/notification.ts
@@ -561,6 +561,7 @@ export const createGotifyNotification = async (
 				volumeBackup: input.volumeBackup,
 				dokployRestart: input.dokployRestart,
 				dockerCleanup: input.dockerCleanup,
+				serverThreshold: input.serverThreshold,
 				notificationType: "gotify",
 				organizationId: organizationId,
 			})
@@ -593,6 +594,7 @@ export const updateGotifyNotification = async (
 				volumeBackup: input.volumeBackup,
 				dokployRestart: input.dokployRestart,
 				dockerCleanup: input.dockerCleanup,
+				serverThreshold: input.serverThreshold,
 				organizationId: input.organizationId,
 			})
 			.where(eq(notifications.notificationId, input.notificationId))
@@ -655,6 +657,7 @@ export const createNtfyNotification = async (
 				volumeBackup: input.volumeBackup,
 				dokployRestart: input.dokployRestart,
 				dockerCleanup: input.dockerCleanup,
+				serverThreshold: input.serverThreshold,
 				notificationType: "ntfy",
 				organizationId: organizationId,
 			})
@@ -687,6 +690,7 @@ export const updateNtfyNotification = async (
 				volumeBackup: input.volumeBackup,
 				dokployRestart: input.dokployRestart,
 				dockerCleanup: input.dockerCleanup,
+				serverThreshold: input.serverThreshold,
 				organizationId: input.organizationId,
 			})
 			.where(eq(notifications.notificationId, input.notificationId))

--- a/packages/server/src/utils/notifications/server-threshold.ts
+++ b/packages/server/src/utils/notifications/server-threshold.ts
@@ -369,22 +369,28 @@ export const sendServerThresholdNotifications = async (
 					`Server: ${payload.ServerName}\nType: ${payload.Type}\nCurrent: ${payload.Value.toFixed(2)}%\nThreshold: ${payload.Threshold.toFixed(2)}%\nMessage: ${payload.Message}\nTime: ${date.toLocaleString()}`,
 				);
 			}
+
+			if (teams) {
+				await sendTeamsNotification(teams, {
+					title: `⚠️ Server ${payload.Type} Alert`,
+					facts: [
+						{ name: "Server Name", value: payload.ServerName },
+						{ name: "Type", value: payload.Type },
+						{
+							name: "Current Value",
+							value: `${payload.Value.toFixed(2)}%`,
+						},
+						{
+							name: "Threshold",
+							value: `${payload.Threshold.toFixed(2)}%`,
+						},
+						{ name: "Time", value: date.toLocaleString() },
+						{ name: "Message", value: payload.Message },
+					],
+				});
+			}
 		} catch (error) {
 			console.log(error);
-		}
-
-		if (teams) {
-			await sendTeamsNotification(teams, {
-				title: `⚠️ Server ${payload.Type} Alert`,
-				facts: [
-					{ name: "Server Name", value: payload.ServerName },
-					{ name: "Type", value: payload.Type },
-					{ name: "Current Value", value: `${payload.Value.toFixed(2)}%` },
-					{ name: "Threshold", value: `${payload.Threshold.toFixed(2)}%` },
-					{ name: "Time", value: date.toLocaleString() },
-					{ name: "Message", value: payload.Message },
-				],
-			});
 		}
 	}
 };


### PR DESCRIPTION
Fixes #5175

- Gotify and Ntfy were missing `serverThreshold` in their create/update Zod schemas and service-layer DB writes, so the toggle silently reset on refresh. Added it to match the other 9 providers, and hydrated/sent it from the notifications form.
- Teams dispatch in `server-threshold.ts` sat outside the loop's try/catch, so a failed `sendTeamsNotification` was an unhandled rejection that aborted notifying the remaining providers. Moved it inside the try/catch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR completes server-threshold persistence for Gotify and Ntfy and contains Teams delivery failures so remaining notification records are still processed.

- Hydrates Gotify’s saved threshold setting in the notification form and submits the setting for Gotify and Ntfy.
- Adds the field to both providers’ validation schemas and create/update database writes.
- Moves Teams threshold dispatch into the existing per-notification error boundary.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The changed form, API schema, and service writes consistently carry the server-threshold value, while Teams failures are now contained per notification record so processing can continue.

<sub>Reviews (1): Last reviewed commit: ["fix: persist serverThreshold for gotify/..."](https://github.com/dokploy/dokploy/commit/47308070a820bcbde1c0364e0a4a7000e39d62dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58945954)</sub>

<!-- /greptile_comment -->