### PR TITLE
fix: block bind mounts to sensitive host paths for non-owner/admin members

### DIFF
--- a/apps/dokploy/server/api/routers/mount.ts
+++ b/apps/dokploy/server/api/routers/mount.ts
@@ -12,12 +12,14 @@ import {
 	findPostgresById,
 	findRedisById,
 	getServiceContainer,
+	isDangerousBindMountPath,
 	updateMount,
 } from "@dokploy/server";
 import type { ServiceType } from "@dokploy/server/db/schema/mount";
 import {
 	checkServiceAccess,
 	checkServicePermissionAndAccess,
+	isPrivilegedOrgRole,
 } from "@dokploy/server/services/permission";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -73,6 +75,23 @@ async function getServiceOrganizationId(
 	}
 }
 
+async function assertSafeBindMountPath(
+	ctx: { session: { userId: string; activeOrganizationId: string } },
+	type: string | undefined,
+	hostPath: string | null | undefined,
+) {
+	if (type !== "bind" || !hostPath) return;
+	if (!isDangerousBindMountPath(hostPath)) return;
+
+	if (!(await isPrivilegedOrgRole(ctx.session))) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message:
+				"This host path is reserved and can't be used in a bind mount. Only an organization owner or admin can do that.",
+		});
+	}
+}
+
 export const mountRouter = createTRPCRouter({
 	create: protectedProcedure
 		.input(apiCreateMount)
@@ -80,6 +99,7 @@ export const mountRouter = createTRPCRouter({
 			await checkServicePermissionAndAccess(ctx, input.serviceId, {
 				volume: ["create"],
 			});
+			await assertSafeBindMountPath(ctx, input.type, input.hostPath);
 			const mount = await createMount(input);
 			await audit(ctx, {
 				action: "create",
@@ -153,6 +173,11 @@ export const mountRouter = createTRPCRouter({
 					volume: ["create"],
 				});
 			}
+			await assertSafeBindMountPath(
+				ctx,
+				input.type ?? mount.type,
+				input.hostPath ?? mount.hostPath,
+			);
 			await audit(ctx, {
 				action: "update",
 				resourceType: "mount",

--- a/packages/server/src/services/mount.ts
+++ b/packages/server/src/services/mount.ts
@@ -23,6 +23,31 @@ import type { z } from "zod";
 
 export type Mount = typeof mounts.$inferSelect;
 
+// Absolute host paths a "bind" mount must never be allowed to target for a
+// non-owner/admin caller - each one gives a way off the container onto the
+// Dokploy control host (docker.sock -> full daemon control, /etc/dokploy ->
+// Dokploy's own config/certs, /root //boot/proc/sys -> host takeover).
+const DANGEROUS_HOST_PATH_PREFIXES = [
+	"/var/run/docker.sock",
+	"/run/docker.sock",
+	"/var/lib/docker",
+	"/etc/dokploy",
+	"/root",
+	"/boot",
+	"/proc",
+	"/sys",
+];
+
+export const isDangerousBindMountPath = (hostPath: string): boolean => {
+	// Resolve against "/" so relative segments and ".." traversal tricks
+	// (e.g. "../../var/run/docker.sock") can't sneak past the prefix check.
+	const normalized = path.posix.resolve("/", hostPath.trim());
+	if (normalized === "/") return true;
+	return DANGEROUS_HOST_PATH_PREFIXES.some(
+		(prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+	);
+};
+
 export const createMount = async (input: z.infer<typeof apiCreateMount>) => {
 	try {
 		const { serviceId, ...rest } = input;

--- a/packages/server/src/services/permission.ts
+++ b/packages/server/src/services/permission.ts
@@ -434,3 +434,22 @@ export const findMemberByUserId = async (
 	}
 	return result;
 };
+
+// Some actions (e.g. a bind mount targeting a sensitive host path) must stay
+// restricted to the org's owner/admin even if a custom role was granted the
+// underlying resource permission (e.g. volume:create) - that permission only
+// covers ordinary use, not host takeover.
+export const isPrivilegedOrgRole = async (session: {
+	userId: string;
+	activeOrganizationId: string;
+}): Promise<boolean> => {
+	const memberRecord = await db.query.member.findFirst({
+		where: and(
+			eq(member.userId, session.userId),
+			eq(member.organizationId, session.activeOrganizationId),
+		),
+		columns: { role: true },
+	});
+
+	return memberRecord?.role === "owner" || memberRecord?.role === "admin";
+};


### PR DESCRIPTION
The Mounts feature (bind mounts on applications, compose, and database services) let any member with `volume:create` access set an arbitrary bind mount `hostPath`, with zero validation. `generateBindMounts` wires that path straight into the Swarm service spec, so a non-privileged member could mount `/var/run/docker.sock`, `/etc/dokploy`, or other host-critical paths and escalate to root on the Dokploy control host — same impact as bringing your own `docker-compose.yml` with a docker.sock mount, but reachable through the plain Mounts UI on any service type, no Compose needed.

- Added `isDangerousBindMountPath()` (fixed blocklist: docker.sock, `/etc/dokploy`, `/root`, `/boot`, `/proc`, `/sys`, docker's data dir) and `isPrivilegedOrgRole()`.
- `mount.create` / `mount.update` now reject a bind mount targeting one of those paths unless the caller is the organization's owner or admin.
- Single-user self-hosted installs are unaffected — the sole user is always the owner, so nothing changes for the common case (DinD, watchtower, etc. keep working). This only restricts members/custom roles that shouldn't have host-level access in the first place.

Verified live: as the org owner, mounting both a safe path and `/var/run/docker.sock` still succeeds (no regression).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds role-sensitive validation intended to prevent non-owner/admin members from binding security-critical host paths into managed workloads.
- Adds lexical normalization and a sensitive-host-path blocklist.
- Enforces the restriction during mount creation and updates.
- Adds an organization membership lookup for owner/admin privilege.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until parent-directory bind mounts that expose protected paths such as the Docker socket are blocked.

A non-privileged member can bind `/run` or `/var/run`, which passes the new predicate and is forwarded directly to Docker, exposing `docker.sock` inside the workload.

**Files Needing Attention:** packages/server/src/services/mount.ts

<details open><summary><h3>Security Review</h3></summary>

The restriction remains bypassable by binding a parent directory such as `/run` or `/var/run`; the resulting workload can still access the enclosed Docker socket and obtain host-level control.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: block bind mounts to sensitive host..."](https://github.com/dokploy/dokploy/commit/18fb2547e47497020c1696353a4fc4441ad72a2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58984540)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Managed databases and storage](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/managed-databases-and-storage.md)
- Knowledge Base — [Identity, permissions, and audit](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/identity-permissions-and-audit.md)

<!-- /greptile_comment -->