### PR TITLE
feat: allow dismissing update notifications

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -27,12 +27,14 @@ import {
 import { api } from "@/utils/api";
 import { ToggleAutoCheckUpdates } from "./toggle-auto-check-updates";
 import { UpdateWebServer } from "./update-webserver";
+import { dismissUpdate } from "@/lib/dismissed-update";
 
 interface Props {
 	updateData?: IUpdateData;
 	children?: React.ReactNode;
 	isOpen?: boolean;
 	onOpenChange?: (open: boolean) => void;
+	onDismissed?: () => void;
 }
 
 export const UpdateServer = ({
@@ -40,6 +42,7 @@ export const UpdateServer = ({
 	children,
 	isOpen: isOpenProp,
 	onOpenChange: onOpenChangeProp,
+	onDismissed,
 }: Props) => {
 	const [hasCheckedUpdate, setHasCheckedUpdate] = useState(!!updateData);
 	const [isUpdateAvailable, setIsUpdateAvailable] = useState(
@@ -83,6 +86,17 @@ export const UpdateServer = ({
 	const onOpenChange = (open: boolean) => {
 		setIsOpenInternal(open);
 		onOpenChangeProp?.(open);
+	};
+
+	const handleSkipVersion = () => {
+		if (latestVersion) {
+			dismissUpdate(latestVersion);
+		}
+		setIsUpdateAvailable(false);
+		setLatestVersion("");
+		setHasCheckedUpdate(true);
+		onOpenChange(false);
+		onDismissed?.();
 	};
 
 	return (
@@ -255,7 +269,12 @@ export const UpdateServer = ({
 					<ToggleAutoCheckUpdates disabled={isPending} />
 				</div>
 
-				<div className="flex items-center justify-end mt-4">
+				<div className="flex items-center justify-between mt-4">
+					{isUpdateAvailable && (
+						<Button variant="outline" onClick={handleSkipVersion}>
+							Skip this version
+						</Button>
+					)}
 					<div className="flex items-center gap-2">
 						<Button variant="outline" onClick={() => onOpenChange?.(false)}>
 							Cancel

--- a/apps/dokploy/components/layouts/update-server.tsx
+++ b/apps/dokploy/components/layouts/update-server.tsx
@@ -10,6 +10,7 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "../ui/tooltip";
+import { isUpdateDismissed } from "@/lib/dismissed-update";
 
 const AUTO_CHECK_UPDATES_INTERVAL_MINUTES = 7;
 
@@ -50,7 +51,11 @@ export const UpdateServerButton = () => {
 
 				const fetchedUpdateData = await getUpdateData();
 
-				if (fetchedUpdateData?.updateAvailable) {
+				if (
+					fetchedUpdateData?.updateAvailable &&
+					fetchedUpdateData.latestVersion &&
+					!isUpdateDismissed(fetchedUpdateData.latestVersion)
+				) {
 					// Stop interval when update is available
 					clearUpdatesInterval();
 					setUpdateData(fetchedUpdateData);
@@ -79,6 +84,9 @@ export const UpdateServerButton = () => {
 				updateData={updateData}
 				isOpen={isOpen}
 				onOpenChange={setIsOpen}
+				onDismissed={() =>
+					setUpdateData({ latestVersion: null, updateAvailable: false })
+				}
 			>
 				<TooltipProvider delayDuration={0}>
 					<Tooltip>

--- a/apps/dokploy/lib/dismissed-update.ts
+++ b/apps/dokploy/lib/dismissed-update.ts
@@ -1,0 +1,44 @@
+const DISMISSED_UPDATE_KEY = "dismissed_update";
+
+const versionNumber = (version: string): number[] | null => {
+	const match = version.replace(/^v/, "").split(".").map(Number);
+	if (match.some((part) => Number.isNaN(part))) {
+		return null;
+	}
+	return match;
+};
+
+const isNewerVersion = (candidate: string, dismissed: string): boolean => {
+	const candidateParts = versionNumber(candidate);
+	const dismissedParts = versionNumber(dismissed);
+
+	if (!candidateParts || !dismissedParts) {
+		return candidate !== dismissed;
+	}
+
+	const length = Math.max(candidateParts.length, dismissedParts.length);
+	for (let i = 0; i < length; i++) {
+		const a = candidateParts[i] ?? 0;
+		const b = dismissedParts[i] ?? 0;
+		if (a > b) {
+			return true;
+		}
+		if (a < b) {
+			return false;
+		}
+	}
+	return false;
+};
+
+export const isUpdateDismissed = (latestVersion: string): boolean => {
+	const dismissed = localStorage.getItem(DISMISSED_UPDATE_KEY);
+	if (!dismissed) {
+		return false;
+	}
+
+	return !isNewerVersion(latestVersion, dismissed);
+};
+
+export const dismissUpdate = (latestVersion: string): void => {
+	localStorage.setItem(DISMISSED_UPDATE_KEY, latestVersion);
+};


### PR DESCRIPTION
## What is this PR about?

Adds a "Skip this version" button to the update modal.

The skipped version is stored in localStorage, so the update banner won't show again until a newer version is released.
Also the manual "Check for updates" action is not affected. It still shows the skipped version if the user explicitly checks for updates.


## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

closes #5276

## Screenshots (if applicable)

<img width="710" height="785" alt="image" src="https://github.com/user-attachments/assets/7a4396b6-3348-4f5e-be8a-527277c6be8a" />


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a browser-local “Skip this version” preference and filters automatically discovered updates against it while leaving manual checks unaffected.

- Adds version dismissal persistence and comparison logic.
- Adds the skip action to the update dialog.
- Clears the automatic update banner after dismissal.
- Automatic polling is not restarted after dismissal, and channel-based builds cannot be distinguished by the stored value.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until automatic polling resumes after dismissal and successive canary or feature builds can be distinguished.

Dismissing one update permanently stops the current page’s polling, and channel builds reuse the same reported version string, allowing later updates to remain suppressed indefinitely.

**Files Needing Attention:** apps/dokploy/components/layouts/update-server.tsx, apps/dokploy/lib/dismissed-update.ts

<sub>Reviews (1): Last reviewed commit: ["feat: allow dismissing update notificati..."](https://github.com/dokploy/dokploy/commit/39913c287bacd2cdf2d9ab2c3bebb1083f9acb71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60951487)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Dashboard and client state](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dashboard-and-client-state.md)

<!-- /greptile_comment -->