### PR TITLE
fix: Fix server card title overflow for responsiveness

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
@@ -118,7 +118,10 @@ export const ShowServers = () => {
 																	<div className="flex items-start justify-between gap-2 min-w-0">
 																		<div className="flex min-w-0 items-center gap-2">
 																			<ServerIcon className="size-5 shrink-0 text-muted-foreground" />
-																			<CardTitle className="text-lg truncate min-w-0" title={server.name}>
+																			<CardTitle
+																				className="text-lg truncate min-w-0"
+																				title={server.name}
+																			>
 																				{server.name}
 																			</CardTitle>
 																		</div>

--- a/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
@@ -115,10 +115,10 @@ export const ShowServers = () => {
 																className="relative hover:shadow-lg transition-shadow flex flex-col bg-transparent"
 															>
 																<CardHeader className="pb-3">
-																	<div className="flex items-start justify-between gap-2">
+																	<div className="flex items-start justify-between gap-2 min-w-0">
 																		<div className="flex min-w-0 items-center gap-2">
 																			<ServerIcon className="size-5 shrink-0 text-muted-foreground" />
-																			<CardTitle className="text-lg wrap-break-word min-w-0">
+																			<CardTitle className="text-lg truncate min-w-0" title={server.name}>
 																				{server.name}
 																			</CardTitle>
 																		</div>


### PR DESCRIPTION
## What is this PR about?

I fixed a small UI bug to the server list in the dashboard. The change ensures that long server names are truncated with ellipsis and a tooltip is added to display the full name on hover. 

- Updates:
  * Added `min-w-0` to the parent of `CardTitle` so it can truncate 
  * Updated `CardTitle`  in `show-servers.tsx` to use the `truncate` instead of `wrap-break-word`.
  * Added a `title` attribute to `CardTitle` for better handling of long server names.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

n/a

## Screenshots (if applicable)

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/3cc2a164-43db-46fb-b779-d688d6ea9945" width="300"> | <img src="https://github.com/user-attachments/assets/3e44836a-bcf1-4366-802a-f16b8f365467" width="300"> |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves server-card responsiveness for long server names.
- Allows the title container to shrink within the card header.
- Truncates overflowing server names with an ellipsis.
- Exposes the full server name through the native hover title.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or maintainability issues identified.

The change is limited to presentation classes and a native title attribute, preserving server data and card behavior while improving long-name handling.

<sub>Reviews (1): Last reviewed commit: ["fix: Fix server card title overflow for ..."](https://github.com/dokploy/dokploy/commit/f904a7bd55436bcc7658beae77d26cf808fa1d5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59467139)</sub>

<!-- /greptile_comment -->