### PR TITLE
fix: write remote traefik config via SFTP instead of exec+base64

### DIFF
--- a/packages/server/src/utils/process/execAsync.ts
+++ b/packages/server/src/utils/process/execAsync.ts
@@ -4,6 +4,20 @@ import { findServerById } from "@dokploy/server/services/server";
 import { Client } from "ssh2";
 import { ExecError } from "./ExecError";
 
+export class WriteFileRemoteError extends Error {
+	constructor(
+		message: string,
+		public readonly context: {
+			remotePath: string;
+			serverId: string;
+			originalError: Error;
+		},
+	) {
+		super(message);
+		this.name = "WriteFileRemoteError";
+	}
+}
+
 // Re-export ExecError for easier imports
 export { ExecError } from "./ExecError";
 
@@ -21,11 +35,11 @@ export const execAsync = async (
 		};
 	} catch (error) {
 		if (error instanceof Error) {
-			// @ts-ignore - exec error has these properties
+			// @ts-expect-error - exec error has these properties
 			const exitCode = error.code;
-			// @ts-ignore
+			// @ts-expect-error
 			const stdout = error.stdout?.toString() || "";
-			// @ts-ignore
+			// @ts-expect-error
 			const stderr = error.stderr?.toString() || "";
 
 			throw new ExecError(`Command execution failed: ${error.message}`, {
@@ -61,7 +75,7 @@ export const execAsyncStream = (
 						command,
 						stdout: stdoutComplete,
 						stderr: stderrComplete,
-						// @ts-ignore
+						// @ts-expect-error
 						exitCode: error.code,
 						originalError: error,
 					}),
@@ -238,6 +252,65 @@ export const execAsyncRemote = async (
 						}),
 					);
 				}
+			})
+			.connect({
+				host: server.ipAddress,
+				port: server.port,
+				username: server.username,
+				privateKey: server.sshKey?.privateKey,
+				timeout: 99999,
+			});
+	});
+};
+
+export const writeFileRemote = async (
+	serverId: string,
+	remotePath: string,
+	content: string,
+): Promise<void> => {
+	const server = await findServerById(serverId);
+	if (!server.sshKeyId) throw new Error("No SSH key available for this server");
+
+	return new Promise((resolve, reject) => {
+		const conn = new Client();
+		conn
+			.once("ready", () => {
+				conn.sftp((err, sftp) => {
+					if (err) {
+						conn.end();
+						reject(
+							new WriteFileRemoteError(`SFTP session failed: ${err.message}`, {
+								remotePath,
+								serverId,
+								originalError: err,
+							}),
+						);
+						return;
+					}
+					sftp.writeFile(remotePath, content, (writeErr) => {
+						conn.end();
+						if (writeErr) {
+							reject(
+								new WriteFileRemoteError(
+									`Failed to write remote file ${remotePath}: ${writeErr.message}`,
+									{ remotePath, serverId, originalError: writeErr },
+								),
+							);
+							return;
+						}
+						resolve();
+					});
+				});
+			})
+			.on("error", (err) => {
+				conn.end();
+				reject(
+					new WriteFileRemoteError(`SSH connection error: ${err.message}`, {
+						remotePath,
+						serverId,
+						originalError: err,
+					}),
+				);
 			})
 			.connect({
 				host: server.ipAddress,

--- a/packages/server/src/utils/traefik/application.ts
+++ b/packages/server/src/utils/traefik/application.ts
@@ -5,8 +5,7 @@ import { paths } from "@dokploy/server/constants";
 import type { Domain } from "@dokploy/server/services/domain";
 import { quote } from "shell-quote";
 import { parse, stringify } from "yaml";
-import { encodeBase64 } from "../docker/utils";
-import { execAsync, execAsyncRemote } from "../process/execAsync";
+import { execAsync, execAsyncRemote, writeFileRemote } from "../process/execAsync";
 import type { FileConfig, HttpLoadBalancerService } from "./file-types";
 
 export const createTraefikConfig = (appName: string) => {
@@ -228,11 +227,7 @@ export const writeConfigRemote = async (
 	try {
 		const { DYNAMIC_TRAEFIK_PATH } = paths(true);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
-		const encoded = encodeBase64(traefikConfig);
-		await execAsyncRemote(
-			serverId,
-			`echo "${encoded}" | base64 -d > ${quote([configPath])}`,
-		);
+		await writeFileRemote(serverId, configPath, traefikConfig);
 	} catch (e) {
 		console.error("Error saving the YAML config file:", e);
 	}
@@ -246,11 +241,7 @@ export const writeTraefikConfigInPath = async (
 	try {
 		const configPath = path.join(pathFile);
 		if (serverId) {
-			const encoded = encodeBase64(traefikConfig);
-			await execAsyncRemote(
-				serverId,
-				`echo "${encoded}" | base64 -d > ${quote([configPath])}`,
-			);
+			await writeFileRemote(serverId, configPath, traefikConfig);
 		} else {
 			fs.writeFileSync(configPath, traefikConfig, "utf8");
 		}
@@ -282,11 +273,7 @@ export const writeTraefikConfigRemote = async (
 		const { DYNAMIC_TRAEFIK_PATH } = paths(true);
 		const configPath = path.join(DYNAMIC_TRAEFIK_PATH, `${appName}.yml`);
 		const yamlStr = stringify(traefikConfig);
-		const encoded = encodeBase64(yamlStr);
-		await execAsyncRemote(
-			serverId,
-			`echo "${encoded}" | base64 -d > ${quote([configPath])}`,
-		);
+		await writeFileRemote(serverId, configPath, yamlStr);
 	} catch (e) {
 		console.error("Error saving the YAML config file:", e);
 	}


### PR DESCRIPTION
Fixes #5222

`writeTraefikConfigRemote`/`writeConfigRemote`/`writeTraefikConfigInPath` embedded the full YAML (base64-encoded) into a single SSH `exec` command. Once that payload passes the SSH transport's packet size ceiling (~90-100KB of plain content), the exec silently fails — the dynamic Traefik config stops updating with no error surfaced anywhere, while the DB keeps accepting new domains.

Switched all three writers to SFTP (`writeFileRemote` in `execAsync.ts`), which has no such size limit, mirroring the pattern already used for remote file uploads in `drop.ts`.

Reproduced against a real remote server: after ~234 domains the dynamic config froze while the DB kept growing (250 domains in DB, 234 routers on disk). After the fix, router count keeps pace 1:1 with new domains past that point.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces base64-encoded SSH command writes with an SFTP helper so large remote Traefik configurations are no longer constrained by SSH command packet limits.
- Adds a contextual `WriteFileRemoteError` and reusable `writeFileRemote` helper.
- Migrates all three remote Traefik configuration writers to SFTP.
- Replaces TypeScript ignore directives with expectation directives in existing execution error handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable changed-code defect identified.

The new SFTP path removes the documented SSH command-size bottleneck without changing Traefik configuration generation or target selection, and the investigated lifecycle and compatibility concerns did not establish a new reachable failure.

<sub>Reviews (1): Last reviewed commit: ["fix: write remote traefik config via SFT..."](https://github.com/dokploy/dokploy/commit/68a05551d04142b541090aea81685e8190b1d0c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58956093)</sub>

**Context used:**

- Knowledge Base — [Infrastructure runtime](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/infrastructure-runtime.md)
- Knowledge Base — [Docker networking and Traefik](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/docker-networking-and-traefik.md)

<!-- /greptile_comment -->