### PR TITLE
fix(vault): expand Infisical secret references when listing secrets

### DIFF
--- a/apps/dokploy/__test__/env/vault.test.ts
+++ b/apps/dokploy/__test__/env/vault.test.ts
@@ -20,6 +20,7 @@ import {
 import { azureClient } from "@dokploy/server/utils/vault/azure";
 import { dopplerClient } from "@dokploy/server/utils/vault/doppler";
 import { hashicorpClient } from "@dokploy/server/utils/vault/hashicorp";
+import { infisicalClient } from "@dokploy/server/utils/vault/infisical";
 import { phaseClient } from "@dokploy/server/utils/vault/phase";
 import { scalewayClient } from "@dokploy/server/utils/vault/scaleway";
 
@@ -428,6 +429,58 @@ describe("azure client", () => {
 		const names = await azureClient.listSecretNames?.(config);
 
 		expect(names).toEqual(["first", "second"]);
+	});
+});
+
+describe("infisical client", () => {
+	const config = {
+		providerType: "infisical" as const,
+		siteUrl: "https://app.infisical.com",
+		clientId: "client-1",
+		clientSecret: "client-secret",
+		projectId: "workspace-1",
+		environmentSlug: "prod",
+		secretPath: "/frontend",
+	};
+
+	const loginResponse = () => jsonResponse({ accessToken: "token-1" });
+
+	it("asks the list endpoint to expand secret references", async () => {
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(
+				jsonResponse({
+					secrets: [{ secretKey: "DB_URL", secretValue: "postgres://real" }],
+				}),
+			);
+
+		const result = await infisicalClient.getSecrets(config, ["DB_URL"]);
+
+		expect(result).toEqual({ DB_URL: "postgres://real" });
+		const [listUrl] = mockFetch.mock.calls[1] as [string];
+		const params = new URL(listUrl).searchParams;
+		expect(params.get("expandSecretReferences")).toBe("true");
+		expect(params.get("workspaceId")).toBe("workspace-1");
+		expect(params.get("environment")).toBe("prod");
+		expect(params.get("secretPath")).toBe("/frontend");
+	});
+
+	it("throws a clear error for a missing secret", async () => {
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(jsonResponse({ secrets: [] }));
+
+		await expect(
+			infisicalClient.getSecrets(config, ["ABSENT"]),
+		).rejects.toThrow('secret "ABSENT" not found in environment "prod"');
+	});
+
+	it("propagates authentication failures with the status code", async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, false, 401));
+
+		await expect(infisicalClient.getSecrets(config, ["DB_URL"])).rejects.toThrow(
+			"authentication failed (status 401)",
+		);
 	});
 });
 

--- a/apps/dokploy/__test__/env/vault.test.ts
+++ b/apps/dokploy/__test__/env/vault.test.ts
@@ -446,13 +446,11 @@ describe("infisical client", () => {
 	const loginResponse = () => jsonResponse({ accessToken: "token-1" });
 
 	it("asks the list endpoint to expand secret references", async () => {
-		mockFetch
-			.mockResolvedValueOnce(loginResponse())
-			.mockResolvedValueOnce(
-				jsonResponse({
-					secrets: [{ secretKey: "DB_URL", secretValue: "postgres://real" }],
-				}),
-			);
+		mockFetch.mockResolvedValueOnce(loginResponse()).mockResolvedValueOnce(
+			jsonResponse({
+				secrets: [{ secretKey: "DB_URL", secretValue: "postgres://real" }],
+			}),
+		);
 
 		const result = await infisicalClient.getSecrets(config, ["DB_URL"]);
 
@@ -478,9 +476,9 @@ describe("infisical client", () => {
 	it("propagates authentication failures with the status code", async () => {
 		mockFetch.mockResolvedValueOnce(jsonResponse({}, false, 401));
 
-		await expect(infisicalClient.getSecrets(config, ["DB_URL"])).rejects.toThrow(
-			"authentication failed (status 401)",
-		);
+		await expect(
+			infisicalClient.getSecrets(config, ["DB_URL"]),
+		).rejects.toThrow("authentication failed (status 401)");
 	});
 });
 

--- a/packages/server/src/utils/vault/infisical.ts
+++ b/packages/server/src/utils/vault/infisical.ts
@@ -38,6 +38,12 @@ const fetchSecrets = async (config: InfisicalConfig) => {
 		workspaceId: config.projectId,
 		environment: config.environmentSlug,
 		secretPath: config.secretPath,
+		// Infisical's list endpoint leaves secret references (`${env.folder.KEY}`)
+		// unexpanded unless asked, so without this a referencing secret arrives as
+		// the literal `${...}` string, lands in the generated .env and the deploy
+		// still reports success. Single secrets read via /raw/{name} expand by
+		// default, which makes the difference easy to miss in the UI.
+		expandSecretReferences: "true",
 	});
 	const response = await vaultFetch(
 		`${baseUrl(config)}/api/v3/secrets/raw?${params.toString()}`,


### PR DESCRIPTION
## Problem

Infisical secrets can reference each other — `${env.folder.KEY}` — which is the only way to keep a value in one place and consume it from several folders. A Dokploy provider is pinned to a single, non-recursive `secretPath`, so references are exactly how you avoid creating one provider (and one machine identity) per folder.

`infisicalClient` fetches the list endpoint without `expandSecretReferences`, and that endpoint leaves references untouched by default. The referencing secret arrives as the literal `${...}` string, gets written into the generated `.env`, and **the deployment still succeeds** — the service just receives a placeholder where its value should be.

What makes this hard to spot: the single-secret endpoint (`/api/v3/secrets/raw/{name}`) *does* expand by default. So the Infisical UI, the API and the MCP server all show the resolved value, and only Dokploy sees the literal.

Measured against `app.infisical.com` with the same machine identity, same project, same path:

| Request | `REF_PROBE` |
|---|---|
| `raw?workspaceId=…&environment=dev&secretPath=/frontend` (what Dokploy sends) | `${dev.infrastructure.redis.KEY}` |
| same + `expandSecretReferences=false` | `${dev.infrastructure.redis.KEY}` |
| same + `expandSecretReferences=true` | the real value |

Permissions are not involved — the same credentials resolve the reference through `/raw/{name}` and fail to through the list call.

## Fix

One parameter on the list request. Reference resolution is server-side in Infisical and requires the caller to have read access to the referenced secrets, which is unchanged behaviour for anyone not using references.

## Tests

`infisicalClient` had no test coverage at all, so this adds an `infisical client` block:

- the list request carries `expandSecretReferences=true` (plus the existing query fields)
- a missing secret raises the documented error
- an auth failure propagates the status code

`vault.test.ts`: **49 passed**. Reverting only the source change makes the new test fail with `expected null to be 'true'`.

## Note on a related gap (not addressed here)

Folder **imports** don't reach Dokploy either: the client reads only `body.secrets` and ignores `body.imports`, so a folder imported into the provider's path contributes nothing. Happy to open a separate PR if that's wanted — kept out of this one to keep the fix reviewable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables server-side expansion of Infisical secret references when listing secrets.
- Adds `expandSecretReferences=true` to the Infisical list request.
- Adds coverage for request parameters, missing secrets, and authentication failures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule violations identified.

The new option is applied to the intended authenticated list request, existing filtering behavior is unchanged, and the added tests accurately exercise the modified request path.

<sub>Reviews (1): Last reviewed commit: ["fix(vault): expand Infisical secret refe..."](https://github.com/dokploy/dokploy/commit/6e760da93bb47a427d2c284e907473fa52860d58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61343449)</sub>

<!-- /greptile_comment -->