### PR TITLE
feat(domains): let users pick the free wildcard DNS provider

### DIFF
--- a/apps/dokploy/__test__/utils/free-domain.test.ts
+++ b/apps/dokploy/__test__/utils/free-domain.test.ts
@@ -1,17 +1,28 @@
 import { generateRandomDomain } from "@dokploy/server/templates";
 import {
 	FREE_DOMAIN_PROVIDERS,
+	getFreeDomainProvider,
 	isFreeDomain,
 } from "@dokploy/server/utils/free-domain";
 import { describe, expect, it } from "vitest";
 
 describe("free domain providers", () => {
-	it("isFreeDomain matches every provider and rejects custom domains", () => {
+	it("isFreeDomain matches only at the domain boundary", () => {
 		expect(isFreeDomain("app-abc-1-2-3-4.sslip.io")).toBe(true);
 		expect(isFreeDomain("app-abc-1-2-3-4.traefik.me")).toBe(true);
+		expect(isFreeDomain("sslip.io")).toBe(true);
+		expect(isFreeDomain("*.traefik.me")).toBe(true);
 		expect(isFreeDomain("api.dokploy.com")).toBe(false);
+		expect(isFreeDomain("api.traefik.me.example.com")).toBe(false);
+		expect(isFreeDomain("nottraefik.me")).toBe(false);
 		expect(isFreeDomain(null)).toBe(false);
 		expect(isFreeDomain(undefined)).toBe(false);
+	});
+
+	it("getFreeDomainProvider returns the matching provider", () => {
+		expect(getFreeDomainProvider("app-1-2-3-4.traefik.me")).toBe("traefik.me");
+		expect(getFreeDomainProvider("app-1-2-3-4.sslip.io")).toBe("sslip.io");
+		expect(getFreeDomainProvider("api.dokploy.com")).toBeUndefined();
 	});
 
 	it("generateRandomDomain defaults to sslip.io", () => {

--- a/apps/dokploy/__test__/utils/free-domain.test.ts
+++ b/apps/dokploy/__test__/utils/free-domain.test.ts
@@ -1,0 +1,33 @@
+import { generateRandomDomain } from "@dokploy/server/templates";
+import {
+	FREE_DOMAIN_PROVIDERS,
+	isFreeDomain,
+} from "@dokploy/server/utils/free-domain";
+import { describe, expect, it } from "vitest";
+
+describe("free domain providers", () => {
+	it("isFreeDomain matches every provider and rejects custom domains", () => {
+		expect(isFreeDomain("app-abc-1-2-3-4.sslip.io")).toBe(true);
+		expect(isFreeDomain("app-abc-1-2-3-4.traefik.me")).toBe(true);
+		expect(isFreeDomain("api.dokploy.com")).toBe(false);
+		expect(isFreeDomain(null)).toBe(false);
+		expect(isFreeDomain(undefined)).toBe(false);
+	});
+
+	it("generateRandomDomain defaults to sslip.io", () => {
+		expect(
+			generateRandomDomain({ serverIp: "1.2.3.4", projectName: "app" }),
+		).toMatch(/\.sslip\.io$/);
+	});
+
+	it("generateRandomDomain honors the chosen provider", () => {
+		for (const provider of FREE_DOMAIN_PROVIDERS) {
+			const domain = generateRandomDomain({
+				serverIp: "1.2.3.4",
+				projectName: "app",
+				domainProvider: provider,
+			});
+			expect(domain.endsWith(`-1-2-3-4.${provider}`)).toBe(true);
+		}
+	});
+});

--- a/apps/dokploy/components/dashboard/application/domains/columns.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/columns.tsx
@@ -1,3 +1,4 @@
+import { isFreeDomain } from "@dokploy/server/utils/free-domain";
 import type { ColumnDef } from "@tanstack/react-table";
 import {
 	ArrowUpDown,
@@ -173,7 +174,7 @@ export const createColumns = ({
 							{domain.certificateType}
 						</Badge>
 					)}
-					{!domain.host.includes("sslip.io") && (
+					{!isFreeDomain(domain.host) && (
 						<TooltipProvider>
 							<Tooltip>
 								<TooltipTrigger asChild>
@@ -299,7 +300,7 @@ export const createColumns = ({
 
 			return (
 				<div className="flex items-center gap-2">
-					{!domain.host.includes("sslip.io") && (
+					{!isFreeDomain(domain.host) && (
 						<DnsHelperModal
 							domain={{
 								host: domain.host,

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -2,6 +2,7 @@ import {
 	DEFAULT_FREE_DOMAIN_PROVIDER,
 	FREE_DOMAIN_PROVIDERS,
 	type FreeDomainProvider,
+	getFreeDomainProvider,
 	isFreeDomain,
 } from "@dokploy/server/utils/free-domain";
 import {
@@ -267,6 +268,9 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 				domainType: data?.domainType || type,
 				middlewares: data?.middlewares || [],
 			});
+			setDomainProvider(
+				getFreeDomainProvider(data.host) ?? DEFAULT_FREE_DOMAIN_PROVIDER,
+			);
 		}
 
 		if (!domainId) {
@@ -284,6 +288,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 				domainType: type,
 				middlewares: [],
 			});
+			setDomainProvider(DEFAULT_FREE_DOMAIN_PROVIDER);
 		}
 	}, [form, data, isPending, domainId]);
 

--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -1,4 +1,10 @@
 import {
+	DEFAULT_FREE_DOMAIN_PROVIDER,
+	FREE_DOMAIN_PROVIDERS,
+	type FreeDomainProvider,
+	isFreeDomain,
+} from "@dokploy/server/utils/free-domain";
+import {
 	INVALID_HOSTNAME_MESSAGE,
 	VALID_HOSTNAME_REGEX,
 } from "@dokploy/server/utils/hostname-validation";
@@ -186,6 +192,10 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 	const { mutateAsync: generateDomain, isPending: isLoadingGenerate } =
 		api.domain.generateDomain.useMutation();
 
+	const [domainProvider, setDomainProvider] = useState<FreeDomainProvider>(
+		DEFAULT_FREE_DOMAIN_PROVIDER,
+	);
+
 	const { data: canGenerateTraefikMeDomains } =
 		api.domain.canGenerateTraefikMeDomains.useQuery(
 			{
@@ -238,7 +248,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 	const https = form.watch("https");
 	const domainType = form.watch("domainType");
 	const host = form.watch("host");
-	const isTraefikMeDomain = host?.includes("sslip.io") || false;
+	const isGeneratedFreeDomain = isFreeDomain(host);
 
 	useEffect(() => {
 		if (data) {
@@ -523,7 +533,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 									render={({ field }) => (
 										<FormItem>
 											{!canGenerateTraefikMeDomains &&
-												field.value.includes("sslip.io") && (
+												isFreeDomain(field.value) && (
 													<AlertBlock type="warning">
 														You need to set an IP address in your{" "}
 														<Link
@@ -534,14 +544,15 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 																? "Remote Servers -> Server -> Edit Server -> Update IP Address"
 																: "Web Server -> Server -> Update Server IP"}
 														</Link>{" "}
-														to make your sslip.io domain work.
+														to make your {domainProvider} domain work.
 													</AlertBlock>
 												)}
-											{isTraefikMeDomain && (
+											{isGeneratedFreeDomain && (
 												<AlertBlock type="info">
-													<strong>Note:</strong> sslip.io is a public HTTP
-													service and does not support SSL/HTTPS. HTTPS and
-													certificate options will not have any effect.
+													<strong>Note:</strong> sslip.io and traefik.me are
+													public HTTP services and do not support SSL/HTTPS.
+													HTTPS and certificate options will not have any
+													effect.
 												</AlertBlock>
 											)}
 											<FormLabel>Host</FormLabel>
@@ -549,6 +560,23 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 												<FormControl>
 													<Input placeholder="api.dokploy.com" {...field} />
 												</FormControl>
+												<Select
+													value={domainProvider}
+													onValueChange={(value) =>
+														setDomainProvider(value as FreeDomainProvider)
+													}
+												>
+													<SelectTrigger className="w-[140px] shrink-0">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{FREE_DOMAIN_PROVIDERS.map((provider) => (
+															<SelectItem key={provider} value={provider}>
+																{provider}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
 												<TooltipProvider delayDuration={0}>
 													<Tooltip>
 														<TooltipTrigger asChild>
@@ -560,6 +588,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 																	generateDomain({
 																		appName: application?.appName || "",
 																		serverId: application?.serverId || "",
+																		domainProvider,
 																	})
 																		.then((domain) => {
 																			field.onChange(domain);
@@ -577,7 +606,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 															sideOffset={5}
 															className="max-w-40"
 														>
-															<p>Generate sslip.io domain</p>
+															<p>Generate {domainProvider} domain</p>
 														</TooltipContent>
 													</Tooltip>
 												</TooltipProvider>

--- a/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/show-domains.tsx
@@ -1,3 +1,4 @@
+import { isFreeDomain } from "@dokploy/server/utils/free-domain";
 import {
 	type ColumnFiltersState,
 	flexRender,
@@ -460,7 +461,7 @@ export const ShowDomains = ({ id, type }: Props) => {
 														</Badge>
 													)}
 													<div className="flex gap-2 flex-wrap">
-														{!item.host.includes("sslip.io") && (
+														{!isFreeDomain(item.host) && (
 															<DnsHelperModal
 																domain={{
 																	host: item.host,

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -7,7 +7,7 @@ import {
 	findEnvironmentById,
 	findPreviewDeploymentsByApplicationId,
 	findProjectById,
-	generateTraefikMeDomain,
+	generateFreeDomain,
 	getAccessibleServerIds,
 	getApplicationStats,
 	getContainerLogs,
@@ -196,7 +196,7 @@ export const applicationRouter = createTRPCRouter({
 				applicationStatus: "idle",
 			});
 
-			const host = await generateTraefikMeDomain(
+			const host = await generateFreeDomain(
 				newApplication.appName,
 				ctx.user.ownerId,
 				input.serverId,

--- a/apps/dokploy/server/api/routers/domain.ts
+++ b/apps/dokploy/server/api/routers/domain.ts
@@ -1,12 +1,13 @@
 import {
 	createDomain,
+	FREE_DOMAIN_PROVIDERS,
 	findApplicationById,
 	findDomainById,
 	findDomainsByApplicationId,
 	findDomainsByComposeId,
 	findPreviewDeploymentById,
 	findServerById,
-	generateTraefikMeDomain,
+	generateFreeDomain,
 	getServerIpCandidates,
 	getWebServerSettings,
 	manageDomain,
@@ -82,12 +83,19 @@ export const domainRouter = createTRPCRouter({
 			return await findDomainsByComposeId(input.composeId);
 		}),
 	generateDomain: withPermission("domain", "create")
-		.input(z.object({ appName: z.string(), serverId: z.string().optional() }))
+		.input(
+			z.object({
+				appName: z.string(),
+				serverId: z.string().optional(),
+				domainProvider: z.enum(FREE_DOMAIN_PROVIDERS).optional(),
+			}),
+		)
 		.mutation(async ({ input, ctx }) => {
-			return generateTraefikMeDomain(
+			return generateFreeDomain(
 				input.appName,
 				ctx.user.ownerId,
 				input.serverId,
+				input.domainProvider,
 			);
 		}),
 	canGenerateTraefikMeDomains: withPermission("domain", "read")

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -110,6 +110,7 @@ export * from "./utils/docker/types";
 export * from "./utils/docker/utils";
 export * from "./utils/filesystem/directory";
 export * from "./utils/filesystem/ssh";
+export * from "./utils/free-domain";
 export * from "./utils/git-branch-validation";
 export * from "./utils/gpu-setup";
 export * from "./utils/hostname-validation";

--- a/packages/server/src/services/domain.ts
+++ b/packages/server/src/services/domain.ts
@@ -5,6 +5,7 @@ import { promisify } from "node:util";
 import { db } from "@dokploy/server/db";
 import { getWebServerSettings } from "@dokploy/server/services/web-server-settings";
 import { generateRandomDomain } from "@dokploy/server/templates";
+import type { FreeDomainProvider } from "@dokploy/server/utils/free-domain";
 import { execAsyncRemote } from "@dokploy/server/utils/process/execAsync";
 import { manageDomain } from "@dokploy/server/utils/traefik/domain";
 import { getPublicIpWithFallback } from "@dokploy/server/wss/utils";
@@ -47,16 +48,18 @@ export const createDomain = async (input: z.infer<typeof apiCreateDomain>) => {
 	return result;
 };
 
-export const generateTraefikMeDomain = async (
+export const generateFreeDomain = async (
 	appName: string,
 	_userId: string,
 	serverId?: string,
+	domainProvider?: FreeDomainProvider,
 ) => {
 	if (serverId) {
 		const server = await findServerById(serverId);
 		return generateRandomDomain({
 			serverIp: server.ipAddress,
 			projectName: appName,
+			domainProvider,
 		});
 	}
 
@@ -64,12 +67,14 @@ export const generateTraefikMeDomain = async (
 		return generateRandomDomain({
 			serverIp: "",
 			projectName: appName,
+			domainProvider,
 		});
 	}
 	const settings = await getWebServerSettings();
 	return generateRandomDomain({
 		serverIp: settings?.serverIp || "",
 		projectName: appName,
+		domainProvider,
 	});
 };
 

--- a/packages/server/src/services/preview-deployment.ts
+++ b/packages/server/src/services/preview-deployment.ts
@@ -11,6 +11,7 @@ import type { z } from "zod";
 import { generatePassword } from "../templates";
 import { removeService } from "../utils/docker/utils";
 import { removeDirectoryCode } from "../utils/filesystem/directory";
+import { isFreeDomain } from "../utils/free-domain";
 import { authGithub } from "../utils/providers/github";
 import { removeTraefikConfig } from "../utils/traefik/application";
 import { manageDomain } from "../utils/traefik/domain";
@@ -248,7 +249,7 @@ const generateWildcardDomain = async (
 		throw new Error('The base domain must start with "*."');
 	}
 	const hash = `${appName}`;
-	if (baseDomain.includes("sslip.io")) {
+	if (isFreeDomain(baseDomain)) {
 		let ip = "";
 
 		if (process.env.NODE_ENV === "development") {

--- a/packages/server/src/templates/index.ts
+++ b/packages/server/src/templates/index.ts
@@ -3,12 +3,17 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Domain } from "@dokploy/server/services/domain";
+import {
+	DEFAULT_FREE_DOMAIN_PROVIDER,
+	type FreeDomainProvider,
+} from "@dokploy/server/utils/free-domain";
 import { TRPCError } from "@trpc/server";
 import { fetchTemplateFiles } from "./github";
 
 export interface Schema {
 	serverIp: string;
 	projectName: string;
+	domainProvider?: FreeDomainProvider;
 }
 
 export type DomainSchema = Pick<Domain, "host" | "port" | "serviceName"> & {
@@ -33,21 +38,21 @@ export interface GenerateJWTOptions {
 export const generateRandomDomain = ({
 	serverIp,
 	projectName,
+	domainProvider = DEFAULT_FREE_DOMAIN_PROVIDER,
 }: Schema): string => {
 	const hash = randomBytes(3).toString("hex");
 	const effectiveIp = serverIp || "127.0.0.1";
 	const slugIp = effectiveIp.replaceAll(".", "-").replaceAll(":", "-");
 
 	// Domain labels have a max length of 63 characters
-	// Reserve space for: hash (6) + separators (1-2) + ip section + dot + sslip.io (8)
-	// Approx: 6 + 2 + (variable ip length) + 9 = ~19-30 chars for other parts
+	// Reserve space for: hash (6) + separators (1-2) + ip section + dot + provider (~10)
 	const maxProjectNameLength = 40;
 	const truncatedProjectName =
 		projectName.length > maxProjectNameLength
 			? projectName.substring(0, maxProjectNameLength)
 			: projectName;
 
-	return `${truncatedProjectName}-${hash}-${slugIp}.sslip.io`;
+	return `${truncatedProjectName}-${hash}-${slugIp}.${domainProvider}`;
 };
 
 export const generateHash = (length = 8): string => {

--- a/packages/server/src/utils/free-domain.ts
+++ b/packages/server/src/utils/free-domain.ts
@@ -1,0 +1,8 @@
+export const FREE_DOMAIN_PROVIDERS = ["sslip.io", "traefik.me"] as const;
+
+export type FreeDomainProvider = (typeof FREE_DOMAIN_PROVIDERS)[number];
+
+export const DEFAULT_FREE_DOMAIN_PROVIDER: FreeDomainProvider = "sslip.io";
+
+export const isFreeDomain = (host?: string | null): boolean =>
+	!!host && FREE_DOMAIN_PROVIDERS.some((provider) => host.includes(provider));

--- a/packages/server/src/utils/free-domain.ts
+++ b/packages/server/src/utils/free-domain.ts
@@ -4,5 +4,14 @@ export type FreeDomainProvider = (typeof FREE_DOMAIN_PROVIDERS)[number];
 
 export const DEFAULT_FREE_DOMAIN_PROVIDER: FreeDomainProvider = "sslip.io";
 
+export const getFreeDomainProvider = (
+	host?: string | null,
+): FreeDomainProvider | undefined =>
+	host == null
+		? undefined
+		: FREE_DOMAIN_PROVIDERS.find(
+				(provider) => host === provider || host.endsWith(`.${provider}`),
+			);
+
 export const isFreeDomain = (host?: string | null): boolean =>
-	!!host && FREE_DOMAIN_PROVIDERS.some((provider) => host.includes(provider));
+	getFreeDomainProvider(host) !== undefined;


### PR DESCRIPTION
Auto-generated domains have been hardcoded to `sslip.io` since #4368, when `traefik.me` went through a global DNS outage (#4373). It's stable again and some users prefer it — so make it a choice instead of a hardcoded string.

Add Domain modal now has a provider dropdown (`sslip.io` / `traefik.me`) next to the generate button. Default stays `sslip.io`; nothing changes for anyone who doesn't touch it.

- new `free-domain.ts`: `FREE_DOMAIN_PROVIDERS` + `isFreeDomain()` helper
- `generateRandomDomain` / `domain.generateDomain` take an optional `domainProvider`
- scattered `host.includes("sslip.io")` checks replaced with `isFreeDomain()`, so a generated `traefik.me` domain behaves identically (DNS helper hidden, preview wildcard IP substitution, HTTP-only notice)
- renamed `generateTraefikMeDomain` → `generateFreeDomain`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a selectable `sslip.io` or `traefik.me` provider to generated domains, passes that selection through the domain API and server generation services, and centralizes recognition of free-provider domains.

- Keeps `sslip.io` as the default provider.
- Extends preview wildcard handling and domain-management UI behavior to recognize `traefik.me`.
- Adds unit coverage for provider recognition and generated-domain suffixes.
- The provider classifier and modal provider-state lifecycle need hardening to avoid misclassifying custom hosts and displaying stale provider information.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after considering two non-blocking correctness improvements around custom-host classification and modal provider-state synchronization.

Core provider generation and API validation are internally consistent, but substring classification produces incorrect behavior for custom hostnames containing provider text, and the persistent selector state can show or use the wrong provider during edit and reopen flows.

**Files Needing Attention:** packages/server/src/utils/free-domain.ts, apps/dokploy/components/dashboard/application/domains/handle-domain.tsx

<sub>Reviews (1): Last reviewed commit: ["feat(domains): let users pick the free w..."](https://github.com/dokploy/dokploy/commit/0939560fdc0e9f7e00324281d1f1d4556d27b11a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61233748)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->