### PR TITLE
fix(domains): stop AddDomain queries flooding the API in table view

### DIFF
--- a/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
+++ b/apps/dokploy/components/dashboard/application/domains/handle-domain.tsx
@@ -156,7 +156,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 			domainId,
 		},
 		{
-			enabled: !!domainId,
+			enabled: isOpen && !!domainId,
 		},
 	);
 
@@ -167,7 +167,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 						applicationId: id,
 					},
 					{
-						enabled: !!id,
+						enabled: isOpen && !!id,
 					},
 				)
 			: api.compose.one.useQuery(
@@ -175,7 +175,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 						composeId: id,
 					},
 					{
-						enabled: !!id,
+						enabled: isOpen && !!id,
 					},
 				);
 
@@ -187,9 +187,14 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 		api.domain.generateDomain.useMutation();
 
 	const { data: canGenerateTraefikMeDomains } =
-		api.domain.canGenerateTraefikMeDomains.useQuery({
-			serverId: application?.serverId || "",
-		});
+		api.domain.canGenerateTraefikMeDomains.useQuery(
+			{
+				serverId: application?.serverId || "",
+			},
+			{
+				enabled: isOpen,
+			},
+		);
 
 	const {
 		data: services,
@@ -204,7 +209,7 @@ export const AddDomain = ({ id, type, domainId = "", children }: Props) => {
 		{
 			retry: false,
 			refetchOnWindowFocus: false,
-			enabled: type === "compose" && !!id,
+			enabled: isOpen && type === "compose" && !!id,
 		},
 	);
 


### PR DESCRIPTION
Fixes #5279

The Domains table (and grid) view mounts one `AddDomain` instance per row for the edit action. Its 4 queries (`domain.one`, `application.one`/`compose.one`, `domain.canGenerateTraefikMeDomains`, `compose.loadServices`) ran unconditionally on mount instead of only when the edit dialog is actually open, so any interaction that re-renders the table (typing in the host filter, sorting a column, toggling column visibility) refired all 4 queries for every domain row.

Gated all 4 queries behind `enabled: isOpen` so they only fetch once the edit dialog is opened.

Verified with Playwright against a compose service with several domains: before the fix, typing in the filter or clicking a sort header fired a new batched tRPC request every time; after the fix, zero extra requests, and the edit dialog still loads and populates correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers four per-domain queries until the AddDomain dialog opens, preventing table filtering, sorting, and visibility changes from refiring requests for every row.

- Gates domain and application/Compose resource queries on dialog state.
- Defers Traefik-domain capability and Compose service discovery queries.
- Introduces an asynchronous initialization mismatch for the uncontrolled Compose service selector.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the Compose edit dialog reliably displays the domain’s existing service selection after deferred queries resolve.

The request-flooding fix is sound, but delaying domain and service data until after the dialog mounts leaves the uncontrolled service selector visually empty for existing Compose domains.

**Files Needing Attention:** apps/dokploy/components/dashboard/application/domains/handle-domain.tsx

<sub>Reviews (1): Last reviewed commit: ["fix(domains): don&#39;t fetch AddDomain quer..."](https://github.com/dokploy/dokploy/commit/0f28775a1e3deb79da78fc3ba0416eb1dcdbf2a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61488411)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Dashboard and client state](https://app.greptile.com/dokploy/-/custom-context/knowledge-base/dokploy/dokploy/-/docs/dashboard-and-client-state.md)

<!-- /greptile_comment -->