### PR TITLE
perf(dns): filter Infomaniak records server-side when upserting

### DIFF
--- a/apps/dokploy/__test__/dns/infomaniak.test.ts
+++ b/apps/dokploy/__test__/dns/infomaniak.test.ts
@@ -326,6 +326,58 @@ describe("infomaniakClient.upsertRecord", () => {
 
 		expect(lastBody().target).toBe('"token-value"');
 	});
+
+	it("queries the API with a source and type filter instead of the whole zone", async () => {
+		mockFetch
+			.mockResolvedValueOnce(ikSuccess([]))
+			.mockResolvedValueOnce(ikSuccess({ id: 50 }));
+
+		await infomaniakClient.upsertRecord(config, {
+			zoneId: "example.com",
+			type: "A",
+			name: "app.example.com",
+			content: "1.2.3.4",
+		});
+
+		const [url] = mockFetch.mock.calls[0] as [string];
+		expect(url).toContain("filter%5Bsource%5D=app");
+		expect(url).toContain("filter%5Btypes%5D%5B%5D=A");
+	});
+
+	it("ignores a partial filter hit rather than overwriting a different record", async () => {
+		// filter[source] matches substrings: asking for "auto" also returns
+		// "autoconfig" and "autodiscover". Trusting it would overwrite one of them.
+		mockFetch
+			.mockResolvedValueOnce(
+				ikSuccess([
+					{
+						id: 61,
+						type: "CNAME",
+						source: "autoconfig",
+						target: "a.example.net",
+						ttl: 300,
+					},
+					{
+						id: 62,
+						type: "CNAME",
+						source: "autodiscover",
+						target: "b.example.net",
+						ttl: 300,
+					},
+				]),
+			)
+			.mockResolvedValueOnce(ikSuccess({ id: 63 }));
+
+		const result = await infomaniakClient.upsertRecord(config, {
+			zoneId: "example.com",
+			type: "CNAME",
+			name: "auto.example.com",
+			content: "c.example.net",
+		});
+
+		expect(result).toEqual({ id: "63" });
+		expect(lastCall()[1].method).toBe("POST");
+	});
 });
 
 describe("infomaniakClient.updateRecord", () => {

--- a/packages/server/src/utils/dns/infomaniak.ts
+++ b/packages/server/src/utils/dns/infomaniak.ts
@@ -148,6 +148,31 @@ const listZoneRecords = async (config: InfomaniakConfig, zoneId: string) =>
 		`/2/zones/${encodeURIComponent(zoneId)}/records?with=records_description`,
 	);
 
+// The API filters server-side, which avoids pulling a whole zone just to find
+// one record. The match is still checked here: filter[source] is documented with
+// a bare subdomain example, so nothing guarantees it compares exactly the way
+// toSource writes the apex, and a filter that silently over-matches would
+// otherwise turn an update into a duplicate.
+const findRecord = async (
+	config: InfomaniakConfig,
+	zoneId: string,
+	type: string,
+	source: string,
+) => {
+	const query = new URLSearchParams({
+		"filter[source]": source,
+		"filter[types][]": type,
+	});
+	const candidates = await ikFetch<InfomaniakRecord[]>(
+		config,
+		`/2/zones/${encodeURIComponent(zoneId)}/records?${query}`,
+	);
+	return candidates.find(
+		(candidate) =>
+			candidate.type === type && normalizeSource(candidate.source) === source,
+	);
+};
+
 export const infomaniakClient: DnsClient<InfomaniakConfig> = {
 	async listZones(config) {
 		const domains = await listDomainProducts(config);
@@ -171,12 +196,7 @@ export const infomaniakClient: DnsClient<InfomaniakConfig> = {
 
 	async upsertRecord(config, record) {
 		const source = toSource(record.name, record.zoneId);
-		const existing = await listZoneRecords(config, record.zoneId);
-		const match = existing.find(
-			(candidate) =>
-				candidate.type === record.type &&
-				normalizeSource(candidate.source) === source,
-		);
+		const match = await findRecord(config, record.zoneId, record.type, source);
 
 		const body = JSON.stringify(recordPayload(record, record.zoneId));
 		const zone = encodeURIComponent(record.zoneId);


### PR DESCRIPTION
## What is this PR about?

Follow-up to the review on #5257. `upsertRecord` listed every record of a zone just to find the one it was about to write, which @narcisonunez pointed out is expensive on large zones. The API supports filtering, so this asks it to filter.

```ts
const query = new URLSearchParams({
  "filter[source]": source,
  "filter[types][]": type,
});
```

## The filter matches substrings, so it narrows but does not decide

This is the part worth reviewing. `filter[source]` is documented with a bare subdomain example (`filter[source]=www`), and testing it against a live account shows it matches substrings rather than exact values:

```
filter[source]=autoconfig  -> [autoconfig]
filter[source]=auto        -> [autoconfig, autodiscover]
filter[source]=disco       -> [autodiscover]
```

So the straightforward version of this change — take the first result the filter returns — would have upserted `auto` onto the existing `autoconfig` record and silently overwritten it. The exact comparison is therefore kept on the filtered result: the filter narrows what is transferred over the wire, and the local check still decides what matches. There is a test that fails if the first candidate is trusted.

The apex was the other thing to check, since Infomaniak represents it as `"."` rather than an empty source. `filter[source]=.` does return the apex records, and an upsert against an existing apex `TXT` returns its id instead of creating a second one — verified end to end, since a duplicate at the apex on a zone with MX or SPF records is how mail breaks.

Two smaller behaviours noted while testing: an empty `filter[source]` is rejected with a validation error (unreachable here — `toSource` writes `"."` for the apex, never `""`), and a source with no match returns an empty array as expected.

`listZoneRecords` is unchanged and still used by `listRecords`, which legitimately needs the whole zone.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance.

Tested against a real Infomaniak account: record creation, an upsert that finds the existing record through the filter and returns its id rather than duplicating, and an upsert on an existing apex record. The test zone was left with exactly its original records. `pnpm -r run typecheck` passes and the DNS suite is green (85 tests).

## Issues related (if applicable)

Follow-up to a review comment on #5257.

## Screenshots (if applicable)

N/A — no user-visible change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces Infomaniak upsert lookup cost by filtering DNS records by source and type at the API while retaining an exact local comparison to prevent substring matches from selecting the wrong record.
- Adds a focused filtered-record lookup for upserts.
- Preserves full-zone listing behavior for operations that require every record.
- Adds coverage for query serialization and substring-filter false positives.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

The filtered lookup retains the exact matching behavior that controls update versus create, and the added tests cover both parameter serialization and the documented substring-overmatch case.

<sub>Reviews (1): Last reviewed commit: ["perf(dns): filter Infomaniak records ser..."](https://github.com/dokploy/dokploy/commit/8409b8ce60da3b5e5cdf08a4620d573f61a32647) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60720827)</sub>

<!-- /greptile_comment -->