### PR TITLE
fix(preview-deployments): copy file mounts so preview bind sources exist

### DIFF
--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -30,7 +30,7 @@ import { createTraefikConfig } from "@dokploy/server/utils/traefik/application";
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 import type { z } from "zod";
-import { encodeBase64 } from "../utils/docker/utils";
+import { encodeBase64, getCopyFileMountsCommand } from "../utils/docker/utils";
 import { getDokployUrl } from "./admin";
 import {
 	createDeployment,
@@ -267,7 +267,7 @@ export const deployApplication = async ({
 			projectName: application.environment.project.name,
 			applicationName: application.name,
 			applicationType: "application",
-			// @ts-ignore
+			// @ts-expect-error
 			errorMessage: error?.message || "Error building",
 			buildLink,
 			organizationId: application.environment.project.organizationId,
@@ -424,6 +424,7 @@ export const deployPreviewApplication = async ({
 			...issueParams,
 			body: `### Dokploy Preview Deployment\n\n${buildingComment}`,
 		});
+		const originalAppName = application.appName;
 		application.appName = previewDeployment.appName;
 		application.env = `${application.previewEnv}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 		application.buildArgs = `${application.previewBuildArgs}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
@@ -440,6 +441,13 @@ export const deployPreviewApplication = async ({
 				appName: previewDeployment.appName,
 				branch: previewDeployment.branch,
 			});
+			// File mount contents live under the base application's directory;
+			// copy them so the preview's bind mount sources exist.
+			command += getCopyFileMountsCommand(
+				originalAppName,
+				previewDeployment.appName,
+				!!application.serverId,
+			);
 			command += await getBuildCommand(application);
 
 			const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
@@ -543,6 +551,7 @@ export const rebuildPreviewApplication = async ({
 		});
 
 		// Set application properties for preview deployment
+		const originalAppName = application.appName;
 		application.appName = previewDeployment.appName;
 		application.env = `${application.previewEnv}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 		application.buildArgs = `${application.previewBuildArgs}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
@@ -555,6 +564,11 @@ export const rebuildPreviewApplication = async ({
 		const serverId = application.serverId;
 		let command = "set -e;";
 		// Only rebuild, don't clone repository
+		command += getCopyFileMountsCommand(
+			originalAppName,
+			previewDeployment.appName,
+			!!application.serverId,
+		);
 		command += await getBuildCommand(application);
 		const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (serverId) {

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -763,6 +763,24 @@ export const generateFileMounts = (
 		});
 };
 
+export const getCopyFileMountsCommand = (
+	sourceAppName: string,
+	targetAppName: string,
+	isRemote: boolean,
+) => {
+	const { APPLICATIONS_PATH } = paths(isRemote);
+	const absoluteBasePath = path.resolve(APPLICATIONS_PATH);
+	const sourceDirectory = path.join(absoluteBasePath, sourceAppName, "files");
+	const targetDirectory = path.join(absoluteBasePath, targetAppName, "files");
+	return `
+		if [ -d ${quote([sourceDirectory])} ]; then
+			rm -rf ${quote([targetDirectory])};
+			mkdir -p ${quote([path.dirname(targetDirectory)])};
+			cp -a ${quote([sourceDirectory])} ${quote([targetDirectory])};
+		fi;
+	`;
+};
+
 export const createFile = async (
 	outputPath: string,
 	filePath: string,


### PR DESCRIPTION
### Summary

File mounts configured in the Advanced tab don't work in preview deployments: the preview container either fails to start with `invalid mount config for type bind: bind source path does not exist`, or the mount shows up as an empty directory instead of the file.

### Root cause

File mount contents are written once, at create/update time, to `APPLICATIONS_PATH/<appName>/files/<filePath>` using the application's real `appName` (`getBaseFilesPath` in `services/mount.ts`).

However, `deployPreviewApplication` overrides `application.appName` with the preview name (e.g. `preview-myapp-x7k2f1`) before calling `mechanizeDockerContainer`, and `generateFileMounts` derives the bind source purely from that appName. The resulting source path `APPLICATIONS_PATH/preview-myapp-x7k2f1/files/...` is never created — the clone only populates `code/` — so the bind mount points at a nonexistent path.

### Fix

Add `getCopyFileMountsCommand`, which copies the base application's `files/` directory into the preview app's directory (removing any stale copy first, so mount edits propagate on redeploy). It runs as part of the existing deploy shell command — after the clone, before the build — in both `deployPreviewApplication` and `rebuildPreviewApplication`, and works for remote servers via the existing `execAsyncRemote` path.

Preview cleanup already deletes the whole preview directory (`removeDirectoryCode`), so the copied files are cleaned up with no extra changes.

### Testing

- `tsc --noEmit` on `packages/server` passes
- `biome check` passes on the changed files

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61775805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete correctness, security, or repository-rule issues identified.

<details><summary><h3>Summary</h3></summary>

- Adds a shell-command helper that safely quotes local or remote application paths.
- Runs the copy after cloning for preview deployments and before building for both deploy and rebuild flows.
- Replaces a broad TypeScript suppression with `@ts-expect-error`.
</details>

<!-- /greptile_comment -->