### PR TITLE
fix(vault): read Infisical secrets pulled in through an import

### DIFF
--- a/apps/dokploy/__test__/env/vault.test.ts
+++ b/apps/dokploy/__test__/env/vault.test.ts
@@ -472,6 +472,50 @@ describe("infisical client", () => {
 		expect(params.get("secretPath")).toBe("/frontend");
 	});
 
+	it("asks for imported secrets and merges them", async () => {
+		mockFetch.mockResolvedValueOnce(loginResponse()).mockResolvedValueOnce(
+			jsonResponse({
+				secrets: [],
+				imports: [
+					{
+						secretPath: "/shared",
+						secrets: [
+							{ secretKey: "DB_URL", secretValue: "postgres://imported" },
+						],
+					},
+				],
+			}),
+		);
+
+		const result = await infisicalClient.getSecrets(config, ["DB_URL"]);
+
+		expect(result).toEqual({ DB_URL: "postgres://imported" });
+		const [listUrl] = mockFetch.mock.calls[1] as [string];
+		// snake_case on purpose: `includeImports` is silently ignored and the
+		// response comes back with an empty `imports` array.
+		expect(new URL(listUrl).searchParams.get("include_imports")).toBe("true");
+	});
+
+	it("lets a folder's own secret win over an imported one of the same name", async () => {
+		mockFetch.mockResolvedValueOnce(loginResponse()).mockResolvedValueOnce(
+			jsonResponse({
+				secrets: [{ secretKey: "DB_URL", secretValue: "postgres://local" }],
+				imports: [
+					{
+						secretPath: "/shared",
+						secrets: [
+							{ secretKey: "DB_URL", secretValue: "postgres://imported" },
+						],
+					},
+				],
+			}),
+		);
+
+		const result = await infisicalClient.getSecrets(config, ["DB_URL"]);
+
+		expect(result).toEqual({ DB_URL: "postgres://local" });
+	});
+
 	it("throws a clear error for a missing secret", async () => {
 		mockFetch
 			.mockResolvedValueOnce(loginResponse())

--- a/apps/dokploy/__test__/env/vault.test.ts
+++ b/apps/dokploy/__test__/env/vault.test.ts
@@ -496,6 +496,33 @@ describe("infisical client", () => {
 		expect(new URL(listUrl).searchParams.get("include_imports")).toBe("true");
 	});
 
+	it("lets the later import win when two define the same key", async () => {
+		mockFetch.mockResolvedValueOnce(loginResponse()).mockResolvedValueOnce(
+			jsonResponse({
+				secrets: [],
+				imports: [
+					{
+						secretPath: "/base",
+						secrets: [{ secretKey: "DB_URL", secretValue: "postgres://base" }],
+					},
+					{
+						secretPath: "/override",
+						secrets: [
+							{ secretKey: "DB_URL", secretValue: "postgres://override" },
+						],
+					},
+				],
+			}),
+		);
+
+		const result = await infisicalClient.getSecrets(config, ["DB_URL"]);
+
+		// Infisical documents this order: "If two imports carry a secret with the
+		// same name, the value from the bottom-most import wins." The response
+		// lists imports in that order, so assigning them in sequence matches it.
+		expect(result).toEqual({ DB_URL: "postgres://override" });
+	});
+
 	it("lets a folder's own secret win over an imported one of the same name", async () => {
 		mockFetch.mockResolvedValueOnce(loginResponse()).mockResolvedValueOnce(
 			jsonResponse({

--- a/packages/server/src/utils/vault/infisical.ts
+++ b/packages/server/src/utils/vault/infisical.ts
@@ -79,6 +79,12 @@ const readPath = async (
 		// still reports success. Single secrets read via /raw/{name} expand by
 		// default, which makes the difference easy to miss in the UI.
 		expandSecretReferences: "true",
+		// Secrets pulled in through "Import Secrets" are not part of `secrets`:
+		// they come back in a separate `imports` array, and only when this is
+		// asked for. Note the snake_case — `includeImports` is silently ignored
+		// (the request still returns 200 with an empty `imports`), which is why
+		// an imported secret looked like it simply did not exist.
+		include_imports: "true",
 	});
 	const response = await vaultFetch(
 		`${baseUrl(config)}/api/v3/secrets/raw?${params.toString()}`,
@@ -93,9 +99,17 @@ const readPath = async (
 
 	const body = (await response.json()) as {
 		secrets?: { secretKey: string; secretValue: string }[];
+		imports?: { secrets?: { secretKey: string; secretValue: string }[] }[];
 	};
 
 	const secrets: Record<string, string> = {};
+	// Imported first, then the folder's own: Infisical resolves a name defined
+	// in both in favour of the local one, so writing local last preserves that.
+	for (const imported of body.imports ?? []) {
+		for (const secret of imported.secrets ?? []) {
+			secrets[secret.secretKey] = secret.secretValue;
+		}
+	}
 	for (const secret of body.secrets ?? []) {
 		secrets[secret.secretKey] = secret.secretValue;
 	}


### PR DESCRIPTION
Fixes #5413.

## What was wrong

A secret brought into a folder with **Import Secrets** was reported as not found. Two independent reasons, and the first is the kind that hides well.

**The flag is snake_case.** `includeImports` is *silently ignored* — the request still returns 200, with `imports` present but empty — so an imported secret looked like it simply did not exist. Measured against `app.infisical.com` with an import that was confirmed registered via `GET /api/v1/secret-imports`:

| query | `imports[]` |
|---|---|
| `expandSecretReferences=true` | empty |
| `…&includeImports=true` | empty |
| `…&include_imports=true` | **contains the secret** |

**Imported secrets never appear in `secrets`.** They come back in a separate `imports` array, one entry per source path, which the client did not read at all.

## The fix

```ts
include_imports: "true",
```

plus merging `imports[].secrets` into the map **before** the folder's own, so a name defined in both resolves to the local value — matching how Infisical resolves it.

No behaviour change for anyone without imports: `imports` comes back empty and the loop is a no-op.

## Also measured, for whoever looks next

- `/api/v4/secrets` returns imports with **no flag at all** — worth knowing if this client ever moves off v3.
- Single-secret reads never see an imported key: `/api/v3/secrets/raw/{name}` returns 404, and `/api/v4/secrets/raw/{name}` is not a route. A folder listing is the only way to reach them.

## Scope

This covers imports, including "from another project" — which is what the issue describes. **Cross-project *references*** (the `${@project-slug.env.KEY}` value syntax) are a separate mechanism and I did not test them: that needs a second Infisical project plus the org-level grant, which I did not have set up. If the reporter's case turns out to be that syntax rather than an import, this PR will not be enough — worth confirming with them.

## Tests

`vault.test.ts`: **57 passed**.

- `asks for imported secrets and merges them` — asserts the resolved value *and* that the query carries `include_imports=true`. Reverting the fix fails this test.
- `lets a folder's own secret win over an imported one of the same name` — passes without the fix too, since an unread import cannot override anything. It is there to guard the precedence if the merge order is ever changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62491148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, though multi-import precedence should be pinned down with a regression test.

<h3>Summary</h3>

- Adds the v3 `include_imports=true` query parameter.
- Incorporates `imports[].secrets` into secret lookup results.
- Adds coverage for imported-secret retrieval and local-over-import precedence.

<sub>Reviews (1) · Last reviewed commit: ["fix(vault): read Infisical secrets pulle..."](https://github.com/dokploy/dokploy/commit/0c1dfe978c237ff91cdff0e64ac0d21fa9c39c0d)</sub>

<!-- /greptile_comment -->