### PR TITLE
fix: narrow zod .required() masks so unrelated nullable fields stay optional

### DIFF
--- a/apps/dokploy/__test__/api/mutation-schema-optionality.test.ts
+++ b/apps/dokploy/__test__/api/mutation-schema-optionality.test.ts
@@ -3,13 +3,17 @@ import {
 	apiSaveBuildType,
 	apiSaveEnvironmentVariables,
 } from "@dokploy/server/db/schema/application";
-import { apiCreateRegistry } from "@dokploy/server/db/schema/registry";
+import { apiCreateRegistry, apiTestRegistry } from "@dokploy/server/db/schema/registry";
 
 // Regression for https://github.com/Dokploy/dokploy/issues/4724:
 // API mutations forced callers to pass fields unrelated to their use case
 // (nullable in the DB) because the input schemas were built with bare
 // `.required()`. The web UI never notices - it submits every form field - but
 // API consumers hit BAD_REQUEST until they discover each field by trial.
+//
+// The masks are optional-with-default-null rather than merely optional:
+// drizzle skips `undefined` on update, so an omitted field must still clear
+// the stale column value, exactly like the UI's explicit null.
 
 describe("mutation schema optionality (#4724)", () => {
 	it("saveBuildType accepts a dockerfile build without heroku/railpack fields", () => {
@@ -18,7 +22,21 @@ describe("mutation schema optionality (#4724)", () => {
 			buildType: "dockerfile",
 		});
 		expect(parsed.buildType).toBe("dockerfile");
-		expect(parsed.herokuVersion).toBeUndefined();
+	});
+
+	it("saveBuildType defaults omitted nullable fields to null so updates clear stale values", () => {
+		const parsed = apiSaveBuildType.parse({
+			applicationId: "app-1",
+			buildType: "dockerfile",
+		});
+		// Switching build type to dockerfile must clear a stale herokuVersion
+		// from a previous heroku_buildpacks configuration - drizzle writes the
+		// nulls, while `undefined` would silently keep the old values.
+		expect(parsed.herokuVersion).toBeNull();
+		expect(parsed.railpackVersion).toBeNull();
+		expect(parsed.dockerfile).toBeNull();
+		expect(parsed.dockerContextPath).toBeNull();
+		expect(parsed.dockerBuildStage).toBeNull();
 	});
 
 	it("saveBuildType still rejects a missing applicationId or buildType", () => {
@@ -50,8 +68,19 @@ describe("mutation schema optionality (#4724)", () => {
 		expect(parsed.buildArgs).toBeUndefined();
 	});
 
+	it("saveEnvironment rejects applicationId-only payloads (env is required)", () => {
+		// Without env, the handler forwards only undefined values and drizzle's
+		// mapUpdateSet throws "No values to set" - surfacing INTERNAL_SERVER_ERROR
+		// where a clean BAD_REQUEST belongs.
+		expect(() =>
+			apiSaveEnvironmentVariables.parse({ applicationId: "app-1" }),
+		).toThrow();
+	});
+
 	it("saveEnvironment still requires applicationId", () => {
-		expect(() => apiSaveEnvironmentVariables.parse({ env: "FOO=bar" })).toThrow();
+		expect(() =>
+			apiSaveEnvironmentVariables.parse({ env: "FOO=bar" }),
+		).toThrow();
 	});
 
 	it("registry.create defaults registryType to cloud", () => {
@@ -60,8 +89,6 @@ describe("mutation schema optionality (#4724)", () => {
 			username: "u",
 			password: "p",
 			registryUrl: "",
-			organizationId: "org-1",
-			registryId: "reg-1",
 		});
 		expect(parsed.registryType).toBe("cloud");
 	});
@@ -70,9 +97,17 @@ describe("mutation schema optionality (#4724)", () => {
 		expect(() =>
 			apiCreateRegistry.parse({
 				registryName: "dockerhub",
-				organizationId: "org-1",
-				registryId: "reg-1",
 			}),
 		).toThrow();
+	});
+
+	it("apiTestRegistry defaults registryType to cloud", () => {
+		const parsed = apiTestRegistry.parse({
+			registryName: "dockerhub",
+			username: "u",
+			password: "p",
+			registryUrl: "",
+		});
+		expect(parsed.registryType).toBe("cloud");
 	});
 });

--- a/apps/dokploy/__test__/api/mutation-schema-optionality.test.ts
+++ b/apps/dokploy/__test__/api/mutation-schema-optionality.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+	apiSaveBuildType,
+	apiSaveEnvironmentVariables,
+} from "@dokploy/server/db/schema/application";
+import { apiCreateRegistry } from "@dokploy/server/db/schema/registry";
+
+// Regression for https://github.com/Dokploy/dokploy/issues/4724:
+// API mutations forced callers to pass fields unrelated to their use case
+// (nullable in the DB) because the input schemas were built with bare
+// `.required()`. The web UI never notices - it submits every form field - but
+// API consumers hit BAD_REQUEST until they discover each field by trial.
+
+describe("mutation schema optionality (#4724)", () => {
+	it("saveBuildType accepts a dockerfile build without heroku/railpack fields", () => {
+		const parsed = apiSaveBuildType.parse({
+			applicationId: "app-1",
+			buildType: "dockerfile",
+		});
+		expect(parsed.buildType).toBe("dockerfile");
+		expect(parsed.herokuVersion).toBeUndefined();
+	});
+
+	it("saveBuildType still rejects a missing applicationId or buildType", () => {
+		expect(() => apiSaveBuildType.parse({ buildType: "dockerfile" })).toThrow();
+		expect(() => apiSaveBuildType.parse({ applicationId: "app-1" })).toThrow();
+	});
+
+	it("saveBuildType still accepts explicit nulls (web UI shape)", () => {
+		const parsed = apiSaveBuildType.parse({
+			applicationId: "app-1",
+			buildType: "heroku_buildpacks",
+			dockerfile: null,
+			dockerContextPath: null,
+			dockerBuildStage: null,
+			herokuVersion: "3.0",
+			railpackVersion: null,
+			publishDirectory: null,
+			isStaticSpa: null,
+		});
+		expect(parsed.herokuVersion).toBe("3.0");
+	});
+
+	it("saveEnvironment accepts env only, without buildArgs/buildSecrets/createEnvFile", () => {
+		const parsed = apiSaveEnvironmentVariables.parse({
+			applicationId: "app-1",
+			env: "FOO=bar",
+		});
+		expect(parsed.env).toBe("FOO=bar");
+		expect(parsed.buildArgs).toBeUndefined();
+	});
+
+	it("saveEnvironment still requires applicationId", () => {
+		expect(() => apiSaveEnvironmentVariables.parse({ env: "FOO=bar" })).toThrow();
+	});
+
+	it("registry.create defaults registryType to cloud", () => {
+		const parsed = apiCreateRegistry.parse({
+			registryName: "dockerhub",
+			username: "u",
+			password: "p",
+			registryUrl: "",
+			organizationId: "org-1",
+			registryId: "reg-1",
+		});
+		expect(parsed.registryType).toBe("cloud");
+	});
+
+	it("registry.create still requires the credential fields", () => {
+		expect(() =>
+			apiCreateRegistry.parse({
+				registryName: "dockerhub",
+				organizationId: "org-1",
+				registryId: "reg-1",
+			}),
+		).toThrow();
+	});
+});

--- a/apps/dokploy/__test__/deploy/railpack.command.test.ts
+++ b/apps/dokploy/__test__/deploy/railpack.command.test.ts
@@ -110,4 +110,12 @@ describe("getRailpackCommand", () => {
 			getSecretsHash(secondCommand),
 		);
 	});
+
+	it("falls back to the column default when railpackVersion is null", () => {
+		const command = getRailpackCommand(createApplication({ railpackVersion: null }));
+
+		expect(command).toContain("railpack-frontend:v0.15.4");
+		expect(command).not.toContain("vnull");
+		expect(command).not.toContain("RAILPACK_VERSION=null");
+	});
 });

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -442,7 +442,10 @@ export const apiSaveBuildType = createSchema
 		herokuVersion: true,
 		railpackVersion: true,
 	})
-	.required()
+	// Only the identity fields are required: herokuVersion/railpackVersion et al.
+	// apply to other build types, and forcing API callers to pass them as null is
+	// trial-and-error friction the web UI never sees (it submits every field).
+	.required({ applicationId: true, buildType: true })
 	.merge(createSchema.pick({ publishDirectory: true, isStaticSpa: true }));
 
 const branchField = z
@@ -540,7 +543,9 @@ export const apiSaveEnvironmentVariables = createSchema
 		buildSecrets: true,
 		createEnvFile: true,
 	})
-	.required();
+	// Only applicationId is required: a caller setting env should not have to
+	// pass buildArgs/buildSecrets/createEnvFile explicitly.
+	.required({ applicationId: true });
 
 export const apiFindMonitoringStats = z.object({
 	appName: z.string().min(1),

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -445,7 +445,18 @@ export const apiSaveBuildType = createSchema
 	// Only the identity fields are required: herokuVersion/railpackVersion et al.
 	// apply to other build types, and forcing API callers to pass them as null is
 	// trial-and-error friction the web UI never sees (it submits every field).
+	// The nullable fields default to null rather than staying optional: Drizzle
+	// skips undefined on update, so optional-without-default would leave stale
+	// values (e.g. switching to dockerfile would keep the old herokuVersion);
+	// defaulting to null clears them exactly like the UI's explicit nulls.
 	.required({ applicationId: true, buildType: true })
+	.extend({
+		dockerfile: z.string().nullable().default(null),
+		dockerContextPath: z.string().nullable().default(null),
+		dockerBuildStage: z.string().nullable().default(null),
+		herokuVersion: z.string().nullable().default(null),
+		railpackVersion: z.string().nullable().default(null),
+	})
 	.merge(createSchema.pick({ publishDirectory: true, isStaticSpa: true }));
 
 const branchField = z
@@ -543,9 +554,12 @@ export const apiSaveEnvironmentVariables = createSchema
 		buildSecrets: true,
 		createEnvFile: true,
 	})
-	// Only applicationId is required: a caller setting env should not have to
-	// pass buildArgs/buildSecrets/createEnvFile explicitly.
-	.required({ applicationId: true });
+	// applicationId and env stay required: env is the point of the mutation,
+	// and an applicationId-only call would pass validation only to die in
+	// drizzle's mapUpdateSet ("No values to set") as an INTERNAL_SERVER_ERROR
+	// instead of a clean BAD_REQUEST. buildArgs/buildSecrets/createEnvFile
+	// stay optional as reported in #4724.
+	.required({ applicationId: true, env: true });
 
 export const apiFindMonitoringStats = z.object({
 	appName: z.string().min(1),

--- a/packages/server/src/db/schema/registry.ts
+++ b/packages/server/src/db/schema/registry.ts
@@ -79,10 +79,12 @@ export const apiCreateRegistry = createSchema
 		username: registryUsernameSchema,
 		password: z.string().min(1),
 		registryUrl: registryUrlSchema,
-		registryType: z.enum(["cloud"]),
+		// Matches the DB default: API callers should not have to pass the only
+		// accepted value explicitly.
+		registryType: z.enum(["cloud"]).default("cloud"),
 		imagePrefix: z.string().nullable().optional(),
 	})
-	.required()
+	.required({ registryName: true, username: true, password: true, registryUrl: true })
 	.extend({
 		serverId: z.string().optional(),
 	});
@@ -92,7 +94,7 @@ export const apiTestRegistry = createSchema.pick({}).extend({
 	username: registryUsernameSchema,
 	password: z.string().min(1),
 	registryUrl: registryUrlSchema,
-	registryType: z.enum(["cloud"]),
+	registryType: z.enum(["cloud"]).default("cloud"),
 	imagePrefix: z.string().nullable().optional(),
 	serverId: z.string().optional(),
 });

--- a/packages/server/src/db/schema/registry.ts
+++ b/packages/server/src/db/schema/registry.ts
@@ -82,7 +82,7 @@ export const apiCreateRegistry = createSchema
 		// Matches the DB default: API callers should not have to pass the only
 		// accepted value explicitly.
 		registryType: z.enum(["cloud"]).default("cloud"),
-		imagePrefix: z.string().nullable().optional(),
+		imagePrefix: z.string().nullable().default(null),
 	})
 	.required({ registryName: true, username: true, password: true, registryUrl: true })
 	.extend({
@@ -95,7 +95,7 @@ export const apiTestRegistry = createSchema.pick({}).extend({
 	password: z.string().min(1),
 	registryUrl: registryUrlSchema,
 	registryType: z.enum(["cloud"]).default("cloud"),
-	imagePrefix: z.string().nullable().optional(),
+	imagePrefix: z.string().nullable().default(null),
 	serverId: z.string().optional(),
 });
 

--- a/packages/server/src/utils/builders/railpack.ts
+++ b/packages/server/src/utils/builders/railpack.ts
@@ -57,7 +57,7 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 		`secrets-hash=${secretsHash}`,
 		...(cacheKey ? ["--build-arg", `cache-key=${cacheKey}`] : []),
 		"--build-arg",
-		`BUILDKIT_SYNTAX=ghcr.io/railwayapp/railpack-frontend:v${application.railpackVersion}`,
+		`BUILDKIT_SYNTAX=ghcr.io/railwayapp/railpack-frontend:v${application.railpackVersion || "0.15.4"}`,
 		"-f",
 		`${buildAppDirectory}/railpack-plan.json`,
 		"--output",
@@ -86,7 +86,7 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 
 # Ensure we have a builder with containerd (isolated per build)
 
-export RAILPACK_VERSION=${application.railpackVersion}
+export RAILPACK_VERSION=${application.railpackVersion || "0.15.4"}
 # use sudo for non-root so the install can write to /usr/local/bin
 if [ "$(id -u)" -eq 0 ]; then
 	SUDO_CMD=""


### PR DESCRIPTION
## Root cause

The API schemas are built with bare `.required()` over picked fields, so fields that only apply to other configurations become mandatory for every API caller. Verified all three reported mutations on current main: `application.saveBuildType` with `buildType: "dockerfile"` demands `herokuVersion: null` + `railpackVersion: null`; `application.saveEnvironment` with only `env` demands `buildArgs`/`buildSecrets`/`createEnvFile`; on `registry.create` the field `.required()` was actually forcing is `imagePrefix` (`.nullable().optional()`) - `registryType` was mandatory on its own as a bare `z.enum(["cloud"])`, and this PR fixes both. The UI never notices because it submits every form field.

## Fix

Mask-form `.required()`: `saveBuildType` requires only `{applicationId, buildType}`, `saveEnvironment` requires `{applicationId, env}`, and `registry.create` requires the 4 credential fields with `registryType` getting `.default("cloud")` matching the DB default (also `apiTestRegistry`).

Two behaviors matter beyond the masks (h/t @ioanbeilic's review):

- `saveEnvironment` keeps `env` required. The handler forwards exactly the four fields to `updateApplication`, and drizzle's `mapUpdateSet` drops `undefined` entries and throws when none are left - so an `applicationId`-only call would pass validation and die as a plain `INTERNAL_SERVER_ERROR` where a clean `BAD_REQUEST` belongs.
- The nullable build-type fields are optional-**with-`.default(null)`**, not merely optional: drizzle skips `undefined` on update, so omitting a field must still clear the stale column value (switching build type to `dockerfile` clears a leftover `herokuVersion`), exactly like the UI's explicit nulls. `registry`'s `imagePrefix` follows the same shape.

Backward-compatible: explicit nulls (the UI's shape) and explicit values parse unchanged.

## Verification

Ten schema-level vitest cases: the 3 reported mutations, the rejection cases (`saveBuildType` missing identity fields, `saveEnvironment` missing `applicationId` **or** `env`), the stale-clear behavior (omitted nullable fields parse to `null` so updates clear), explicit-null compatibility, `registryType` defaulting on both registry schemas. Red-green verified: the two revision cases (default-null clearing, `applicationId`-only rejection) fail against the pre-revision schema, all 10 pass with the fix; the rest of `__test__/api` stays green (16/16). Full-repo `tsc --noEmit` left to CI (exceeded our sandbox's limits), but the change is schema-local.

Fixes #4724

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61981574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable correctness, security, or maintainability issues identified.

<details><summary><h3>Summary</h3></summary>

- Requires only `applicationId` and `buildType` when saving build configuration.
- Requires only `applicationId` when saving environment configuration.
- Defaults registry creation and connection-test inputs to the database-supported `cloud` registry type.
- Adds schema-level regression coverage for omitted fields, required fields, defaults, and explicit-null compatibility.
</details>

<!-- /greptile_comment -->

**Update (reporter review, round 2):** ioanbeilic flagged that `.default(null)` on all five build-type fields puts a `NULL` `railpackVersion` on the happy path, and railpack.ts interpolated it unguarded (`BUILDKIT_SYNTAX=...railpack-frontend:vnull`, `RAILPACK_VERSION=null`), breaking railpack builds. Commit 0b85bf6 adds `railpackVersion || "0.15.4"` (column default) in both spots, mirroring `herokuVersion || "24"`. The hole is pre-existing (nullable column + `.partial()` `apiUpdateApplication`); this PR closes it. `__test__/api` re-run 16/16.
