### PR TITLE
test: fix CI failures and improve test robustness

### DIFF
--- a/apps/dokploy/__test__/compose/env-file-literals.test.ts
+++ b/apps/dokploy/__test__/compose/env-file-literals.test.ts
@@ -54,7 +54,16 @@ const inputEncoding: Record<string, string> = {
 	DB_HOST: '"${UNDEFINED_HOST:-localhost}"',
 };
 
-describe("getCreateEnvFileCommand", () => {
+const hasDocker = () => {
+	try {
+		execFileSync("docker", ["info"], { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+describe.skipIf(!hasDocker())("getCreateEnvFileCommand", () => {
 	it("writes special environment values that Docker Compose reads back literally", () => {
 		mkdirSync(codePath, { recursive: true });
 

--- a/apps/dokploy/__test__/setup/monitoring-setup.real.test.ts
+++ b/apps/dokploy/__test__/setup/monitoring-setup.real.test.ts
@@ -154,7 +154,16 @@ const hasRealMonitoring = () => {
 	);
 };
 
-describe.skipIf(hasRealMonitoring())(
+const hasDocker = () => {
+	try {
+		execSync("docker info", { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+describe.skipIf(!hasDocker() || hasRealMonitoring() || !process.env.CI)(
 	"setupMonitoring - legacy container cleanup (real docker)",
 	() => {
 		beforeEach(async () => {

--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -26,9 +26,13 @@ export const getDockerCommand = (application: ApplicationNested) => {
 	try {
 		const image = `${appName}`;
 
-		const dockerContextPath = getDockerContextPath(application);
+		const defaultContextPath =
+			dockerFilePath.substring(0, dockerFilePath.lastIndexOf("/") + 1) || ".";
 
-		const commandArgs = ["build", "-t", image, "-f", dockerFilePath, "."];
+		const dockerContextPath =
+			getDockerContextPath(application) || defaultContextPath;
+
+		const commandArgs = ["build", "-t", image, "-f", dockerFilePath, dockerContextPath];
 
 		if (dockerBuildStage) {
 			commandArgs.push("--target", dockerBuildStage);

--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -32,7 +32,14 @@ export const getDockerCommand = (application: ApplicationNested) => {
 		const dockerContextPath =
 			getDockerContextPath(application) || defaultContextPath;
 
-		const commandArgs = ["build", "-t", image, "-f", dockerFilePath, dockerContextPath];
+		const commandArgs = [
+			"build",
+			"-t",
+			image,
+			"-f",
+			dockerFilePath,
+			dockerContextPath,
+		];
 
 		if (dockerBuildStage) {
 			commandArgs.push("--target", dockerBuildStage);

--- a/packages/server/src/utils/filesystem/directory.ts
+++ b/packages/server/src/utils/filesystem/directory.ts
@@ -142,10 +142,5 @@ export const getDockerContextPath = (application: Application) => {
 		return null;
 	}
 
-	return path.join(
-		APPLICATIONS_PATH,
-		appName,
-		"code",
-		dockerContextPath,
-	);
+	return path.join(APPLICATIONS_PATH, appName, "code", dockerContextPath);
 };

--- a/packages/server/src/utils/filesystem/directory.ts
+++ b/packages/server/src/utils/filesystem/directory.ts
@@ -138,10 +138,14 @@ export const getDockerContextPath = (application: Application) => {
 	const { APPLICATIONS_PATH } = paths(!!application.serverId);
 	const { appName, dockerContextPath } = application;
 
+	if (!dockerContextPath) {
+		return null;
+	}
+
 	return path.join(
 		APPLICATIONS_PATH,
 		appName,
 		"code",
-		dockerContextPath || ".",
+		dockerContextPath,
 	);
 };


### PR DESCRIPTION
This PR addresses two separate testing issues that are currently causing friction in `canary`:

1. **Fix fatal CI failure in `application.real.test.ts` (Regression from #5231)**
   The recent change in `getDockerContextPath` forced a fallback to `.` instead of returning `null`. This broke `docker-file.ts`, which relied on the `null` return to accurately infer the `defaultContextPath` from the Dockerfile's parent directory. Because of this, Docker builds in the test suite started failing in CI as they were given an invalid context path. This restores the `null` return and the correct fallback logic.

2. **Fix `ENOENT /var/run/docker.sock` crashes for local contributors (#5141, #5197)**
   Tests like `monitoring-setup.real.test.ts` and `env-file-literals.test.ts` require a running Docker daemon. When contributors (especially those on macOS using Colima/Orbstack or without Docker running) run `pnpm test` locally, the entire test suite crashes with socket errors. I've added a simple `hasDocker()` check so these tests gracefully skip locally instead of crashing, while still running properly in CI.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores Dockerfile build-context fallback behavior and makes Docker-dependent tests skip when their required local daemon is unavailable.

- Derives the default Docker build context from the Dockerfile’s parent directory when no explicit context is configured.
- Restores `null` from `getDockerContextPath` for an omitted context.
- Adds Docker availability guards to Compose and monitoring integration tests.
- Restricts the destructive monitoring integration suite to CI and hosts without an existing monitoring resource.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The Docker builder once again distinguishes an omitted context from an explicitly configured one, while the integration-test guards prevent unavailable local Docker daemons from crashing the suite without weakening the configured CI path.

<sub>Reviews (1): Last reviewed commit: ["test: fix CI failures and improve local ..."](https://github.com/dokploy/dokploy/commit/8c9e473b4eb23f6b02d7f4ed42632f32c83bb86c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59462259)</sub>

**Context used:**

- Knowledge Base — [Build and Compose workflows](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/build-and-compose.md)
- Knowledge Base — [Restore monitoring after the Swarm migration](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/reverts/incident-mitigation_5141-20260827-monitoring-zombie-3c6a96a.md)

<!-- /greptile_comment -->