### PR TITLE
fix(monitoring): stop double-counting partition I/O in disk stats

### DIFF
--- a/apps/dokploy/__test__/monitoring/disk-stats-double-count.test.ts
+++ b/apps/dokploy/__test__/monitoring/disk-stats-double-count.test.ts
@@ -1,0 +1,48 @@
+import { shouldIncludeDiskStat } from "@dokploy/server/monitoring/utils";
+import { describe, expect, it } from "vitest";
+
+describe("shouldIncludeDiskStat", () => {
+	it("excludes partitions when their parent disk is present (every byte would be counted twice)", () => {
+		// /proc/diskstats lists partition I/O in both the partition row and the
+		// parent disk row; summing both double-counts.
+		const devices = ["sda", "sda1", "sda2", "sdb", "sdb1"];
+		expect(shouldIncludeDiskStat("sda", devices)).toBe(true);
+		expect(shouldIncludeDiskStat("sdb", devices)).toBe(true);
+		expect(shouldIncludeDiskStat("sda1", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("sda2", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("sdb1", devices)).toBe(false);
+	});
+
+	it("handles nvme/mmc/md partition naming (pN suffix)", () => {
+		const devices = [
+			"nvme0n1",
+			"nvme0n1p1",
+			"nvme0n1p2",
+			"mmcblk0",
+			"mmcblk0p1",
+		];
+		expect(shouldIncludeDiskStat("nvme0n1", devices)).toBe(true);
+		expect(shouldIncludeDiskStat("nvme0n1p1", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("nvme0n1p2", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("mmcblk0", devices)).toBe(true);
+		expect(shouldIncludeDiskStat("mmcblk0p1", devices)).toBe(false);
+	});
+
+	it("keeps whole disks whose names end in a digit", () => {
+		const devices = ["nvme0n1", "mmcblk0"];
+		expect(shouldIncludeDiskStat("nvme0n1", devices)).toBe(true);
+		expect(shouldIncludeDiskStat("mmcblk0", devices)).toBe(true);
+	});
+
+	it("excludes virtual devices", () => {
+		const devices = ["loop0", "loop1", "ram0", "sr0", "sda"];
+		expect(shouldIncludeDiskStat("loop0", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("ram0", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("sr0", devices)).toBe(false);
+		expect(shouldIncludeDiskStat("sda", devices)).toBe(true);
+	});
+
+	it("keeps a partition-looking row if its parent disk is absent (defensive)", () => {
+		expect(shouldIncludeDiskStat("sda1", ["sda1"])).toBe(true);
+	});
+});

--- a/packages/server/src/monitoring/utils.ts
+++ b/packages/server/src/monitoring/utils.ts
@@ -59,6 +59,39 @@ export const recordAdvancedStats = async (
 	}
 };
 
+// Virtual devices that never represent real disk I/O.
+const virtualDiskPatterns = [/^loop/, /^ram/, /^sr\d+$/, /^fd\d+$/];
+
+// Partition suffix patterns: sdX1, vdX1, xvdX1, hdX1 (trailing digits) and
+// nvme0n1p1 / mmcblk0p1 / md0p1 (p<digits> after a digit-bearing base).
+const partitionSuffixPatterns = [/p\d+$/, /\d+$/];
+
+/**
+ * Decides whether a /proc/diskstats row should be summed into host disk I/O.
+ * Virtual devices (loop, ram, cdrom, floppy) are excluded, and a partition
+ * row is excluded whenever its parent disk is also present, because the
+ * parent disk's counters already include all of its partitions' I/O -
+ * summing both counts every byte twice.
+ */
+export const shouldIncludeDiskStat = (
+	device: string,
+	allDevices: string[],
+): boolean => {
+	if (virtualDiskPatterns.some((pattern) => pattern.test(device))) {
+		return false;
+	}
+	for (const suffixPattern of partitionSuffixPatterns) {
+		if (!suffixPattern.test(device)) {
+			continue;
+		}
+		const parent = device.replace(suffixPattern, "");
+		if (parent !== device && allDevices.includes(parent)) {
+			return false;
+		}
+	}
+	return true;
+};
+
 /**
  * Get host system statistics using node-os-utils
  * This is used when monitoring "dokploy" to show host stats instead of container stats
@@ -99,14 +132,14 @@ export const getHostSystemStats = async (): Promise<Container> => {
 	let blockWriteBytes = 0;
 	const diskStats = await osutils.disk.stats();
 	if (diskStats.success && diskStats.data.length > 0) {
-		// Filter out virtual devices (loop, ram, sr, etc.) - only include real disk devices
-		const excludePatterns = [/^loop/, /^ram/, /^sr\d+$/, /^fd\d+$/];
+		const devices = diskStats.data
+			.map((stat) => stat.device)
+			.filter((device): device is string => !!device);
 		for (const stat of diskStats.data) {
-			// Skip virtual devices
-			if (
-				stat.device &&
-				excludePatterns.some((pattern) => pattern.test(stat.device))
-			) {
+			// Skip virtual devices and partitions: /proc/diskstats lists a
+			// partition's I/O in both its own row and its parent disk's row,
+			// so summing both counts every byte twice.
+			if (!stat.device || !shouldIncludeDiskStat(stat.device, devices)) {
 				continue;
 			}
 			// readBytes and writeBytes are DataSize objects with .toBytes() method


### PR DESCRIPTION
Fixes #5385.

Confirmed - /proc/diskstats reports partition I/O in both the partition row and the parent disk row, and getHostSystemStats was summing both, so Block I/O reads ~2x real. This adds a shouldIncludeDiskStat filter: virtual devices stay excluded, and a partition row is skipped when its parent disk is present (handles sdX1/vdX1 and nvme0n1p1/mmcblk0p1 naming without dropping whole disks like nvme0n1 that end in a digit). Tests cover sd/nvme/mmc naming, virtual devices, and the no-parent edge case.

Verification: new vitest suite red against unpatched utils (5/5 fail), 5/5 green with the fix.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62083144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no actionable correctness, security, or test-integration issues identified.

<details><summary><h3>Summary</h3></summary>

- Adds partition-parent detection for conventional, NVMe, MMC, and MD naming forms.
- Preserves whole disks whose names end in digits and partition-like rows whose parent is absent.
- Adds focused regression coverage for filtering behavior.
</details>

<!-- /greptile_comment -->