### PR TITLE
fix(billing): don't init Stripe at module scope without a publishable key

### DIFF
--- a/apps/dokploy/components/dashboard/onboarding/steps/plan-step.tsx
+++ b/apps/dokploy/components/dashboard/onboarding/steps/plan-step.tsx
@@ -11,9 +11,13 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/utils/api";
 import { displayFont } from "../font";
 
-const stripePromise = loadStripe(
-	process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
-);
+// Guard the module-level init: without a publishable key (self-hosted),
+// loadStripe still loads Stripe.js and the wrapper throws an IntegrationError
+// for the missing apiKey, and the rejected promise at module scope breaks
+// every page that imports this module (e.g. login -> onboarding wizard).
+const stripePromise = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+	? loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
+	: Promise.resolve(null);
 
 interface Props {
 	onNext: () => void;

--- a/apps/dokploy/components/dashboard/settings/billing/show-billing.tsx
+++ b/apps/dokploy/components/dashboard/settings/billing/show-billing.tsx
@@ -42,9 +42,13 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 
-const stripePromise = loadStripe(
-	process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!,
-);
+// Guard the module-level init: without a publishable key (self-hosted),
+// loadStripe still loads Stripe.js and the wrapper throws an IntegrationError
+// for the missing apiKey, and the rejected promise at module scope breaks
+// every page that imports this module (e.g. login -> onboarding wizard).
+const stripePromise = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+	? loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY)
+	: Promise.resolve(null);
 
 /** Precio legacy / Hobby: $4.50/mo primer servidor, $3.50 siguientes; anual $45.90 primero, $35.70 siguientes. */
 export const calculatePrice = (count: number, isAnnual = false) => {
@@ -170,7 +174,7 @@ export const ShowBilling = () => {
 
 	const useNewPricing = data?.hobbyProductId && data?.startupProductId;
 	const products = data?.products.filter((product) => {
-		// @ts-ignore
+		// @ts-expect-error
 		const interval = product?.default_price?.recurring?.interval;
 		return isAnnual ? interval === "year" : interval === "month";
 	});


### PR DESCRIPTION
Fixes #5344.

On self-hosted installs `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is unset. `loadStripe(undefined)` still loads Stripe.js and the wrapper rejects with an `IntegrationError` for the missing `apiKey` - and because that promise sits at module scope, every page importing the module crashes at render, which on self-hosted is the login -> onboarding path itself.

This guards both module-level init sites (`plan-step.tsx`, `show-billing.tsx`): with no publishable key, `stripePromise` resolves to `null`. Both consumers are already null-safe (`stripe?.redirectToCheckout`), so the guard is inert on cloud - nothing changes when the key is present. The `@ts-ignore` on the price filter also became `@ts-expect-error` (same suppression, fails loudly if the type error is ever fixed upstream).

Honest limit: the crash is traced, not replayed (no DOM in my environment); verified against the repo's own stripe-js 4.8.0 build - the unguarded call is the only module-level Stripe call in the import graph, and the guarded one cannot reject.

> Built by breken, your AI support engineer - breken.ai - this one's on us.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62167828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge and directly addresses the missing-key import failure without changing configured Stripe behavior.

<details><summary><h3>Summary</h3></summary>

- Guards both onboarding and billing initialization sites.
- Preserves normal cloud behavior when the key is configured.
- Replaces a broad TypeScript suppression with an expectation-checked suppression.
</details>

<!-- /greptile_comment -->