### PR TITLE
fix(notifications): escape and truncate Telegram build-error messages, surface API rejections

### DIFF
--- a/apps/dokploy/__test__/notifications/telegram-text.test.ts
+++ b/apps/dokploy/__test__/notifications/telegram-text.test.ts
@@ -3,7 +3,7 @@ import {
 	TELEGRAM_MAX_MESSAGE_LENGTH,
 	truncateTelegramText,
 } from "@dokploy/server/utils/notifications/telegram-text";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 describe("escapeTelegramHtml", () => {
 	it("escapes markup characters from build output", () => {
@@ -45,5 +45,48 @@ describe("truncateTelegramText", () => {
 		const message = `<b>⚠️ Build Failed</b>\n\n<b>Project:</b> p\n<b>Application:</b> a\n<b>Type:</b> docker-compose\n<b>Date:</b> Sep 9, 2026\n<b>Time:</b> 2:00:00 AM\n\n<b>Error:</b>\n<pre>${errorText}</pre>`;
 		expect(message.length).toBeLessThan(TELEGRAM_MAX_MESSAGE_LENGTH);
 		expect(errorText.includes("<")).toBe(false);
+	});
+});
+
+describe("truncateTelegramText surrogate safety", () => {
+	it("never leaves a dangling high surrogate at the cut", () => {
+		// 11 BMP chars + emoji (2 UTF-16 units) straddling the cut at 12
+		const text = "01234567890🚀tail";
+		const out = truncateTelegramText(text, 12);
+		const body = out.slice(0, -1); // strip the ellipsis
+		const lastCode = body.charCodeAt(body.length - 1);
+		expect(lastCode >= 0xd800 && lastCode <= 0xdbff).toBe(false);
+	});
+});
+
+describe("sendTelegramNotification delivery result", () => {
+	it("resolves false when Telegram rejects the message", async () => {
+		const { sendTelegramNotification } = await import(
+			"@dokploy/server/utils/notifications/utils"
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: false,
+				status: 400,
+				text: async () => "Bad Request: message text is empty",
+			})),
+		);
+		const ok = await sendTelegramNotification({ chatId: "1" } as never, "test");
+		expect(ok).toBe(false);
+		vi.unstubAllGlobals();
+	});
+
+	it("resolves true on a 2xx response", async () => {
+		const { sendTelegramNotification } = await import(
+			"@dokploy/server/utils/notifications/utils"
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({ ok: true, status: 200, text: async () => "" })),
+		);
+		const ok = await sendTelegramNotification({ chatId: "1" } as never, "test");
+		expect(ok).toBe(true);
+		vi.unstubAllGlobals();
 	});
 });

--- a/apps/dokploy/__test__/notifications/telegram-text.test.ts
+++ b/apps/dokploy/__test__/notifications/telegram-text.test.ts
@@ -1,0 +1,49 @@
+import {
+	escapeTelegramHtml,
+	TELEGRAM_MAX_MESSAGE_LENGTH,
+	truncateTelegramText,
+} from "@dokploy/server/utils/notifications/telegram-text";
+import { describe, expect, it } from "vitest";
+
+describe("escapeTelegramHtml", () => {
+	it("escapes markup characters from build output", () => {
+		expect(escapeTelegramHtml("expected ';' before '<' token & more")).toBe(
+			"expected ';' before '&lt;' token &amp; more",
+		);
+	});
+
+	it("escapes ampersands before introducing new ones", () => {
+		expect(escapeTelegramHtml("&<")).toBe("&amp;&lt;");
+	});
+});
+
+describe("truncateTelegramText", () => {
+	it("leaves short text untouched", () => {
+		expect(truncateTelegramText("short error")).toBe("short error");
+	});
+
+	it("truncates long text with an ellipsis", () => {
+		const long = "x".repeat(5000);
+		const result = truncateTelegramText(long);
+		expect(result.length).toBe(801);
+		expect(result.endsWith("…")).toBe(true);
+	});
+
+	it("never leaves a dangling HTML entity at the cut point", () => {
+		// An entity starting just before the 800-char cut: "&amp;" begins at
+		// index 798, so a naive cut lands mid-entity at "&am".
+		const text = `${"y".repeat(798)}&amp;${"z".repeat(5000)}`;
+		const result = truncateTelegramText(text);
+		expect(result).toBe(`${"y".repeat(798)}…`);
+	});
+
+	it("keeps a full build-error payload under Telegram's message limit", () => {
+		const pathologicalError = "&<>".repeat(2000);
+		const errorText = truncateTelegramText(
+			escapeTelegramHtml(pathologicalError),
+		);
+		const message = `<b>⚠️ Build Failed</b>\n\n<b>Project:</b> p\n<b>Application:</b> a\n<b>Type:</b> docker-compose\n<b>Date:</b> Sep 9, 2026\n<b>Time:</b> 2:00:00 AM\n\n<b>Error:</b>\n<pre>${errorText}</pre>`;
+		expect(message.length).toBeLessThan(TELEGRAM_MAX_MESSAGE_LENGTH);
+		expect(errorText.includes("<")).toBe(false);
+	});
+});

--- a/apps/dokploy/server/api/routers/notification.ts
+++ b/apps/dokploy/server/api/routers/notification.ts
@@ -212,7 +212,16 @@ export const notificationRouter = createTRPCRouter({
 		.input(apiTestTelegramConnection)
 		.mutation(async ({ input }) => {
 			try {
-				await sendTelegramNotification(input, "Hi, From Dokploy 👋");
+				// sendTelegramNotification resolves false when Telegram rejects
+				// the message (fetch does not throw on 4xx) - surface that as a
+				// failed test instead of reporting success.
+				const delivered = await sendTelegramNotification(
+					input,
+					"Hi, From Dokploy 👋",
+				);
+				if (!delivered) {
+					throw new Error("Telegram rejected the test message");
+				}
 				return true;
 			} catch (error) {
 				throw new TRPCError({

--- a/packages/server/src/utils/notifications/build-error.ts
+++ b/packages/server/src/utils/notifications/build-error.ts
@@ -4,6 +4,7 @@ import BuildFailedEmail from "@dokploy/server/emails/emails/build-failed";
 import { render } from "@react-email/components";
 import { format } from "date-fns";
 import { and, eq } from "drizzle-orm";
+import { escapeTelegramHtml, truncateTelegramText } from "./telegram-text";
 import {
 	sendCustomNotification,
 	sendDiscordNotification,
@@ -201,7 +202,7 @@ export const sendBuildErrorNotifications = async ({
 
 				await sendTelegramNotification(
 					telegram,
-					`<b>⚠️ Build Failed</b>\n\n<b>Project:</b> ${projectName}\n<b>Application:</b> ${applicationName}\n<b>Type:</b> ${applicationType}\n<b>Date:</b> ${format(date, "PP")}\n<b>Time:</b> ${format(date, "pp")}\n\n<b>Error:</b>\n<pre>${errorMessage}</pre>`,
+					`<b>⚠️ Build Failed</b>\n\n<b>Project:</b> ${escapeTelegramHtml(projectName)}\n<b>Application:</b> ${escapeTelegramHtml(applicationName)}\n<b>Type:</b> ${escapeTelegramHtml(applicationType)}\n<b>Date:</b> ${format(date, "PP")}\n<b>Time:</b> ${format(date, "pp")}\n\n<b>Error:</b>\n<pre>${truncateTelegramText(escapeTelegramHtml(errorMessage))}</pre>`,
 					inlineButton,
 				);
 			}

--- a/packages/server/src/utils/notifications/build-error.ts
+++ b/packages/server/src/utils/notifications/build-error.ts
@@ -200,9 +200,12 @@ export const sendBuildErrorNotifications = async ({
 					],
 				];
 
+				// Names have no server-side length limit; bound each so the
+				// composed message can never approach Telegram's 4096-char
+				// ceiling (which Telegram answers with a silent 400).
 				await sendTelegramNotification(
 					telegram,
-					`<b>⚠️ Build Failed</b>\n\n<b>Project:</b> ${escapeTelegramHtml(projectName)}\n<b>Application:</b> ${escapeTelegramHtml(applicationName)}\n<b>Type:</b> ${escapeTelegramHtml(applicationType)}\n<b>Date:</b> ${format(date, "PP")}\n<b>Time:</b> ${format(date, "pp")}\n\n<b>Error:</b>\n<pre>${truncateTelegramText(escapeTelegramHtml(errorMessage))}</pre>`,
+					`<b>⚠️ Build Failed</b>\n\n<b>Project:</b> ${truncateTelegramText(escapeTelegramHtml(projectName), 200)}\n<b>Application:</b> ${truncateTelegramText(escapeTelegramHtml(applicationName), 200)}\n<b>Type:</b> ${truncateTelegramText(escapeTelegramHtml(applicationType), 200)}\n<b>Date:</b> ${format(date, "PP")}\n<b>Time:</b> ${format(date, "pp")}\n\n<b>Error:</b>\n<pre>${truncateTelegramText(escapeTelegramHtml(errorMessage))}</pre>`,
 					inlineButton,
 				);
 			}

--- a/packages/server/src/utils/notifications/telegram-text.ts
+++ b/packages/server/src/utils/notifications/telegram-text.ts
@@ -32,5 +32,15 @@ export const truncateTelegramText = (
 		truncated = truncated.substring(0, lastAmpersand);
 	}
 
+	// The cut can also split a surrogate pair (emoji and other non-BMP
+	// characters common in build output); a dangling high surrogate is
+	// invalid in the JSON payload, so back off one more code unit.
+	if (truncated.length > 0) {
+		const lastCode = truncated.charCodeAt(truncated.length - 1);
+		if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+			truncated = truncated.substring(0, truncated.length - 1);
+		}
+	}
+
 	return `${truncated}…`;
 };

--- a/packages/server/src/utils/notifications/telegram-text.ts
+++ b/packages/server/src/utils/notifications/telegram-text.ts
@@ -1,0 +1,36 @@
+/**
+ * Helpers for Telegram's HTML parse_mode payloads.
+ *
+ * Telegram answers sendMessage with HTTP 400 when the text exceeds 4096
+ * characters or when its HTML fails to parse, and in both cases the message
+ * is simply never delivered - so dynamic content must be escaped and kept
+ * well under the length limit.
+ */
+
+/** Maximum length of a Telegram message text. */
+export const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
+
+/** Escapes the characters Telegram's HTML parse_mode treats as markup. */
+export const escapeTelegramHtml = (text: string): string =>
+	text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/**
+ * Truncates already-escaped text, backing off from a cut that would split an
+ * HTML entity (a dangling "&" is itself a parse error under parse_mode=HTML).
+ */
+export const truncateTelegramText = (
+	escapedText: string,
+	maxLength = 800,
+): string => {
+	if (escapedText.length <= maxLength) {
+		return escapedText;
+	}
+
+	let truncated = escapedText.substring(0, maxLength);
+	const lastAmpersand = truncated.lastIndexOf("&");
+	if (lastAmpersand > truncated.lastIndexOf(";")) {
+		truncated = truncated.substring(0, lastAmpersand);
+	}
+
+	return `${truncated}…`;
+};

--- a/packages/server/src/utils/notifications/utils.ts
+++ b/packages/server/src/utils/notifications/utils.ts
@@ -111,7 +111,7 @@ export const sendTelegramNotification = async (
 ) => {
 	try {
 		const url = `https://api.telegram.org/bot${connection.botToken}/sendMessage`;
-		await fetch(url, {
+		const response = await fetch(url, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
@@ -125,6 +125,14 @@ export const sendTelegramNotification = async (
 				},
 			}),
 		});
+		if (!response.ok) {
+			// Telegram signals rejection (message too long, unparseable
+			// entities, ...) as a 4xx with a JSON body; fetch does not throw,
+			// so without this the notification vanishes without a trace.
+			console.error(
+				`Telegram notification failed with status ${response.status}: ${await response.text()}`,
+			);
+		}
 	} catch (err) {
 		console.log(err);
 	}

--- a/packages/server/src/utils/notifications/utils.ts
+++ b/packages/server/src/utils/notifications/utils.ts
@@ -132,9 +132,12 @@ export const sendTelegramNotification = async (
 			console.error(
 				`Telegram notification failed with status ${response.status}: ${await response.text()}`,
 			);
+			return false;
 		}
+		return true;
 	} catch (err) {
 		console.log(err);
+		return false;
 	}
 };
 


### PR DESCRIPTION
Fixes #5392.

Telegram build-error notifications were silently dropped on any substantial build failure, for three stacked reasons:

1. The error message was interpolated unescaped into a parse_mode=HTML payload - typical build output contains <, > and &, so Telegram rejected it with "can't parse entities".
2. Unlike the Discord/Lark/Teams branches, the Telegram branch never truncated the error; anything past Telegram's 4096-character message limit was rejected with "message is too long".
3. sendTelegramNotification never checked response.ok, and fetch doesn't throw on HTTP 400 - so both rejection modes vanished without a single log line.

The Telegram branch now escapes all dynamic fields and truncates the escaped error text (with a guard against splitting an HTML entity at the cut point), matching the 800-character convention of the other channels, and sendTelegramNotification logs the status and response body when Telegram rejects a message.

Tests: __test__/notifications/telegram-text.test.ts covers escaping (including & ordering), truncation, entity-safe cuts, and that a pathological all-markup error still produces a sub-4096 payload. 6/6 green locally (vitest, __test__/vitest.config.ts).

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62034682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until Telegram API rejections propagate to callers so failed connection tests cannot report success.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Rejections Still Report Success** <a href="https://github.com/Dokploy/dokploy/pull/5398#discussion_r3966920966">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Metadata Can Exceed Limit** <a href="https://github.com/Dokploy/dokploy/pull/5398#discussion_r3966920974">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Truncation Can Corrupt Unicode** <a href="https://github.com/Dokploy/dokploy/pull/5398#discussion_r3966920982">▶</a>

<details><summary><h3>Summary</h3></summary>

- Escapes project, application, type, and error fields before HTML interpolation.
- Truncates escaped build errors while avoiding partial HTML entities.
- Captures non-success Telegram response status and body.
- Adds focused tests for escaping and truncation behavior.
</details>

<!-- /greptile_comment -->