### PR TITLE
feat(docker): pin Docker Model Runner CLI plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,16 @@ COPY --from=build /prod/dokploy/components.json ./components.json
 COPY --from=build /prod/dokploy/node_modules ./node_modules
 
 
-# Install docker
-RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh --version 28.5.2 && rm get-docker.sh && curl https://rclone.org/install.sh | bash
+# Install docker. get.docker.com already pulls docker-model-plugin unpinned
+# for Engine 28.2+; pin it in this same layer so rebuilds stay deterministic
+# without a second-layer downgrade keeping both binaries.
+RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh --version 28.5.2 && rm get-docker.sh \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends --allow-downgrades docker-model-plugin=1.2.6-1~debian.12~bookworm \
+	&& dpkg-query -W -f='${Version}\n' docker-model-plugin | grep -Fx '1.2.6-1~debian.12~bookworm' \
+	&& timeout -k 5s 15s docker model version >/dev/null \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl https://rclone.org/install.sh | bash
 
 # Install Nixpacks and tsx
 # | VERBOSE=1 VERSION=1.21.0 bash

--- a/apps/dokploy/__test__/docker/dockerfile-model-plugin.test.ts
+++ b/apps/dokploy/__test__/docker/dockerfile-model-plugin.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const dockerfile = readFileSync(
+	path.resolve(__dirname, "../../../../Dockerfile"),
+	"utf8",
+);
+
+const PLUGIN_PIN = "docker-model-plugin=1.2.6-1~debian.12~bookworm";
+const PLUGIN_VERSION = "1.2.6-1~debian.12~bookworm";
+
+const dockerInstallRun = () => {
+	const lines = dockerfile.split("\n");
+	const hit = lines.findIndex((line) =>
+		line.includes("https://get.docker.com"),
+	);
+	expect(hit).toBeGreaterThanOrEqual(0);
+	let start = hit;
+	while (start > 0 && !lines[start]?.startsWith("RUN ")) start--;
+	let end = start;
+	while (end < lines.length && lines[end]?.endsWith("\\")) end++;
+	return lines.slice(start, end + 1).join("\n");
+};
+
+describe("Dockerfile docker-model-plugin pin", () => {
+	it("pins the plugin in the same RUN as get.docker.com", () => {
+		const run = dockerInstallRun();
+		expect(run).toContain(PLUGIN_PIN);
+		expect(run).toContain("--allow-downgrades");
+		expect(run).toContain("--no-install-recommends");
+		expect(run.indexOf("get.docker.com")).toBeLessThan(
+			run.indexOf("apt-get update"),
+		);
+		expect(run.indexOf("apt-get update")).toBeLessThan(run.indexOf(PLUGIN_PIN));
+	});
+
+	it("asserts the installed dpkg version and a bounded plugin smoke check", () => {
+		const run = dockerInstallRun();
+		expect(run).toContain(
+			"dpkg-query -W -f='${Version}\\n' docker-model-plugin",
+		);
+		expect(run).toContain(`grep -Fx '${PLUGIN_VERSION}'`);
+		expect(run).toContain("timeout -k 5s 15s docker model version");
+		expect(run).toContain("rm -rf /var/lib/apt/lists/*");
+	});
+
+	it("does not download the plugin from GitHub or run mutating docker model commands", () => {
+		expect(dockerfile).not.toMatch(
+			/github\.com\/docker\/model-runner|releases\/download/,
+		);
+		const run = dockerInstallRun();
+		for (const cmd of [
+			"docker model status",
+			"docker model list",
+			"docker model ls",
+			"docker model inspect",
+			"docker model pull",
+			"docker model install-runner",
+		]) {
+			expect(run).not.toContain(cmd);
+		}
+	});
+});


### PR DESCRIPTION
## What is this PR about?

Pins the Docker Model Runner CLI package already installed in the Dokploy production image so rebuilds do not silently float to a different plugin version.

`get.docker.com` with Docker 28.5.2 already installs `docker-model-plugin` unpinned. Current Dokploy images therefore already contain the plugin; this PR makes that dependency explicit and reproducible.

## Changes

- Pins `docker-model-plugin` to `1.2.6-1~debian.12~bookworm`
- Keeps the pin in the same Docker layer as the Docker installer to avoid duplicate plugin bytes if the upstream candidate becomes newer
- Verifies the exact installed version with `dpkg-query`
- Runs a bounded `docker model version` smoke check
- Cleans apt package lists after installation
- Adds a focused Dockerfile contract test

## Multi-architecture

Verified on both supported image architectures:

- `linux/amd64`
- `linux/arm64`

Both install the exact pinned package and successfully execute the Model Runner CLI.

## Safety

The package is CLI-only and does not install or start the Model Runner service.

The smoke test intentionally uses `docker model version`.

It does not run commands such as:

- `docker model status`
- `docker model list`
- `docker model pull`
- `docker model install-runner`

which may initialize or modify Model Runner state.

No Docker socket is required for the build-time smoke check.

## Supply chain

The plugin continues to come from Docker's existing signed Debian repository configured by `get.docker.com`.

This PR introduces no new download origin or third-party binary source.

## Scope

This PR only makes the Docker Model Runner CLI package deterministic in the production image.

It does not add:

- Model Runner lifecycle management
- model pulling or execution
- API or UI changes
- model catalog support
- hardware/model-fit logic
- runner networking changes

## Testing

Verified with:

- focused Dockerfile contract tests
- real package validation on amd64 and arm64
- exact package-version assertion
- bounded `docker model version` smoke test
- newer-candidate downgrade simulation
- missing-version failure validation
- image/layer size comparison
- `pnpm typecheck`
- `pnpm dokploy:build`
- Biome
- `git diff --check`



## Validation update

No additional source change was needed for this PR; the branch remains at `36fdb1cad`.

The combined PR2-PR5 integration verified the exact Docker Model Runner CLI pin and `docker model version` smoke check on amd64 and arm64 (arm64 under QEMU). The combined focused suite passed 270/270 tests. This PR remains independent of the capability code.

Dependency clarification: only #5423 depends on #5424. This PR is independent of both capability endpoints and can be reviewed/merged separately.

## Review follow-up (2026-09-19)

No source changes were required in this PR for the Health integration requested on #5424. A local integration of current upstream `canary` (`f397c1a86`), all four PRs, and that correction passed 496 tests (1 skipped), plus a separate cross-endpoint parity test, and workspace typecheck. This includes the current Dockerfile pin contract tests. This follow-up did not rerun a multi-architecture image build or a physical NVIDIA test. Earlier validation and automated review text refer to their stated commits.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63297273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding findings or new issues since the previous review.

<h3>Summary</h3>

- Installs and verifies version `1.2.6-1~debian.12~bookworm` in the existing Docker installation layer.
- Adds a bounded, non-mutating CLI smoke check and cleans apt metadata.
- Adds focused Dockerfile contract tests covering the pin, verification, cleanup, and prohibited commands.

<sub>Reviews (2) · Last reviewed commit: ["feat(docker): pin Docker Model Runner CL..."](https://github.com/dokploy/dokploy/commit/36fdb1cad6012292f87d1d552e16fc47021f7e02)</sub>

<!-- /greptile_comment -->
