### PR TITLE
Reduce trial duration from 14 to 7 days

### DIFF
--- a/apps/dokploy/components/dashboard/onboarding/steps/plan-step.tsx
+++ b/apps/dokploy/components/dashboard/onboarding/steps/plan-step.tsx
@@ -56,7 +56,7 @@ export const PlanStep = ({ onNext }: Props) => {
 		try {
 			await startFreeTrial();
 			await utils.project.onboardingStatus.invalidate();
-			toast.success("Your 14-day trial has started");
+			toast.success("Your 7-day trial has started");
 			onNext();
 		} catch (error) {
 			toast.error(
@@ -90,7 +90,7 @@ export const PlanStep = ({ onNext }: Props) => {
 							Recommended
 						</span>
 						<p className={`${displayFont.className} text-2xl mt-3`}>
-							14-day free trial
+							7-day free trial
 						</p>
 						<p className="text-sm text-zinc-400 dark:text-zinc-600 mt-1 max-w-xs">
 							No card required — cancel anytime.

--- a/apps/dokploy/components/dashboard/settings/billing/show-billing.tsx
+++ b/apps/dokploy/components/dashboard/settings/billing/show-billing.tsx
@@ -117,7 +117,7 @@ export const ShowBilling = () => {
 				utils.stripe.getProducts.invalidate(),
 				utils.user.get.invalidate(),
 			]);
-			toast.success("Your 14-day trial has started");
+			toast.success("Your 7-day trial has started");
 		} catch (error) {
 			toast.error(
 				error instanceof Error ? error.message : "Error starting trial",
@@ -326,7 +326,7 @@ export const ShowBilling = () => {
 											<Clock className="h-5 w-5 text-primary shrink-0" />
 											<div className="flex flex-col gap-1.5">
 												<span className="text-sm font-medium">
-													14-day free trial
+													7-day free trial
 												</span>
 												<span className="text-sm text-muted-foreground">
 													No credit card required — cancel anytime.

--- a/apps/dokploy/server/utils/billing.ts
+++ b/apps/dokploy/server/utils/billing.ts
@@ -77,7 +77,7 @@ export const getCurrentPlan = async (
 	return getCurrentPlanForUser(ownerId);
 };
 
-export const TRIAL_DURATION_DAYS = 14;
+export const TRIAL_DURATION_DAYS = 7;
 export const TRIAL_SERVER_LIMIT = 1;
 
 export interface BillingStatus {


### PR DESCRIPTION
Lowers the free trial period from 14 to 7 days.

- `TRIAL_DURATION_DAYS` constant (used for Stripe's `trial_period_days`)
- Onboarding plan step copy/toast
- Billing settings page copy/toast

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consistently reduces the free trial from 14 days to 7 days.
- Updates the backend duration passed to Stripe when creating trial subscriptions.
- Updates onboarding and billing offer labels and success notifications.
- Preserves existing trials by deriving their status and remaining time from Stripe’s stored trial end date.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the backend trial duration and all changed user-facing copy are consistent.

New trials use the updated seven-day constant, while existing trial status and expiration remain based on Stripe’s stored timestamps; no actionable failure remains.

<sub>Reviews (1): Last reviewed commit: ["Reduce trial duration from 14 to 7 days"](https://github.com/dokploy/dokploy/commit/91eaab6a43f0ece4f4ccc10c70063476f5f6c396) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61480822)</sub>

<!-- /greptile_comment -->