### PR TITLE
fix: verify swarm task convergence before marking db deploys done

### DIFF
--- a/packages/server/src/services/libsql.ts
+++ b/packages/server/src/services/libsql.ts
@@ -7,7 +7,10 @@ import {
 } from "@dokploy/server/db/schema";
 import { generatePassword } from "@dokploy/server/templates";
 import { buildLibsql } from "@dokploy/server/utils/databases/libsql";
-import { pullImage } from "@dokploy/server/utils/docker/utils";
+import {
+	pullImage,
+	waitForSwarmServiceConvergence,
+} from "@dokploy/server/utils/docker/utils";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { eq, getTableColumns } from "drizzle-orm";
@@ -149,6 +152,7 @@ export const deployLibsql = async (
 		}
 
 		await buildLibsql(libsql);
+		await waitForSwarmServiceConvergence(libsql.appName, libsql.serverId);
 		await updateLibsqlById(libsqlId, {
 			applicationStatus: "done",
 		});

--- a/packages/server/src/services/mariadb.ts
+++ b/packages/server/src/services/mariadb.ts
@@ -7,7 +7,10 @@ import {
 } from "@dokploy/server/db/schema";
 import { generatePassword } from "@dokploy/server/templates";
 import { buildMariadb } from "@dokploy/server/utils/databases/mariadb";
-import { pullImage } from "@dokploy/server/utils/docker/utils";
+import {
+	pullImage,
+	waitForSwarmServiceConvergence,
+} from "@dokploy/server/utils/docker/utils";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { eq, getTableColumns } from "drizzle-orm";
@@ -154,6 +157,7 @@ export const deployMariadb = async (
 		}
 
 		await buildMariadb(mariadb);
+		await waitForSwarmServiceConvergence(mariadb.appName, mariadb.serverId);
 		await updateMariadbById(mariadbId, {
 			applicationStatus: "done",
 		});

--- a/packages/server/src/services/mongo.ts
+++ b/packages/server/src/services/mongo.ts
@@ -8,7 +8,10 @@ import {
 } from "@dokploy/server/db/schema";
 import { generatePassword } from "@dokploy/server/templates";
 import { buildMongo } from "@dokploy/server/utils/databases/mongo";
-import { pullImage } from "@dokploy/server/utils/docker/utils";
+import {
+	pullImage,
+	waitForSwarmServiceConvergence,
+} from "@dokploy/server/utils/docker/utils";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { eq, getTableColumns } from "drizzle-orm";
@@ -169,6 +172,7 @@ export const deployMongo = async (
 		}
 
 		await buildMongo(mongo);
+		await waitForSwarmServiceConvergence(mongo.appName, mongo.serverId);
 		await updateMongoById(mongoId, {
 			applicationStatus: "done",
 		});

--- a/packages/server/src/services/mysql.ts
+++ b/packages/server/src/services/mysql.ts
@@ -7,7 +7,10 @@ import {
 } from "@dokploy/server/db/schema";
 import { generatePassword } from "@dokploy/server/templates";
 import { buildMysql } from "@dokploy/server/utils/databases/mysql";
-import { pullImage } from "@dokploy/server/utils/docker/utils";
+import {
+	pullImage,
+	waitForSwarmServiceConvergence,
+} from "@dokploy/server/utils/docker/utils";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { eq, getTableColumns } from "drizzle-orm";
@@ -152,6 +155,7 @@ export const deployMySql = async (
 		}
 
 		await buildMysql(mysql);
+		await waitForSwarmServiceConvergence(mysql.appName, mysql.serverId);
 		await updateMySqlById(mysqlId, {
 			applicationStatus: "done",
 		});

--- a/packages/server/src/services/postgres.ts
+++ b/packages/server/src/services/postgres.ts
@@ -7,7 +7,10 @@ import {
 } from "@dokploy/server/db/schema";
 import { generatePassword } from "@dokploy/server/templates";
 import { buildPostgres } from "@dokploy/server/utils/databases/postgres";
-import { pullImage } from "@dokploy/server/utils/docker/utils";
+import {
+	pullImage,
+	waitForSwarmServiceConvergence,
+} from "@dokploy/server/utils/docker/utils";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { eq, getTableColumns } from "drizzle-orm";
@@ -164,6 +167,8 @@ export const deployPostgres = async (
 		}
 
 		await buildPostgres(postgres);
+
+		await waitForSwarmServiceConvergence(postgres.appName, postgres.serverId);
 
 		await updatePostgresById(postgresId, {
 			applicationStatus: "done",

--- a/packages/server/src/services/redis.ts
+++ b/packages/server/src/services/redis.ts
@@ -6,7 +6,10 @@ import {
 } from "@dokploy/server/db/schema";
 import { generatePassword } from "@dokploy/server/templates";
 import { buildRedis } from "@dokploy/server/utils/databases/redis";
-import { pullImage } from "@dokploy/server/utils/docker/utils";
+import {
+	pullImage,
+	waitForSwarmServiceConvergence,
+} from "@dokploy/server/utils/docker/utils";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
@@ -119,6 +122,7 @@ export const deployRedis = async (
 		}
 
 		await buildRedis(redis);
+		await waitForSwarmServiceConvergence(redis.appName, redis.serverId);
 		await updateRedisById(redisId, {
 			applicationStatus: "done",
 		});

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -934,6 +934,57 @@ const getSwarmServiceContainerId = async (
 	}
 };
 
+export class ServiceConvergenceError extends Error {}
+
+export const waitForSwarmServiceConvergence = async (
+	appName: string,
+	serverId?: string | null,
+	options?: { timeoutMs?: number; intervalMs?: number },
+): Promise<void> => {
+	const timeoutMs = options?.timeoutMs ?? 45_000;
+	const intervalMs = options?.intervalMs ?? 2_000;
+	const remoteDocker = await getRemoteDocker(serverId);
+	const service = remoteDocker.getService(appName);
+	const deadline = Date.now() + timeoutMs;
+
+	let lastState = "unknown";
+	while (true) {
+		const info = await service.inspect();
+		const desiredTasksCount = info.Spec?.Mode?.Replicated?.Replicas ?? 1;
+
+		const tasks = await remoteDocker.listTasks({
+			filters: JSON.stringify({ service: [appName] }),
+		});
+		const currentTasks = tasks.filter(
+			(task) => task.DesiredState === "running",
+		);
+		const runningTasksCount = currentTasks.filter(
+			(task) => task.Status?.State === "running",
+		).length;
+
+		if (runningTasksCount >= desiredTasksCount) {
+			return;
+		}
+
+		const failedTask = currentTasks.find((task) =>
+			["failed", "rejected"].includes(task.Status?.State ?? ""),
+		);
+		lastState =
+			failedTask?.Status?.Err ??
+			failedTask?.Status?.State ??
+			currentTasks[0]?.Status?.State ??
+			lastState;
+
+		if (Date.now() >= deadline) {
+			throw new ServiceConvergenceError(
+				`Service ${appName} did not converge within ${timeoutMs}ms: ${runningTasksCount}/${desiredTasksCount} tasks running (last state: ${lastState})`,
+			);
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, intervalMs));
+	}
+};
+
 export const checkPostgresHealth = async (): Promise<ServiceHealthStatus> => {
 	const serviceCheck = await checkSwarmServiceRunning("dokploy-postgres");
 	if (serviceCheck.status === "unhealthy") {


### PR DESCRIPTION
Related to #5174

DB deploys (postgres/mariadb/mysql/mongo/redis/libsql) marked `applicationStatus: "done"" right after `buildX()" returned, without checking whether the swarm service actually converged. `docker service create/update" only accepts the spec — Swarm still has to schedule the task, which can fail (e.g. after attaching a new overlay network) with no feedback in the panel: the UI showed "done" while `docker service ls" reported 0/1 replicas.

Added `waitForSwarmServiceConvergence" (`packages/server/src/utils/docker/utils.ts") — polls `RunningTasksCount" vs `DesiredTasksCount" for up to 45s after each deploy, before marking "done". On timeout it throws with the last observed task state, which the existing catch block turns into `applicationStatus: "error"".

This doesn't fix whatever underlying Swarm scheduling issue causes the task to fail in the first place (that root cause is still unconfirmed — I couldn't reproduce it locally, single-node swarm). It closes the observability gap: a failed deploy now surfaces as an error instead of a false "done".

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a shared Swarm convergence poll before six managed-database deployment flows mark themselves complete.
- Polls service tasks for up to 45 seconds and throws a diagnostic convergence error on timeout.
- Applies the check to PostgreSQL, MySQL, MariaDB, MongoDB, Redis, and LibSQL deployments.
- The current task count does not distinguish previous and current service-spec generations during rolling updates.

<h3>Confidence Score: 4/5</h3>

The rolling-update task-generation bug should be fixed before merging because it leaves the false-success condition reachable for supported start-first database updates.

The new helper counts previous-spec tasks alongside replacement tasks, allowing an already-running old task to satisfy the desired replica count and mark an unconverged update done.

**Files Needing Attention:** packages/server/src/utils/docker/utils.ts

<sub>Reviews (1): Last reviewed commit: ["fix: verify swarm task convergence befor..."](https://github.com/dokploy/dokploy/commit/5624dff5c1d4ea72f80cee649c93634212673219) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58956799)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->