### PR TITLE
fix(environment): prevent stale poll reset after save

### DIFF
--- a/apps/dokploy/__test__/env/application-environment-cache.test.ts
+++ b/apps/dokploy/__test__/env/application-environment-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	isSavedApplicationEnvironment,
 	mergeSavedApplicationEnvironment,
+	shouldIgnoreApplicationEnvironment,
 } from "../../components/dashboard/application/environment/cache";
 
 describe("mergeSavedApplicationEnvironment", () => {
@@ -58,6 +59,31 @@ describe("isSavedApplicationEnvironment", () => {
 					buildSecrets: "",
 					createEnvFile: true,
 				},
+			),
+		).toBe(false);
+	});
+});
+
+describe("shouldIgnoreApplicationEnvironment", () => {
+	it("does not carry saved state from application A into application B", () => {
+		const savedForApplicationA = {
+			applicationId: "application-a",
+			env: "A_VALUE=1",
+			buildArgs: "",
+			buildSecrets: "",
+			createEnvFile: true,
+		};
+
+		expect(
+			shouldIgnoreApplicationEnvironment(
+				"application-b",
+				{
+					env: "B_VALUE=1",
+					buildArgs: "",
+					buildSecrets: "",
+					createEnvFile: true,
+				},
+				savedForApplicationA,
 			),
 		).toBe(false);
 	});

--- a/apps/dokploy/__test__/env/application-environment-cache.test.ts
+++ b/apps/dokploy/__test__/env/application-environment-cache.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+	isSavedApplicationEnvironment,
+	mergeSavedApplicationEnvironment,
+} from "../../components/dashboard/application/environment/cache";
+
+describe("mergeSavedApplicationEnvironment", () => {
+	it("keeps the committed environment fields when a stale query result exists", () => {
+		const staleApplication = {
+			env: "TIMEFRAME=151m",
+			buildArgs: "OLD_ARG=1",
+			buildSecrets: "OLD_SECRET=1",
+			createEnvFile: false,
+			name: "Kripto",
+		};
+
+		expect(
+			mergeSavedApplicationEnvironment(staleApplication, {
+				env: "TIMEFRAME=15m",
+				buildArgs: "NEW_ARG=1",
+				buildSecrets: "NEW_SECRET=1",
+				createEnvFile: true,
+			}),
+		).toEqual({
+			...staleApplication,
+			env: "TIMEFRAME=15m",
+			buildArgs: "NEW_ARG=1",
+			buildSecrets: "NEW_SECRET=1",
+			createEnvFile: true,
+		});
+	});
+
+	it("preserves an absent cache entry", () => {
+		expect(
+			mergeSavedApplicationEnvironment(undefined, {
+				env: "TIMEFRAME=15m",
+				buildArgs: "",
+				buildSecrets: "",
+				createEnvFile: true,
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("isSavedApplicationEnvironment", () => {
+	it("rejects a stale poll result after a successful save", () => {
+		expect(
+			isSavedApplicationEnvironment(
+				{
+					env: "TIMEFRAME=151m",
+					buildArgs: "",
+					buildSecrets: "",
+					createEnvFile: true,
+				},
+				{
+					env: "TIMEFRAME=15m",
+					buildArgs: "",
+					buildSecrets: "",
+					createEnvFile: true,
+				},
+			),
+		).toBe(false);
+	});
+});

--- a/apps/dokploy/components/dashboard/application/environment/cache.ts
+++ b/apps/dokploy/components/dashboard/application/environment/cache.ts
@@ -5,6 +5,10 @@ export type SavedApplicationEnvironment = {
 	createEnvFile: boolean;
 };
 
+export type SavedApplicationEnvironmentState = SavedApplicationEnvironment & {
+	applicationId: string;
+};
+
 export const mergeSavedApplicationEnvironment = <T extends object>(
 	application: T | undefined,
 	environment: SavedApplicationEnvironment,
@@ -29,3 +33,13 @@ export const isSavedApplicationEnvironment = (
 	application.buildArgs === environment.buildArgs &&
 	application.buildSecrets === environment.buildSecrets &&
 	application.createEnvFile === environment.createEnvFile;
+
+export const shouldIgnoreApplicationEnvironment = (
+	applicationId: string,
+	application: Partial<
+		Record<keyof SavedApplicationEnvironment, string | boolean | null>
+	>,
+	savedEnvironment: SavedApplicationEnvironmentState | undefined,
+) =>
+	savedEnvironment?.applicationId === applicationId &&
+	!isSavedApplicationEnvironment(application, savedEnvironment);

--- a/apps/dokploy/components/dashboard/application/environment/cache.ts
+++ b/apps/dokploy/components/dashboard/application/environment/cache.ts
@@ -1,0 +1,31 @@
+export type SavedApplicationEnvironment = {
+	env: string;
+	buildArgs: string;
+	buildSecrets: string;
+	createEnvFile: boolean;
+};
+
+export const mergeSavedApplicationEnvironment = <T extends object>(
+	application: T | undefined,
+	environment: SavedApplicationEnvironment,
+) => {
+	if (!application) {
+		return application;
+	}
+
+	return {
+		...application,
+		...environment,
+	};
+};
+
+export const isSavedApplicationEnvironment = (
+	application: Partial<
+		Record<keyof SavedApplicationEnvironment, string | boolean | null>
+	>,
+	environment: SavedApplicationEnvironment,
+) =>
+	application.env === environment.env &&
+	application.buildArgs === environment.buildArgs &&
+	application.buildSecrets === environment.buildSecrets &&
+	application.createEnvFile === environment.createEnvFile;

--- a/apps/dokploy/components/dashboard/application/environment/show.tsx
+++ b/apps/dokploy/components/dashboard/application/environment/show.tsx
@@ -1,5 +1,5 @@
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -17,6 +17,11 @@ import {
 import { Secrets } from "@/components/ui/secrets";
 import { Switch } from "@/components/ui/switch";
 import { api } from "@/utils/api";
+import {
+	isSavedApplicationEnvironment,
+	mergeSavedApplicationEnvironment,
+	type SavedApplicationEnvironment,
+} from "./cache";
 
 const addEnvironmentSchema = z.object({
 	env: z.string(),
@@ -34,6 +39,8 @@ interface Props {
 export const ShowEnvironment = ({ applicationId }: Props) => {
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const canWrite = permissions?.envVars.write ?? false;
+	const utils = api.useUtils();
+	const savedEnvironment = useRef<SavedApplicationEnvironment>();
 	const { mutateAsync, isPending } =
 		api.application.saveEnvironment.useMutation();
 
@@ -78,31 +85,53 @@ export const ShowEnvironment = ({ applicationId }: Props) => {
 	// Skip reset while editing so background refetches don't wipe edits
 	useEffect(() => {
 		if (data && !isDirty) {
-			form.reset({
+			const nextEnvironment = {
 				env: data.env || "",
 				buildArgs: data.buildArgs || "",
 				buildSecrets: data.buildSecrets || "",
 				createEnvFile: data.createEnvFile ?? true,
-			});
+			};
+
+			if (
+				savedEnvironment.current &&
+				!isSavedApplicationEnvironment(data, savedEnvironment.current)
+			) {
+				return;
+			}
+
+			savedEnvironment.current = undefined;
+			if (isSavedApplicationEnvironment(form.getValues(), nextEnvironment)) {
+				return;
+			}
+
+			form.reset(nextEnvironment);
 		}
 	}, [data, isDirty, form]);
 
 	const onSubmit = async (formData: EnvironmentSchema) => {
-		mutateAsync({
+		const nextEnvironment = {
 			env: formData.env,
 			buildArgs: formData.buildArgs,
 			buildSecrets: formData.buildSecrets,
 			createEnvFile: formData.createEnvFile,
-			applicationId,
-		})
-			.then(async () => {
-				toast.success("Environments Added");
-				form.reset(formData);
-				await refetch();
-			})
-			.catch(() => {
-				toast.error("Error adding environment");
+		};
+
+		try {
+			await utils.application.one.cancel({ applicationId });
+			await mutateAsync({
+				...nextEnvironment,
+				applicationId,
 			});
+			savedEnvironment.current = nextEnvironment;
+			utils.application.one.setData({ applicationId }, (application) =>
+				mergeSavedApplicationEnvironment(application, nextEnvironment),
+			);
+			form.reset(nextEnvironment);
+			toast.success("Environments Added");
+			await refetch({ cancelRefetch: false });
+		} catch {
+			toast.error("Error adding environment");
+		}
 	};
 
 	const handleCancel = () => {

--- a/apps/dokploy/components/dashboard/application/environment/show.tsx
+++ b/apps/dokploy/components/dashboard/application/environment/show.tsx
@@ -20,7 +20,8 @@ import { api } from "@/utils/api";
 import {
 	isSavedApplicationEnvironment,
 	mergeSavedApplicationEnvironment,
-	type SavedApplicationEnvironment,
+	shouldIgnoreApplicationEnvironment,
+	type SavedApplicationEnvironmentState,
 } from "./cache";
 
 const addEnvironmentSchema = z.object({
@@ -40,7 +41,7 @@ export const ShowEnvironment = ({ applicationId }: Props) => {
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const canWrite = permissions?.envVars.write ?? false;
 	const utils = api.useUtils();
-	const savedEnvironment = useRef<SavedApplicationEnvironment>();
+	const savedEnvironment = useRef<SavedApplicationEnvironmentState>();
 	const { mutateAsync, isPending } =
 		api.application.saveEnvironment.useMutation();
 
@@ -93,8 +94,11 @@ export const ShowEnvironment = ({ applicationId }: Props) => {
 			};
 
 			if (
-				savedEnvironment.current &&
-				!isSavedApplicationEnvironment(data, savedEnvironment.current)
+				shouldIgnoreApplicationEnvironment(
+					applicationId,
+					data,
+					savedEnvironment.current,
+				)
 			) {
 				return;
 			}
@@ -122,7 +126,7 @@ export const ShowEnvironment = ({ applicationId }: Props) => {
 				...nextEnvironment,
 				applicationId,
 			});
-			savedEnvironment.current = nextEnvironment;
+			savedEnvironment.current = { ...nextEnvironment, applicationId };
 			utils.application.one.setData({ applicationId }, (application) =>
 				mergeSavedApplicationEnvironment(application, nextEnvironment),
 			);


### PR DESCRIPTION
## Summary

- cancel in-flight application detail queries before saving environment settings
- update cache with committed environment values and reject pre-save polling responses
- avoid unnecessary form resets so CodeMirror keeps cursor position
- add regression coverage for stale environment comparisons

## Test plan

- [x] `pnpm exec vitest run --config __test__/vitest.config.ts __test__/env/application-environment-cache.test.ts`
- [x] `pnpm typecheck`

Fixes #5277

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR coordinates application-environment saves with query cancellation and cache updates to prevent stale polling responses from resetting the editor.
- Adds helpers for merging committed environment fields into cached application data and comparing query results with the saved state.
- Updates the environment form to avoid redundant resets and preserve editor cursor position.
- Adds regression tests for stale environment comparisons.

<h3>Confidence Score: 4/5</h3>

The application-switch state leak should be fixed before merging because it can show and subsequently save one application's environment values under another application.

The stale-response guard persists the previous application's committed values across same-page service navigation and rejects the newly selected application's valid query data.

**Files Needing Attention:** apps/dokploy/components/dashboard/application/environment/show.tsx

<sub>Reviews (1): Last reviewed commit: ["fix(environment): prevent stale poll res..."](https://github.com/dokploy/dokploy/commit/f1d2670b776196bef524a640a21a3c3b15e5ff89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59555556)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboard and client state](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dashboard-and-client-state.md)

<!-- /greptile_comment -->