### PR TITLE
fix(wss): bind Docker access to authorized service resources

### DIFF
--- a/apps/dokploy/__test__/permissions/server-terminal.test.ts
+++ b/apps/dokploy/__test__/permissions/server-terminal.test.ts
@@ -65,6 +65,21 @@ beforeEach(() => {
 });
 
 describe("server.terminal on custom roles", () => {
+	it.each([false, true])(
+		"SSH key management (%s) does not grant members a host shell",
+		async (enabled) => {
+			memberToReturn = {
+				...mockMemberData("member"),
+				canAccessToSSHKeys: enabled,
+			};
+			await expect(
+				checkPermission(ctx, { server: ["terminal"] }),
+			).rejects.toThrow();
+			const perms = await resolvePermissions(ctx);
+			expect(perms.sshKeys.read).toBe(enabled);
+			expect(perms.server.terminal).toBe(false);
+		},
+	);
 	it("a role with server.read alone cannot open a terminal", async () => {
 		withPermissions({ server: ["read"] });
 

--- a/apps/dokploy/__test__/wss/authorize.test.ts
+++ b/apps/dokploy/__test__/wss/authorize.test.ts
@@ -11,11 +11,28 @@ vi.mock("@dokploy/server/services/permission", () => ({
 }));
 
 const mockGetAccessibleServerIds = vi.hoisted(() => vi.fn());
+const mockFindServer = vi.hoisted(() => vi.fn());
+const mockFindService = vi.hoisted(() => vi.fn());
+const mockExec = vi.hoisted(() => vi.fn());
+const mockExecRemote = vi.hoisted(() => vi.fn());
+const deployment = vi.hoisted(() => ({ cloud: false }));
+vi.mock("@/server/wss/service-resource", () => ({
+	findWssService: mockFindService,
+}));
+vi.mock("@dokploy/server/utils/process/execAsync", () => ({
+	execAsync: mockExec,
+	execAsyncRemote: mockExecRemote,
+}));
 vi.mock("@dokploy/server", () => ({
 	getAccessibleServerIds: mockGetAccessibleServerIds,
+	findServerById: mockFindServer,
+	get IS_CLOUD() {
+		return deployment.cloud;
+	},
 }));
 
 import {
+	authorizeDockerOverWss,
 	canAccessDockerOverWss,
 	canAccessTerminalOverWss,
 } from "@/server/wss/authorize";
@@ -24,7 +41,26 @@ const USER = { id: "user-1" };
 const SESSION = { activeOrganizationId: "org-1" };
 
 beforeEach(() => {
-	vi.clearAllMocks();
+	vi.resetAllMocks();
+	deployment.cloud = false;
+	mockHasPermission.mockResolvedValue(true);
+	mockFindMember.mockResolvedValue({ role: "member" });
+	mockGetAccessibleServerIds.mockResolvedValue(new Set(["srv-1"]));
+	mockFindServer.mockResolvedValue({ organizationId: "org-1" });
+	mockFindService.mockResolvedValue({
+		appName: "my-app",
+		serverId: null,
+		appType: "application",
+	});
+	mockExec.mockResolvedValue({
+		stdout: JSON.stringify([
+			{
+				Id: "a".repeat(64),
+				Config: { Labels: { "com.docker.swarm.service.name": "my-app" } },
+			},
+		]),
+	});
+	mockExecRemote.mockImplementation((...args) => mockExec(...args));
 });
 
 describe("canAccessDockerOverWss", () => {
@@ -35,46 +71,245 @@ describe("canAccessDockerOverWss", () => {
 
 	it("denies a member without docker permission", async () => {
 		mockHasPermission.mockResolvedValue(false);
-		expect(await canAccessDockerOverWss(USER, SESSION)).toBe(false);
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, "srv-1", null, {
+				containerId: "my-container",
+			}),
+		).toBe(false);
 	});
 
-	it("allows when the caller has docker permission (no server)", async () => {
-		mockHasPermission.mockResolvedValue(true);
-		expect(await canAccessDockerOverWss(USER, SESSION)).toBe(true);
+	it("denies requests that omit the target", async () => {
+		expect(await canAccessDockerOverWss(USER, SESSION)).toBe(false);
 	});
 
 	it("denies a remote server the caller cannot access, even with docker permission", async () => {
 		mockHasPermission.mockResolvedValue(true);
 		mockGetAccessibleServerIds.mockResolvedValue(new Set(["other-server"]));
-		expect(await canAccessDockerOverWss(USER, SESSION, "srv-1")).toBe(false);
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, "srv-1", null, {
+				containerId: "my-container",
+			}),
+		).toBe(false);
 	});
 
 	it("allows a remote server the caller can access", async () => {
 		mockHasPermission.mockResolvedValue(true);
 		mockGetAccessibleServerIds.mockResolvedValue(new Set(["srv-1"]));
-		expect(await canAccessDockerOverWss(USER, SESSION, "srv-1")).toBe(true);
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, "srv-1", null, {
+				containerId: "my-container",
+			}),
+		).toBe(true);
 	});
 
 	it("denies when the container belongs to a service the caller cannot access", async () => {
 		mockCheckServiceAccess.mockRejectedValue(new Error("no access"));
-		expect(await canAccessDockerOverWss(USER, SESSION, null, "svc-1")).toBe(
-			false,
-		);
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "my-container",
+			}),
+		).toBe(false);
 	});
 
-	it("allows service access even without docker permission or server access", async () => {
-		// A member granted the service but without canAccessToDocker, whose
-		// service runs on a server they were not individually granted, must still
-		// read its logs — matches application.readLogs (service access only).
+	it("denies service access without Docker permission", async () => {
 		mockHasPermission.mockResolvedValue(false);
-		mockGetAccessibleServerIds.mockResolvedValue(new Set());
-		mockCheckServiceAccess.mockResolvedValue(undefined);
 		expect(
-			await canAccessDockerOverWss(USER, SESSION, "srv-remote", "svc-1"),
+			await canAccessDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "my-container",
+			}),
+		).toBe(false);
+		expect(mockHasPermission).toHaveBeenCalled();
+		expect(mockExec).not.toHaveBeenCalled();
+	});
+
+	const access = (
+		serverId: string | null = null,
+		serviceId: string | null = "svc-1",
+	) =>
+		canAccessDockerOverWss(USER, SESSION, serverId, serviceId, {
+			containerId: "my-container",
+		});
+	const stats = (appName: string, appType = "application") =>
+		canAccessDockerOverWss(USER, SESSION, null, "svc-1", { appName, appType });
+
+	it("denies local resources in cloud mode, including for administrators", async () => {
+		deployment.cloud = true;
+		mockFindMember.mockResolvedValue({ role: "admin" });
+		expect(await access()).toBe(false);
+		expect(await access(null, null)).toBe(false);
+		expect(mockExec).not.toHaveBeenCalled();
+	});
+	it("rejects the local alias and command injection before inspection", async () => {
+		expect(await access("local")).toBe(false);
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "my-container;id",
+			}),
+		).toBe(false);
+		expect(mockExec).not.toHaveBeenCalled();
+	});
+	it("restricts host statistics to administrators without service context", async () => {
+		const target = { appName: "dokploy", appType: "application" };
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, null, null, target),
+		).toBe(false);
+		mockFindMember.mockResolvedValue({ role: "admin" });
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, null, null, target),
 		).toBe(true);
-		// Service path is authoritative — it must not fall through to docker/server.
-		expect(mockHasPermission).not.toHaveBeenCalled();
-		expect(mockGetAccessibleServerIds).not.toHaveBeenCalled();
+		expect(await stats("dokploy")).toBe(false);
+	});
+
+	it("allows a matching service container and returns its immutable ID", async () => {
+		expect(await access()).toBe(true);
+		expect(
+			await authorizeDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "my-container",
+			}),
+		).toEqual({ containerId: "a".repeat(64) });
+		expect(mockFindService).toHaveBeenCalledWith("svc-1", "org-1");
+	});
+	it("denies inaccessible services", async () => {
+		mockCheckServiceAccess.mockRejectedValue(new Error("denied"));
+		expect(await access()).toBe(false);
+		expect(mockExec).not.toHaveBeenCalled();
+	});
+	it("denies missing or foreign organization services", async () => {
+		mockFindService.mockResolvedValue(null);
+		expect(await access()).toBe(false);
+	});
+	it("denies a service on an inaccessible server", async () => {
+		mockGetAccessibleServerIds.mockResolvedValue(new Set());
+		expect(await access("srv-1")).toBe(false);
+		expect(mockExecRemote).not.toHaveBeenCalled();
+	});
+	it("denies a different accessible deployment server", async () => {
+		expect(await access("srv-1")).toBe(false);
+	});
+	it("denies an omitted remote server ID", async () => {
+		mockFindService.mockResolvedValue({
+			appName: "my-app",
+			serverId: "srv-1",
+			appType: "application",
+		});
+		expect(await access()).toBe(false);
+		expect(await access("srv-1")).toBe(true);
+		expect(mockExecRemote).toHaveBeenCalled();
+	});
+	it("denies foreign organization servers even if in the accessible set", async () => {
+		mockFindServer.mockResolvedValue({ organizationId: "org-2" });
+		expect(await access("srv-1", null)).toBe(false);
+	});
+	it.each(["other-app", "dokploy", "dokploy-postgres", "my-app-extra"])(
+		"denies unrelated container %s",
+		async (appName) => {
+			mockExec.mockResolvedValue({
+				stdout: JSON.stringify([
+					{
+						Id: "b".repeat(64),
+						Config: { Labels: { "com.docker.swarm.service.name": appName } },
+					},
+				]),
+			});
+			expect(await access()).toBe(false);
+		},
+	);
+	it("denies unlabelled containers and inspect failures", async () => {
+		mockExec.mockResolvedValue({
+			stdout: JSON.stringify([{ Id: "b".repeat(64) }]),
+		});
+		expect(await access()).toBe(false);
+		mockExec.mockRejectedValue(new Error("unavailable"));
+		expect(await access()).toBe(false);
+	});
+	it("denies local generic Docker access to members, allows administrators", async () => {
+		expect(await access(null, null)).toBe(false);
+		mockFindMember.mockResolvedValue({ role: "admin" });
+		expect(await access(null, null)).toBe(true);
+	});
+	it("binds monitoring to the service app name and type", async () => {
+		expect(await stats("my-app")).toBe(true);
+		expect(await stats("other-app")).toBe(false);
+		expect(await stats("dokploy")).toBe(false);
+		expect(await stats("my-app", "invalid")).toBe(false);
+		expect(await stats("my-app", "stack")).toBe(false);
+	});
+	it.each(["stack", "docker-compose"])(
+		"binds %s monitoring to Docker ownership labels",
+		async (appType) => {
+			mockFindService.mockResolvedValue({
+				appName: "my-app",
+				serverId: null,
+				appType,
+			});
+			const label =
+				appType === "stack"
+					? "com.docker.stack.namespace"
+					: "com.docker.compose.project";
+			mockExec.mockResolvedValue({
+				stdout: JSON.stringify([
+					{ Id: "c".repeat(64), Config: { Labels: { [label]: "my-app" } } },
+				]),
+			});
+			expect(await stats("custom-container-name", appType)).toBe(true);
+			mockExec.mockResolvedValue({
+				stdout: JSON.stringify([
+					{
+						Id: "c".repeat(64),
+						Config: { Labels: { [label]: "my-app-extra" } },
+					},
+				]),
+			});
+			expect(await stats("custom-container-name", appType)).toBe(false);
+		},
+	);
+	it("checks Swarm service logs using service metadata", async () => {
+		mockExec.mockResolvedValue({
+			stdout: JSON.stringify([{ ID: "swarm-id", Spec: { Name: "my-app" } }]),
+		});
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "my-app",
+				runType: "swarm",
+			}),
+		).toBe(true);
+		mockExec.mockResolvedValue({
+			stdout: JSON.stringify([{ ID: "swarm-id", Spec: { Name: "dokploy" } }]),
+		});
+		expect(
+			await canAccessDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "dokploy",
+				runType: "swarm",
+			}),
+		).toBe(false);
+	});
+	it("resolves Swarm task ownership and retains the task ID for logs", async () => {
+		mockExec.mockResolvedValueOnce({
+			stdout: JSON.stringify([{ ID: "task-id", ServiceID: "service-id" }]),
+		});
+		mockExec.mockResolvedValueOnce({
+			stdout: JSON.stringify([{ ID: "service-id", Spec: { Name: "my-app" } }]),
+		});
+		expect(
+			await authorizeDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "task-id",
+				runType: "swarm",
+			}),
+		).toEqual({ containerId: "task-id" });
+		mockExec.mockResolvedValueOnce({
+			stdout: JSON.stringify([{ ID: "task-id", ServiceID: "foreign-service" }]),
+		});
+		mockExec.mockResolvedValueOnce({
+			stdout: JSON.stringify([
+				{ ID: "foreign-service", Spec: { Name: "other-app" } },
+			]),
+		});
+		expect(
+			await authorizeDockerOverWss(USER, SESSION, null, "svc-1", {
+				containerId: "task-id",
+				runType: "swarm",
+			}),
+		).toBeNull();
 	});
 });
 

--- a/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
+++ b/apps/dokploy/components/dashboard/settings/users/add-permissions.tsx
@@ -519,7 +519,8 @@ export const AddUserPermissions = ({ userId, role }: Props) => {
 											<div className="space-y-0.5">
 												<FormLabel>Access to SSH Keys</FormLabel>
 												<FormDescription>
-													Allow to users to access to the SSH Keys section
+													Manage SSH keys. Host terminal access requires the
+													separate Server Terminal permission in a custom role.
 												</FormDescription>
 											</div>
 											<FormControl>

--- a/apps/dokploy/server/wss/authorize.ts
+++ b/apps/dokploy/server/wss/authorize.ts
@@ -1,9 +1,20 @@
-import { getAccessibleServerIds } from "@dokploy/server";
+import {
+	findServerById,
+	getAccessibleServerIds,
+	IS_CLOUD,
+} from "@dokploy/server";
 import {
 	checkServiceAccess,
 	findMemberByUserId,
 	hasPermission,
 } from "@dokploy/server/services/permission";
+import {
+	execAsync,
+	execAsyncRemote,
+} from "@dokploy/server/utils/process/execAsync";
+import { quote } from "shell-quote";
+import { findWssService } from "./service-resource";
+import { isValidContainerId } from "./utils";
 
 type WssUser = { id: string } | null | undefined;
 type WssSession = { activeOrganizationId?: string | null } | null | undefined;
@@ -13,52 +24,111 @@ const buildCtx = (user: { id: string }, activeOrganizationId: string) => ({
 	session: { activeOrganizationId },
 });
 
-// Authorizes docker/container operations opened over a WebSocket (container
-// terminal, container logs, container stats). Requires the docker permission
-// (owner/admin, or a member explicitly granted canAccessToDocker) and, for a
-// remote server, that the server is accessible to the caller. Previously these
-// handlers only checked session + organization, so any member could reach a
-// root shell / logs of any container.
-export const canAccessDockerOverWss = async (
+type DockerTarget =
+	| { containerId: string; runType?: string | null }
+	| { appName: string; appType: string };
+
+export const authorizeDockerOverWss = async (
 	user: WssUser,
 	session: WssSession,
 	serverId?: string | null,
 	serviceId?: string | null,
-): Promise<boolean> => {
-	// return false;
-	if (!user || !session?.activeOrganizationId) return false;
-
-	const ctx = buildCtx(user, session.activeOrganizationId);
-
-	// When the container belongs to a specific Dokploy service (opened from a
-	// service page, so serviceId is present), access to that service is the
-	// authoritative gate — matching the service tRPC endpoints (e.g.
-	// application.readLogs, which check service access only). A member granted
-	// the service can read its logs / open its terminal even without the broad
-	// "docker" permission or explicit access to the server it runs on.
-	if (serviceId) {
-		try {
-			await checkServiceAccess(ctx, serviceId, "read");
-			return true;
-		} catch {
-			return false;
+	target?: DockerTarget,
+): Promise<{ containerId?: string } | null> => {
+	if (!user || !session?.activeOrganizationId || !target) return null;
+	try {
+		const ctx = buildCtx(user, session.activeOrganizationId);
+		if (!(await hasPermission(ctx, { docker: ["read"] }))) return null;
+		// The handlers interpret an absent server ID as the control-plane host.
+		if (serverId === "local" || (!serverId && IS_CLOUD)) return null;
+		if (serverId) {
+			const accessible = await getAccessibleServerIds({
+				userId: user.id,
+				activeOrganizationId: session.activeOrganizationId,
+			});
+			if (!accessible.has(serverId)) return null;
+			const server = await findServerById(serverId);
+			if (server.organizationId !== session.activeOrganizationId) return null;
 		}
+		const member = await findMemberByUserId(
+			user.id,
+			session.activeOrganizationId,
+		);
+		const privileged = member.role === "owner" || member.role === "admin";
+		// A Docker grant alone must not expose the local control plane to members.
+		if (!serviceId && !serverId && !privileged) return null;
+		let service: Awaited<ReturnType<typeof findWssService>> = null;
+		if (serviceId) {
+			await checkServiceAccess(ctx, serviceId, "read");
+			service = await findWssService(serviceId, session.activeOrganizationId);
+			if (!service || (service.serverId || null) !== (serverId || null))
+				return null;
+		}
+		if ("appName" in target) {
+			if (!["application", "stack", "docker-compose"].includes(target.appType))
+				return null;
+			if (target.appName === "dokploy")
+				return privileged && !serviceId ? {} : null;
+			if (!service) return privileged ? {} : null;
+			if (target.appType !== service.appType) return null;
+			if (target.appType === "application")
+				return target.appName === service.appName ? {} : null;
+		}
+		const isContainer = "containerId" in target;
+		const name = isContainer ? target.containerId : target.appName;
+		if (!isValidContainerId(name)) return null;
+		const swarm = isContainer && target.runType === "swarm";
+		const command = quote([
+			"docker",
+			...(swarm ? [] : ["container"]),
+			"inspect",
+			name,
+		]);
+		const inspect = async (command: string) =>
+			serverId ? execAsyncRemote(serverId, command) : execAsync(command);
+		const { stdout } = await inspect(command);
+		const [resource] = JSON.parse(stdout);
+		let swarmService = resource;
+		// docker service logs accepts task IDs as well as service IDs. Resolve
+		// task ownership through its ServiceID, while retaining the task log target.
+		if (swarm && resource.ServiceID) {
+			if (
+				typeof resource.ServiceID !== "string" ||
+				!isValidContainerId(resource.ServiceID)
+			)
+				return null;
+			const result = await inspect(
+				quote(["docker", "service", "inspect", resource.ServiceID]),
+			);
+			[swarmService] = JSON.parse(result.stdout);
+		}
+		const labels =
+			(swarm ? swarmService.Spec?.Labels : resource.Config?.Labels) ?? {};
+		if (service) {
+			const matches =
+				service.appType === "stack"
+					? labels["com.docker.stack.namespace"] === service.appName
+					: service.appType === "docker-compose"
+						? !swarm && labels["com.docker.compose.project"] === service.appName
+						: (swarm
+								? swarmService.Spec?.Name
+								: labels["com.docker.swarm.service.name"]) === service.appName;
+			if (!matches) return null;
+		}
+		const containerId = swarm ? resource.ID : resource.Id;
+		if (typeof containerId !== "string" || !isValidContainerId(containerId))
+			return null;
+		// Execute against the inspected ID so a renamed/replaced container cannot
+		// change the target between authorization and docker exec/logs.
+		return { containerId };
+	} catch {
+		return null;
 	}
-
-	// Generic Docker overview (no service context): mirror the docker tRPC router
-	// — require the docker permission and access to the target server.
-	if (!(await hasPermission(ctx, { docker: ["read"] }))) return false;
-
-	if (serverId && serverId !== "local") {
-		const accessible = await getAccessibleServerIds({
-			userId: user.id,
-			activeOrganizationId: session.activeOrganizationId,
-		});
-		if (!accessible.has(serverId)) return false;
-	}
-
-	return true;
 };
+
+export const canAccessDockerOverWss = async (
+	...args: Parameters<typeof authorizeDockerOverWss>
+) => (await authorizeDockerOverWss(...args)) !== null;
 
 // Authorizes the host/server SSH terminal opened over a WebSocket. The local
 // host terminal is a root shell on the control-plane host, so it is restricted

--- a/apps/dokploy/server/wss/docker-container-logs.ts
+++ b/apps/dokploy/server/wss/docker-container-logs.ts
@@ -3,7 +3,7 @@ import { findServerById, IS_CLOUD, validateRequest } from "@dokploy/server";
 import { spawn } from "node-pty";
 import { Client } from "ssh2";
 import { WebSocketServer } from "ws";
-import { canAccessDockerOverWss } from "./authorize";
+import { authorizeDockerOverWss } from "./authorize";
 import {
 	getShell,
 	isValidContainerId,
@@ -36,7 +36,7 @@ export const setupDockerContainerLogsWebSocketServer = (
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	wssTerm.on("connection", async (ws, req) => {
 		const url = new URL(req.url || "", `http://${req.headers.host}`);
-		const containerId = url.searchParams.get("containerId");
+		let containerId = url.searchParams.get("containerId");
 		const tail = url.searchParams.get("tail") ?? "100";
 		const search = url.searchParams.get("search") ?? "";
 		const since = url.searchParams.get("since") ?? "all";
@@ -76,10 +76,18 @@ export const setupDockerContainerLogsWebSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, serverId, serviceId))) {
+		const authorized = await authorizeDockerOverWss(
+			user,
+			session,
+			serverId,
+			serviceId,
+			{ containerId, runType },
+		);
+		if (!authorized?.containerId) {
 			ws.close(4003, "Not authorized");
 			return;
 		}
+		containerId = authorized.containerId;
 
 		// Set up keep-alive ping mechanism to prevent timeout
 		// Send ping every 45 seconds to keep connection alive
@@ -190,14 +198,14 @@ export const setupDockerContainerLogsWebSocketServer = (
 						}
 						ptyProcess.write(command.toString());
 					} catch (error) {
-						// @ts-ignore
+						// @ts-expect-error
 						const errorMessage = error?.message as unknown as string;
 						ws.send(errorMessage);
 					}
 				});
 			}
 		} catch (error) {
-			// @ts-ignore
+			// @ts-expect-error
 			const errorMessage = error?.message as unknown as string;
 
 			ws.send(errorMessage);

--- a/apps/dokploy/server/wss/docker-container-terminal.ts
+++ b/apps/dokploy/server/wss/docker-container-terminal.ts
@@ -3,7 +3,7 @@ import { findServerById, IS_CLOUD, validateRequest } from "@dokploy/server";
 import { spawn } from "node-pty";
 import { Client } from "ssh2";
 import { WebSocketServer } from "ws";
-import { canAccessDockerOverWss } from "./authorize";
+import { authorizeDockerOverWss } from "./authorize";
 import {
 	isValidContainerId,
 	isValidShell,
@@ -35,7 +35,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 	// eslint-disable-next-line @typescript-eslint/no-misused-promises
 	wssTerm.on("connection", async (ws, req) => {
 		const url = new URL(req.url || "", `http://${req.headers.host}`);
-		const containerId = url.searchParams.get("containerId");
+		let containerId = url.searchParams.get("containerId");
 		const activeWay = url.searchParams.get("activeWay");
 		const serverId = url.searchParams.get("serverId");
 		const serviceId = url.searchParams.get("serviceId");
@@ -70,10 +70,18 @@ export const setupDockerContainerTerminalWebSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, serverId, serviceId))) {
+		const authorized = await authorizeDockerOverWss(
+			user,
+			session,
+			serverId,
+			serviceId,
+			{ containerId },
+		);
+		if (!authorized?.containerId) {
 			ws.close(4003, "Not authorized");
 			return;
 		}
+		containerId = authorized.containerId;
 		try {
 			if (serverId) {
 				const server = await findServerById(serverId);
@@ -140,7 +148,7 @@ export const setupDockerContainerTerminalWebSocketServer = (
 									}
 									stream.write(text);
 								} catch (error) {
-									// @ts-ignore
+									// @ts-expect-error
 									const errorMessage = error?.message as unknown as string;
 									ws.send(errorMessage);
 								}
@@ -205,14 +213,14 @@ export const setupDockerContainerTerminalWebSocketServer = (
 						}
 						ptyProcess.write(text);
 					} catch (error) {
-						// @ts-ignore
+						// @ts-expect-error
 						const errorMessage = error?.message as unknown as string;
 						ws.send(errorMessage);
 					}
 				});
 			}
 		} catch (error) {
-			// @ts-ignore
+			// @ts-expect-error
 			const errorMessage = error?.message as unknown as string;
 
 			ws.send(errorMessage);

--- a/apps/dokploy/server/wss/docker-stats.ts
+++ b/apps/dokploy/server/wss/docker-stats.ts
@@ -10,7 +10,7 @@ import {
 } from "@dokploy/server";
 import { quote } from "shell-quote";
 import { WebSocketServer } from "ws";
-import { canAccessDockerOverWss } from "./authorize";
+import { authorizeDockerOverWss } from "./authorize";
 
 type AppType = "application" | "stack" | "docker-compose";
 
@@ -106,7 +106,14 @@ export const setupDockerStatsMonitoringSocketServer = (
 			return;
 		}
 
-		if (!(await canAccessDockerOverWss(user, session, null, serviceId))) {
+		const authorized = await authorizeDockerOverWss(
+			user,
+			session,
+			null,
+			serviceId,
+			{ appName, appType },
+		);
+		if (!authorized) {
 			ws.close(4003, "Not authorized");
 			return;
 		}
@@ -129,6 +136,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 
 				const filter = {
 					status: ["running"],
+					...(authorized.containerId && { id: [authorized.containerId] }),
 					...(appType === "application" && {
 						label: [`com.docker.swarm.service.name=${appName}`],
 					}),
@@ -156,7 +164,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 					return;
 				}
 				const { stdout, stderr } = await execAsync(
-					`docker stats ${container.Id} --no-stream --format \'{"BlockIO":"{{.BlockIO}}","CPUPerc":"{{.CPUPerc}}","Container":"{{.Container}}","ID":"{{.ID}}","MemPerc":"{{.MemPerc}}","MemUsage":"{{.MemUsage}}","Name":"{{.Name}}","NetIO":"{{.NetIO}}"}\'`,
+					`docker stats ${container.Id} --no-stream --format '{"BlockIO":"{{.BlockIO}}","CPUPerc":"{{.CPUPerc}}","Container":"{{.Container}}","ID":"{{.ID}}","MemPerc":"{{.MemPerc}}","MemUsage":"{{.MemUsage}}","Name":"{{.Name}}","NetIO":"{{.NetIO}}"}'`,
 				);
 				if (stderr) {
 					console.error("Docker stats error:", stderr);
@@ -173,7 +181,7 @@ export const setupDockerStatsMonitoringSocketServer = (
 					}),
 				);
 			} catch (error) {
-				// @ts-ignore
+				// @ts-expect-error
 				ws.close(4000, `Error: ${error.message}`);
 			}
 		}, 1300);

--- a/apps/dokploy/server/wss/service-resource.ts
+++ b/apps/dokploy/server/wss/service-resource.ts
@@ -1,0 +1,53 @@
+import { db } from "@dokploy/server/db";
+import {
+	applications,
+	compose,
+	environments,
+	libsql,
+	mariadb,
+	mongo,
+	mysql,
+	postgres,
+	projects,
+	redis,
+} from "@dokploy/server/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+
+// Resolve the organization and deployment target from persisted data, never
+// from the service ID or app name supplied by a WebSocket client.
+export const findWssService = async (
+	serviceId: string,
+	organizationId: string,
+) => {
+	const configs = [
+		{ table: applications, id: applications.applicationId },
+		{ table: compose, id: compose.composeId },
+		{ table: postgres, id: postgres.postgresId },
+		{ table: mysql, id: mysql.mysqlId },
+		{ table: mariadb, id: mariadb.mariadbId },
+		{ table: mongo, id: mongo.mongoId },
+		{ table: redis, id: redis.redisId },
+		{ table: libsql, id: libsql.libsqlId },
+	];
+	for (const { table, id } of configs) {
+		const [service] = await db
+			.select({
+				appName: table.appName,
+				serverId: table.serverId,
+				appType:
+					table === compose ? compose.composeType : sql<string>`'application'`,
+			})
+			.from(table)
+			.innerJoin(
+				environments,
+				eq(table.environmentId, environments.environmentId),
+			)
+			.innerJoin(projects, eq(environments.projectId, projects.projectId))
+			.where(
+				and(eq(id, serviceId), eq(projects.organizationId, organizationId)),
+			)
+			.limit(1);
+		if (service) return service;
+	}
+	return null;
+};


### PR DESCRIPTION
﻿## What is this PR about?

Docker WebSocket authorization previously treated access to a client-supplied `serviceId` as sufficient to open a container terminal, stream logs, or read monitoring data. That bypassed Docker and server permissions and did not establish that the requested container or monitoring target belonged to the service.

This change requires Docker permission and remote server access, resolves the service's organization and deployment server from the database, and checks Docker ownership metadata before granting access. A service ID can no longer authorize an unrelated container or monitoring target.

## Changes

- Add `findWssService` to resolve application, Compose, and database services within the active organization, returning their persisted app name, server, and deployment type.
- Bind container access to exact Swarm service, stack namespace, or Compose project metadata. Resolve Swarm task ownership through its parent service while preserving task-specific logs.
- Execute terminals and logs against the inspected Docker ID so renaming or replacing a container cannot redirect a previously authorized name.
- Validate monitoring app names and deployment types; pin Compose and stack monitoring to the inspected container ID.
- Restrict generic local Docker access and host statistics to owners/admins, and deny local Docker access in cloud mode. Generic remote Docker access still requires Docker permission and access to that server.
- Preserve the independent `server:terminal` permission. Clarify that SSH key management does not grant a host shell; the existing custom-role Server Terminal permission controls remote shell access.
- Replace the permission-bypass expectation with regression coverage for mismatched services, organizations, servers, container labels, monitoring targets, cloud restrictions, and Swarm tasks.

## Validation

- Passed: 86 tests across six WebSocket authorization and permission test files.
  - `node node_modules/vitest/vitest.mjs run --config __test__/vitest.config.ts __test__/wss/authorize.test.ts __test__/permissions` (from `apps/dokploy`).
- Passed: Biome checks for the authorizer, service resolver, permission UI, and changed tests; `git diff --check`.
- Full type checking and two additional WebSocket utility suites are blocked by the existing missing `@aws-sdk/client-ssm` dependency in the local installation.
- Live Docker/SSH end-to-end verification has not been performed. The authorization tests mock Docker inspection and service lookup.

## Checklist

- [x] Created a dedicated branch based on `canary`.
- [x] Read the contribution guidelines.
- [x] Ran the authorization and permission regression tests.
- [ ] Tested against a running local Docker/SSH instance.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62539226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until service monitoring supplies service context so authorized non-administrative users retain access.

<h3>Summary</h3>

- Adds organization-scoped resolution for application, Compose, and database services.
- Validates standalone, Compose, stack, and Swarm ownership before granting access.
- Restricts generic local Docker and host-stat access to owners and administrators.
- Preserves the independent remote server-terminal permission.
- Leaves service monitoring unavailable to non-administrative users because its existing clients do not provide the newly required service context.

<sub>Reviews (1) · Last reviewed commit: ["fix(wss): bind Docker access to authoriz..."](https://github.com/dokploy/dokploy/commit/d07f3788580b387d8eb693f89e8b9862f4659092)</sub>

<!-- /greptile_comment -->