### PR TITLE
fix(ui): standardize settings layout widths to full width

### DIFF
--- a/apps/dokploy/components/dashboard/docker/show/show-containers.tsx
+++ b/apps/dokploy/components/dashboard/docker/show/show-containers.tsx
@@ -114,7 +114,7 @@ export const ShowContainers = ({ serverId }: Props) => {
 					</CardHeader>
 					<CardContent className="space-y-2 py-8 border-t">
 						<div className="gap-4 pb-20 w-full">
-							<div className="flex flex-col gap-4  w-full overflow-auto">
+							<div className="flex flex-col gap-4 w-full overflow-auto">
 								<div className="flex items-center gap-2 max-sm:flex-wrap">
 									<Input
 										placeholder="Filter by name..."

--- a/apps/dokploy/components/dashboard/requests/requests-table.tsx
+++ b/apps/dokploy/components/dashboard/requests/requests-table.tsx
@@ -189,7 +189,7 @@ export const RequestsTable = ({ dateRange }: RequestsTableProps) => {
 		<>
 			<div className="flex flex-col gap-6 w-full ">
 				<div className="mt-6 grid gap-4 pb-20 w-full">
-					<div className="flex flex-col gap-4  w-full overflow-auto">
+					<div className="flex flex-col gap-4 w-full overflow-auto">
 						<div className="flex items-center gap-2 max-sm:flex-wrap">
 							<Input
 								placeholder="Filter by hostname..."

--- a/apps/dokploy/components/dashboard/settings/ai-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/ai-form.tsx
@@ -24,7 +24,7 @@ export const AiForm = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="flex flex-row gap-2 justify-between">
 						<div>
@@ -62,7 +62,7 @@ export const AiForm = () => {
 												key={config.aiId}
 												className="flex items-center justify-between bg-sidebar p-1 w-full rounded-lg"
 											>
-												<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border  w-full">
+												<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border w-full">
 													<div>
 														<span className="text-sm font-medium">
 															{config.name}

--- a/apps/dokploy/components/dashboard/settings/api/show-api-keys.tsx
+++ b/apps/dokploy/components/dashboard/settings/api/show-api-keys.tsx
@@ -22,7 +22,7 @@ export const ShowApiKeys = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md">
 					<CardHeader className="flex flex-row gap-2 flex-wrap justify-between items-center">
 						<div>

--- a/apps/dokploy/components/dashboard/settings/billing/show-billing-invoices.tsx
+++ b/apps/dokploy/components/dashboard/settings/billing/show-billing-invoices.tsx
@@ -29,7 +29,7 @@ export const ShowBillingInvoices = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto">
+			<Card className="bg-sidebar p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md">
 					<CardHeader>
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/certificates/show-certificates.tsx
+++ b/apps/dokploy/components/dashboard/settings/certificates/show-certificates.tsx
@@ -38,7 +38,7 @@ export const ShowCertificates = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
@@ -111,7 +111,7 @@ export const ShowCertificates = () => {
 														key={certificate.certificateId}
 														className="flex items-center justify-between bg-sidebar p-1 w-full rounded-lg"
 													>
-														<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border  w-full">
+														<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border w-full">
 															<div className="flex items-center justify-between">
 																<div className="flex gap-2 flex-col">
 																	<span className="text-sm font-medium">

--- a/apps/dokploy/components/dashboard/settings/cluster/registry/show-registry.tsx
+++ b/apps/dokploy/components/dashboard/settings/cluster/registry/show-registry.tsx
@@ -20,7 +20,7 @@ export const ShowRegistry = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
@@ -55,7 +55,7 @@ export const ShowRegistry = () => {
 													key={registry.registryId}
 													className="flex items-center justify-between bg-sidebar p-1 w-full rounded-lg"
 												>
-													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border  w-full">
+													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border w-full">
 														<div className="flex items-center justify-between">
 															<div className="flex gap-2 flex-col">
 																<span className="text-sm font-medium">

--- a/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
+++ b/apps/dokploy/components/dashboard/settings/destination/show-destinations.tsx
@@ -19,7 +19,7 @@ export const ShowDestinations = () => {
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
@@ -56,7 +56,7 @@ export const ShowDestinations = () => {
 													key={destination.destinationId}
 													className="flex items-center justify-between bg-sidebar p-1 w-full rounded-lg"
 												>
-													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border  w-full">
+													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border w-full">
 														<div className="flex flex-col gap-1">
 															<span className="text-sm">
 																{index + 1}. {destination.name}

--- a/apps/dokploy/components/dashboard/settings/dns/show-dns-providers.tsx
+++ b/apps/dokploy/components/dashboard/settings/dns/show-dns-providers.tsx
@@ -35,7 +35,7 @@ export const ShowDnsProviders = () => {
 	const { data: permissions } = api.user.getPermissions.useQuery();
 
 	return (
-		<div className="w-full max-w-5xl mx-auto">
+		<div className="w-full">
 			<Card className="h-full bg-sidebar p-2.5 rounded-xl">
 				<div className="rounded-xl bg-background shadow-md">
 					<div className="flex flex-wrap items-center justify-between gap-4 p-6">

--- a/apps/dokploy/components/dashboard/settings/dns/show-dns-zones.tsx
+++ b/apps/dokploy/components/dashboard/settings/dns/show-dns-zones.tsx
@@ -52,7 +52,7 @@ export const ShowDnsZones = ({ dnsProviderId }: Props) => {
 		api.dnsProvider.listZones.useQuery({ dnsProviderId });
 
 	return (
-		<div className="w-full max-w-5xl mx-auto">
+		<div className="w-full">
 			<Card className="h-full bg-sidebar p-2.5 rounded-xl">
 				<div className="rounded-xl bg-background shadow-md">
 					<div className="flex flex-wrap items-center justify-between gap-4 p-6">

--- a/apps/dokploy/components/dashboard/settings/git/show-git-providers.tsx
+++ b/apps/dokploy/components/dashboard/settings/git/show-git-providers.tsx
@@ -69,7 +69,7 @@ export const ShowGitProviders = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/notifications/show-notifications.tsx
+++ b/apps/dokploy/components/dashboard/settings/notifications/show-notifications.tsx
@@ -31,7 +31,7 @@ export const ShowNotifications = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
@@ -70,7 +70,7 @@ export const ShowNotifications = () => {
 													key={notification.notificationId}
 													className="flex items-center justify-between bg-sidebar p-1 w-full rounded-lg"
 												>
-													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border  w-full">
+													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border w-full">
 														<span className="text-sm flex flex-row items-center gap-4">
 															{notification.notificationType === "slack" && (
 																<div className="flex  items-center justify-center rounded-lg">

--- a/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
+++ b/apps/dokploy/components/dashboard/settings/profile/profile-form.tsx
@@ -150,7 +150,7 @@ export const ProfileForm = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="flex flex-row gap-2 flex-wrap justify-between items-center">
 						<div>

--- a/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/show-servers.tsx
@@ -49,7 +49,7 @@ export const ShowServers = () => {
 	return (
 		<div className="w-full">
 			{query?.success && isCloud && <WelcomeSubscription />}
-			<Card className="h-full  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/ssh-keys/show-ssh-keys.tsx
+++ b/apps/dokploy/components/dashboard/settings/ssh-keys/show-ssh-keys.tsx
@@ -21,7 +21,7 @@ export const ShowDestinations = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">
@@ -57,7 +57,7 @@ export const ShowDestinations = () => {
 													key={sshKey.sshKeyId}
 													className="flex items-center justify-between bg-sidebar p-1 w-full rounded-lg"
 												>
-													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border  w-full">
+													<div className="flex items-center justify-between p-3.5 rounded-lg bg-background border w-full">
 														<div className="flex items-center justify-between">
 															<div className="flex flex-col">
 																<span className="text-sm font-medium">

--- a/apps/dokploy/components/dashboard/settings/tags/tag-manager.tsx
+++ b/apps/dokploy/components/dashboard/settings/tags/tag-manager.tsx
@@ -22,7 +22,7 @@ export const TagManager = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md">
 					<CardHeader>
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
@@ -320,7 +320,7 @@ export const AddUserPermissions = ({ userId, role }: Props) => {
 					<form
 						id="hook-form-add-permissions"
 						onSubmit={form.handleSubmit(onSubmit)}
-						className="grid  grid-cols-1 md:grid-cols-2  w-full gap-4"
+						className="grid  grid-cols-1 md:grid-cols-2 w-full gap-4"
 					>
 						{isCustomRole && (
 							<div className="md:col-span-2 rounded-lg border p-3 bg-muted/50 text-sm text-muted-foreground">

--- a/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-invitations.tsx
@@ -40,7 +40,7 @@ export const ShowInvitations = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/users/show-users.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/show-users.tsx
@@ -52,7 +52,7 @@ export const ShowUsers = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/vault/show-vault-providers.tsx
+++ b/apps/dokploy/components/dashboard/settings/vault/show-vault-providers.tsx
@@ -33,7 +33,7 @@ export const ShowVaultProviders = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md">
 					<CardHeader>
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/dashboard/settings/web-domain.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-domain.tsx
@@ -123,7 +123,7 @@ export const WebDomain = () => {
 
 	return (
 		<div className="w-full">
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="flex flex-row gap-2 flex-wrap justify-between items-center">
 						<div className="flex flex-col gap-1">

--- a/apps/dokploy/components/dashboard/settings/web-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server.tsx
@@ -24,7 +24,7 @@ export const WebServer = () => {
 	return (
 		<div className="w-full">
 			{/* <Card className={cn("rounded-lg w-full bg-transparent p-0", className)}></Card> */}
-			<Card className="h-full bg-sidebar  p-2.5 rounded-xl  max-w-5xl mx-auto">
+			<Card className="h-full bg-sidebar  p-2.5 rounded-xl w-full">
 				<div className="rounded-xl bg-background shadow-md ">
 					<CardHeader className="">
 						<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx
+++ b/apps/dokploy/components/proprietary/roles/manage-custom-roles.tsx
@@ -605,7 +605,7 @@ type CreateRoleSchema = z.infer<typeof createRoleSchema>;
 
 export const ManageCustomRoles = () => {
 	return (
-		<Card className="h-full bg-sidebar p-2.5 rounded-xl max-w-5xl mx-auto w-full">
+		<Card className="h-full bg-sidebar p-2.5 rounded-xl w-full">
 			<div className="rounded-xl bg-background shadow-md">
 				<CardHeader>
 					<CardTitle className="text-xl flex flex-row gap-2">

--- a/apps/dokploy/pages/dashboard/settings/deployments.tsx
+++ b/apps/dokploy/pages/dashboard/settings/deployments.tsx
@@ -21,7 +21,7 @@ const Page = () => {
 
 	return (
 		<div className="w-full">
-			<div className="h-full rounded-xl max-w-5xl mx-auto flex flex-col gap-4">
+			<div className="h-full rounded-xl w-full flex flex-col gap-4">
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl mx-auto w-full">
 					<div className="rounded-xl bg-background shadow-md">
 						<CardHeader>

--- a/apps/dokploy/pages/dashboard/settings/license.tsx
+++ b/apps/dokploy/pages/dashboard/settings/license.tsx
@@ -11,7 +11,7 @@ import { appRouter } from "@/server/api/root";
 const Page = () => {
 	return (
 		<div className="w-full">
-			<div className="h-full rounded-xl max-w-5xl mx-auto flex flex-col gap-4">
+			<div className="h-full rounded-xl w-full flex flex-col gap-4">
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl mx-auto w-full">
 					<div className="rounded-xl bg-background shadow-md">
 						<div className="p-6">

--- a/apps/dokploy/pages/dashboard/settings/profile.tsx
+++ b/apps/dokploy/pages/dashboard/settings/profile.tsx
@@ -16,7 +16,7 @@ const Page = () => {
 
 	return (
 		<div className="w-full">
-			<div className="h-full rounded-xl max-w-5xl mx-auto flex flex-col gap-4">
+			<div className="h-full rounded-xl w-full flex flex-col gap-4">
 				<ProfileForm />
 				{isCloud && <LinkingAccount />}
 				{permissions?.api.read && <ShowApiKeys />}

--- a/apps/dokploy/pages/dashboard/settings/server.tsx
+++ b/apps/dokploy/pages/dashboard/settings/server.tsx
@@ -15,7 +15,7 @@ const Page = () => {
 	const { data: user } = api.user.get.useQuery();
 	return (
 		<div className="w-full">
-			<div className="h-full rounded-xl  max-w-5xl mx-auto flex flex-col gap-4">
+			<div className="h-full rounded-xl w-full flex flex-col gap-4">
 				<WebDomain />
 				<WebServer />
 				<div className="w-full flex flex-col gap-4">

--- a/apps/dokploy/pages/dashboard/settings/sso.tsx
+++ b/apps/dokploy/pages/dashboard/settings/sso.tsx
@@ -25,7 +25,7 @@ interface Props {
 const Page = ({ isCloud }: Props) => {
 	return (
 		<div className="w-full">
-			<div className="h-full rounded-xl max-w-5xl mx-auto flex flex-col gap-4">
+			<div className="h-full rounded-xl w-full flex flex-col gap-4">
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl mx-auto w-full">
 					<div className="rounded-xl bg-background shadow-md">
 						<EnterpriseFeatureGate

--- a/apps/dokploy/pages/dashboard/settings/whitelabeling.tsx
+++ b/apps/dokploy/pages/dashboard/settings/whitelabeling.tsx
@@ -12,7 +12,7 @@ import { appRouter } from "@/server/api/root";
 const Page = () => {
 	return (
 		<div className="w-full">
-			<div className="h-full rounded-xl max-w-5xl mx-auto flex flex-col gap-4">
+			<div className="h-full rounded-xl w-full flex flex-col gap-4">
 				<Card className="h-full bg-sidebar p-2.5 rounded-xl mx-auto w-full">
 					<div className="rounded-xl bg-background shadow-md">
 						<div className="p-6">


### PR DESCRIPTION
## What is this PR about?

This PR addresses **Point 6** of issue #5395. 

Currently, the Deployments, Server, Whitelabeling, Profile, SSO, and License settings pages seem much less wide compared to the other sections. This PR updates all of those pages to be fully wide, bringing them in line with the Home section pages in the sidebar. 

This ensures that the page width remains completely consistent across the entire dashboard when navigating between different sections.

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.


## Validation
Tested that changes are correctly working and screenshot can't prove changes.

## Issues related (if applicable)

solves #5395 (specifically Point 6)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62173601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the layout changes are intentional and no actionable regressions were identified.

<details><summary><h3>Summary</h3></summary>

- Makes settings pages and cards consistently use the available dashboard content width.
- Covers deployments, server, profile, SSO, licensing, whitelabeling, and related settings components.
- Includes minor Tailwind class whitespace cleanup with no behavioral effect.
</details>

<!-- /greptile_comment -->