### PR TITLE
fix(build): redact secrets from thrown build errors

### DIFF
--- a/apps/dokploy/__test__/process/redact.test.ts
+++ b/apps/dokploy/__test__/process/redact.test.ts
@@ -55,3 +55,30 @@ describe("execAsync build-secret redaction (dokploy#5354)", () => {
 		expect(stdout.trim()).toBe("build-ok");
 	});
 });
+
+describe("redaction follow-ups (greptile review on dokploy#5354)", () => {
+	const secretPair = "MY_API_KEY=sk-test-1234567890abcdef";
+	const exportForm = "export MY_API_KEY=sk-test-1234567890abcdef";
+
+	it("railpack export-line form is stripped when included in the redaction set", () => {
+		const out = redactSecrets(`Dockerfile:2\n${exportForm} && buildx build`, [
+			exportForm,
+		]);
+		expect(out).not.toContain("sk-test-1234567890abcdef");
+		expect(out).toContain("***");
+	});
+
+	it("the nested originalError no longer carries the raw command", async () => {
+		const failure = await execAsync(`${secretPair} false`, {
+			redact: [secretPair],
+		}).catch((e: unknown) => e);
+		expect(failure).toBeInstanceOf(ExecError);
+		const err = failure as ExecError;
+		// deploy handlers log the complete error object - the nested error must
+		// not smuggle the command past the redaction set
+		expect(String(err.originalError)).not.toContain(
+			"sk-test-1234567890abcdef",
+		);
+		expect(String(err.originalError)).not.toContain(secretPair);
+	});
+});

--- a/apps/dokploy/__test__/process/redact.test.ts
+++ b/apps/dokploy/__test__/process/redact.test.ts
@@ -1,0 +1,57 @@
+import { ExecError, execAsync } from "@dokploy/server/utils/process/execAsync";
+import { redactSecrets } from "@dokploy/server/utils/process/redact";
+import { describe, expect, it } from "vitest";
+
+describe("redactSecrets", () => {
+	it("replaces every occurrence of each secret", () => {
+		const out = redactSecrets("cmd KEY=hunter2 run KEY=hunter2 done", [
+			"KEY=hunter2",
+		]);
+		expect(out).toBe("cmd *** run *** done");
+		expect(out).not.toContain("hunter2");
+	});
+
+	it("redacts longest-first so overlapping values cannot partially survive", () => {
+		const out = redactSecrets("prefix abcdefgh suffix", ["abcd", "abcdefgh"]);
+		expect(out).toBe("prefix *** suffix");
+	});
+
+	it("skips empty entries and leaves text untouched without secrets", () => {
+		expect(redactSecrets("plain text", [])).toBe("plain text");
+		expect(redactSecrets("plain text", [""])).toBe("plain text");
+	});
+});
+
+describe("execAsync build-secret redaction (dokploy#5354)", () => {
+	const secretPair = "MY_API_KEY=sk-test-1234567890abcdef";
+
+	it("failed build commands do not retain embedded secrets on the thrown error", async () => {
+		// mirrors a failed nixpacks/docker build: non-zero exit, secrets inline
+		const failure = await execAsync(`${secretPair} false`, {
+			redact: [secretPair],
+		}).catch((e: unknown) => e);
+
+		expect(failure).toBeInstanceOf(ExecError);
+		const err = failure as ExecError;
+		expect(err.command).not.toContain("sk-test-1234567890abcdef");
+		expect(err.command).toContain("***");
+		expect(err.message).not.toContain("sk-test-1234567890abcdef");
+		expect(err.getDetailedMessage()).not.toContain("sk-test-1234567890abcdef");
+	});
+
+	it("without a redaction set the old leak shape is still visible (control)", async () => {
+		const failure = await execAsync(`${secretPair} false`).catch(
+			(e: unknown) => e,
+		);
+		expect(failure).toBeInstanceOf(ExecError);
+		// documents what callers got before the redact option existed
+		expect((failure as ExecError).command).toContain(
+			"sk-test-1234567890abcdef",
+		);
+	});
+
+	it("successful commands resolve normally", async () => {
+		const { stdout } = await execAsync("echo build-ok");
+		expect(stdout.trim()).toBe("build-ok");
+	});
+});

--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -8,6 +8,7 @@ import {
 import { getAdvancedStats } from "@dokploy/server/monitoring/utils";
 import {
 	getBuildCommand,
+	getBuildCommandRedactionSet,
 	mechanizeDockerContainer,
 } from "@dokploy/server/utils/builders";
 import { sendBuildErrorNotifications } from "@dokploy/server/utils/notifications/build-error";
@@ -223,12 +224,15 @@ export const deployApplication = async ({
 		}
 
 		command += await getBuildCommand(application);
+		const buildRedaction = await getBuildCommandRedactionSet(application);
 
 		const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (serverId) {
-			await execAsyncRemote(serverId, commandWithLog);
+			await execAsyncRemote(serverId, commandWithLog, undefined, {
+				redact: buildRedaction,
+			});
 		} else {
-			await execAsync(commandWithLog);
+			await execAsync(commandWithLog, { redact: buildRedaction });
 		}
 
 		await mechanizeDockerContainer(application);
@@ -267,7 +271,7 @@ export const deployApplication = async ({
 			projectName: application.environment.project.name,
 			applicationName: application.name,
 			applicationType: "application",
-			// @ts-ignore
+			// @ts-expect-error
 			errorMessage: error?.message || "Error building",
 			buildLink,
 			organizationId: application.environment.project.organizationId,
@@ -316,11 +320,14 @@ export const rebuildApplication = async ({
 		let command = "set -e;";
 		// Check case for docker only
 		command += await getBuildCommand(application);
+		const buildRedaction = await getBuildCommandRedactionSet(application);
 		const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (serverId) {
-			await execAsyncRemote(serverId, commandWithLog);
+			await execAsyncRemote(serverId, commandWithLog, undefined, {
+				redact: buildRedaction,
+			});
 		} else {
-			await execAsync(commandWithLog);
+			await execAsync(commandWithLog, { redact: buildRedaction });
 		}
 		await mechanizeDockerContainer(application);
 		await updateDeploymentStatus(deployment.deploymentId, "done");
@@ -441,12 +448,15 @@ export const deployPreviewApplication = async ({
 				branch: previewDeployment.branch,
 			});
 			command += await getBuildCommand(application);
+			const buildRedaction = await getBuildCommandRedactionSet(application);
 
 			const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 			if (application.serverId) {
-				await execAsyncRemote(application.serverId, commandWithLog);
+				await execAsyncRemote(application.serverId, commandWithLog, undefined, {
+					redact: buildRedaction,
+				});
 			} else {
-				await execAsync(commandWithLog);
+				await execAsync(commandWithLog, { redact: buildRedaction });
 			}
 			await mechanizeDockerContainer(application);
 		}
@@ -556,11 +566,14 @@ export const rebuildPreviewApplication = async ({
 		let command = "set -e;";
 		// Only rebuild, don't clone repository
 		command += await getBuildCommand(application);
+		const buildRedaction = await getBuildCommandRedactionSet(application);
 		const commandWithLog = `(${command}) >> ${deployment.logPath} 2>&1`;
 		if (serverId) {
-			await execAsyncRemote(serverId, commandWithLog);
+			await execAsyncRemote(serverId, commandWithLog, undefined, {
+				redact: buildRedaction,
+			});
 		} else {
-			await execAsync(commandWithLog);
+			await execAsync(commandWithLog, { redact: buildRedaction });
 		}
 		await mechanizeDockerContainer(application);
 

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -11,6 +11,7 @@ import {
 	generateFileMounts,
 	generateVolumeMounts,
 	getEnvironmentVariablesObject,
+	parseEnvironmentKeyValuePair,
 	prepareEnvironmentVariables,
 	prepareEnvironmentVariablesForShell,
 } from "../docker/utils";
@@ -68,7 +69,23 @@ export const getBuildCommandRedactionSet = async (
 	const dockerPrefixArgs = Object.entries(secrets).map(
 		([key, value]) => `${key}=${quote([value])}`,
 	);
-	return [...envArgs, ...dockerPrefixArgs];
+	// Railpack additionally embeds each value as a dotted-shell `export KEY=...`
+	// line in the build command (see getRailpackCommand) - a differently
+	// escaped form that the entries above do not cover. Without this, a failed
+	// railpack build leaks the secret through error.message/command.
+	const rawEnv = prepareEnvironmentVariables(
+		application.env,
+		application.environment.project.env,
+		application.environment.env,
+	);
+	const railpackExports: string[] = [];
+	for (const pair of rawEnv) {
+		const [key, value] = parseEnvironmentKeyValuePair(pair);
+		if (key && value) {
+			railpackExports.push(`export ${key}=${quote([value])}`);
+		}
+	}
+	return [...envArgs, ...dockerPrefixArgs, ...railpackExports];
 };
 
 export const getBuildCommand = async (rawApplication: ApplicationNested) => {

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -2,6 +2,7 @@ import { resolveServiceNetworks } from "@dokploy/server/services/network";
 import { findRegistryByIdWithCredentials } from "@dokploy/server/services/registry";
 import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
+import { quote } from "shell-quote";
 import { getRegistryTag, uploadImageRemoteCommand } from "../cluster/upload";
 import {
 	calculateResources,
@@ -9,7 +10,9 @@ import {
 	generateConfigContainer,
 	generateFileMounts,
 	generateVolumeMounts,
+	getEnvironmentVariablesObject,
 	prepareEnvironmentVariables,
+	prepareEnvironmentVariablesForShell,
 } from "../docker/utils";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
@@ -38,6 +41,35 @@ export type ApplicationNested = InferResultType<
 		environment: { with: { project: true } };
 	}
 >;
+
+/**
+ * The exact secret-bearing substrings that getBuildCommand embeds in the returned
+ * command string: shell-escaped `KEY=VALUE` pairs passed as `--env` args
+ * (nixpacks/railpack) and the `KEY=VALUE docker build ...` prefix (docker-file).
+ * Vault refs are resolved first so the redaction set matches what actually lands
+ * in the command. Callers executing the command should pass these to
+ * execAsync/execAsyncRemote so a failed build's error cannot carry cleartext
+ * secrets into logs (see dokploy#5354).
+ */
+export const getBuildCommandRedactionSet = async (
+	rawApplication: ApplicationNested,
+): Promise<string[]> => {
+	const application = await withResolvedVaultRefs(rawApplication);
+	const envArgs = prepareEnvironmentVariablesForShell(
+		application.env,
+		application.environment.project.env,
+		application.environment.env,
+	);
+	const secrets = getEnvironmentVariablesObject(
+		application.buildSecrets,
+		application.environment.project.env,
+		application.environment.env,
+	);
+	const dockerPrefixArgs = Object.entries(secrets).map(
+		([key, value]) => `${key}=${quote([value])}`,
+	);
+	return [...envArgs, ...dockerPrefixArgs];
+};
 
 export const getBuildCommand = async (rawApplication: ApplicationNested) => {
 	const application = await withResolvedVaultRefs(rawApplication);

--- a/packages/server/src/utils/process/ExecError.ts
+++ b/packages/server/src/utils/process/ExecError.ts
@@ -12,6 +12,13 @@ export class ExecError extends Error {
 	public readonly stdout?: string;
 	public readonly stderr?: string;
 	public readonly exitCode?: number;
+	/**
+	 * The underlying error the runtime handed us, retained for programmatic
+	 * diagnostics (e.g. exit-code and signal details). It may still contain the
+	 * RAW command text in its message - every string field on ExecError itself
+	 * is already redacted, but deploy handlers should never log this nested
+	 * error directly (greptile follow-up on dokploy#5354).
+	 */
 	public readonly originalError?: Error;
 	public readonly serverId?: string | null;
 

--- a/packages/server/src/utils/process/execAsync.ts
+++ b/packages/server/src/utils/process/execAsync.ts
@@ -60,7 +60,11 @@ export const execAsync = async (
 					stdout: redact(stdout),
 					stderr: redact(stderr),
 					exitCode,
-					originalError: error,
+					// child_process's ExecException carries the RAW command in its
+					// message and .cmd - swap it for a sanitized value-only error
+					// so deploy handlers logging the complete ExecError (including
+					// the nested error) cannot leak embedded secrets.
+					originalError: new Error(redact(error.message)),
 				},
 			);
 		}
@@ -184,6 +188,11 @@ export const execAsyncRemote = async (
 	let stderr = "";
 	return new Promise((resolve, reject) => {
 		const conn = new Client();
+		// Redaction must also cover the pre-exec branches: authentication and
+		// connection failures throw an ExecError that retains the command, and
+		// deploy handlers log the complete error object.
+		const redact = (text: string) =>
+			options?.redact ? redactSecrets(text, options.redact) : text;
 
 		sleep(1000);
 		conn
@@ -256,9 +265,9 @@ export const execAsyncRemote = async (
 					onData?.(friendlyMessage);
 					reject(
 						new ExecError(
-							`Authentication failed: Invalid SSH private key. ${friendlyMessage}`,
+							redact(`Authentication failed: Invalid SSH private key. ${friendlyMessage}`),
 							{
-								command,
+								command: redact(command),
 								serverId,
 								originalError: err,
 							},
@@ -268,8 +277,8 @@ export const execAsyncRemote = async (
 					const errorMsg = `SSH connection error: ${err.message}`;
 					onData?.(errorMsg);
 					reject(
-						new ExecError(errorMsg, {
-							command,
+						new ExecError(redact(errorMsg), {
+							command: redact(command),
 							serverId,
 							originalError: err,
 						}),

--- a/packages/server/src/utils/process/execAsync.ts
+++ b/packages/server/src/utils/process/execAsync.ts
@@ -3,6 +3,7 @@ import util from "node:util";
 import { findServerById } from "@dokploy/server/services/server";
 import { Client } from "ssh2";
 import { ExecError } from "./ExecError";
+import { redactSecrets } from "./redact";
 
 export class WriteFileRemoteError extends Error {
 	constructor(
@@ -25,7 +26,15 @@ const execAsyncBase = util.promisify(exec);
 
 export const execAsync = async (
 	command: string,
-	options?: { cwd?: string; env?: NodeJS.ProcessEnv; shell?: string },
+	options?: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+		shell?: string;
+		// Exact secret-bearing substrings embedded in `command` (e.g. escaped
+		// KEY=VALUE build args). Redacted from the retained command/stdout/stderr
+		// when the command fails, so ExecError cannot leak them into logs.
+		redact?: string[];
+	},
 ): Promise<{ stdout: string; stderr: string }> => {
 	try {
 		const result = await execAsyncBase(command, options);
@@ -41,14 +50,19 @@ export const execAsync = async (
 			const stdout = error.stdout?.toString() || "";
 			// @ts-expect-error
 			const stderr = error.stderr?.toString() || "";
+			const redact = (text: string) =>
+				options?.redact ? redactSecrets(text, options.redact) : text;
 
-			throw new ExecError(`Command execution failed: ${error.message}`, {
-				command,
-				stdout,
-				stderr,
-				exitCode,
-				originalError: error,
-			});
+			throw new ExecError(
+				`Command execution failed: ${redact(error.message)}`,
+				{
+					command: redact(command),
+					stdout: redact(stdout),
+					stderr: redact(stderr),
+					exitCode,
+					originalError: error,
+				},
+			);
 		}
 		throw error;
 	}
@@ -156,6 +170,11 @@ export const execAsyncRemote = async (
 	serverId: string | null,
 	command: string,
 	onData?: (data: string) => void,
+	options?: {
+		// Exact secret-bearing substrings embedded in `command`; redacted from the
+		// retained command/stdout/stderr when the remote command fails.
+		redact?: string[];
+	},
 ): Promise<{ stdout: string; stderr: string }> => {
 	if (!serverId) return { stdout: "", stderr: "" };
 	const server = await findServerById(serverId);
@@ -170,14 +189,19 @@ export const execAsyncRemote = async (
 		conn
 			.once("ready", () => {
 				conn.exec(command, (err, stream) => {
+					const redact = (text: string) =>
+						options?.redact ? redactSecrets(text, options.redact) : text;
 					if (err) {
 						onData?.(err.message);
 						reject(
-							new ExecError(`Remote command execution failed: ${err.message}`, {
-								command,
-								serverId,
-								originalError: err,
-							}),
+							new ExecError(
+								`Remote command execution failed: ${redact(err.message)}`,
+								{
+									command: redact(command),
+									serverId,
+									originalError: err,
+								},
+							),
 						);
 						return;
 					}
@@ -191,9 +215,9 @@ export const execAsyncRemote = async (
 									new ExecError(
 										`Remote command failed with exit code ${code}`,
 										{
-											command,
-											stdout,
-											stderr,
+											command: redact(command),
+											stdout: redact(stdout),
+											stderr: redact(stderr),
 											exitCode: code,
 											serverId,
 										},

--- a/packages/server/src/utils/process/redact.ts
+++ b/packages/server/src/utils/process/redact.ts
@@ -1,0 +1,20 @@
+/**
+ * Secret redaction for build/deploy command errors.
+ *
+ * Build commands embed environment secrets inline (nixpacks/railpack
+ * `--env KEY=VALUE` args, docker-file's `KEY=VALUE docker build ...` shell
+ * prefix), and ExecError retains the full command string - so a failed build
+ * can carry every secret into whatever surface logs or displays the error.
+ * Redaction happens once, at the error boundary, so downstream log and UI
+ * surfaces only ever see "***".
+ */
+export const redactSecrets = (text: string, secrets: string[]): string => {
+	let redacted = text;
+	// Longest first so overlapping values cannot partially survive.
+	for (const secret of secrets
+		.filter(Boolean)
+		.sort((a, b) => b.length - a.length)) {
+		redacted = redacted.split(secret).join("***");
+	}
+	return redacted;
+};


### PR DESCRIPTION
Fixes #5354.

Build commands inline env secrets (`KEY=value cmd ...`), and when a build fails the thrown `ExecError` carried the full command - secrets included - into whatever consumed the error (build-error notifications, logs). This adds a redaction boundary at the throw site:

- `execAsync` / `execAsyncRemote` take an optional `redact` set; the `ExecError` command and message surfaces carry `***` instead of secret values (longest-first replacement so overlapping values cannot partially survive).
- `getBuildCommandRedactionSet` collects the secrets the application build command embeds.
- The application deploy / rebuild / preview paths pass the redaction set. Compose/database build paths can adopt the same `redact` option later; this is scoped to the application build paths the issue names.

Credit: @John-Dormevil identified the affected paths precisely in #5354; the redaction-boundary design is ours.

Verification: new vitest suite 6/6 green on the repo harness; the core case (failed command does not retain embedded secrets on the thrown error) is red against pre-patch `execAsync` (secret retained) and green with the fix; a control test documents the pre-fix leak shape. Biome clean.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62107458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 0/5</h2>

This PR is not safe to merge because realistic local, Railpack, and remote connection failure paths can still place application secrets in server logs or build-error surfaces.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Railpack exports evade redaction** <a href="https://github.com/Dokploy/dokploy/pull/5400#discussion_r3969038187">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Original error retains secrets** <a href="https://github.com/Dokploy/dokploy/pull/5400#discussion_r3969038197">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**SSH failures bypass redaction** <a href="https://github.com/Dokploy/dokploy/pull/5400#discussion_r3969038208">▶</a>

<details><summary><h3>Summary</h3></summary>

- Railpack’s exported environment assignments do not match the generated redaction strings.
- Local ExecErrors retain the unsanitized child-process error.
- Remote SSH connection failures bypass command redaction.
</details>

<!-- /greptile_comment -->