### PR TITLE
fix(traefik): disable swarm provider on worker nodes

### DIFF
--- a/apps/dokploy/__test__/traefik/default-config-write.test.ts
+++ b/apps/dokploy/__test__/traefik/default-config-write.test.ts
@@ -1,0 +1,132 @@
+import { fs, vol } from "memfs";
+
+vi.mock("node:fs", () => ({
+	...fs,
+	default: fs,
+}));
+
+import {
+	createDefaultTraefikConfig,
+	docker,
+	restartStandaloneTraefik,
+} from "@dokploy/server";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+
+const configPath = "/etc/dokploy/traefik/traefik.yml";
+
+beforeEach(() => {
+	vol.reset();
+	vi.stubEnv("NODE_ENV", "production");
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+it.each([
+	["manager", true, true],
+	["worker", false, false],
+] as const)(
+	"writes a role-aware config on a local %s",
+	async (_role, controlAvailable, expectSwarmProvider) => {
+		vi.spyOn(docker, "info").mockResolvedValue({
+			Swarm: {
+				LocalNodeState: "active",
+				ControlAvailable: controlAvailable,
+			},
+		});
+
+		const configChanged = await createDefaultTraefikConfig();
+
+		const config = parse(vol.readFileSync(configPath, "utf8") as string);
+		expect(config.providers.swarm !== undefined).toBe(expectSwarmProvider);
+		expect(config.providers.docker).toBeDefined();
+		expect(config.providers.file).toBeDefined();
+		expect(configChanged).toBe(false);
+	},
+);
+
+it("removes the Swarm provider from an existing local worker config", async () => {
+	vol.fromJSON({
+		[configPath]: `
+providers:
+  swarm:
+    exposedByDefault: false
+    watch: true
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /etc/dokploy/traefik/dynamic
+log:
+  level: DEBUG
+`,
+	});
+	vi.spyOn(docker, "info").mockResolvedValue({
+		Swarm: {
+			LocalNodeState: "active",
+			ControlAvailable: false,
+		},
+	});
+
+	const configChanged = await createDefaultTraefikConfig();
+
+	const config = parse(vol.readFileSync(configPath, "utf8") as string);
+	expect(config.providers.swarm).toBeUndefined();
+	expect(config.providers.docker).toBeDefined();
+	expect(config.providers.file).toBeDefined();
+	expect(config.log.level).toBe("DEBUG");
+	expect(configChanged).toBe(true);
+});
+
+it("restores the Swarm provider when a local worker becomes a manager", async () => {
+	vol.fromJSON({
+		[configPath]: `
+providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /custom/dynamic
+log:
+  level: DEBUG
+`,
+	});
+	vi.spyOn(docker, "info").mockResolvedValue({
+		Swarm: {
+			LocalNodeState: "active",
+			ControlAvailable: true,
+		},
+	});
+
+	const configChanged = await createDefaultTraefikConfig();
+
+	const config = parse(vol.readFileSync(configPath, "utf8") as string);
+	expect(config.providers.swarm).toEqual({
+		exposedByDefault: false,
+		watch: true,
+	});
+	expect(config.providers.file.directory).toBe("/custom/dynamic");
+	expect(config.log.level).toBe("DEBUG");
+	expect(configChanged).toBe(true);
+});
+
+it("writes a worker-safe config when Docker role detection is unavailable", async () => {
+	vi.spyOn(docker, "info").mockRejectedValue(new Error("Docker unavailable"));
+
+	const configChanged = await createDefaultTraefikConfig();
+
+	const config = parse(vol.readFileSync(configPath, "utf8") as string);
+	expect(config.providers.swarm).toBeUndefined();
+	expect(config.providers.docker).toBeDefined();
+	expect(configChanged).toBe(false);
+});
+
+it("restarts the standalone Traefik container", async () => {
+	const restart = vi.fn().mockResolvedValue(undefined);
+	vi.spyOn(docker, "getContainer").mockReturnValue({ restart } as never);
+
+	await restartStandaloneTraefik();
+
+	expect(restart).toHaveBeenCalledOnce();
+});

--- a/apps/dokploy/__test__/traefik/default-config.test.ts
+++ b/apps/dokploy/__test__/traefik/default-config.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync } from "node:child_process";
+import {
+	createServerTraefikConfigCommand,
+	defaultCommand,
+	getDefaultServerTraefikConfig,
+	getDefaultTraefikConfig,
+	isSwarmManager,
+} from "@dokploy/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
+
+type TraefikConfig = {
+	providers: Record<string, unknown>;
+};
+
+const providersFrom = (config: string) =>
+	(parse(config) as TraefikConfig).providers;
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("default Traefik provider configuration", () => {
+	it("enables the Swarm provider on the local manager", () => {
+		vi.stubEnv("NODE_ENV", "production");
+
+		const providers = providersFrom(
+			getDefaultTraefikConfig({ enableSwarmProvider: true }),
+		);
+
+		expect(providers.swarm).toBeDefined();
+		expect(providers.docker).toBeDefined();
+		expect(providers.file).toBeDefined();
+	});
+
+	it("omits the Swarm provider on a local worker", () => {
+		vi.stubEnv("NODE_ENV", "production");
+
+		const providers = providersFrom(
+			getDefaultTraefikConfig({ enableSwarmProvider: false }),
+		);
+
+		expect(providers.swarm).toBeUndefined();
+		expect(providers.docker).toBeDefined();
+		expect(providers.file).toBeDefined();
+	});
+
+	it("enables the Swarm provider on a remote manager", () => {
+		const providers = providersFrom(
+			getDefaultServerTraefikConfig({ enableSwarmProvider: true }),
+		);
+
+		expect(providers.swarm).toBeDefined();
+	});
+
+	it("omits the Swarm provider on a remote worker", () => {
+		const providers = providersFrom(
+			getDefaultServerTraefikConfig({ enableSwarmProvider: false }),
+		);
+
+		expect(providers.swarm).toBeUndefined();
+		expect(providers.docker).toBeDefined();
+		expect(providers.file).toBeDefined();
+	});
+
+	it.each([
+		["manager", { LocalNodeState: "active", ControlAvailable: true }, true],
+		["worker", { LocalNodeState: "active", ControlAvailable: false }, false],
+		["non-Swarm node", { LocalNodeState: "inactive" }, false],
+	])("identifies a %s from Docker info", (_role, swarm, expected) => {
+		expect(isSwarmManager({ Swarm: swarm })).toBe(expected);
+	});
+
+	it("makes remote server setup choose providers from the node role", () => {
+		const setupCommand = createServerTraefikConfigCommand();
+
+		expect(setupCommand).toContain(
+			"docker info --format '{{.Swarm.LocalNodeState}} {{.Swarm.ControlAvailable}}'",
+		);
+		expect(setupCommand).toContain(
+			getDefaultServerTraefikConfig({ enableSwarmProvider: true }),
+		);
+		expect(setupCommand).toContain(
+			getDefaultServerTraefikConfig({ enableSwarmProvider: false }),
+		);
+	});
+
+	it("repairs and restarts an existing worker Traefik config", () => {
+		const setupCommand = defaultCommand();
+
+		expect(setupCommand).toContain("/^  swarm:[[:space:]]*$/");
+		expect(setupCommand).toContain("TRAEFIK_CONFIG_CHANGED=true");
+		expect(setupCommand).toContain("docker restart dokploy-traefik");
+	});
+
+	it("generates a syntactically valid remote setup script", () => {
+		const result = spawnSync("bash", ["-n"], {
+			input: defaultCommand(),
+			encoding: "utf8",
+		});
+
+		expect(result.stderr).toBe("");
+		expect(result.status).toBe(0);
+	});
+});

--- a/apps/dokploy/__test__/traefik/server-config-command.test.ts
+++ b/apps/dokploy/__test__/traefik/server-config-command.test.ts
@@ -1,0 +1,136 @@
+import { execFileSync } from "node:child_process";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	createServerTraefikConfigCommand,
+	createTraefikInstance,
+} from "@dokploy/server";
+import { afterEach, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const temporaryDirectories: string[] = [];
+
+const createDockerSandbox = (swarmRole: "active false" | "active true") => {
+	const root = mkdtempSync(path.join(tmpdir(), "dokploy-traefik-worker-"));
+	temporaryDirectories.push(root);
+	const binDirectory = path.join(root, "bin");
+	const restartMarker = path.join(root, "traefik-restarted");
+	mkdirSync(binDirectory);
+
+	const dockerShim = path.join(binDirectory, "docker");
+	writeFileSync(
+		dockerShim,
+		`#!/bin/sh
+case "$1" in
+  info)
+    echo "${swarmRole}"
+    ;;
+  service)
+    exit 1
+    ;;
+  inspect)
+    exit 0
+    ;;
+  restart)
+    touch "${restartMarker}"
+    ;;
+esac
+`,
+	);
+	chmodSync(dockerShim, 0o755);
+
+	return { binDirectory, restartMarker, root };
+};
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+it("repairs an existing worker config and restarts Traefik", () => {
+	const { binDirectory, restartMarker, root } =
+		createDockerSandbox("active false");
+	const configDirectory = path.join(root, "traefik");
+	const dynamicDirectory = path.join(configDirectory, "dynamic");
+	const configPath = path.join(configDirectory, "traefik.yml");
+	mkdirSync(dynamicDirectory, { recursive: true });
+	writeFileSync(
+		configPath,
+		`providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /custom/dynamic
+  swarm:
+    exposedByDefault: false
+    watch: true
+log:
+  level: DEBUG
+`,
+	);
+
+	const command = `${createServerTraefikConfigCommand()}
+${createTraefikInstance()}`.replaceAll("/etc/dokploy", root);
+	execFileSync("/bin/bash", ["-c", command], {
+		env: {
+			...process.env,
+			PATH: `${binDirectory}:${process.env.PATH}`,
+			SUDO_CMD: "",
+		},
+	});
+
+	const config = parse(readFileSync(configPath, "utf8"));
+	expect(config.providers.swarm).toBeUndefined();
+	expect(config.providers.docker).toBeDefined();
+	expect(config.providers.file.directory).toBe("/custom/dynamic");
+	expect(config.log.level).toBe("DEBUG");
+	expect(readFileSync(restartMarker, "utf8")).toBe("");
+});
+
+it("repairs an existing manager config and restarts Traefik", () => {
+	const { binDirectory, restartMarker, root } =
+		createDockerSandbox("active true");
+	const configDirectory = path.join(root, "traefik");
+	const dynamicDirectory = path.join(configDirectory, "dynamic");
+	const configPath = path.join(configDirectory, "traefik.yml");
+	mkdirSync(dynamicDirectory, { recursive: true });
+	writeFileSync(
+		configPath,
+		`providers:
+  docker:
+    exposedByDefault: false
+  file:
+    directory: /custom/dynamic
+log:
+  level: DEBUG
+`,
+	);
+
+	const command = `${createServerTraefikConfigCommand()}
+${createTraefikInstance()}`.replaceAll("/etc/dokploy", root);
+	execFileSync("/bin/bash", ["-c", command], {
+		env: {
+			...process.env,
+			PATH: `${binDirectory}:${process.env.PATH}`,
+			SUDO_CMD: "",
+		},
+	});
+
+	const config = parse(readFileSync(configPath, "utf8"));
+	expect(config.providers.swarm).toEqual({
+		exposedByDefault: false,
+		watch: true,
+	});
+	expect(config.providers.file.directory).toBe("/custom/dynamic");
+	expect(config.log.level).toBe("DEBUG");
+	expect(readFileSync(restartMarker, "utf8")).toBe("");
+});

--- a/apps/dokploy/server/server.ts
+++ b/apps/dokploy/server/server.ts
@@ -10,6 +10,7 @@ import {
 	initializeNetwork,
 	initSchedules,
 	initVolumeBackupsCronJobs,
+	restartStandaloneTraefik,
 	sendDokployRestartNotifications,
 	setupDirectories,
 } from "@dokploy/server";
@@ -32,7 +33,10 @@ const dev = process.env.NODE_ENV !== "production";
 // This prevents race conditions with the install script
 if (process.env.NODE_ENV === "production" && !IS_CLOUD) {
 	setupDirectories();
-	createDefaultTraefikConfig();
+	const traefikConfigChanged = await createDefaultTraefikConfig();
+	if (traefikConfigChanged) {
+		await restartStandaloneTraefik();
+	}
 	createDefaultServerTraefikConfig();
 	console.log("✅ initialization complete");
 }

--- a/apps/dokploy/setup.ts
+++ b/apps/dokploy/setup.ts
@@ -24,7 +24,7 @@ import {
 		createDefaultMiddlewares();
 		await initializeSwarm();
 		await initializeNetwork();
-		createDefaultTraefikConfig();
+		await createDefaultTraefikConfig();
 		createDefaultServerTraefikConfig();
 		await execAsync(`docker pull traefik:v${TRAEFIK_VERSION}`);
 		await initializeStandaloneTraefik();

--- a/packages/server/src/setup/server-setup.ts
+++ b/packages/server/src/setup/server-setup.ts
@@ -241,7 +241,7 @@ ${setupMainDirectory()}
 ${setupDirectories()}
 
 echo -e "8. Setting up Traefik"
-${createTraefikConfig()}
+${createServerTraefikConfigCommand()}
 
 echo -e "9. Setting up Middlewares"
 ${createDefaultMiddlewares()}
@@ -662,17 +662,57 @@ else
 fi
 `;
 
-const createTraefikConfig = () => {
-	const config = getDefaultServerTraefikConfig();
+export const createServerTraefikConfigCommand = () => {
+	const managerConfig = getDefaultServerTraefikConfig({
+		enableSwarmProvider: true,
+	});
+	const workerConfig = getDefaultServerTraefikConfig({
+		enableSwarmProvider: false,
+	});
 
 	const command = `
+	TRAEFIK_CONFIG_CHANGED=false
+	NODE_SWARM_ROLE="$($SUDO_CMD docker info --format '{{.Swarm.LocalNodeState}} {{.Swarm.ControlAvailable}}' 2>/dev/null || true)"
 	if [ -f "/etc/dokploy/traefik/dynamic/acme.json" ]; then
 		chmod 600 "/etc/dokploy/traefik/dynamic/acme.json"
 	fi
 	if [ -f "/etc/dokploy/traefik/traefik.yml" ]; then
+		if [ "$NODE_SWARM_ROLE" = "active true" ] && ! grep -q '^  swarm:[[:space:]]*$' /etc/dokploy/traefik/traefik.yml; then
+			TEMP_TRAEFIK_CONFIG=$(mktemp)
+			awk '
+				/^providers:[[:space:]]*$/ {
+					print
+					print "  swarm:"
+					print "    exposedByDefault: false"
+					print "    watch: true"
+					next
+				}
+				{ print }
+			' /etc/dokploy/traefik/traefik.yml > "$TEMP_TRAEFIK_CONFIG"
+			mv "$TEMP_TRAEFIK_CONFIG" /etc/dokploy/traefik/traefik.yml
+			TRAEFIK_CONFIG_CHANGED=true
+			echo "Restored Swarm provider in manager Traefik config ✅"
+		elif [ "$NODE_SWARM_ROLE" = "active false" ] && grep -q '^  swarm:[[:space:]]*$' /etc/dokploy/traefik/traefik.yml; then
+			TEMP_TRAEFIK_CONFIG=$(mktemp)
+			awk '
+				/^  swarm:[[:space:]]*$/ { skipping_swarm = 1; next }
+				skipping_swarm && /^[^[:space:]]/ { skipping_swarm = 0 }
+				skipping_swarm && /^  [^[:space:]][^:]*:/ { skipping_swarm = 0 }
+				!skipping_swarm { print }
+			' /etc/dokploy/traefik/traefik.yml > "$TEMP_TRAEFIK_CONFIG"
+			mv "$TEMP_TRAEFIK_CONFIG" /etc/dokploy/traefik/traefik.yml
+			TRAEFIK_CONFIG_CHANGED=true
+			echo "Removed Swarm provider from worker Traefik config ✅"
+		fi
 		echo "Traefik config already exists ✅"
+	elif [ "$NODE_SWARM_ROLE" = "active true" ]; then
+		cat <<'DOKPLOY_TRAEFIK_CONFIG' > /etc/dokploy/traefik/traefik.yml
+${managerConfig}
+DOKPLOY_TRAEFIK_CONFIG
 	else
-		echo "${config}" > /etc/dokploy/traefik/traefik.yml
+		cat <<'DOKPLOY_TRAEFIK_CONFIG' > /etc/dokploy/traefik/traefik.yml
+${workerConfig}
+DOKPLOY_TRAEFIK_CONFIG
 	fi
 	`;
 
@@ -712,7 +752,12 @@ export const createTraefikInstance = () => {
 		fi
 
 		if $SUDO_CMD docker inspect dokploy-traefik > /dev/null 2>&1; then
-			echo "Traefik already exists ✅"
+			if [ "$TRAEFIK_CONFIG_CHANGED" = "true" ]; then
+				$SUDO_CMD docker restart dokploy-traefik >/dev/null
+				echo "Traefik restarted with worker-safe config ✅"
+			else
+				echo "Traefik already exists ✅"
+			fi
 		else
 			# Create the dokploy-traefik container
 			TRAEFIK_VERSION=${TRAEFIK_VERSION}

--- a/packages/server/src/setup/traefik-setup.ts
+++ b/packages/server/src/setup/traefik-setup.ts
@@ -2,13 +2,14 @@ import {
 	chmodSync,
 	existsSync,
 	mkdirSync,
+	readFileSync,
 	rmSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import type { ContainerCreateOptions, CreateServiceOptions } from "dockerode";
-import { stringify } from "yaml";
+import { parseDocument, stringify } from "yaml";
 import { paths } from "../constants";
 import { getRemoteDocker } from "../utils/servers/remote-docker";
 import type { FileConfig } from "../utils/traefik/file-types";
@@ -31,6 +32,40 @@ export interface TraefikOptions {
 		protocol?: string;
 	}[];
 }
+
+export interface DefaultTraefikConfigOptions {
+	enableSwarmProvider?: boolean;
+}
+
+interface DockerInfo {
+	Swarm?: {
+		LocalNodeState?: string;
+		ControlAvailable?: boolean;
+	};
+}
+
+export const isSwarmManager = ({ Swarm }: DockerInfo) =>
+	Swarm?.LocalNodeState === "active" && Swarm.ControlAvailable === true;
+
+const detectSwarmManager = async () => {
+	try {
+		const docker = await getRemoteDocker();
+		return isSwarmManager(await docker.info());
+	} catch (error) {
+		console.warn("Could not verify Docker Swarm role", error);
+		return undefined;
+	}
+};
+
+export const restartStandaloneTraefik = async (serverId?: string) => {
+	try {
+		const docker = await getRemoteDocker(serverId);
+		await docker.getContainer("dokploy-traefik").restart();
+		console.log("Traefik restarted with role-aware config ✅");
+	} catch (error) {
+		console.warn("Could not restart standalone Traefik", error);
+	}
+};
 
 export const initializeStandaloneTraefik = async ({
 	env,
@@ -250,7 +285,9 @@ export const createDefaultServerTraefikConfig = () => {
 	);
 };
 
-export const getDefaultTraefikConfig = () => {
+export const getDefaultTraefikConfig = ({
+	enableSwarmProvider = true,
+}: DefaultTraefikConfigOptions = {}) => {
 	const configObject: MainTraefikConfig = {
 		global: {
 			sendAnonymousUsage: false,
@@ -264,10 +301,12 @@ export const getDefaultTraefikConfig = () => {
 						},
 					}
 				: {
-						swarm: {
-							exposedByDefault: false,
-							watch: true,
-						},
+						...(enableSwarmProvider && {
+							swarm: {
+								exposedByDefault: false,
+								watch: true,
+							},
+						}),
 						docker: {
 							exposedByDefault: false,
 							watch: true,
@@ -320,13 +359,17 @@ export const getDefaultTraefikConfig = () => {
 	return yamlStr;
 };
 
-export const getDefaultServerTraefikConfig = () => {
+export const getDefaultServerTraefikConfig = ({
+	enableSwarmProvider = true,
+}: DefaultTraefikConfigOptions = {}) => {
 	const configObject: MainTraefikConfig = {
 		providers: {
-			swarm: {
-				exposedByDefault: false,
-				watch: true,
-			},
+			...(enableSwarmProvider && {
+				swarm: {
+					exposedByDefault: false,
+					watch: true,
+				},
+			}),
 			docker: {
 				exposedByDefault: false,
 				watch: true,
@@ -374,7 +417,7 @@ export const getDefaultServerTraefikConfig = () => {
 	return yamlStr;
 };
 
-export const createDefaultTraefikConfig = () => {
+export const createDefaultTraefikConfig = async () => {
 	const { MAIN_TRAEFIK_PATH, DYNAMIC_TRAEFIK_PATH } = paths();
 	const mainConfig = path.join(MAIN_TRAEFIK_PATH, "traefik.yml");
 	const acmeJsonPath = path.join(DYNAMIC_TRAEFIK_PATH, "acme.json");
@@ -394,14 +437,41 @@ export const createDefaultTraefikConfig = () => {
 			console.log("Found traefik.yml as directory, removing it...");
 			rmSync(mainConfig, { recursive: true, force: true });
 		} else if (stats.isFile()) {
+			const swarmManager = await detectSwarmManager();
+			if (swarmManager === undefined) {
+				console.log("Main config already exists");
+				return false;
+			}
+
+			const configDocument = parseDocument(readFileSync(mainConfig, "utf8"));
+			const hasSwarmProvider = configDocument.hasIn(["providers", "swarm"]);
+			if (swarmManager && !hasSwarmProvider) {
+				configDocument.setIn(["providers", "swarm"], {
+					exposedByDefault: false,
+					watch: true,
+				});
+				writeFileSync(mainConfig, configDocument.toString(), "utf8");
+				console.log("Restored Swarm provider in manager Traefik config");
+				return true;
+			}
+			if (!swarmManager && hasSwarmProvider) {
+				configDocument.deleteIn(["providers", "swarm"]);
+				writeFileSync(mainConfig, configDocument.toString(), "utf8");
+				console.log("Removed Swarm provider from worker Traefik config");
+				return true;
+			}
 			console.log("Main config already exists");
-			return;
+			return false;
 		}
 	}
 
-	const yamlStr = getDefaultTraefikConfig();
+	const swarmManager = await detectSwarmManager();
+	const yamlStr = getDefaultTraefikConfig({
+		enableSwarmProvider: swarmManager === true,
+	});
 	writeFileSync(mainConfig, yamlStr, "utf8");
 	console.log("Traefik config created successfully");
+	return false;
 };
 
 export const getDefaultMiddlewares = () => {


### PR DESCRIPTION
Fixes #5112

Traefik default config now checks the local Docker Swarm role. Managers keep the Swarm provider, while workers and non-Swarm nodes use only the Docker and file providers.

Existing configs are reconciled in both directions when a node role changes. Other settings are preserved, and the standalone Traefik container restarts only when the static config changed. If Docker role detection is temporarily unavailable during first boot, startup continues with the worker-safe config and reconciles on a later start.

Tested with 23 focused tests covering manager and worker generation, both role transitions, existing config preservation, Docker lookup failure, shell syntax, restart behavior, and sandboxed remote setup execution. Server typecheck and the production server build also pass.

The full local suite passed 956 tests. Eight real-infrastructure tests failed because this Docker daemon is not a Swarm manager and local Nixpacks/Docker builds are unavailable. CI passed all 968 other tests and failed only the unrelated real Dockerfile build test.