### PR TITLE
fix(server-health): detect custom default-address-pools via docker info

### DIFF
--- a/packages/server/src/services/server-health.ts
+++ b/packages/server/src/services/server-health.ts
@@ -118,7 +118,9 @@ diskTotal=$(df -B1 / 2>/dev/null | awk 'NR==2{print $2}'); [ -z "$diskTotal" ] &
 diskUsed=$(df -B1 / 2>/dev/null | awk 'NR==2{print $3}'); [ -z "$diskUsed" ] && diskUsed=0
 
 networkCount=$(docker network ls -q 2>/dev/null | wc -l | tr -d ' ')
-daemonConfigB64=$(cat /etc/docker/daemon.json 2>/dev/null | base64 2>/dev/null | tr -d '\\n')
+# /etc/docker/daemon.json isn't mounted into the dokploy container (only docker.sock is), so read
+# the effective config over the socket instead of the file.
+daemonConfigB64=$(docker info --format '{{json .DefaultAddressPools}}' 2>/dev/null | base64 2>/dev/null | tr -d '\\n')
 
 daemonLogsToEpoch=$(date +%s 2>/dev/null); [ -z "$daemonLogsToEpoch" ] && daemonLogsToEpoch=0
 daemonLogsFromEpoch=$((daemonLogsToEpoch - ${sinceHours} * 3600))
@@ -319,11 +321,11 @@ export const getServerHealth = async (
 		.filter(Boolean);
 
 	let addressPools: unknown = null;
-	const daemonConfigText = b64Decode(parsed.daemonConfigBase64);
+	const daemonConfigText = b64Decode(parsed.daemonConfigBase64).trim();
 	if (daemonConfigText) {
 		try {
-			addressPools =
-				JSON.parse(daemonConfigText)?.["default-address-pools"] ?? null;
+			// `docker info` already returns the pools array (or `null`) directly, unlike daemon.json.
+			addressPools = JSON.parse(daemonConfigText) ?? null;
 		} catch {
 			addressPools = null;
 		}


### PR DESCRIPTION
Fixes #5383

**Before:** health check read `/etc/docker/daemon.json` via `cat`, but that file isn't mounted into the dokploy container (only `docker.sock` is), so the read always failed silently and a genuinely configured custom pool never showed as detected.

**After:** reads the effective config over the already-mounted socket via `docker info --format '{{json .DefaultAddressPools}}'`.

Repro: on this host, `cat /etc/docker/daemon.json` fails while `docker info --format '{{json .DefaultAddressPools}}'` succeeds (returns `null` when unset, the pools array when set) — confirmed via `docker-getServerHealth` returning correctly with no regressions after the change.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61828657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no concrete regression identified in the changed health-check path.

<details><summary><h3>Summary</h3></summary>

- Replaces `/etc/docker/daemon.json` access with a formatted `docker info` query.
- Parses the returned address-pool array or `null` directly.
- Trims decoded output and retains safe fallback behavior for empty or malformed responses.
</details>

<!-- /greptile_comment -->