### PR TITLE
fix: stop leaking git provider secrets to non-owner org members

### DIFF
--- a/apps/dokploy/server/api/routers/bitbucket.ts
+++ b/apps/dokploy/server/api/routers/bitbucket.ts
@@ -1,5 +1,6 @@
 import {
 	assertGitProviderAccess,
+	canViewGitProviderSecrets,
 	createBitbucket,
 	findBitbucketById,
 	getAccessibleGitProviderIds,
@@ -55,6 +56,17 @@ export const bitbucketRouter = createTRPCRouter({
 		.query(async ({ input, ctx }) => {
 			const bitbucket = await findBitbucketById(input.bitbucketId);
 			await assertGitProviderAccess(ctx.session, bitbucket.gitProvider);
+
+			if (
+				!(await canViewGitProviderSecrets(ctx.session, bitbucket.gitProvider))
+			) {
+				return {
+					...bitbucket,
+					appPassword: null,
+					apiToken: null,
+				};
+			}
+
 			return bitbucket;
 		}),
 	bitbucketProviders: protectedProcedure.query(async ({ ctx }) => {

--- a/apps/dokploy/server/api/routers/gitea.ts
+++ b/apps/dokploy/server/api/routers/gitea.ts
@@ -1,5 +1,6 @@
 import {
 	assertGitProviderAccess,
+	canViewGitProviderSecrets,
 	createGitea,
 	findGiteaById,
 	getAccessibleGitProviderIds,
@@ -59,6 +60,16 @@ export const giteaRouter = createTRPCRouter({
 		.query(async ({ input, ctx }) => {
 			const gitea = await findGiteaById(input.giteaId);
 			await assertGitProviderAccess(ctx.session, gitea.gitProvider);
+
+			if (!(await canViewGitProviderSecrets(ctx.session, gitea.gitProvider))) {
+				return {
+					...gitea,
+					clientSecret: null,
+					accessToken: null,
+					refreshToken: null,
+				};
+			}
+
 			return gitea;
 		}),
 

--- a/apps/dokploy/server/api/routers/github.ts
+++ b/apps/dokploy/server/api/routers/github.ts
@@ -1,5 +1,6 @@
 import {
 	assertGitProviderAccess,
+	canViewGitProviderSecrets,
 	findGithubById,
 	getAccessibleGitProviderIds,
 	getGithubBranches,
@@ -28,6 +29,16 @@ export const githubRouter = createTRPCRouter({
 		.query(async ({ input, ctx }) => {
 			const github = await findGithubById(input.githubId);
 			await assertGitProviderAccess(ctx.session, github.gitProvider);
+
+			if (!(await canViewGitProviderSecrets(ctx.session, github.gitProvider))) {
+				return {
+					...github,
+					githubClientSecret: null,
+					githubPrivateKey: null,
+					githubWebhookSecret: null,
+				};
+			}
+
 			return github;
 		}),
 	getGithubRepositories: protectedProcedure

--- a/apps/dokploy/server/api/routers/gitlab.ts
+++ b/apps/dokploy/server/api/routers/gitlab.ts
@@ -1,5 +1,6 @@
 import {
 	assertGitProviderAccess,
+	canViewGitProviderSecrets,
 	createGitlab,
 	findGitlabById,
 	getAccessibleGitProviderIds,
@@ -57,6 +58,16 @@ export const gitlabRouter = createTRPCRouter({
 		.query(async ({ input, ctx }) => {
 			const gitlab = await findGitlabById(input.gitlabId);
 			await assertGitProviderAccess(ctx.session, gitlab.gitProvider);
+
+			if (!(await canViewGitProviderSecrets(ctx.session, gitlab.gitProvider))) {
+				return {
+					...gitlab,
+					secret: null,
+					accessToken: null,
+					refreshToken: null,
+				};
+			}
+
 			return gitlab;
 		}),
 	gitlabProviders: protectedProcedure.query(async ({ ctx }) => {

--- a/packages/server/src/services/compose.ts
+++ b/packages/server/src/services/compose.ts
@@ -125,10 +125,24 @@ export const findComposeById = async (composeId: string) => {
 			deployments: true,
 			mounts: true,
 			domains: true,
-			github: true,
-			gitlab: true,
-			bitbucket: true,
-			gitea: true,
+			github: {
+				columns: {
+					githubClientSecret: false,
+					githubPrivateKey: false,
+					githubWebhookSecret: false,
+				},
+			},
+			gitlab: {
+				columns: { secret: false, accessToken: false, refreshToken: false },
+			},
+			bitbucket: { columns: { appPassword: false, apiToken: false } },
+			gitea: {
+				columns: {
+					clientSecret: false,
+					accessToken: false,
+					refreshToken: false,
+				},
+			},
 			server: true,
 			backups: {
 				with: {

--- a/packages/server/src/services/git-provider.ts
+++ b/packages/server/src/services/git-provider.ts
@@ -124,8 +124,12 @@ export const getAccessibleGitProviderIds = async (session: {
  * Authorizes read access to a specific git provider for the current session.
  * Throws if the provider belongs to a different organization (cross-org IDOR)
  * or if the caller is not entitled to it within the active organization.
- * Must be called before returning any git-provider record that carries secrets
- * (OAuth tokens, app private keys, webhook secrets).
+ *
+ * This only proves the caller may *use* the provider (e.g. pick it as a repo
+ * source when creating a deploy) - it does NOT mean they may see its raw
+ * credentials. Being able to use a shared provider and being able to read its
+ * OAuth tokens / client secrets / private keys are different privileges; gate
+ * the latter with canViewGitProviderSecrets before returning secret fields.
  */
 export const assertGitProviderAccess = async (
 	session: { userId: string; activeOrganizationId: string },
@@ -145,4 +149,25 @@ export const assertGitProviderAccess = async (
 			message: "You don't have access to this git provider",
 		});
 	}
+};
+
+// Being allowed to use a shared provider (assertGitProviderAccess) must not
+// imply being allowed to read its raw OAuth tokens / client secrets / private
+// keys. Only the provider's owner or an org owner/admin gets those back.
+export const canViewGitProviderSecrets = async (
+	session: { userId: string; activeOrganizationId: string },
+	provider: { userId: string; organizationId: string },
+): Promise<boolean> => {
+	if (provider.organizationId !== session.activeOrganizationId) return false;
+	if (provider.userId === session.userId) return true;
+
+	const memberRecord = await db.query.member.findFirst({
+		where: and(
+			eq(member.userId, session.userId),
+			eq(member.organizationId, session.activeOrganizationId),
+		),
+		columns: { role: true },
+	});
+
+	return memberRecord?.role === "owner" || memberRecord?.role === "admin";
 };


### PR DESCRIPTION
`gitlab.one`, `github.one`, `gitea.one`, `bitbucket.one` and `compose.one` returned the full git provider record — OAuth access/refresh tokens, client secrets, private keys, webhook secrets, app passwords — to any org member who merely had access to *use* the provider (e.g. `sharedWithOrganization: true`), not just its owner or an org owner/admin.

- Added `canViewGitProviderSecrets()` in `packages/server/src/services/git-provider.ts`: true only for the provider owner or an org owner/admin.
- `gitlab.one` / `github.one` / `gitea.one` / `bitbucket.one` now null out the secret fields when the caller fails that check, while still returning the rest of the record for legitimate UI use (e.g. picking a shared provider when creating a deploy).
- `findComposeById` embedded the git provider relations without excluding secret columns at all (unlike `findApplicationById`, which already did), so `compose.one` leaked full credentials to anyone with read access to the compose service. Now it excludes the same columns `findApplicationById` excludes. Deploys are unaffected — the actual clone step always re-fetches the provider fresh by id, never off the embedded relation.

Verified live against a running instance: owner still gets full secrets back (no regression), a plain `member` with only shared access now gets `null` for the secret fields.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR separates permission to use a shared Git provider from permission to read its credentials and removes provider secrets from Compose query relations.
- Adds an owner/admin authorization check for viewing provider secrets.
- Redacts credential fields from GitHub, GitLab, Gitea, and Bitbucket single-provider responses.
- Excludes provider credential columns from `findComposeById`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code regression or remaining credential-disclosure path identified.

The new authorization predicate preserves provider-owner and organization owner/admin access, all credential-bearing fields are covered by the redaction projections, and Compose clone paths independently refetch full provider records when credentials are required.

<sub>Reviews (1): Last reviewed commit: ["fix: strip git provider secrets from com..."](https://github.com/dokploy/dokploy/commit/6239073e2a25d4c1e20d15971e9589e611544b50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58978667)</sub>

**Context used:**

- Knowledge Base — [API boundary](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/api-boundary.md)
- Knowledge Base — [Source providers and operational automation](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/source-providers-and-automation.md)

<!-- /greptile_comment -->