### PR TITLE
fix(mounts): refuse empty filePath for file mounts

### DIFF
--- a/apps/dokploy/__test__/mounts/file-mount-filepath-guard.test.ts
+++ b/apps/dokploy/__test__/mounts/file-mount-filepath-guard.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+	createFile,
+	getCreateFileCommand,
+} from "@dokploy/server/utils/docker/utils";
+import { describe, expect, it } from "vitest";
+
+// dokploy#5292: a file mount with an empty filePath made path.join(outputPath, "")
+// === outputPath, so the mount's content was written onto the service's `files/`
+// directory path itself - turning it into a regular file and breaking every
+// sibling mount with "not a directory".
+
+describe("file mount filePath guards (dokploy#5292)", () => {
+	it("createFile refuses to write when filePath is empty", async () => {
+		const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-5292-"));
+		await expect(createFile(outputPath, "", "secret-content")).rejects.toThrow(
+			/filePath is required/,
+		);
+		// the directory path must survive as a directory, not become a file
+		expect(fs.statSync(outputPath).isDirectory()).toBe(true);
+	});
+
+	it("createFile refuses a whitespace-only filePath", async () => {
+		const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-5292-"));
+		await expect(createFile(outputPath, "   ", "x")).rejects.toThrow(
+			/filePath is required/,
+		);
+	});
+
+	it("createFile still writes real files", async () => {
+		const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-5292-"));
+		await createFile(outputPath, "nested/config.yml", "key: value");
+		expect(
+			fs.readFileSync(path.join(outputPath, "nested/config.yml"), "utf-8"),
+		).toBe("key: value");
+	});
+
+	it("createFile still creates directory mounts (trailing slash)", async () => {
+		const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-5292-"));
+		await createFile(outputPath, "mydir/", "");
+		expect(fs.statSync(path.join(outputPath, "mydir")).isDirectory()).toBe(
+			true,
+		);
+	});
+
+	it("getCreateFileCommand refuses an empty filePath", () => {
+		expect(() => getCreateFileCommand("/srv/app/files", "", "x")).toThrow(
+			/filePath is required/,
+		);
+	});
+
+	it("getCreateFileCommand still builds the remote write command", () => {
+		const cmd = getCreateFileCommand("/srv/app/files", "a/b.txt", "hello");
+		expect(cmd).toContain("mkdir -p");
+		expect(cmd).toContain("base64 -d");
+	});
+});

--- a/apps/dokploy/__test__/mounts/file-mount-filepath-guard.test.ts
+++ b/apps/dokploy/__test__/mounts/file-mount-filepath-guard.test.ts
@@ -57,3 +57,25 @@ describe("file mount filePath guards (dokploy#5292)", () => {
 		expect(cmd).toContain("base64 -d");
 	});
 });
+
+describe("file mount filePath resolves-inside guard (greptile follow-up)", () => {
+	it('createFile refuses a "." filePath (resolves to the directory itself)', async () => {
+		const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-5292-"));
+		await expect(createFile(outputPath, ".", "x")).rejects.toThrow(
+			/inside the service's files directory/,
+		);
+		expect(fs.statSync(outputPath).isDirectory()).toBe(true);
+	});
+
+	it('createFile still allows "."-prefixed real files', async () => {
+		const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), "dokploy-5292-"));
+		await createFile(outputPath, "./ok.txt", "y");
+		expect(fs.readFileSync(path.join(outputPath, "ok.txt"), "utf-8")).toBe("y");
+	});
+
+	it('getCreateFileCommand refuses a "." filePath', () => {
+		expect(() => getCreateFileCommand("/srv/app/files", ".", "x")).toThrow(
+			/inside the service's files directory/,
+		);
+	});
+});

--- a/packages/server/src/db/schema/mount.ts
+++ b/packages/server/src/db/schema/mount.ts
@@ -134,6 +134,18 @@ export const apiCreateMount = createSchema
 	})
 	.extend({
 		serviceId: z.string().min(1),
+	})
+	.superRefine((value, ctx) => {
+		// A file mount without a filePath would be materialized with an empty
+		// path, which overwrites the service's whole `files/` directory path with
+		// a regular file and breaks every sibling mount (dokploy#5292).
+		if (value.type === "file" && !value.filePath?.trim()) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["filePath"],
+				message: "filePath is required for file mounts",
+			});
+		}
 	});
 
 export const apiFindOneMount = z.object({

--- a/packages/server/src/services/mount.ts
+++ b/packages/server/src/services/mount.ts
@@ -82,6 +82,13 @@ export const createMount = async (input: z.infer<typeof apiCreateMount>) => {
 export const createFileMount = async (mountId: string) => {
 	try {
 		const mount = await findMountById(mountId);
+		if (!mount.filePath?.trim()) {
+			throw new TRPCError({
+				code: "BAD_REQUEST",
+				message:
+					"filePath is required for file mounts - an empty filePath would overwrite the service's files directory",
+			});
+		}
 		const baseFilePath = await getBaseFilesPath(mountId);
 
 		const serverId = await getServerId(mount);

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -769,6 +769,12 @@ export const createFile = async (
 	content: string,
 ) => {
 	try {
+		if (!filePath?.trim()) {
+			// path.join(outputPath, "") === outputPath: without this guard the
+			// mount's content would be written onto the `files/` directory path
+			// itself, turning it into a regular file (dokploy#5292).
+			throw new Error("filePath is required to create a file mount");
+		}
 		const fullPath = path.join(outputPath, filePath);
 		if (fullPath.endsWith(path.sep) || filePath.endsWith("/")) {
 			fs.mkdirSync(fullPath, { recursive: true });
@@ -790,6 +796,9 @@ export const getCreateFileCommand = (
 	filePath: string,
 	content: string,
 ) => {
+	if (!filePath?.trim()) {
+		throw new Error("filePath is required to create a file mount");
+	}
 	const fullPath = path.join(outputPath, filePath);
 	if (fullPath.endsWith(path.sep) || filePath.endsWith("/")) {
 		return `mkdir -p ${quote([fullPath])};`;

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -776,6 +776,13 @@ export const createFile = async (
 			throw new Error("filePath is required to create a file mount");
 		}
 		const fullPath = path.join(outputPath, filePath);
+		if (path.resolve(fullPath) === path.resolve(outputPath)) {
+			// "." and similar no-op relative paths resolve back to the base and
+			// would overwrite the service's whole files directory (dokploy#5292).
+			throw new Error(
+				"filePath must name a path inside the service's files directory, not the directory itself",
+			);
+		}
 		if (fullPath.endsWith(path.sep) || filePath.endsWith("/")) {
 			fs.mkdirSync(fullPath, { recursive: true });
 			return;
@@ -800,6 +807,11 @@ export const getCreateFileCommand = (
 		throw new Error("filePath is required to create a file mount");
 	}
 	const fullPath = path.join(outputPath, filePath);
+	if (path.resolve(fullPath) === path.resolve(outputPath)) {
+		throw new Error(
+			"filePath must name a path inside the service's files directory, not the directory itself",
+		);
+	}
 	if (fullPath.endsWith(path.sep) || filePath.endsWith("/")) {
 		return `mkdir -p ${quote([fullPath])};`;
 	}


### PR DESCRIPTION
Fixes #5292.

@safuapy's observation was the decisive one: the mounts come up as plain files, not directories. The mechanism: when a file mount's `filePath` is empty (unset), `createFile` writes the mount content at the service's `files/` directory path itself. The mount becomes a regular file where a directory was expected - hence the empty-directory / `not a directory` failures, and every sibling mount under the same files path breaking with it.

Guards at all three layers:

- `apiCreateMount` (zod): `superRefine` rejects `type: "file"` mounts without a non-empty `filePath`, so new corrupt mounts can't be created.
- `createFileMount` (service): refuses an empty `filePath` with a clear Bad Request, covering mounts created before the schema change.
- `createFile` / `getCreateFileCommand` (filesystem): decline to write to an empty path, so the content can never land on the `files/` directory path itself.

Verification: TRUE red-proof on the repo vitest harness - the 3 guard tests fail against pre-patch code (the write goes through), the 3 behavior tests (real file writes, directory mounts, remote command build) pass both ways; 6/6 green with the fix. Biome clean. Honest limit: the zod schema layer is not runnable in my sandbox (circular pgEnum under vitest) - it follows the repo's existing zod v3 refinement conventions and was verified by eye; the runnable filesystem guards are the ones that actually prevent the corruption.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62112052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because `"."` bypasses every new validation layer and can still reproduce the directory-corruption failure.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Normalized paths bypass guard** <a href="https://github.com/Dokploy/dokploy/pull/5402#discussion_r3969149792">▶</a>

<details><summary><h3>Summary</h3></summary>

- Validates empty and whitespace-only paths during mount creation.
- Adds local and remote filesystem guards.
- Adds regression tests for blank paths and normal file/directory behavior.
- The protection remains incomplete for normalized aliases such as `"."`.
</details>

<!-- /greptile_comment -->