### PR TITLE
fix(ui): truncate organization name properly in sidebar without clipp…

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -660,7 +660,9 @@ function SidebarLogo() {
 													{activeOrganization?.name ?? "Select Organization"}
 												</p>
 												{haveValidLicense && (
-													<Badge variant="blue" className="shrink-0">Enterprise</Badge>
+													<Badge variant="blue" className="shrink-0">
+														Enterprise
+													</Badge>
 												)}
 											</div>
 										</div>

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -616,7 +616,7 @@ function SidebarLogo() {
 					)}
 				>
 					{/* Organization Logo and Selector */}
-					<SidebarMenuItem className={"w-full"}>
+					<SidebarMenuItem className={"w-full min-w-0"}>
 						<Popover
 							open={organizationSelectorOpen}
 							onOpenChange={setOrganizationSelectorOpen}
@@ -632,14 +632,13 @@ function SidebarLogo() {
 								>
 									<div
 										className={cn(
-											"flex items-center gap-2",
+											"flex min-w-0 flex-1 items-center gap-2",
 											isCollapsed && "justify-center",
 										)}
 									>
 										<div
 											className={cn(
-												"flex items-center justify-center rounded-sm border",
-												"size-6",
+												"flex size-6 shrink-0 items-center justify-center rounded-sm border",
 											)}
 										>
 											<Logo
@@ -652,22 +651,22 @@ function SidebarLogo() {
 										</div>
 										<div
 											className={cn(
-												"flex flex-col items-start",
+												"flex flex-col items-start min-w-0 flex-1",
 												isCollapsed && "hidden",
 											)}
 										>
-											<div className="flex items-center gap-1.5">
-												<p className="text-sm font-medium leading-none">
+											<div className="flex items-center gap-1.5 min-w-0 w-full">
+												<p className="text-sm font-medium truncate">
 													{activeOrganization?.name ?? "Select Organization"}
 												</p>
 												{haveValidLicense && (
-													<Badge variant="blue">Enterprise</Badge>
+													<Badge variant="blue" className="shrink-0">Enterprise</Badge>
 												)}
 											</div>
 										</div>
 									</div>
 									<ChevronsUpDown
-										className={cn("ml-auto", isCollapsed && "hidden")}
+										className={cn("ml-auto shrink-0", isCollapsed && "hidden")}
 									/>
 								</SidebarMenuButton>
 							</PopoverTrigger>


### PR DESCRIPTION
## What is this PR about?

This PR fixes a UI layout bug in the sidebar's organization selector (`side.tsx`). Previously, long organization names would awkwardly wrap to multiple lines and break the sidebar layout instead of truncating properly with an ellipsis. 

To fix this, proper Flexbox constraints (`min-w-0` and `flex-1`) were added to the parent containers alongside the `truncate` utility to allow the organization name to gracefully truncate into a single line when the sidebar width is constrained.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #5286 

## Screenshots (if applicable)

### Before

**Enterprise users POV**
<img width="725" height="200" alt="Screenshot 2026-09-03 at 09 19 05" src="https://github.com/user-attachments/assets/231e6c3e-c9f2-4842-a307-0d22e1e649f5" />

**Normal users POV** 
<img width="725" height="200" alt="Screenshot 2026-09-03 at 09 19 35" src="https://github.com/user-attachments/assets/5a7121a1-4f19-47a7-8e01-fdb43dadd6b7" />

### After

**Enterprise users POV**
<img width="638" height="164" alt="Screenshot 2026-09-03 at 09 21 13" src="https://github.com/user-attachments/assets/c0875073-d382-4a26-a5d3-be8011c950c9" />

**Normal users POV** 
<img width="670" height="165" alt="Screenshot 2026-09-03 at 09 20 29" src="https://github.com/user-attachments/assets/3a34d950-c7f1-4215-9d34-57d986572883" />

## Open Questions for Maintainers

The "Enterprise" tag is currently occupying space within the organization selector, resulting in a shorter available space for the organization name itself for Enterprise users. 

Since the Enterprise license applies to the entire Dokploy instance globally (and not at the individual organization level), would it be better to move this tag globally to the top right side (next to the timer)? This would free up much-needed horizontal space in the sidebar for the organization name.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects organization-selector truncation in the sidebar by making its nested flex containers shrinkable while preserving the logo, Enterprise badge, and chevron dimensions.
- Adds `min-w-0` and `flex-1` constraints through the organization-name container hierarchy.
- Applies single-line truncation to long organization names.
- Prevents the logo, Enterprise badge, and selector chevron from shrinking.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the layout-only changes consistently constrain shrinkable content while preserving fixed-size controls.

The updated flex hierarchy permits long organization names to shrink and truncate, while collapsed-state visibility rules prevent the hidden name, badge, and chevron from causing overflow.

<sub>Reviews (2): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dokploy/dokploy/commit/d1fda6368ceee14245c99b289c6d0fafae3dd320) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59823836)</sub>

<!-- /greptile_comment -->