### PR TITLE
fix(cron): register cron jobs once the first owner exists

### DIFF
--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -320,8 +320,20 @@ const createBetterAuth = () =>
 								// schedule them either. Now that the first owner exists,
 								// register the jobs. node-schedule replaces same-named
 								// jobs, so a repeated call after a restart is safe.
-								const { initCronJobs } = await import("../utils/backups/index");
-								await initCronJobs();
+								// Isolated: a failing DB read here must not surface as a
+								// signup error after the user and owner org are already
+								// committed - that would leave a partial account AND an
+								// error the admin can't retry past. Cron registration is
+								// confirmed on the next server boot instead.
+								try {
+									const { initCronJobs } = await import("../utils/backups/index");
+									await initCronJobs();
+								} catch (error) {
+									console.error(
+										"Failed to register cron jobs after first-owner signup; they will be registered on the next server start",
+										error,
+									);
+								}
 							}
 						} else if (isSSORequest) {
 							const providerId = context?.params?.providerId;

--- a/packages/server/src/lib/auth.ts
+++ b/packages/server/src/lib/auth.ts
@@ -311,6 +311,18 @@ const createBetterAuth = () =>
 									isDefault: true, // Mark first organization as default
 								});
 							});
+
+							if (!IS_CLOUD && process.env.NODE_ENV === "production") {
+								// On a fresh self-hosted install the server boot ran
+								// initCronJobs() before any owner existed, so it returned
+								// early and nothing was scheduled - and docker/log cleanup
+								// default to enabled, so no settings toggle ever fires to
+								// schedule them either. Now that the first owner exists,
+								// register the jobs. node-schedule replaces same-named
+								// jobs, so a repeated call after a restart is safe.
+								const { initCronJobs } = await import("../utils/backups/index");
+								await initCronJobs();
+							}
 						} else if (isSSORequest) {
 							const providerId = context?.params?.providerId;
 							if (!providerId) {


### PR DESCRIPTION
Fixes #5403.

On a fresh self-hosted install the boot order is the bug: `initCronJobs()` runs at server start, before any owner exists, and early-returns when `db.query.member.findFirst({ role: "owner" })` finds nothing. Nothing ever calls it again, and since docker/log cleanup default to enabled, no settings toggle ever fires to schedule them either - the default-on cleanup jobs are silently dead until the next restart.

This re-runs `initCronJobs()` right after the first-owner onboarding commit, gated `!IS_CLOUD && production` (cloud schedules its own; dev doesn't need cleanup). `node-schedule` replaces same-named jobs, so the repeated call after a restart is safe - no duplicate stacking (verified against the repo's own build).

Honest limit: no executable e2e (needs Postgres + a better-auth context); verified by path trace of the onboarding hook and the scheduler's same-name semantics.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62167808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until cron initialization failures are isolated from the first-owner signup response.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Cron failure breaks onboarding** <a href="https://github.com/Dokploy/dokploy/pull/5404#discussion_r3970416187">▶</a>

<details><summary><h3>Summary</h3></summary>

- Uses the same cloud and production gating as startup initialization.
- Runs after the owner organization transaction commits.
- Introduces an unisolated scheduler failure path into first-owner onboarding.
</details>

<!-- /greptile_comment -->