### PR TITLE
feat(vault): address an Infisical folder from the reference

### DIFF
--- a/apps/dokploy/__test__/env/vault.test.ts
+++ b/apps/dokploy/__test__/env/vault.test.ts
@@ -444,13 +444,22 @@ describe("infisical client", () => {
 	};
 
 	const loginResponse = () => jsonResponse({ accessToken: "token-1" });
+	const list = (secrets: Record<string, string>) =>
+		jsonResponse({
+			secrets: Object.entries(secrets).map(([secretKey, secretValue]) => ({
+				secretKey,
+				secretValue,
+			})),
+		});
+	const listPathOf = (callIndex: number) => {
+		const [url] = mockFetch.mock.calls[callIndex] as [string];
+		return new URL(url).searchParams.get("secretPath");
+	};
 
 	it("asks the list endpoint to expand secret references", async () => {
-		mockFetch.mockResolvedValueOnce(loginResponse()).mockResolvedValueOnce(
-			jsonResponse({
-				secrets: [{ secretKey: "DB_URL", secretValue: "postgres://real" }],
-			}),
-		);
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(list({ DB_URL: "postgres://real" }));
 
 		const result = await infisicalClient.getSecrets(config, ["DB_URL"]);
 
@@ -479,6 +488,93 @@ describe("infisical client", () => {
 		await expect(
 			infisicalClient.getSecrets(config, ["DB_URL"]),
 		).rejects.toThrow("authentication failed (status 401)");
+	});
+
+	it("resolves a relative <path>:<KEY> ref against the provider path", async () => {
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(list({ SENTRY_DSN: "https://key@sentry.io/1" }));
+
+		const result = await infisicalClient.getSecrets(config, [
+			"shared/sentry:SENTRY_DSN",
+		]);
+
+		expect(result).toEqual({
+			"shared/sentry:SENTRY_DSN": "https://key@sentry.io/1",
+		});
+		expect(listPathOf(1)).toBe("/frontend/shared/sentry");
+	});
+
+	it("treats a leading slash as an absolute path", async () => {
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(list({ SENTRY_DSN: "https://key@sentry.io/1" }));
+
+		await infisicalClient.getSecrets(config, ["/external/sentry:SENTRY_DSN"]);
+
+		expect(listPathOf(1)).toBe("/external/sentry");
+	});
+
+	it("keeps the root path clean when the provider sits at /", async () => {
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(list({ KEY: "value" }));
+
+		await infisicalClient.getSecrets({ ...config, secretPath: "/" }, [
+			"external/sentry:KEY",
+		]);
+
+		expect(listPathOf(1)).toBe("/external/sentry");
+	});
+
+	it("logs in once and fetches each path once", async () => {
+		const byPath: Record<string, Record<string, string>> = {
+			"/frontend": { A: "a", B: "b" },
+			"/frontend/other": { C: "c" },
+		};
+		mockFetch.mockImplementation(async (url: string) => {
+			if (url.includes("/auth/universal-auth/login")) return loginResponse();
+			const path = new URL(url).searchParams.get("secretPath") as string;
+			return list(byPath[path] ?? {});
+		});
+
+		const result = await infisicalClient.getSecrets(config, [
+			"A",
+			"B",
+			"other:C",
+		]);
+
+		expect(result).toEqual({ A: "a", B: "b", "other:C": "c" });
+
+		const urls = mockFetch.mock.calls.map(([url]) => url as string);
+		expect(urls.filter((u) => u.includes("/login"))).toHaveLength(1);
+		expect(
+			urls
+				.filter((u) => u.includes("/secrets/raw?"))
+				.map((u) => new URL(u).searchParams.get("secretPath"))
+				.sort(),
+		).toEqual(["/frontend", "/frontend/other"]);
+	});
+
+	it("names the path when a secret is missing from an explicit one", async () => {
+		mockFetch
+			.mockResolvedValueOnce(loginResponse())
+			.mockResolvedValueOnce(list({}));
+
+		await expect(
+			infisicalClient.getSecrets(config, ["external/sentry:ABSENT"]),
+		).rejects.toThrow(
+			'secret "ABSENT" not found at "/frontend/external/sentry"',
+		);
+	});
+
+	it("rejects a ref with an empty path or key", async () => {
+		await expect(infisicalClient.getSecrets(config, [":KEY"])).rejects.toThrow(
+			"expected format <path>:<KEY>",
+		);
+		await expect(
+			infisicalClient.getSecrets(config, ["external/sentry:"]),
+		).rejects.toThrow("expected format <path>:<KEY>");
 	});
 });
 

--- a/packages/server/src/utils/vault/infisical.ts
+++ b/packages/server/src/utils/vault/infisical.ts
@@ -32,12 +32,47 @@ const login = async (config: InfisicalConfig) => {
 	return body.accessToken;
 };
 
-const fetchSecrets = async (config: InfisicalConfig) => {
-	const accessToken = await login(config);
+// A reference may address a folder: `<path>:<KEY>`, mirroring the HashiCorp
+// client in this directory. Without a colon the whole ref is the secret name
+// and the provider's own `secretPath` is used, which is the previous
+// behaviour. Dots cannot serve as the separator here because Infisical allows
+// them inside secret names, so `a.b.C` is genuinely ambiguous.
+const parseRef = (ref: string) => {
+	const separatorIndex = ref.lastIndexOf(":");
+	if (separatorIndex === -1) {
+		return { path: null, key: ref };
+	}
+	const path = ref.slice(0, separatorIndex);
+	const key = ref.slice(separatorIndex + 1);
+	if (!path || !key) {
+		throw new Error(
+			`Invalid Infisical reference "${ref}": expected format <path>:<KEY> (e.g. external/sentry:SENTRY_DSN)`,
+		);
+	}
+	return { path, key };
+};
+
+const resolveSecretPath = (config: InfisicalConfig, refPath: string | null) => {
+	if (!refPath) {
+		return config.secretPath;
+	}
+	if (refPath.startsWith("/")) {
+		return refPath;
+	}
+	const base = config.secretPath.replace(/\/+$/, "");
+	return `${base}/${refPath}`;
+};
+
+// One login serves every path a batch of refs touches.
+const readPath = async (
+	config: InfisicalConfig,
+	accessToken: string,
+	secretPath: string,
+) => {
 	const params = new URLSearchParams({
 		workspaceId: config.projectId,
 		environment: config.environmentSlug,
-		secretPath: config.secretPath,
+		secretPath,
 		// Infisical's list endpoint leaves secret references (`${env.folder.KEY}`)
 		// unexpanded unless asked, so without this a referencing secret arrives as
 		// the literal `${...}` string, lands in the generated .env and the deploy
@@ -52,7 +87,7 @@ const fetchSecrets = async (config: InfisicalConfig) => {
 
 	if (!response.ok) {
 		throw new Error(
-			`Infisical: failed to fetch secrets (status ${response.status})`,
+			`Infisical: failed to fetch secrets at "${secretPath}" (status ${response.status})`,
 		);
 	}
 
@@ -67,18 +102,41 @@ const fetchSecrets = async (config: InfisicalConfig) => {
 	return secrets;
 };
 
+const fetchSecrets = async (
+	config: InfisicalConfig,
+	secretPath = config.secretPath,
+) => readPath(config, await login(config), secretPath);
+
 export const infisicalClient: VaultClient<InfisicalConfig> = {
 	async getSecrets(config, refs) {
-		const secrets = await fetchSecrets(config);
-		const result: Record<string, string> = {};
+		const byPath = new Map<string, string[]>();
 		for (const ref of refs) {
-			if (secrets[ref] === undefined) {
-				throw new Error(
-					`Infisical: secret "${ref}" not found in environment "${config.environmentSlug}"`,
-				);
-			}
-			result[ref] = secrets[ref];
+			const { path } = parseRef(ref);
+			const secretPath = resolveSecretPath(config, path);
+			byPath.set(secretPath, [...(byPath.get(secretPath) ?? []), ref]);
 		}
+
+		const accessToken = await login(config);
+		const result: Record<string, string> = {};
+		await Promise.all(
+			[...byPath.entries()].map(async ([secretPath, pathRefs]) => {
+				const secrets = await readPath(config, accessToken, secretPath);
+				for (const ref of pathRefs) {
+					const { path, key } = parseRef(ref);
+					if (secrets[key] === undefined) {
+						// The path is only worth naming when the ref asked for one;
+						// for a bare ref the wording stays as it was, so existing
+						// error messages don't change for anyone.
+						throw new Error(
+							path
+								? `Infisical: secret "${key}" not found at "${secretPath}" in environment "${config.environmentSlug}"`
+								: `Infisical: secret "${key}" not found in environment "${config.environmentSlug}"`,
+						);
+					}
+					result[ref] = secrets[key];
+				}
+			}),
+		);
 		return result;
 	},
 


### PR DESCRIPTION
## Why

An Infisical provider is pinned to a single `secretPath`, and the list request is not recursive. So a project that organises secrets into folders — `/external/sentry`, `/infrastructure/database`, one per service — needs **one provider per folder per environment**, each with its own machine identity and its own credential to rotate. Seven folders across two environments is fourteen providers for what is conceptually one vault.

This lets the reference name the folder instead:

```
${{vault.my-provider.external/sentry:SENTRY_DSN}}
```

## Syntax

`<path>:<KEY>` — the same format the HashiCorp client in this directory already uses and documents (`myapp/prod:DB_PASSWORD`), so it is not a new convention for users to learn.

- relative path resolves against the provider's `secretPath`
- leading slash is absolute (`/external/sentry:KEY`)
- **no colon keeps today's meaning exactly**: the whole ref is the secret name at the provider's own path

### Why not a dot

A dotted form (`provider.external.sentry.KEY`) reads nicely but cannot be parsed: Infisical accepts dots inside secret names, so `A.B.C` is a legitimate key and `provider.a.b.C` is genuinely ambiguous between "key `a.b.C`" and "path `a/b`, key `C`". Choosing dots would silently break anyone who has one, with the value arriving as a "not found" error or, worse, from the wrong path. Verified against `app.infisical.com` — creating a secret named `DOT.IN.KEY.PROBE` succeeds.

## Implementation notes

- refs are grouped by resolved path, so each distinct path is listed once regardless of how many refs point into it
- the login moved out of the per-path fetch: one token now serves the whole batch instead of one login per path (the first draft of this patch authenticated per path; a test on grouping caught it)
- the fetch error now names the path it failed on, which matters once a single provider can read several

## Tests

`vault.test.ts`: **53 passed**. The new `infisical client` block covers a bare ref, a relative path, an absolute path, a provider sitting at `/`, grouping with exactly one login, the missing-secret error naming the path, and a malformed ref (`:KEY`, `path:`).

## Relation to #5374

#5374 fixes a bug in the same function — the list request omits `expandSecretReferences`, so Infisical's own `${env.folder.KEY}` references arrive as literal strings. The two are independent and either can merge first; whichever goes second needs a two-line rebase in `fetchSecrets`.

They also overlap in purpose: with #5374, cross-folder access is possible through Infisical's references. This PR is still worth having because a reference must name the environment slug (`${dev.external.sentry.KEY}` resolves, `${external.sentry.KEY}` does not), so the same logical value needs a different string in every environment. A `path:KEY` ref is environment-agnostic, because the provider already carries the environment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Infisical vault client so references can select relative or absolute folders using `<path>:<KEY>`.
- Groups references by resolved folder and fetches each folder once.
- Reuses one Infisical authentication token across the batch.
- Adds the requested folder to fetch and missing-secret errors.
- Adds tests for legacy references, path resolution, grouping, authentication reuse, missing secrets, and malformed references.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete behavioral, security, or repository-rule violations were identified.

The folder-resolution semantics match the documented feature, preserve bare-reference behavior, and are covered across the important path and batching cases.

<sub>Reviews (1): Last reviewed commit: ["feat(vault): address an Infisical folder..."](https://github.com/dokploy/dokploy/commit/7128a2709d5f0c7f262a8ef27c2a8e1215d8eaaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61344780)</sub>

<!-- /greptile_comment -->