### PR TITLE
feat(sidebar): restructure navigation and add a nav filter

### DIFF
--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -597,43 +597,62 @@ function useIsIconMode() {
 	return state === "collapsed" && !isMobile;
 }
 
-/** A single destination row, or an expandable group of destinations. */
-function NavEntry({
+/** A single destination row. */
+function NavLink({
+	item,
+	pathname,
+}: {
+	item: SingleNavItem;
+	pathname: string;
+}) {
+	const isActive = isActiveRoute({ itemUrl: item.url, pathname });
+
+	return (
+		<SidebarMenuItem>
+			<SidebarMenuButton
+				asChild
+				isActive={isActive}
+				tooltip={item.title}
+				className={NAV_ROW}
+			>
+				<Link href={item.url}>
+					{item.icon && (
+						<item.icon className={cn(NAV_ICON, isActive && "text-primary")} />
+					)}
+					<span className={cn(isActive && "font-medium")}>{item.title}</span>
+				</Link>
+			</SidebarMenuButton>
+		</SidebarMenuItem>
+	);
+}
+
+/** An expandable group of destinations. */
+function NavGroup({
 	item,
 	pathname,
 	forceOpen,
 }: {
-	item: NavItem;
+	item: Extract<NavItem, { isSingle: false }>;
 	pathname: string;
 	forceOpen?: boolean;
 }) {
 	const isIconMode = useIsIconMode();
-
-	if (item.isSingle !== false) {
-		const isActive = isActiveRoute({ itemUrl: item.url, pathname });
-
-		return (
-			<SidebarMenuItem>
-				<SidebarMenuButton
-					asChild
-					isActive={isActive}
-					tooltip={item.title}
-					className={NAV_ROW}
-				>
-					<Link href={item.url}>
-						{item.icon && (
-							<item.icon className={cn(NAV_ICON, isActive && "text-primary")} />
-						)}
-						<span className={cn(isActive && "font-medium")}>{item.title}</span>
-					</Link>
-				</SidebarMenuButton>
-			</SidebarMenuItem>
-		);
-	}
-
 	const isActive = item.items.some((subItem) =>
 		isActiveRoute({ itemUrl: subItem.url, pathname }),
 	);
+
+	// Icon mode swaps the Collapsible out for a dropdown, which unmounts it. The
+	// open state is held here, where the component survives that swap, so the
+	// user's choice is not reset on the way back.
+	const [isOpen, setIsOpen] = useState(isActive);
+
+	// Landing inside a collapsed group, via the filter or the icon-mode
+	// dropdown, should reveal where you ended up.
+	useEffect(() => {
+		if (isActive) {
+			setIsOpen(true);
+		}
+	}, [isActive]);
 
 	// `SidebarMenuSub` is hidden in icon mode, so the children need somewhere
 	// else to go or the group becomes a dead end.
@@ -679,8 +698,8 @@ function NavEntry({
 	return (
 		<Collapsible
 			asChild
-			defaultOpen={isActive}
-			open={forceOpen || undefined}
+			open={forceOpen || isOpen}
+			onOpenChange={setIsOpen}
 			className="group/collapsible"
 		>
 			<SidebarMenuItem>
@@ -727,6 +746,23 @@ function NavEntry({
 				</CollapsibleContent>
 			</SidebarMenuItem>
 		</Collapsible>
+	);
+}
+
+/** A single destination row, or an expandable group of destinations. */
+function NavEntry({
+	item,
+	pathname,
+	forceOpen,
+}: {
+	item: NavItem;
+	pathname: string;
+	forceOpen?: boolean;
+}) {
+	return item.isSingle !== false ? (
+		<NavLink item={item} pathname={pathname} />
+	) : (
+		<NavGroup item={item} pathname={pathname} forceOpen={forceOpen} />
 	);
 }
 

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -8,6 +8,8 @@ import {
 	BookIcon,
 	BotIcon,
 	Boxes,
+	Building2,
+	ChevronDown,
 	ChevronRight,
 	ChevronsUpDown,
 	CircleHelp,
@@ -29,6 +31,7 @@ import {
 	type LucideIcon,
 	Package,
 	Palette,
+	Search,
 	Server,
 	ShieldCheck,
 	Smartphone,
@@ -38,17 +41,19 @@ import {
 	User,
 	Users,
 	Vault,
+	X,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import {
 	Breadcrumb,
 	BreadcrumbItem,
-	BreadcrumbLink,
 	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import {
 	Collapsible,
@@ -82,8 +87,8 @@ import {
 	SidebarContent,
 	SidebarFooter,
 	SidebarGroup,
-	SidebarGroupLabel,
 	SidebarHeader,
+	SidebarInput,
 	SidebarInset,
 	SidebarMenu,
 	SidebarMenuButton,
@@ -151,19 +156,26 @@ type ExternalLink = {
 };
 
 // Menu type
-// Consists of home, settings, and help items
+// `quick` renders unlabeled at the top, the rest as labeled, collapsible
+// sections.
 type Menu = {
-	home: NavItem[];
+	quick: NavItem[];
+	platform: NavItem[];
 	settings: NavItem[];
 	help: ExternalLink[];
 };
 
+const NAV_ROW =
+	"h-9 gap-2.5 rounded-lg px-2.5 text-sm data-active:ring-1 data-active:ring-sidebar-border data-active:ring-inset";
+const NAV_ICON = "text-sidebar-foreground/60";
+const SECTION_LABEL =
+	"flex h-7 w-full items-center gap-1 rounded-md px-1.5 text-[11px] font-semibold tracking-wider text-sidebar-foreground/50 uppercase transition-colors hover:text-sidebar-foreground/80 group-data-[collapsible=icon]:hidden";
+
 // Menu items
-// Consists of unfiltered home, settings, and help items
 // The items are filtered based on the user's role and permissions
 // The `isEnabled` function is called to determine if the item should be displayed
 const MENU: Menu = {
-	home: [
+	quick: [
 		{
 			isSingle: true,
 			title: "Home",
@@ -184,6 +196,9 @@ const MENU: Menu = {
 			// Only enabled for users with access to services
 			isEnabled: ({ permissions }) => !!permissions?.service.read,
 		},
+	],
+
+	platform: [
 		{
 			isSingle: true,
 			title: "Monitoring",
@@ -225,221 +240,182 @@ const MENU: Menu = {
 			isEnabled: ({ permissions, isCloud }) =>
 				!!(permissions?.docker.read && !isCloud),
 		},
-
-		// Legacy unused menu, adjusted to the new structure
-		// {
-		// 	isSingle: true,
-		// 	title: "Projects",
-		// 	url: "/dashboard/projects",
-		// 	icon: Folder,
-		// },
-		// {
-		// 	isSingle: true,
-		// 	title: "Monitoring",
-		// 	icon: BarChartHorizontalBigIcon,
-		// 	url: "/dashboard/settings/monitoring",
-		// },
-		// {
-		//   isSingle: false,
-		//   title: "Settings",
-		//   icon: Settings2,
-		//   items: [
-		//     {
-		//       title: "Profile",
-		//       url: "/dashboard/settings/profile",
-		//     },
-		//     {
-		//       title: "Users",
-		//       url: "/dashboard/settings/users",
-		//     },
-		//     {
-		//       title: "SSH Key",
-		//       url: "/dashboard/settings/ssh-keys",
-		//     },
-		//     {
-		//       title: "Git",
-		//       url: "/dashboard/settings/git-providers",
-		//     },
-		//   ],
-		// },
-		// {
-		//   isSingle: false,
-		//   title: "Integrations",
-		//   icon: BlocksIcon,
-		//   items: [
-		//     {
-		//       title: "S3 Destinations",
-		//       url: "/dashboard/settings/destinations",
-		//     },
-		//     {
-		//       title: "Registry",
-		//       url: "/dashboard/settings/registry",
-		//     },
-		//     {
-		//       title: "Notifications",
-		//       url: "/dashboard/settings/notifications",
-		//     },
-		//   ],
-		// },
 	],
 
+	// Settings are grouped by concern so the section stays scannable: the flat
+	// list had grown to 21 entries with no hierarchy.
 	settings: [
 		{
-			isSingle: true,
-			title: "Web Server",
-			url: "/dashboard/settings/server",
-			icon: Activity,
-			// Only enabled for admins in non-cloud environments
-			isEnabled: ({ permissions, isCloud }) =>
-				!!(permissions?.organization.update && !isCloud),
-		},
-		{
-			isSingle: true,
-			title: "Profile",
-			url: "/dashboard/settings/profile",
+			isSingle: false,
+			title: "Account",
 			icon: User,
+			items: [
+				{
+					title: "Profile",
+					url: "/dashboard/settings/profile",
+					icon: User,
+				},
+				{
+					title: "Sessions",
+					url: "/dashboard/settings/sessions",
+					icon: Smartphone,
+				},
+			],
 		},
 		{
-			isSingle: true,
-			title: "Sessions",
-			icon: Smartphone,
-			url: "/dashboard/settings/sessions",
-		},
-		{
-			isSingle: true,
-			title: "Remote Servers",
-			url: "/dashboard/settings/servers",
+			isSingle: false,
+			title: "Infrastructure",
 			icon: Server,
-			isEnabled: ({ permissions }) => !!permissions?.server.read,
+			items: [
+				{
+					title: "Web Server",
+					url: "/dashboard/settings/server",
+					icon: Activity,
+					// Only enabled for admins in non-cloud environments
+					isEnabled: ({ permissions, isCloud }) =>
+						!!(permissions?.organization.update && !isCloud),
+				},
+				{
+					title: "Remote Servers",
+					url: "/dashboard/settings/servers",
+					icon: Server,
+					isEnabled: ({ permissions }) => !!permissions?.server.read,
+				},
+				{
+					title: "Deployments",
+					url: "/dashboard/settings/deployments",
+					icon: Boxes,
+					isEnabled: ({ permissions, isCloud }) =>
+						!!(permissions?.server.read && !isCloud),
+				},
+				{
+					title: "Certificates",
+					url: "/dashboard/settings/certificates",
+					icon: ShieldCheck,
+					isEnabled: ({ permissions }) => !!permissions?.certificate.read,
+				},
+			],
 		},
 		{
-			isSingle: true,
-			title: "Deployments",
-			url: "/dashboard/settings/deployments",
-			icon: Boxes,
-			isEnabled: ({ permissions, isCloud }) =>
-				!!(permissions?.server.read && !isCloud),
-		},
-		{
-			isSingle: true,
-			title: "Users",
-			icon: Users,
-			url: "/dashboard/settings/users",
-			// Only enabled for users with member.read permission
-			isEnabled: ({ permissions }) => !!permissions?.member.read,
-		},
-		{
-			isSingle: true,
-			title: "Audit Logs",
-			icon: ClipboardList,
-			url: "/dashboard/settings/audit-logs",
-			isEnabled: ({ permissions }) => !!permissions?.auditLog.read,
-		},
-		{
-			isSingle: true,
-			title: "SSH Keys",
+			isSingle: false,
+			title: "Credentials",
 			icon: KeyRound,
-			url: "/dashboard/settings/ssh-keys",
-			// Only enabled for users with access to SSH keys
-			isEnabled: ({ permissions }) => !!permissions?.sshKeys.read,
+			items: [
+				{
+					title: "SSH Keys",
+					url: "/dashboard/settings/ssh-keys",
+					icon: KeyRound,
+					// Only enabled for users with access to SSH keys
+					isEnabled: ({ permissions }) => !!permissions?.sshKeys.read,
+				},
+				{
+					title: "Secrets",
+					url: "/dashboard/settings/secrets",
+					icon: Vault,
+					isEnabled: ({ permissions }) => !!permissions?.vaultProvider.create,
+				},
+			],
 		},
 		{
-			title: "AI",
-			icon: BotIcon,
-			url: "/dashboard/settings/ai",
-			isSingle: true,
-			isEnabled: ({ permissions }) => !!permissions?.organization.update,
+			isSingle: false,
+			title: "Integrations",
+			icon: BlocksIcon,
+			items: [
+				{
+					title: "Git",
+					url: "/dashboard/settings/git-providers",
+					icon: GitBranch,
+					// Only enabled for users with access to Git providers
+					isEnabled: ({ permissions }) => !!permissions?.gitProviders.read,
+				},
+				{
+					title: "Registry",
+					url: "/dashboard/settings/registry",
+					icon: Package,
+					isEnabled: ({ permissions }) => !!permissions?.registry.read,
+				},
+				{
+					title: "S3 Destinations",
+					url: "/dashboard/settings/destinations",
+					icon: HardDrive,
+					isEnabled: ({ permissions }) => !!permissions?.destination.read,
+				},
+				{
+					title: "DNS Providers",
+					url: "/dashboard/settings/dns",
+					icon: Globe,
+					isEnabled: ({ permissions }) => !!permissions?.dnsProvider.read,
+				},
+				{
+					title: "Notifications",
+					url: "/dashboard/settings/notifications",
+					icon: Bell,
+					// Only enabled for users with access to notifications
+					isEnabled: ({ permissions }) => !!permissions?.notification.read,
+				},
+				{
+					title: "AI",
+					url: "/dashboard/settings/ai",
+					icon: BotIcon,
+					isEnabled: ({ permissions }) => !!permissions?.organization.update,
+				},
+			],
 		},
 		{
-			isSingle: true,
-			title: "Tags",
-			url: "/dashboard/settings/tags",
-			icon: Tags,
-			isEnabled: ({ permissions }) => !!permissions?.tag.read,
-		},
-		{
-			isSingle: true,
-			title: "Git",
-			url: "/dashboard/settings/git-providers",
-			icon: GitBranch,
-			// Only enabled for users with access to Git providers
-			isEnabled: ({ permissions }) => !!permissions?.gitProviders.read,
-		},
-		{
-			isSingle: true,
-			title: "Registry",
-			url: "/dashboard/settings/registry",
-			icon: Package,
-			isEnabled: ({ permissions }) => !!permissions?.registry.read,
-		},
-		{
-			isSingle: true,
-			title: "Secrets",
-			url: "/dashboard/settings/secrets",
-			icon: Vault,
-			isEnabled: ({ permissions }) => !!permissions?.vaultProvider.create,
-		},
-		{
-			isSingle: true,
-			title: "DNS Providers",
-			url: "/dashboard/settings/dns",
-			icon: Globe,
-			isEnabled: ({ permissions }) => !!permissions?.dnsProvider.read,
-		},
-		{
-			isSingle: true,
-			title: "S3 Destinations",
-			url: "/dashboard/settings/destinations",
-			icon: HardDrive,
-			isEnabled: ({ permissions }) => !!permissions?.destination.read,
-		},
-
-		{
-			isSingle: true,
-			title: "Certificates",
-			url: "/dashboard/settings/certificates",
-			icon: ShieldCheck,
-			isEnabled: ({ permissions }) => !!permissions?.certificate.read,
-		},
-		{
-			isSingle: true,
-			title: "Notifications",
-			url: "/dashboard/settings/notifications",
-			icon: Bell,
-			// Only enabled for users with access to notifications
-			isEnabled: ({ permissions }) => !!permissions?.notification.read,
-		},
-		{
-			isSingle: true,
-			title: "Billing",
-			url: "/dashboard/settings/billing",
-			icon: CreditCard,
-			// Only enabled for owners in cloud environments
-			isEnabled: ({ auth, isCloud }) => !!(auth?.role === "owner" && isCloud),
-		},
-		{
-			isSingle: true,
-			title: "License",
-			url: "/dashboard/settings/license",
-			icon: Key,
-			// Only enabled for owners
-			isEnabled: ({ auth }) => !!(auth?.role === "owner"),
-		},
-		{
-			isSingle: true,
-			title: "SSO",
-			url: "/dashboard/settings/sso",
-			icon: LogIn,
-			// Enabled for admins in both cloud and self-hosted (enterprise)
-			isEnabled: ({ permissions }) => !!permissions?.organization.update,
-		},
-		{
-			isSingle: true,
-			title: "Whitelabeling",
-			url: "/dashboard/settings/whitelabeling",
-			icon: Palette,
-			// Only enabled for owners in non-cloud environments (enterprise)
-			isEnabled: ({ auth, isCloud }) => !!(auth?.role === "owner" && !isCloud),
+			isSingle: false,
+			title: "Organization",
+			icon: Building2,
+			items: [
+				{
+					title: "Users",
+					url: "/dashboard/settings/users",
+					icon: Users,
+					// Only enabled for users with member.read permission
+					isEnabled: ({ permissions }) => !!permissions?.member.read,
+				},
+				{
+					title: "Audit Logs",
+					url: "/dashboard/settings/audit-logs",
+					icon: ClipboardList,
+					isEnabled: ({ permissions }) => !!permissions?.auditLog.read,
+				},
+				{
+					title: "Tags",
+					url: "/dashboard/settings/tags",
+					icon: Tags,
+					isEnabled: ({ permissions }) => !!permissions?.tag.read,
+				},
+				{
+					title: "SSO",
+					url: "/dashboard/settings/sso",
+					icon: LogIn,
+					// Enabled for admins in both cloud and self-hosted (enterprise)
+					isEnabled: ({ permissions }) => !!permissions?.organization.update,
+				},
+				{
+					title: "Whitelabeling",
+					url: "/dashboard/settings/whitelabeling",
+					icon: Palette,
+					// Only enabled for owners in non-cloud environments (enterprise)
+					isEnabled: ({ auth, isCloud }) =>
+						!!(auth?.role === "owner" && !isCloud),
+				},
+				{
+					title: "Billing",
+					url: "/dashboard/settings/billing",
+					icon: CreditCard,
+					// Only enabled for owners in cloud environments
+					isEnabled: ({ auth, isCloud }) =>
+						!!(auth?.role === "owner" && isCloud),
+				},
+				{
+					title: "License",
+					url: "/dashboard/settings/license",
+					icon: Key,
+					// Only enabled for owners
+					isEnabled: ({ auth }) => !!(auth?.role === "owner"),
+				},
+			],
 		},
 	],
 
@@ -459,7 +435,6 @@ const MENU: Menu = {
 
 /**
  * Creates a menu based on the current user's role and permissions
- * @returns a menu object with the home, settings, and help items
  */
 function createMenuForAuthUser(opts: {
 	auth?: AuthQueryOutput;
@@ -487,6 +462,22 @@ function createMenuForAuthUser(opts: {
 					}),
 		) as T[];
 
+	// Groups are filtered recursively, then dropped when every child is denied,
+	// so a group never renders as an empty expandable row.
+	const filterNavItems = (items: readonly NavItem[]): NavItem[] =>
+		filterEnabled(items).reduce<NavItem[]>((acc, item) => {
+			if (item.isSingle !== false) {
+				acc.push(item);
+				return acc;
+			}
+
+			const subItems = filterEnabled(item.items);
+			if (subItems.length) {
+				acc.push({ ...item, items: subItems });
+			}
+			return acc;
+		}, []);
+
 	// Apply whitelabeling URL overrides to help items
 	const helpItems = filterEnabled(MENU.help).map((item) => {
 		if (opts.whitelabeling?.docsUrl && item.name === "Documentation") {
@@ -499,15 +490,15 @@ function createMenuForAuthUser(opts: {
 	});
 
 	return {
-		home: filterEnabled(MENU.home),
-		settings: filterEnabled(MENU.settings),
+		quick: filterNavItems(MENU.quick),
+		platform: filterNavItems(MENU.platform),
+		settings: filterNavItems(MENU.settings),
 		help: helpItems,
 	};
 }
 
 /**
  * Determines if an item url is active based on the current pathname
- * @returns true if the item url is active, false otherwise
  */
 function isActiveRoute(opts: {
 	/** The url of the item. Usually obtained from `item.url` */
@@ -532,43 +523,249 @@ function isActiveRoute(opts: {
 
 /**
  * Finds the active nav item based on the current pathname
- * @returns the active nav item with `SingleNavItem` type or undefined if none is active
+ * @returns the active item along with the title of its group, if it has one
  */
 function findActiveNavItem(
 	navItems: NavItem[],
 	pathname: string,
-): SingleNavItem | undefined {
-	const found = navItems.find((item) =>
-		item.isSingle !== false
-			? // The current item is single, so check if the item url is active
-				isActiveRoute({ itemUrl: item.url, pathname })
-			: // The current item is not single, so check if any of the sub items are active
-				item.items.some((item) =>
-					isActiveRoute({ itemUrl: item.url, pathname }),
-				),
-	);
+): { item: SingleNavItem; groupTitle?: string } | undefined {
+	for (const navItem of navItems) {
+		if (navItem.isSingle !== false) {
+			if (isActiveRoute({ itemUrl: navItem.url, pathname })) {
+				return { item: navItem };
+			}
+			continue;
+		}
 
-	if (found?.isSingle !== false) {
-		// The found item is single, so return it
-		return found;
+		const subItem = navItem.items.find((item) =>
+			isActiveRoute({ itemUrl: item.url, pathname }),
+		);
+
+		if (subItem) {
+			return { item: subItem, groupTitle: navItem.title };
+		}
 	}
 
-	// The found item is not single, so find the active sub item
-	return found?.items.find((item) =>
-		isActiveRoute({ itemUrl: item.url, pathname }),
+	return undefined;
+}
+
+/**
+ * Narrows the nav tree down to the items matching a search query.
+ * A group matches either by its own title (keeping all its children) or by any
+ * of its children.
+ */
+function searchNavItems(items: NavItem[], query: string): NavItem[] {
+	const needle = query.trim().toLowerCase();
+	if (!needle) return items;
+
+	const matches = (title: string) => title.toLowerCase().includes(needle);
+
+	return items.reduce<NavItem[]>((acc, item) => {
+		if (item.isSingle !== false) {
+			if (matches(item.title)) {
+				acc.push(item);
+			}
+			return acc;
+		}
+
+		if (matches(item.title)) {
+			acc.push(item);
+			return acc;
+		}
+
+		const subItems = item.items.filter((subItem) => matches(subItem.title));
+		if (subItems.length) {
+			acc.push({ ...item, items: subItems });
+		}
+		return acc;
+	}, []);
+}
+
+function searchExternalLinks(
+	items: ExternalLink[],
+	query: string,
+): ExternalLink[] {
+	const needle = query.trim().toLowerCase();
+	if (!needle) return items;
+
+	return items.filter((item) => item.name.toLowerCase().includes(needle));
+}
+
+/** True while the sidebar is showing icons only. */
+function useIsIconMode() {
+	const { state, isMobile } = useSidebar();
+	return state === "collapsed" && !isMobile;
+}
+
+/** A single destination row, or an expandable group of destinations. */
+function NavEntry({
+	item,
+	pathname,
+	forceOpen,
+}: {
+	item: NavItem;
+	pathname: string;
+	forceOpen?: boolean;
+}) {
+	const isIconMode = useIsIconMode();
+
+	if (item.isSingle !== false) {
+		const isActive = isActiveRoute({ itemUrl: item.url, pathname });
+
+		return (
+			<SidebarMenuItem>
+				<SidebarMenuButton
+					asChild
+					isActive={isActive}
+					tooltip={item.title}
+					className={NAV_ROW}
+				>
+					<Link href={item.url}>
+						{item.icon && (
+							<item.icon className={cn(NAV_ICON, isActive && "text-primary")} />
+						)}
+						<span className={cn(isActive && "font-medium")}>{item.title}</span>
+					</Link>
+				</SidebarMenuButton>
+			</SidebarMenuItem>
+		);
+	}
+
+	const isActive = item.items.some((subItem) =>
+		isActiveRoute({ itemUrl: subItem.url, pathname }),
+	);
+
+	// `SidebarMenuSub` is hidden in icon mode, so the children need somewhere
+	// else to go or the group becomes a dead end.
+	if (isIconMode) {
+		return (
+			<SidebarMenuItem>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<SidebarMenuButton isActive={isActive} className={NAV_ROW}>
+							<item.icon className={cn(NAV_ICON, isActive && "text-primary")} />
+							<span>{item.title}</span>
+						</SidebarMenuButton>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent side="right" align="start" className="w-56">
+						<DropdownMenuLabel>{item.title}</DropdownMenuLabel>
+						{item.items.map((subItem) => {
+							const isSubActive = isActiveRoute({
+								itemUrl: subItem.url,
+								pathname,
+							});
+
+							return (
+								<DropdownMenuItem key={subItem.title} asChild>
+									<Link
+										href={subItem.url}
+										className={cn(
+											"flex items-center gap-2",
+											isSubActive && "font-medium text-primary",
+										)}
+									>
+										{subItem.icon && <subItem.icon className="size-4" />}
+										<span>{subItem.title}</span>
+									</Link>
+								</DropdownMenuItem>
+							);
+						})}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</SidebarMenuItem>
+		);
+	}
+
+	return (
+		<Collapsible
+			asChild
+			defaultOpen={isActive}
+			open={forceOpen || undefined}
+			className="group/collapsible"
+		>
+			<SidebarMenuItem>
+				<CollapsibleTrigger asChild>
+					<SidebarMenuButton isActive={isActive} className={NAV_ROW}>
+						<item.icon className={cn(NAV_ICON, isActive && "text-primary")} />
+						<span className={cn(isActive && "font-medium")}>{item.title}</span>
+						<ChevronRight className="ml-auto size-3.5! text-sidebar-foreground/40 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+					</SidebarMenuButton>
+				</CollapsibleTrigger>
+				<CollapsibleContent>
+					<SidebarMenuSub className="mx-0 border-none px-0 pl-6">
+						{item.items.map((subItem) => {
+							const isSubActive = isActiveRoute({
+								itemUrl: subItem.url,
+								pathname,
+							});
+
+							return (
+								<SidebarMenuSubItem key={subItem.title}>
+									<SidebarMenuSubButton
+										asChild
+										isActive={isSubActive}
+										className="h-8 gap-2.5 rounded-lg px-2.5 data-active:ring-1 data-active:ring-sidebar-border data-active:ring-inset"
+									>
+										<Link href={subItem.url}>
+											{subItem.icon && (
+												<subItem.icon
+													className={cn(
+														"text-sidebar-foreground/60!",
+														isSubActive && "text-primary!",
+													)}
+												/>
+											)}
+											<span className={cn(isSubActive && "font-medium")}>
+												{subItem.title}
+											</span>
+										</Link>
+									</SidebarMenuSubButton>
+								</SidebarMenuSubItem>
+							);
+						})}
+					</SidebarMenuSub>
+				</CollapsibleContent>
+			</SidebarMenuItem>
+		</Collapsible>
 	);
 }
 
-interface Props {
+/** A labeled, collapsible block of nav entries. */
+function NavSection({
+	label,
+	forceOpen,
+	children,
+}: {
+	label: string;
+	forceOpen?: boolean;
 	children: React.ReactNode;
+}) {
+	const isIconMode = useIsIconMode();
+
+	return (
+		<Collapsible
+			defaultOpen
+			// A section the user collapsed would otherwise unmount its rows, leaving
+			// nothing but a hidden label once the sidebar shrinks to icons.
+			open={forceOpen || isIconMode || undefined}
+			className="group/section"
+		>
+			<SidebarGroup className="gap-1 px-2 py-2">
+				<CollapsibleTrigger className={SECTION_LABEL}>
+					<ChevronDown className="size-3.5 shrink-0 transition-transform duration-200 group-data-[state=closed]/section:-rotate-90" />
+					{label}
+				</CollapsibleTrigger>
+				<CollapsibleContent>
+					<SidebarMenu className="gap-0.5">{children}</SidebarMenu>
+				</CollapsibleContent>
+			</SidebarGroup>
+		</Collapsible>
+	);
 }
 
-function LogoWrapper() {
-	return <SidebarLogo />;
-}
-
-function SidebarLogo() {
-	const { state } = useSidebar();
+function OrganizationSwitcher() {
+	const { isMobile } = useSidebar();
+	const isIconMode = useIsIconMode();
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 	const { data: user } = api.user.get.useQuery();
 	const { data: session } = api.user.session.useQuery();
@@ -581,332 +778,386 @@ function SidebarLogo() {
 		api.organization.delete.useMutation();
 	const { mutateAsync: setDefaultOrganization, isPending: isSettingDefault } =
 		api.organization.setDefault.useMutation();
-	const { isMobile } = useSidebar();
-	const isCollapsed = state === "collapsed" && !isMobile;
 	const { data: activeOrganization } = api.organization.active.useQuery();
 	const { data: haveValidLicense } =
 		api.licenseKey.haveValidLicenseKey.useQuery();
 
-	const { data: invitations, refetch: refetchInvitations } =
-		api.user.getInvitations.useQuery();
-
-	const [_activeTeam, setActiveTeam] = useState<
-		typeof activeOrganization | null
-	>(null);
 	const [organizationSelectorOpen, setOrganizationSelectorOpen] =
 		useState(false);
 
-	useEffect(() => {
-		if (activeOrganization) {
-			setActiveTeam(activeOrganization);
-		}
-	}, [activeOrganization]);
+	if (isLoading) {
+		return (
+			<div className="flex h-9 flex-1 items-center justify-center text-muted-foreground">
+				<Loader2 className="size-4 animate-spin" />
+			</div>
+		);
+	}
 
 	return (
-		<>
-			{isLoading ? (
-				<div className="flex flex-row gap-2 items-center justify-center text-sm text-muted-foreground min-h-[5vh] pt-4">
-					<Loader2 className="animate-spin size-4" />
-				</div>
-			) : (
-				<SidebarMenu
+		<Popover
+			open={organizationSelectorOpen}
+			onOpenChange={setOrganizationSelectorOpen}
+		>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					aria-label={activeOrganization?.name ?? "Select organization"}
 					className={cn(
-						"flex gap-2",
-						isCollapsed ? "flex-col" : "flex-row justify-between items-center",
+						"flex min-w-0 items-center gap-2 rounded-lg text-left transition-colors hover:bg-sidebar-accent data-[state=open]:bg-sidebar-accent",
+						isIconMode ? "size-8 justify-center" : "h-9 flex-1 px-1.5",
 					)}
 				>
-					{/* Organization Logo and Selector */}
-					<SidebarMenuItem className={"w-full min-w-0"}>
-						<Popover
-							open={organizationSelectorOpen}
-							onOpenChange={setOrganizationSelectorOpen}
-						>
-							<PopoverTrigger asChild>
-								<SidebarMenuButton
-									size={isCollapsed ? "sm" : "lg"}
-									className={cn(
-										"data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground",
-										isCollapsed &&
-											"flex justify-center items-center p-2 h-10 w-10 mx-auto",
-									)}
-								>
-									<div
-										className={cn(
-											"flex min-w-0 flex-1 items-center gap-2",
-											isCollapsed && "justify-center",
-										)}
+					<div className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-background">
+						<Logo
+							className="size-4"
+							logoUrl={activeOrganization?.logo || undefined}
+						/>
+					</div>
+					{!isIconMode && (
+						<>
+							<span className="truncate text-sm font-semibold">
+								{activeOrganization?.name ?? "Select Organization"}
+							</span>
+							{haveValidLicense && (
+								<Badge variant="blue" className="shrink-0">
+									Enterprise
+								</Badge>
+							)}
+							<ChevronsUpDown className="ml-auto size-3.5 shrink-0 text-sidebar-foreground/50" />
+						</>
+					)}
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-96 p-0"
+				align="start"
+				side={isMobile ? "bottom" : "right"}
+				sideOffset={4}
+			>
+				<Command>
+					<CommandInput placeholder="Search organizations..." className="h-9" />
+					<CommandList className="max-h-[min(60vh,24rem)]">
+						<CommandEmpty>No organizations found.</CommandEmpty>
+						<CommandGroup heading="Organizations">
+							{organizations?.map((org) => {
+								const isDefault = org.members?.[0]?.isDefault ?? false;
+								return (
+									<CommandItem
+										key={org.id}
+										value={org.name}
+										onSelect={async () => {
+											setOrganizationSelectorOpen(false);
+											await authClient.organization.setActive({
+												organizationId: org.id,
+											});
+											window.location.reload();
+										}}
+										className="flex items-center justify-between gap-1"
 									>
+										<div className="flex min-w-0 flex-1 items-center gap-2">
+											<div className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-sm border">
+												<Logo
+													className="size-4"
+													logoUrl={org.logo ?? undefined}
+												/>
+											</div>
+											<span className="truncate">{org.name}</span>
+										</div>
+
 										<div
-											className={cn(
-												"flex size-6 shrink-0 items-center justify-center rounded-sm border",
-											)}
+											className="flex shrink-0 items-center gap-2"
+											onClick={(e) => e.stopPropagation()}
+											onKeyDown={(e) => e.stopPropagation()}
 										>
-											<Logo
+											<Button
+												variant="ghost"
+												size="icon"
 												className={cn(
-													"transition-all",
-													isCollapsed ? "size-4" : "size-5",
+													"group",
+													isDefault
+														? "hover:bg-yellow-500/10"
+														: "hover:bg-blue-500/10",
 												)}
-												logoUrl={activeOrganization?.logo || undefined}
-											/>
-										</div>
-										<div
-											className={cn(
-												"flex flex-col items-start min-w-0 flex-1",
-												isCollapsed && "hidden",
-											)}
-										>
-											<div className="flex items-center gap-1.5 min-w-0 w-full">
-												<p className="text-sm font-medium truncate">
-													{activeOrganization?.name ?? "Select Organization"}
-												</p>
-												{haveValidLicense && (
-													<Badge variant="blue" className="shrink-0">
-														Enterprise
-													</Badge>
-												)}
-											</div>
-										</div>
-									</div>
-									<ChevronsUpDown
-										className={cn("ml-auto shrink-0", isCollapsed && "hidden")}
-									/>
-								</SidebarMenuButton>
-							</PopoverTrigger>
-							<PopoverContent
-								className="w-96 p-0"
-								align="start"
-								side={isMobile ? "bottom" : "right"}
-								sideOffset={4}
-							>
-								<Command>
-									<CommandInput
-										placeholder="Search organizations..."
-										className="h-9"
-									/>
-									<CommandList className="max-h-[min(60vh,24rem)]">
-										<CommandEmpty>No organizations found.</CommandEmpty>
-										<CommandGroup heading="Organizations">
-											{organizations?.map((org) => {
-												const isDefault = org.members?.[0]?.isDefault ?? false;
-												return (
-													<CommandItem
-														key={org.id}
-														value={org.name}
-														onSelect={async () => {
-															setOrganizationSelectorOpen(false);
-															await authClient.organization.setActive({
-																organizationId: org.id,
-															});
-															window.location.reload();
-														}}
-														className="flex items-center justify-between gap-1"
-													>
-														<div className="flex min-w-0 flex-1 items-center gap-2">
-															<div className="flex size-6 shrink-0 items-center justify-center rounded-sm border">
-																<Logo
-																	className={cn(
-																		"transition-all",
-																		state === "collapsed" ? "size-4" : "size-5",
-																	)}
-																	logoUrl={org.logo ?? undefined}
-																/>
-															</div>
-															<span className="truncate">{org.name}</span>
-														</div>
-
-														<div
-															className="flex shrink-0 items-center gap-2"
-															onClick={(e) => e.stopPropagation()}
-															onKeyDown={(e) => e.stopPropagation()}
-														>
-															<Button
-																variant="ghost"
-																size="icon"
-																className={cn(
-																	"group",
-																	isDefault
-																		? "hover:bg-yellow-500/10"
-																		: "hover:bg-blue-500/10",
-																)}
-																isLoading={isSettingDefault && !isDefault}
-																disabled={isDefault}
-																onClick={async (e) => {
-																	if (isDefault) return;
-																	e.stopPropagation();
-																	await setDefaultOrganization({
-																		organizationId: org.id,
-																	})
-																		.then(() => {
-																			refetch();
-																			toast.success(
-																				"Default organization updated",
-																			);
-																		})
-																		.catch((error) => {
-																			toast.error(
-																				error?.message ||
-																					"Error setting default organization",
-																			);
-																		});
-																}}
-																title={
-																	isDefault
-																		? "Default organization"
-																		: "Set as default"
-																}
-															>
-																{isDefault ? (
-																	<Star
-																		fill="#eab308"
-																		stroke="#eab308"
-																		className="size-4 text-yellow-500"
-																	/>
-																) : (
-																	<Star
-																		fill="none"
-																		stroke="currentColor"
-																		className="size-4 text-gray-400 group-hover:text-blue-500 transition-colors"
-																	/>
-																)}
-															</Button>
-															{org.ownerId === session?.user?.id && (
-																<>
-																	<AddOrganization organizationId={org.id} />
-																	<DialogAction
-																		title="Delete Organization"
-																		description="Are you sure you want to delete this organization?"
-																		type="destructive"
-																		onClick={async () => {
-																			await deleteOrganization({
-																				organizationId: org.id,
-																			})
-																				.then(() => {
-																					refetch();
-																					toast.success(
-																						"Organization deleted successfully",
-																					);
-																				})
-																				.catch((error) => {
-																					toast.error(
-																						error?.message ||
-																							"Error deleting organization",
-																					);
-																				});
-																		}}
-																	>
-																		<Button
-																			variant="ghost"
-																			size="icon"
-																			className="group hover:bg-red-500/10"
-																			isLoading={isRemoving}
-																		>
-																			<Trash2 className="size-4 text-primary group-hover:text-red-500" />
-																		</Button>
-																	</DialogAction>
-																</>
-															)}
-														</div>
-													</CommandItem>
-												);
-											})}
-										</CommandGroup>
-									</CommandList>
-									{(user?.role === "owner" ||
-										user?.role === "admin" ||
-										isCloud) && (
-										<div className="border-t p-1">
-											<AddOrganization />
-										</div>
-									)}
-								</Command>
-							</PopoverContent>
-						</Popover>
-					</SidebarMenuItem>
-
-					{/* Notification Bell */}
-					<SidebarMenuItem className={cn(isCollapsed && "mt-2")}>
-						<DropdownMenu>
-							<DropdownMenuTrigger asChild>
-								<Button
-									variant="ghost"
-									size="icon"
-									className={cn(
-										"relative",
-										isCollapsed && "h-8 w-8 p-1.5 mx-auto",
-									)}
-								>
-									<Bell className="size-4" />
-									{invitations && invitations.length > 0 && (
-										<span className="absolute top-0 right-0 flex size-4 items-center justify-center rounded-full bg-blue-500 text-xs text-white">
-											{invitations.length}
-										</span>
-									)}
-								</Button>
-							</DropdownMenuTrigger>
-							<DropdownMenuContent
-								align="start"
-								side={"right"}
-								className="w-80"
-							>
-								<DropdownMenuLabel>Pending Invitations</DropdownMenuLabel>
-								<div className="flex flex-col gap-2">
-									{invitations && invitations.length > 0 ? (
-										invitations.map((invitation) => (
-											<div key={invitation.id} className="flex flex-col gap-2">
-												<DropdownMenuItem
-													className="flex flex-col items-start gap-1 p-3"
-													onSelect={(e) => e.preventDefault()}
-												>
-													<div className="font-medium">
-														{invitation?.organization?.name}
-													</div>
-													<div className="text-xs text-muted-foreground">
-														Expires:{" "}
-														{new Date(invitation.expiresAt).toLocaleString()}
-													</div>
-													<div className="text-xs text-muted-foreground">
-														Role: {invitation.role}
-													</div>
-												</DropdownMenuItem>
-												<DialogAction
-													title="Accept Invitation"
-													description="Are you sure you want to accept this invitation?"
-													type="default"
-													onClick={async () => {
-														const { error } =
-															await authClient.organization.acceptInvitation({
-																invitationId: invitation.id,
-															});
-
-														if (error) {
+												isLoading={isSettingDefault && !isDefault}
+												disabled={isDefault}
+												onClick={async (e) => {
+													if (isDefault) return;
+													e.stopPropagation();
+													await setDefaultOrganization({
+														organizationId: org.id,
+													})
+														.then(() => {
+															refetch();
+															toast.success("Default organization updated");
+														})
+														.catch((error) => {
 															toast.error(
-																error.message || "Error accepting invitation",
+																error?.message ||
+																	"Error setting default organization",
 															);
-														} else {
-															toast.success("Invitation accepted successfully");
-															await refetchInvitations();
-															await refetch();
-														}
-													}}
-												>
-													<Button size="sm" variant="secondary">
-														Accept Invitation
-													</Button>
-												</DialogAction>
-											</div>
-										))
-									) : (
-										<DropdownMenuItem disabled>
-											No pending invitations
-										</DropdownMenuItem>
-									)}
-								</div>
-							</DropdownMenuContent>
-						</DropdownMenu>
+														});
+												}}
+												title={
+													isDefault ? "Default organization" : "Set as default"
+												}
+											>
+												{isDefault ? (
+													<Star
+														fill="#eab308"
+														stroke="#eab308"
+														className="size-4 text-yellow-500"
+													/>
+												) : (
+													<Star
+														fill="none"
+														stroke="currentColor"
+														className="size-4 text-gray-400 transition-colors group-hover:text-blue-500"
+													/>
+												)}
+											</Button>
+											{org.ownerId === session?.user?.id && (
+												<>
+													<AddOrganization organizationId={org.id} />
+													<DialogAction
+														title="Delete Organization"
+														description="Are you sure you want to delete this organization?"
+														type="destructive"
+														onClick={async () => {
+															await deleteOrganization({
+																organizationId: org.id,
+															})
+																.then(() => {
+																	refetch();
+																	toast.success(
+																		"Organization deleted successfully",
+																	);
+																})
+																.catch((error) => {
+																	toast.error(
+																		error?.message ||
+																			"Error deleting organization",
+																	);
+																});
+														}}
+													>
+														<Button
+															variant="ghost"
+															size="icon"
+															className="group hover:bg-red-500/10"
+															isLoading={isRemoving}
+														>
+															<Trash2 className="size-4 text-primary group-hover:text-red-500" />
+														</Button>
+													</DialogAction>
+												</>
+											)}
+										</div>
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
+					</CommandList>
+					{(user?.role === "owner" || user?.role === "admin" || isCloud) && (
+						<div className="border-t p-1">
+							<AddOrganization />
+						</div>
+					)}
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function InvitationsBell() {
+	const { isMobile } = useSidebar();
+	const isIconMode = useIsIconMode();
+	const { data: invitations, refetch: refetchInvitations } =
+		api.user.getInvitations.useQuery();
+	const { refetch: refetchOrganizations } = api.organization.all.useQuery();
+
+	const pendingCount = invitations?.length ?? 0;
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label={
+						pendingCount > 0
+							? `${pendingCount} pending invitations`
+							: "Pending invitations"
+					}
+					className={cn(
+						"relative flex shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground data-[state=open]:bg-sidebar-accent",
+						isIconMode ? "size-8" : "size-9",
+					)}
+				>
+					<Bell className="size-4" />
+					{pendingCount > 0 && (
+						<span className="absolute top-1 right-1 flex size-4 items-center justify-center rounded-full bg-blue-500 text-[10px] font-medium text-white">
+							{pendingCount}
+						</span>
+					)}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align={isMobile ? "center" : "start"}
+				side={isMobile ? "bottom" : "right"}
+				className="w-80"
+			>
+				<DropdownMenuLabel>Pending Invitations</DropdownMenuLabel>
+				<div className="flex flex-col gap-2">
+					{invitations && invitations.length > 0 ? (
+						invitations.map((invitation) => (
+							<div key={invitation.id} className="flex flex-col gap-2">
+								<DropdownMenuItem
+									className="flex flex-col items-start gap-1 p-3"
+									onSelect={(e) => e.preventDefault()}
+								>
+									<div className="font-medium">
+										{invitation?.organization?.name}
+									</div>
+									<div className="text-xs text-muted-foreground">
+										Expires: {new Date(invitation.expiresAt).toLocaleString()}
+									</div>
+									<div className="text-xs text-muted-foreground">
+										Role: {invitation.role}
+									</div>
+								</DropdownMenuItem>
+								<DialogAction
+									title="Accept Invitation"
+									description="Are you sure you want to accept this invitation?"
+									type="default"
+									onClick={async () => {
+										const { error } =
+											await authClient.organization.acceptInvitation({
+												invitationId: invitation.id,
+											});
+
+										if (error) {
+											toast.error(
+												error.message || "Error accepting invitation",
+											);
+										} else {
+											toast.success("Invitation accepted successfully");
+											await refetchInvitations();
+											await refetchOrganizations();
+										}
+									}}
+								>
+									<Button size="sm" variant="secondary">
+										Accept Invitation
+									</Button>
+								</DialogAction>
+							</div>
+						))
+					) : (
+						<DropdownMenuItem disabled>No pending invitations</DropdownMenuItem>
+					)}
+				</div>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+/**
+ * Organization switcher, invitations, collapse control and the nav filter.
+ * Collapses from two rows into a single centered icon column.
+ */
+function SidebarNavHeader({
+	search,
+	onSearchChange,
+	focusRequested,
+	onFocusHandled,
+	onExpand,
+}: {
+	search: string;
+	onSearchChange: (value: string) => void;
+	focusRequested: boolean;
+	onFocusHandled: () => void;
+	onExpand: () => void;
+}) {
+	const isIconMode = useIsIconMode();
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	// The input is display:none while collapsed, so focusing has to wait for the
+	// expanded render.
+	useEffect(() => {
+		if (focusRequested && !isIconMode) {
+			inputRef.current?.focus();
+			onFocusHandled();
+		}
+	}, [focusRequested, isIconMode, onFocusHandled]);
+
+	return (
+		<SidebarHeader className="gap-0 p-0">
+			{/* h-14 plus a bottom border mirrors the content header, so the two
+			    rules meet at the same y offset. */}
+			<div
+				className={cn(
+					"flex h-14 shrink-0 items-center border-b border-sidebar-border px-2",
+					isIconMode ? "justify-center" : "gap-1",
+				)}
+			>
+				<OrganizationSwitcher />
+				{!isIconMode && <InvitationsBell />}
+			</div>
+
+			{isIconMode ? (
+				<SidebarMenu className="gap-1 p-2">
+					<SidebarMenuItem className="flex justify-center">
+						<InvitationsBell />
+					</SidebarMenuItem>
+					<SidebarMenuItem>
+						<SidebarMenuButton
+							tooltip="Search"
+							className={NAV_ROW}
+							onClick={onExpand}
+						>
+							<Search className={NAV_ICON} />
+							<span>Search</span>
+						</SidebarMenuButton>
 					</SidebarMenuItem>
 				</SidebarMenu>
+			) : (
+				<div className="relative m-2">
+					<Search className="pointer-events-none absolute top-1/2 left-2.5 z-10 size-3.5 -translate-y-1/2 text-sidebar-foreground/40" />
+					<SidebarInput
+						ref={inputRef}
+						value={search}
+						onChange={(event) => onSearchChange(event.target.value)}
+						onKeyDown={(event) => {
+							if (event.key === "Escape") {
+								onSearchChange("");
+								event.currentTarget.blur();
+							}
+						}}
+						placeholder="Search"
+						aria-label="Search navigation"
+						className="h-9 rounded-lg border-transparent bg-sidebar-accent/60 pr-8 pl-8"
+					/>
+					{search ? (
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-xs"
+							aria-label="Clear search"
+							className="absolute top-1/2 right-1 z-10 -translate-y-1/2 text-sidebar-foreground/50"
+							onClick={() => {
+								onSearchChange("");
+								inputRef.current?.focus();
+							}}
+						>
+							<X className="size-3.5" />
+						</Button>
+					) : (
+						<kbd className="pointer-events-none absolute top-1/2 right-2.5 z-10 -translate-y-1/2 text-xs text-sidebar-foreground/40">
+							/
+						</kbd>
+					)}
+				</div>
 			)}
-		</>
+		</SidebarHeader>
 	);
 }
 
@@ -923,11 +1174,17 @@ function MobileCloser() {
 	return null;
 }
 
+interface Props {
+	children: React.ReactNode;
+}
+
 export default function Page({ children }: Props) {
 	const [defaultOpen, setDefaultOpen] = useState<boolean | undefined>(
 		undefined,
 	);
 	const [isLoaded, setIsLoaded] = useState(false);
+	const [search, setSearch] = useState("");
+	const [focusSearchRequested, setFocusSearchRequested] = useState(false);
 
 	useEffect(() => {
 		const cookieValue = document.cookie
@@ -951,11 +1208,7 @@ export default function Page({ children }: Props) {
 	const includesProjects = pathname?.includes("/dashboard/project");
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 
-	const {
-		home: filteredHome,
-		settings: filteredSettings,
-		help,
-	} = createMenuForAuthUser({
+	const { quick, platform, settings, help } = createMenuForAuthUser({
 		auth,
 		permissions,
 		isCloud: !!isCloud,
@@ -963,12 +1216,54 @@ export default function Page({ children }: Props) {
 	});
 
 	const activeItem = findActiveNavItem(
-		[...filteredHome, ...filteredSettings],
+		[...quick, ...platform, ...settings],
 		pathname,
 	);
 
+	const isSearching = search.trim().length > 0;
+	const visibleQuick = searchNavItems(quick, search);
+	const visiblePlatform = searchNavItems(platform, search);
+	const visibleSettings = searchNavItems(settings, search);
+	const visibleHelp = searchExternalLinks(help, search);
+	const hasResults =
+		visibleQuick.length > 0 ||
+		visiblePlatform.length > 0 ||
+		visibleSettings.length > 0 ||
+		visibleHelp.length > 0;
+
+	const requestSearchFocus = useCallback(() => {
+		setDefaultOpen(true);
+		setFocusSearchRequested(true);
+	}, []);
+
+	const handleFocusHandled = useCallback(
+		() => setFocusSearchRequested(false),
+		[],
+	);
+
+	// "/" is the shortcut advertised next to the search field.
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== "/" || event.metaKey || event.ctrlKey) return;
+
+			const target = event.target as HTMLElement | null;
+			if (
+				target?.isContentEditable ||
+				["INPUT", "TEXTAREA", "SELECT"].includes(target?.tagName ?? "")
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			requestSearchFocus();
+		};
+
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [requestSearchFocus]);
+
 	if (!isLoaded) {
-		return <div className="w-full h-screen bg-background" />; // Placeholder mientras se carga
+		return <div className="h-screen w-full bg-background" />;
 	}
 
 	return (
@@ -983,275 +1278,155 @@ export default function Page({ children }: Props) {
 			}}
 			style={
 				{
-					"--sidebar-width": "19.5rem",
+					"--sidebar-width": "17.5rem",
 					"--sidebar-width-mobile": "19.5rem",
 				} as React.CSSProperties
 			}
 		>
 			<MobileCloser />
-			<Sidebar collapsible="icon" variant="floating">
-				<SidebarHeader>
-					{/* <SidebarMenuButton
-						className="group-data-[collapsible=icon]:p-0!"
-						size="lg"
-					> */}
-					<LogoWrapper />
-					{/* </SidebarMenuButton> */}
-				</SidebarHeader>
-				<SidebarContent>
-					<SidebarGroup>
-						<SidebarGroupLabel>Home</SidebarGroupLabel>
-						<SidebarMenu>
-							{filteredHome.map((item) => {
-								const isSingle = item.isSingle !== false;
-								const isActive = isSingle
-									? isActiveRoute({ itemUrl: item.url, pathname })
-									: item.items.some((item) =>
-											isActiveRoute({ itemUrl: item.url, pathname }),
-										);
+			<Sidebar collapsible="icon" variant="sidebar">
+				<SidebarNavHeader
+					search={search}
+					onSearchChange={setSearch}
+					focusRequested={focusSearchRequested}
+					onFocusHandled={handleFocusHandled}
+					onExpand={requestSearchFocus}
+				/>
 
-								return (
-									<Collapsible
+				<SidebarContent className="gap-0">
+					{visibleQuick.length > 0 && (
+						<SidebarGroup className="gap-1 border-b border-sidebar-border px-2 py-2">
+							<SidebarMenu className="gap-0.5">
+								{visibleQuick.map((item) => (
+									<NavEntry
 										key={item.title}
-										asChild
-										defaultOpen={isActive}
-										className="group/collapsible"
-									>
-										<SidebarMenuItem>
-											{isSingle ? (
-												<SidebarMenuButton
-													asChild
-													tooltip={item.title}
-													className={cn(isActive && "bg-border")}
-												>
-													<Link
-														href={item.url}
-														className="flex w-full items-center gap-2"
-													>
-														{item.icon && (
-															<item.icon
-																className={cn(isActive && "text-primary")}
-															/>
-														)}
-														<span>{item.title}</span>
-													</Link>
-												</SidebarMenuButton>
-											) : (
-												<>
-													<CollapsibleTrigger asChild>
-														<SidebarMenuButton
-															tooltip={item.title}
-															isActive={isActive}
-														>
-															{item.icon && <item.icon />}
+										item={item}
+										pathname={pathname}
+										forceOpen={isSearching}
+									/>
+								))}
+							</SidebarMenu>
+						</SidebarGroup>
+					)}
 
-															<span>{item.title}</span>
-															{item.items?.length && (
-																<ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-															)}
-														</SidebarMenuButton>
-													</CollapsibleTrigger>
-													<CollapsibleContent>
-														<SidebarMenuSub>
-															{item.items?.map((subItem) => (
-																<SidebarMenuSubItem key={subItem.title}>
-																	<SidebarMenuSubButton
-																		asChild
-																		className={cn(isActive && "bg-border")}
-																	>
-																		<Link
-																			href={subItem.url}
-																			className="flex w-full items-center"
-																		>
-																			{subItem.icon && (
-																				<span className="mr-2">
-																					<subItem.icon
-																						className={cn(
-																							"h-4 w-4 text-muted-foreground",
-																							isActive && "text-primary",
-																						)}
-																					/>
-																				</span>
-																			)}
-																			<span>{subItem.title}</span>
-																		</Link>
-																	</SidebarMenuSubButton>
-																</SidebarMenuSubItem>
-															))}
-														</SidebarMenuSub>
-													</CollapsibleContent>
-												</>
-											)}
-										</SidebarMenuItem>
-									</Collapsible>
-								);
-							})}
-						</SidebarMenu>
-					</SidebarGroup>
-					<SidebarGroup>
-						<SidebarGroupLabel>Settings</SidebarGroupLabel>
-						<SidebarMenu className="gap-1">
-							{filteredSettings.map((item) => {
-								const isSingle = item.isSingle !== false;
-								const isActive = isSingle
-									? isActiveRoute({ itemUrl: item.url, pathname })
-									: item.items.some((item) =>
-											isActiveRoute({ itemUrl: item.url, pathname }),
-										);
-
-								return (
-									<Collapsible
+					{visiblePlatform.length > 0 && (
+						<div className="border-b border-sidebar-border">
+							<NavSection label="Platform" forceOpen={isSearching}>
+								{visiblePlatform.map((item) => (
+									<NavEntry
 										key={item.title}
-										asChild
-										defaultOpen={isActive}
-										className="group/collapsible"
-									>
-										<SidebarMenuItem>
-											{isSingle ? (
-												<SidebarMenuButton
-													asChild
-													tooltip={item.title}
-													className={cn(isActive && "bg-border")}
-												>
-													<Link
-														href={item.url}
-														className="flex w-full items-center gap-2"
-													>
-														{item.icon && (
-															<item.icon
-																className={cn(isActive && "text-primary")}
-															/>
-														)}
-														<span>{item.title}</span>
-													</Link>
-												</SidebarMenuButton>
-											) : (
-												<>
-													<CollapsibleTrigger asChild>
-														<SidebarMenuButton
-															tooltip={item.title}
-															isActive={isActive}
-														>
-															{item.icon && <item.icon />}
+										item={item}
+										pathname={pathname}
+										forceOpen={isSearching}
+									/>
+								))}
+							</NavSection>
+						</div>
+					)}
 
-															<span>{item.title}</span>
-															{item.items?.length && (
-																<ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-															)}
-														</SidebarMenuButton>
-													</CollapsibleTrigger>
-													<CollapsibleContent>
-														<SidebarMenuSub>
-															{item.items?.map((subItem) => (
-																<SidebarMenuSubItem key={subItem.title}>
-																	<SidebarMenuSubButton
-																		asChild
-																		className={cn(isActive && "bg-border")}
-																	>
-																		<Link
-																			href={subItem.url}
-																			className="flex w-full items-center"
-																		>
-																			{subItem.icon && (
-																				<span className="mr-2">
-																					<subItem.icon
-																						className={cn(
-																							"h-4 w-4 text-muted-foreground",
-																							isActive && "text-primary",
-																						)}
-																					/>
-																				</span>
-																			)}
-																			<span>{subItem.title}</span>
-																		</Link>
-																	</SidebarMenuSubButton>
-																</SidebarMenuSubItem>
-															))}
-														</SidebarMenuSub>
-													</CollapsibleContent>
-												</>
-											)}
-										</SidebarMenuItem>
-									</Collapsible>
-								);
-							})}
-						</SidebarMenu>
-					</SidebarGroup>
-					<SidebarGroup className="group-data-[collapsible=icon]:hidden">
-						<SidebarGroupLabel>Extra</SidebarGroupLabel>
-						<SidebarMenu>
-							{help.map((item: ExternalLink) => (
+					{visibleSettings.length > 0 && (
+						<div className="border-b border-sidebar-border">
+							<NavSection label="Settings" forceOpen={isSearching}>
+								{visibleSettings.map((item) => (
+									<NavEntry
+										key={item.title}
+										item={item}
+										pathname={pathname}
+										forceOpen={isSearching}
+									/>
+								))}
+							</NavSection>
+						</div>
+					)}
+
+					{visibleHelp.length > 0 && (
+						<NavSection label="Help" forceOpen={isSearching}>
+							{visibleHelp.map((item) => (
 								<SidebarMenuItem key={item.name}>
-									<SidebarMenuButton asChild>
+									<SidebarMenuButton
+										asChild
+										tooltip={item.name}
+										className={NAV_ROW}
+									>
 										<a
 											href={item.url}
 											target="_blank"
 											rel="noopener noreferrer"
-											className="flex w-full items-center gap-2"
 										>
-											<span className="mr-2">
-												<item.icon className="h-4 w-4" />
-											</span>
+											<item.icon className={NAV_ICON} />
 											<span>{item.name}</span>
 										</a>
 									</SidebarMenuButton>
 								</SidebarMenuItem>
 							))}
-						</SidebarMenu>
-					</SidebarGroup>
+						</NavSection>
+					)}
+
+					{isSearching && !hasResults && (
+						<div className="px-4 py-6 text-center text-sm text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
+							No matches for “{search.trim()}”
+						</div>
+					)}
 				</SidebarContent>
-				<SidebarFooter>
-					<SidebarMenu className="flex flex-col gap-2">
-						{!isCloud && permissions?.organization.update && (
+
+				<SidebarFooter className="gap-2 border-t border-sidebar-border p-2">
+					{!isCloud && permissions?.organization.update && (
+						<SidebarMenu>
 							<SidebarMenuItem>
 								<UpdateServerButton />
 							</SidebarMenuItem>
-						)}
+						</SidebarMenu>
+					)}
+					{(whitelabeling?.footerText || dokployVersion) && (
+						<div className="flex flex-col items-center gap-0.5 text-[11px] text-sidebar-foreground/40 group-data-[collapsible=icon]:hidden">
+							{whitelabeling?.footerText && (
+								<span>{whitelabeling.footerText}</span>
+							)}
+							{dokployVersion && <span>Version {dokployVersion}</span>}
+						</div>
+					)}
+					<SidebarMenu>
 						<SidebarMenuItem>
 							<UserNav />
 						</SidebarMenuItem>
-						{whitelabeling?.footerText && (
-							<div className="px-3 text-xs text-muted-foreground text-center group-data-[collapsible=icon]:hidden">
-								{whitelabeling.footerText}
-							</div>
-						)}
-						{dokployVersion && (
-							<div className="px-3 text-xs text-muted-foreground text-center group-data-[collapsible=icon]:hidden">
-								Version {dokployVersion}
-							</div>
-						)}
 					</SidebarMenu>
 				</SidebarFooter>
 				<SidebarRail />
 			</Sidebar>
 			<SidebarInset>
 				{!includesProjects && (
-					<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-						<div className="flex items-center justify-between w-full px-4">
-							<div className="flex items-center gap-2">
+					<header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b bg-background/80 backdrop-blur-sm transition-[width,height] ease-linear">
+						<div className="flex w-full items-center justify-between gap-2 px-4">
+							<div className="flex min-w-0 items-center gap-2">
 								<SidebarTrigger className="-ml-1" />
-								<Separator orientation="vertical" className="mr-2 h-4" />
+								<Separator orientation="vertical" className="mr-1 h-4" />
 								<Breadcrumb>
 									<BreadcrumbList>
-										<BreadcrumbItem className="block">
-											<BreadcrumbLink asChild>
-												<Link
-													href={activeItem?.url || "/"}
-													className="flex items-center gap-1.5"
-												>
-													{activeItem?.title}
-												</Link>
-											</BreadcrumbLink>
+										{activeItem?.groupTitle && (
+											<>
+												<BreadcrumbItem className="hidden sm:block">
+													{activeItem.groupTitle}
+												</BreadcrumbItem>
+												<BreadcrumbSeparator className="hidden sm:block" />
+											</>
+										)}
+										<BreadcrumbItem>
+											<BreadcrumbPage className="truncate font-medium">
+												{activeItem?.item.title}
+											</BreadcrumbPage>
 										</BreadcrumbItem>
 									</BreadcrumbList>
 								</Breadcrumb>
 							</div>
-							{!isCloud && <TimeBadge />}
+							<div className="flex shrink-0 items-center gap-2">
+								{!isCloud && <TimeBadge />}
+								<UserNav compact />
+							</div>
 						</div>
 					</header>
 				)}
 
-				<div className="flex flex-col w-full p-4 pt-0">{children}</div>
+				<div className="flex w-full flex-col p-4">{children}</div>
 			</SidebarInset>
 		</SidebarProvider>
 	);

--- a/apps/dokploy/components/layouts/update-server.tsx
+++ b/apps/dokploy/components/layouts/update-server.tsx
@@ -74,46 +74,44 @@ export const UpdateServerButton = () => {
 	}, []);
 
 	return !isCloud && updateData.updateAvailable ? (
-		<div className="border-t pt-4">
-			<UpdateServer
-				updateData={updateData}
-				isOpen={isOpen}
-				onOpenChange={setIsOpen}
-			>
-				<TooltipProvider delayDuration={0}>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Button
-								variant={updateData ? "outline" : "secondary"}
-								className="w-full"
-								onClick={() => setIsOpen(true)}
-							>
-								<Download className="h-4 w-4 shrink-0" />
-								{updateData ? (
-									<span className="font-medium truncate group-data-[collapsible=icon]:hidden">
-										Update Available
-									</span>
-								) : (
-									<span className="font-medium truncate group-data-[collapsible=icon]:hidden">
-										Check for updates
-									</span>
-								)}
-								{updateData && (
-									<span className="absolute right-2 flex h-2 w-2 group-data-[collapsible=icon]:hidden">
-										<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
-										<span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
-									</span>
-								)}
-							</Button>
-						</TooltipTrigger>
-						{updateData && (
-							<TooltipContent side="right" sideOffset={10}>
-								<p>Update Available</p>
-							</TooltipContent>
-						)}
-					</Tooltip>
-				</TooltipProvider>
-			</UpdateServer>
-		</div>
+		<UpdateServer
+			updateData={updateData}
+			isOpen={isOpen}
+			onOpenChange={setIsOpen}
+		>
+			<TooltipProvider delayDuration={0}>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant={updateData ? "outline" : "secondary"}
+							className="w-full"
+							onClick={() => setIsOpen(true)}
+						>
+							<Download className="h-4 w-4 shrink-0" />
+							{updateData ? (
+								<span className="font-medium truncate group-data-[collapsible=icon]:hidden">
+									Update Available
+								</span>
+							) : (
+								<span className="font-medium truncate group-data-[collapsible=icon]:hidden">
+									Check for updates
+								</span>
+							)}
+							{updateData && (
+								<span className="absolute right-2 flex h-2 w-2 group-data-[collapsible=icon]:hidden">
+									<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+									<span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
+								</span>
+							)}
+						</Button>
+					</TooltipTrigger>
+					{updateData && (
+						<TooltipContent side="right" sideOffset={10}>
+							<p>Update Available</p>
+						</TooltipContent>
+					)}
+				</Tooltip>
+			</TooltipProvider>
+		</UpdateServer>
 	) : null;
 };

--- a/apps/dokploy/components/layouts/user-nav.tsx
+++ b/apps/dokploy/components/layouts/user-nav.tsx
@@ -11,14 +11,20 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { authClient } from "@/lib/auth-client";
-import { getFallbackAvatarInitials } from "@/lib/utils";
+import { cn, getFallbackAvatarInitials } from "@/lib/utils";
 import { api } from "@/utils/api";
+import { Button } from "../ui/button";
 import { ModeToggle } from "../ui/modeToggle";
 import { SidebarMenuButton } from "../ui/sidebar";
 
 const _AUTO_CHECK_UPDATES_INTERVAL_MINUTES = 7;
 
-export const UserNav = () => {
+interface UserNavProps {
+	/** Renders the trigger as a bare avatar button, for use in a top bar. */
+	compact?: boolean;
+}
+
+export const UserNav = ({ compact = false }: UserNavProps) => {
 	const router = useRouter();
 	const { data } = api.user.get.useQuery();
 	const { data: permissions } = api.user.getPermissions.useQuery();
@@ -26,34 +32,52 @@ export const UserNav = () => {
 
 	// const { mutateAsync } = api.auth.logout.useMutation();
 
+	const avatar = (
+		<Avatar className={cn("rounded-lg", compact ? "size-7" : "size-8")}>
+			<AvatarImage
+				className="object-cover"
+				src={data?.user?.image || ""}
+				alt={data?.user?.image || ""}
+			/>
+			<AvatarFallback className="rounded-lg text-xs">
+				{getFallbackAvatarInitials(
+					`${data?.user?.firstName} ${data?.user?.lastName}`.trim(),
+				)}
+			</AvatarFallback>
+		</Avatar>
+	);
+
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<SidebarMenuButton
-					size="lg"
-					className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-				>
-					<Avatar className="h-8 w-8 rounded-lg">
-						<AvatarImage
-							className="object-cover"
-							src={data?.user?.image || ""}
-							alt={data?.user?.image || ""}
-						/>
-						<AvatarFallback className="rounded-lg">
-							{getFallbackAvatarInitials(
-								`${data?.user?.firstName} ${data?.user?.lastName}`.trim(),
-							)}
-						</AvatarFallback>
-					</Avatar>
-					<div className="grid flex-1 text-left text-sm leading-tight">
-						<span className="truncate font-semibold">Account</span>
-						<span className="truncate text-xs">{data?.user?.email}</span>
-					</div>
-					<ChevronsUpDown className="ml-auto size-4" />
-				</SidebarMenuButton>
+				{compact ? (
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						aria-label="Account"
+						className="shrink-0 p-0 data-[state=open]:bg-accent"
+					>
+						{avatar}
+					</Button>
+				) : (
+					<SidebarMenuButton
+						size="lg"
+						className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+					>
+						{avatar}
+						<div className="grid flex-1 text-left text-sm leading-tight">
+							<span className="truncate font-semibold">Account</span>
+							<span className="truncate text-xs">{data?.user?.email}</span>
+						</div>
+						<ChevronsUpDown className="ml-auto size-4" />
+					</SidebarMenuButton>
+				)}
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
-				className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
+				className={cn(
+					"min-w-56 rounded-lg",
+					!compact && "w-(--radix-dropdown-menu-trigger-width)",
+				)}
 				side="bottom"
 				align="end"
 				sideOffset={4}

--- a/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
+++ b/apps/dokploy/components/shared/breadcrumb-sidebar.tsx
@@ -19,6 +19,7 @@ import { Separator } from "@/components/ui/separator";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { TimeBadge } from "@/components/ui/time-badge";
 import { api } from "@/utils/api";
+import { UserNav } from "../layouts/user-nav";
 
 interface BreadcrumbEntry {
 	name: string;
@@ -37,7 +38,7 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 	const { data: isCloud } = api.settings.isCloud.useQuery();
 
 	return (
-		<header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+		<header className="sticky top-0 z-10 flex h-14 shrink-0 items-center gap-2 border-b bg-background/80 backdrop-blur-sm transition-[width,height] ease-linear">
 			<div className="flex items-center justify-between w-full px-4">
 				<div className="flex items-center gap-2">
 					<SidebarTrigger className="-ml-1" />
@@ -79,7 +80,10 @@ export const BreadcrumbSidebar = ({ list }: Props) => {
 						</BreadcrumbList>
 					</Breadcrumb>
 				</div>
-				{!isCloud && <TimeBadge />}
+				<div className="flex shrink-0 items-center gap-2">
+					{!isCloud && <TimeBadge />}
+					<UserNav compact />
+				</div>
 			</div>
 		</header>
 	);


### PR DESCRIPTION
## Problem

The sidebar had grown to a flat list of 29 destinations. 21 of them sat under a single `Settings` heading with no hierarchy, there was no way to search it, and the `Extra` group carrying Documentation and Support was hidden outright once the sidebar collapsed to icons.

## Structure

- Split the panel into an unlabeled quick group (Home, Projects, Overview) and collapsible `Platform` / `Settings` / `Help` sections.
- Group the 21 settings entries under **Account**, **Infrastructure**, **Credentials**, **Integrations** and **Organization**, expandable in place. Every existing entry is preserved, with its `isEnabled` predicate unchanged.
- Add a nav filter with a `/` shortcut spanning every section, pinned in the header so it does not scroll away with the nav.
- Drop the `floating` variant so the sidebar sits flush against the viewport edges.
- Give the organization row the content header's height and bottom border in both layouts, so the two rules meet at the same offset.
- Show the version above the account block, and surface the account as an avatar in the content header.

## Fixes

- Single items set `className={cn(isActive && "bg-border")}` instead of the primitive's `isActive` prop, so they never got the intended `data-active` styling. They now use the prop.
- Sub-items were passed the **parent group's** `isActive`, so every sibling in an expanded group was highlighted whenever any one of them was active. Each sub-item now computes its own state.
- `SidebarMenuSub` is hidden in icon mode, so the new grouped entries would have been dead ends when collapsed. They open as a dropdown instead.
- Sections are forced open in icon mode, otherwise a section the user had collapsed unmounts its rows and leaves a gap behind a label that is itself hidden.
- The invitations dropdown hardcoded `side="right"`, which opens off-screen on mobile. It now picks a side based on `isMobile`.
- The organization and invitations buttons were sized `size-9` (2.25rem) inside a 3rem rail with `px-2`, overflowing it. They are `size-8` in icon mode.
- The update button carried its own `border-t pt-4`, drawing a second rule right below the footer's.

## Cleanup

- One `NavEntry` renderer replaces two ~90-line duplicated blocks between the Home and Settings groups.
- Removes ~50 lines of commented-out legacy menu definitions.
- Both content headers become sticky, so the breadcrumb survives scrolling.

## Notes for reviewers

- `permissions` / `isCloud` gating is untouched. Group-level filtering is recursive and drops a group once all of its children are denied, so a group never renders as an empty expandable row.
- `breadcrumb-sidebar.tsx` is touched so the project pages' header stays aligned with the sidebar's first row and carries the same account avatar.
- Not addressed: the update button keeps `w-full` without the primitives' size constraint, so it overflows the 3rem column when collapsed. That behaviour predates this PR and felt out of scope.

Verified with `tsc --noEmit` and `biome check`, and by walking the dashboard, settings and project pages in both expanded and collapsed states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reorganizes the dashboard sidebar into permission-aware sections, adds recursive navigation filtering and collapsed-mode dropdowns, and aligns shared content headers and account controls.

- Groups settings destinations by concern while preserving their access predicates.
- Adds a keyboard-accessible navigation filter and active-route breadcrumbs.
- Updates sidebar organization, invitation, version, update, and account presentation.
- Makes dashboard and project headers sticky and visually aligned.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking navigation-state regression when users round-trip through icon mode.

The new icon-mode branch unmounts nested Collapsibles, so manually selected group expansion state is reinitialized from route activity when the sidebar expands again; no blocking functional or security failure remains.

**Files Needing Attention:** apps/dokploy/components/layouts/side.tsx

<sub>Reviews (1): Last reviewed commit: ["feat(sidebar): restructure navigation an..."](https://github.com/dokploy/dokploy/commit/40f2c42e834c5a96eddc2d02f6dd601b25a4ffa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59989974)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboard and client state](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dashboard-and-client-state.md)

<!-- /greptile_comment -->