### PR TITLE
fix(auth): prefetch SSO state in SSR to prevent layout flash

### DIFF
--- a/apps/dokploy/pages/index.tsx
+++ b/apps/dokploy/pages/index.tsx
@@ -498,6 +498,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 	// Prefetch the public branding so the login/onboarding logo and app name
 	// render correctly on the server (no flash of default branding).
 	await helpers.whitelabeling.getPublic.prefetch();
+	await helpers.sso.showSignInWithSSO.prefetch();
 
 	if (IS_CLOUD) {
 		try {


### PR DESCRIPTION
## What is this PR about?

This PR partially addresses **Point 1** of issue #5395. Specifically, it resolves the layout flashing issue (sso hide toggle not added intentionaly until maintainers confirmation). 

It adds a prefetch for the SSO state within `getServerSideProps` on the login page (`pages/index.tsx`). This ensures the application knows whether the "Sign in with SSO" button should be displayed *before* the page renders on the client, completely eliminating the visual layout flash that occurs when an enterprise license is active.

*(Note: This PR focuses solely on the layout flash and does not introduce the toggle/button configurations for hiding/showing the SSO UI).*

## Checklist

Before submitting this PR, please make sure that:

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

## Validation

Tested that changes are correctly working and screenshot can't prove changes.

## Issues related (if applicable)

partially solves #5395 (Point 1 - flashing issue only)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62176070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dokploy/-/pull-requests/dokploy/dokploy/5407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because no new actionable failures were introduced since the previous review.

<details><summary><h3>Summary</h3></summary>

- Adds the SSO visibility query to the existing server-side tRPC hydration flow.
- Leaves authentication, authorization, and SSO configuration behavior unchanged.
</details>

<!-- /greptile_comment -->