### PR TITLE
fix: orphaned BullMQ job when updating an enabled schedule in cloud

### DIFF
--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -25,7 +25,7 @@ import { asc, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { audit } from "@/server/api/utils/audit";
 import { assertScheduledJobLimit } from "@/server/api/utils/plan-limits";
-import { removeJob, schedule } from "@/server/utils/backup";
+import { removeJob, schedule, updateJob } from "@/server/utils/backup";
 import { createTRPCRouter, protectedProcedure } from "../trpc";
 
 export const scheduleRouter = createTRPCRouter({
@@ -130,7 +130,7 @@ export const scheduleRouter = createTRPCRouter({
 
 			if (IS_CLOUD) {
 				if (updatedSchedule?.enabled) {
-					schedule({
+					await updateJob({
 						scheduleId: updatedSchedule.scheduleId,
 						type: "schedule",
 						cronSchedule: updatedSchedule.cronExpression,

--- a/apps/dokploy/server/api/routers/schedule.ts
+++ b/apps/dokploy/server/api/routers/schedule.ts
@@ -141,6 +141,7 @@ export const scheduleRouter = createTRPCRouter({
 						cronSchedule: updatedSchedule.cronExpression,
 						scheduleId: updatedSchedule.scheduleId,
 						type: "schedule",
+						timezone: updatedSchedule.timezone,
 					});
 				}
 			} else {
@@ -185,6 +186,7 @@ export const scheduleRouter = createTRPCRouter({
 					cronSchedule: scheduleItem.cronExpression,
 					scheduleId: scheduleItem.scheduleId,
 					type: "schedule",
+					timezone: scheduleItem.timezone,
 				});
 			} else {
 				removeScheduleJob(scheduleItem.scheduleId);

--- a/apps/schedules/src/index.ts
+++ b/apps/schedules/src/index.ts
@@ -60,6 +60,7 @@ app.post("/update-backup", zValidator("json", jobQueueSchema), async (c) => {
 				scheduleId: data.scheduleId,
 				type: "schedule",
 				cronSchedule: job.pattern || "",
+				timezone: job.tz || data.timezone,
 			});
 		} else if (data.type === "volume-backup") {
 			result = await removeJob({

--- a/apps/schedules/src/queue.ts
+++ b/apps/schedules/src/queue.ts
@@ -66,9 +66,10 @@ export const removeJob = async (data: QueueJob) => {
 		return result;
 	}
 	if (data.type === "schedule") {
-		const { scheduleId, cronSchedule } = data;
+		const { scheduleId, cronSchedule, timezone } = data;
 		const result = await jobQueue.removeRepeatable(scheduleId, {
 			pattern: cronSchedule,
+			tz: timezone || "UTC",
 		});
 		return result;
 	}


### PR DESCRIPTION
Fixes #5233

Two bugs in the cloud schedules queue, both causing an orphaned BullMQ repeatable job to keep firing in Redis independent of the DB state:

**1. Update while enabled never removed the old job.** Editing an enabled schedule's cron/timezone called `schedule()` (`/create-backup`, which only `jobQueue.add`s), instead of `updateJob()` (`/update-backup`, which looks up the currently registered repeatable pattern via `getJobRepeatable`, removes it, then re-adds) — the same pattern already used for backups in `backup.ts`.

**2. Disable/delete never actually matched the job to remove.** `removeJob()` for type `schedule` built the BullMQ repeat key from the cron pattern only, omitting `tz`. But `scheduleJob()` always registers the job with `tz: job.timezone || "UTC"`. BullMQ's repeat key is `name:jobId:endDate:tz:pattern`, so removing without `tz` computes a different key than the one that was actually stored — `removeRepeatable` silently no-ops, and the job keeps firing forever, surviving disable, delete, and even a full reboot (it lives in Redis, not the app process).

Fixed by threading `timezone` through `removeJob` (queue.ts), the `/update-backup` lookup (index.ts), and the disable/delete call sites in the schedule router.