### PR TITLE
fix(auth): enforce SSO on server-side sign-in endpoints

### DIFF
--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -125,6 +125,19 @@ const createBetterAuth = () =>
 					...(ctx.context.baseURL ? [new URL(ctx.context.baseURL).origin] : []),
 					...(await resolveTrustedOrigins()),
 				].filter(Boolean);
+
+				if (
+					!IS_CLOUD &&
+					(ctx.path.startsWith("/sign-in/email") ||
+						ctx.path.startsWith("/sign-in/social"))
+				) {
+					const settings = await getWebServerSettings();
+					if (settings?.enforceSSO) {
+						throw new APIError("FORBIDDEN", {
+							message: "SSO is enforced. Direct password and social sign-in are disabled.",
+						});
+					}
+				}
 			}),
 		},
 		emailVerification: {

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -126,16 +126,20 @@ const createBetterAuth = () =>
 					...(await resolveTrustedOrigins()),
 				].filter(Boolean);
 
-				if (
-					!IS_CLOUD &&
-					(ctx.path.startsWith("/sign-in/email") ||
-						ctx.path.startsWith("/sign-in/social"))
-				) {
+				const isBlockedAuthPath =
+					ctx.path.startsWith("/sign-in/email") ||
+					ctx.path.startsWith("/sign-in/social") ||
+					ctx.path.startsWith("/sign-in/passkey") ||
+					ctx.path.startsWith("/sign-up/email") ||
+					ctx.path.startsWith("/passkey/verify-authentication") ||
+					ctx.path.startsWith("/passkey/generate-authenticate-options");
+
+				if (!IS_CLOUD && isBlockedAuthPath) {
 					const settings = await getWebServerSettings();
 					if (settings?.enforceSSO) {
 						throw new APIError("FORBIDDEN", {
 							message:
-								"SSO is enforced. Direct password and social sign-in are disabled.",
+								"SSO is enforced. Direct password, social, and passkey sign-in are disabled.",
 						});
 					}
 				}

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -134,7 +134,8 @@ const createBetterAuth = () =>
 					const settings = await getWebServerSettings();
 					if (settings?.enforceSSO) {
 						throw new APIError("FORBIDDEN", {
-							message: "SSO is enforced. Direct password and social sign-in are disabled.",
+							message:
+								"SSO is enforced. Direct password and social sign-in are disabled.",
 						});
 					}
 				}


### PR DESCRIPTION
### Summary
Resolves #5288.

### Problem
When *Enforce SSO* is enabled (`webServerSettings.enforceSSO = true`), the UI toggles to hide the email/password form in `pages/index.tsx`, but the underlying better-auth endpoint (`/api/auth/sign-in/email` and social providers) remained active and allowed direct password logins via curl or direct API requests.

### Solution
In `packages/server/src/lib/auth.ts`, added an authentication check within `hooks.before` using `createAuthMiddleware`:
- When `!IS_CLOUD` and the path starts with `/sign-in/email` or `/sign-in/social`, checks `getWebServerSettings()`.
- If `settings.enforceSSO` is `true`, throws `new APIError("FORBIDDEN", { message: "SSO is enforced. Direct password and social sign-in are disabled." })`.
- When `enforceSSO` is `false`, normal password and social authentication proceed without interruption.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enforces the self-hosted SSO policy at the server-side authentication boundary rather than relying on the UI.
- Blocks email, social, passkey, and direct email-signup routes while SSO enforcement is enabled.
- Extends the original fix to cover the passkey authentication endpoints identified in the previous review.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current guard covers the passkey authentication endpoints needed to prevent the previously reported non-SSO session bypass.

<sub>Reviews (2): Last reviewed commit: ["fix(auth): block passkey authentication ..."](https://github.com/dokploy/dokploy/commit/5f10ed6884af889365d7f0a639fa22a25d3fa571) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59922083)</sub>

<!-- /greptile_comment -->