### PR TITLE
fix(notifications): add missing newline to ntfy database backup message

### DIFF
--- a/packages/server/src/utils/notifications/database-backup.ts
+++ b/packages/server/src/utils/notifications/database-backup.ts
@@ -196,7 +196,7 @@ export const sendDatabaseBackupNotifications = async ({
 					`🛠Project: ${projectName}\n` +
 						`⚙️Application: ${applicationName}\n` +
 						`❔Type: ${databaseType}\n` +
-						`📂Database Name: ${databaseName}` +
+						`📂Database Name: ${databaseName}\n` +
 						`🕒Date: ${date.toLocaleString()}\n` +
 						`${type === "error" && errorMessage ? `❌Error:\n${errorMessage}` : ""}`,
 				);


### PR DESCRIPTION
## What is this PR about?

The database name and date are rendered on one line in ntfy database backup notifications. Added the missing `\n` that every other line has.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes ntfy database-backup notification formatting by adding the missing newline between the database name and date.
- Keeps each notification field on a separate line.
- Aligns database-backup messages with existing ntfy notification formatting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and correctly fixes the notification formatting defect.

The ntfy sender preserves the added newline in its plain-text request body, and equivalent notification templates use the same delimiter pattern; no actionable issues remain.

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): add missing newline ..."](https://github.com/dokploy/dokploy/commit/341f38bba66e92bb4be70ee6f46f79910218dd95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60543537)</sub>

<!-- /greptile_comment -->