### PR TITLE
fix(ui): align close button in web server update modal

### DIFF
--- a/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server.tsx
@@ -7,6 +7,7 @@ import {
 	Server,
 	Sparkles,
 	Stars,
+	X,
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
@@ -14,6 +15,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogTitle,
 	DialogTrigger,
@@ -126,13 +128,13 @@ export const UpdateServer = ({
 					</TooltipProvider>
 				)}
 			</DialogTrigger>
-			<DialogContent className="max-w-lg">
-				<div className="flex items-center justify-between mb-8">
-					<DialogTitle className="text-2xl font-semibold">
+			<DialogContent className="max-w-lg" showCloseButton={false}>
+				<div className="flex items-center gap-2 mb-8">
+					<DialogTitle className="text-2xl font-semibold mr-auto">
 						Web Server Update
 					</DialogTitle>
 					{dokployVersion && (
-						<div className="flex items-center gap-1.5 rounded-full px-3 py-1 mr-2 bg-muted">
+						<div className="flex items-center gap-1.5 rounded-full px-3 py-1 bg-muted">
 							<Server className="h-4 w-4 text-muted-foreground" />
 							<span className="text-sm text-muted-foreground">
 								{dokployVersion}{" "}
@@ -141,6 +143,12 @@ export const UpdateServer = ({
 							</span>
 						</div>
 					)}
+					<DialogClose asChild>
+						<Button variant="ghost" size="icon-sm" className="shrink-0">
+							<X />
+							<span className="sr-only">Close</span>
+						</Button>
+					</DialogClose>
 				</div>
 
 				{/* Initial state */}


### PR DESCRIPTION
## What is this PR about?

The close button on the Web Server Update modal was absolutely positioned in the corner, so it sat above the title/version badge and overlapped the badge. This keeps the close button in the header row so it is vertically aligned with the title and badge, with a small gap and no overlap.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Issues related (if applicable)

N/A - small UI alignment fix.

## Screenshots (if applicable)

### Before

The close button sat in the top-right corner and overlapped the version badge.

<img width="720" alt="Before: close button overlapping the version badge" src="https://raw.githubusercontent.com/kcybe/dokploy/pr-5373-screenshots/pr-screenshots/before-full.png" />

<img width="420" alt="Before close-up: close button overlapping v0.30.2" src="https://raw.githubusercontent.com/kcybe/dokploy/pr-5373-screenshots/pr-screenshots/before-closeup.png" />

### After

The close button sits in the header row, vertically centered with the title and version badge, with no overlap.

<img width="720" alt="After: close button aligned with title and version badge" src="https://raw.githubusercontent.com/kcybe/dokploy/pr-5373-screenshots/pr-screenshots/after-dialog.png" />

<img width="900" alt="After: update modal on the Web Server settings page" src="https://raw.githubusercontent.com/kcybe/dokploy/pr-5373-screenshots/pr-screenshots/after-full.png" />

I verified this locally on the Web Server settings page: opened the modal, confirmed title/badge/close share the same vertical center with a gap between the badge and close button, and confirmed the close button dismisses the modal.