### PR TITLE
fix(compose): prevent unsupported models in Swarm stack deployments

### DIFF
--- a/apps/dokploy/__test__/compose/stack-compose-models.test.ts
+++ b/apps/dokploy/__test__/compose/stack-compose-models.test.ts
@@ -214,6 +214,61 @@ services:
 		expect(isStackDeployCommand("-cD remote stack deploy --help")).toBe(false);
 	});
 
+	it("treats stack up as the documented stack deploy alias", () => {
+		expect(isStackDeployCommand("stack up -c docker-compose.yml demo")).toBe(
+			true,
+		);
+		expect(
+			isStackDeployCommand("'stack' 'up' -c docker-compose.yml demo"),
+		).toBe(true);
+		expect(
+			isStackDeployCommand(
+				"--context remote stack up -c docker-compose.yml demo",
+			),
+		).toBe(true);
+		expect(
+			isStackDeployCommand(
+				"--context=remote stack up -c docker-compose.yml demo",
+			),
+		).toBe(true);
+		expect(isStackDeployCommand("-D stack up -c docker-compose.yml demo")).toBe(
+			true,
+		);
+		expect(
+			isStackDeployCommand("st\"ack\" u'p' -c docker-compose.yml demo"),
+		).toBe(true);
+	});
+
+	it("does not treat compose commands as stack up", () => {
+		expect(isStackDeployCommand("compose up")).toBe(false);
+		expect(isStackDeployCommand("compose run app stack up")).toBe(false);
+		expect(isStackDeployCommand("compose exec app stack up")).toBe(false);
+		expect(isStackDeployCommand("compose -f stack.yml up")).toBe(false);
+		expect(isStackDeployCommand("--context stack compose up")).toBe(false);
+	});
+
+	it("skips deprecated stack --orchestrator before deploy or up", () => {
+		expect(
+			isStackDeployCommand(
+				"stack --orchestrator swarm deploy -c docker-compose.yml demo",
+			),
+		).toBe(true);
+		expect(
+			isStackDeployCommand(
+				"stack --orchestrator=swarm up -c docker-compose.yml demo",
+			),
+		).toBe(true);
+		expect(
+			isStackDeployCommand(
+				"--context remote stack --orchestrator swarm up -c docker-compose.yml demo",
+			),
+		).toBe(true);
+		expect(isStackDeployCommand("stack --orchestrator deploy")).toBe(false);
+		expect(
+			isStackDeployCommand("stack --orchestrator deploy -c file.yml demo"),
+		).toBe(false);
+	});
+
 	it("classifies quoted shell argv the way /bin/sh does", () => {
 		expect(
 			isStackDeployCommand("'stack' 'deploy' -c docker-compose.yml demo"),
@@ -405,6 +460,50 @@ services:
 				}),
 			),
 		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("rejects custom stack up commands when models are present", async () => {
+		const models = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		for (const command of [
+			"stack up -c docker-compose.yml demo",
+			"'stack' 'up' -c docker-compose.yml demo",
+			"--context remote stack up -c docker-compose.yml demo",
+			"--context=remote stack up -c docker-compose.yml demo",
+			"-D stack up -c docker-compose.yml demo",
+			"stack --orchestrator swarm up -c docker-compose.yml demo",
+			"stack --orchestrator=swarm deploy -c docker-compose.yml demo",
+		]) {
+			await expect(
+				writeDeploy(
+					compose({
+						composeType: "docker-compose",
+						command,
+						composeFile: models,
+					}),
+				),
+			).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		}
+	});
+
+	it("allows compose commands that only resemble stack up", async () => {
+		const models = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		for (const command of [
+			"compose up",
+			"compose run app stack up",
+			"compose exec app stack up",
+			"compose -f stack.yml up",
+			"--context stack compose up",
+		]) {
+			await expect(
+				writeDeploy(
+					compose({
+						composeType: "docker-compose",
+						command,
+						composeFile: models,
+					}),
+				),
+			).resolves.toContain("base64 -d");
+		}
 	});
 
 	it("does not treat a compose file token containing 'stack deploy' as stack deploy", async () => {
@@ -627,6 +726,27 @@ describe("getBuildComposeCommand stack models", () => {
 			),
 		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
 	});
+
+	it("does not emit stack up when models are present", async () => {
+		await expect(
+			getBuildComposeCommand(
+				buildArgs({
+					composeType: "docker-compose",
+					command: "stack up -c docker-compose.yml demo",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		await expect(
+			getBuildComposeCommand(
+				buildArgs({
+					composeType: "docker-compose",
+					command: "--context remote stack up -c docker-compose.yml demo",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
 });
 
 const fakeDockerArgv = (command: string, pathPrefix: string) => {
@@ -753,6 +873,13 @@ process.stdout.write(JSON.stringify(process.argv.slice(2)));
 		expect(
 			fakeDockerArgv("'stack' 'deploy' -c file.yml demo", fakePath),
 		).toEqual(["stack", "deploy", "-c", "file.yml", "demo"]);
+		expect(fakeDockerArgv("'stack' 'up' -c file.yml demo", fakePath)).toEqual([
+			"stack",
+			"up",
+			"-c",
+			"file.yml",
+			"demo",
+		]);
 		expect(
 			fakeDockerArgv(
 				'--config "/tmp/docker config" stack deploy -c file.yml demo',

--- a/apps/dokploy/__test__/compose/stack-compose-models.test.ts
+++ b/apps/dokploy/__test__/compose/stack-compose-models.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { db } from "@dokploy/server/db";
 import {
 	createCommand,
@@ -11,7 +15,15 @@ import {
 	writeDomainsToCompose,
 } from "@dokploy/server/utils/docker/domain";
 import type { ComposeSpecification } from "@dokploy/server/utils/docker/types";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { parse, stringify } from "yaml";
 
 const disk = vi.hoisted(() => ({
@@ -140,6 +152,112 @@ services:
 		expect(
 			isStackDeployCommand("compose -f my-stack deploy-file.yml up -d"),
 		).toBe(false);
+	});
+
+	it("skips Docker root global options before stack deploy", () => {
+		const file = "stack deploy -c docker-compose.yml demo";
+		expect(isStackDeployCommand(`--context remote ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--context=remote ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-c remote ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-c=remote ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-cremote ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-D ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--debug ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--debug=true ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--tlsverify ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--config /tmp/config ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--config=deploy ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-H unix:///var/run/docker.sock ${file}`)).toBe(
+			true,
+		);
+		expect(isStackDeployCommand(`-Hunix:///var/run/docker.sock ${file}`)).toBe(
+			true,
+		);
+		expect(
+			isStackDeployCommand(`--context remote -D --tlsverify ${file}`),
+		).toBe(true);
+		expect(isStackDeployCommand(`-- ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-Dc remote ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--config deploy ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--log-level=debug ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`-v ${file}`)).toBe(true);
+		expect(isStackDeployCommand(`--config stack ${file}`)).toBe(true);
+	});
+
+	it("does not treat option values or compose args as stack deploy", () => {
+		expect(isStackDeployCommand("--context remote compose up")).toBe(false);
+		expect(isStackDeployCommand("-D compose up")).toBe(false);
+		expect(isStackDeployCommand("compose run app stack deploy")).toBe(false);
+		expect(isStackDeployCommand("compose exec app stack deploy")).toBe(false);
+		expect(isStackDeployCommand("compose -f my-stack deploy-file.yml up")).toBe(
+			false,
+		);
+		expect(isStackDeployCommand("--context stack compose up")).toBe(false);
+		expect(isStackDeployCommand("compose run app stack deploy")).toBe(false);
+		expect(isStackDeployCommand("--context")).toBe(false);
+		expect(isStackDeployCommand("--config")).toBe(false);
+		expect(isStackDeployCommand("-H")).toBe(false);
+		expect(isStackDeployCommand("-l")).toBe(false);
+		expect(
+			isStackDeployCommand(
+				"--something-new value stack deploy -c file.yml demo",
+			),
+		).toBe(false);
+		expect(isStackDeployCommand("stack --context remote deploy")).toBe(false);
+		expect(isStackDeployCommand("-c stack deploy -c file.yml demo")).toBe(
+			false,
+		);
+		expect(isStackDeployCommand("--debug false stack deploy --help")).toBe(
+			false,
+		);
+		expect(isStackDeployCommand("-H stack deploy --help")).toBe(false);
+		expect(isStackDeployCommand("-cD remote stack deploy --help")).toBe(false);
+	});
+
+	it("classifies quoted shell argv the way /bin/sh does", () => {
+		expect(
+			isStackDeployCommand("'stack' 'deploy' -c docker-compose.yml demo"),
+		).toBe(true);
+		expect(
+			isStackDeployCommand("st\"ack\" de'ploy' -c docker-compose.yml demo"),
+		).toBe(true);
+		expect(
+			isStackDeployCommand(
+				'--config "/tmp/docker config" stack deploy -c file.yml demo',
+			),
+		).toBe(true);
+		expect(
+			isStackDeployCommand(
+				"--config '/tmp/docker config' stack deploy -c file.yml demo",
+			),
+		).toBe(true);
+		expect(
+			isStackDeployCommand('--context "remote" stack deploy -c file.yml demo'),
+		).toBe(true);
+		expect(
+			isStackDeployCommand("-c 'remote' stack deploy -c file.yml demo"),
+		).toBe(true);
+		expect(isStackDeployCommand("'compose' up")).toBe(false);
+		expect(isStackDeployCommand("compose run app 'stack' 'deploy'")).toBe(
+			false,
+		);
+		expect(isStackDeployCommand("stack\tdeploy -c file.yml demo")).toBe(true);
+		expect(isStackDeployCommand('--context="" stack deploy --help')).toBe(true);
+		expect(isStackDeployCommand("--context= stack deploy --help")).toBe(true);
+		expect(isStackDeployCommand("--context '' stack deploy --help")).toBe(true);
+		expect(isStackDeployCommand("-c '' stack deploy --help")).toBe(true);
+		expect(
+			isStackDeployCommand("stack deploy -c file.yml demo # trailing comment"),
+		).toBe(true);
+		expect(isStackDeployCommand("# stack deploy -c file.yml demo")).toBe(false);
+		expect(isStackDeployCommand("~ stack deploy --help")).toBe(false);
+		expect(isStackDeployCommand("'' stack deploy --help")).toBe(false);
+	});
+
+	it("does not crash on malformed quotes", () => {
+		expect(() => isStackDeployCommand("'stack deploy")).not.toThrow();
+		expect(() => isStackDeployCommand('"stack deploy')).not.toThrow();
+		expect(() => isStackDeployCommand('stack "deploy')).not.toThrow();
 	});
 
 	it("does not crash on malformed specs", () => {
@@ -300,6 +418,92 @@ services:
 			),
 		).resolves.toContain("base64 -d");
 	});
+
+	it("rejects stack deploy after Docker root global options when models are present", async () => {
+		const models = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		for (const command of [
+			"--context remote stack deploy -c docker-compose.yml demo",
+			"--context=remote stack deploy -c docker-compose.yml demo",
+			"-c remote stack deploy -c docker-compose.yml demo",
+			"-D stack deploy -c docker-compose.yml demo",
+			"--tlsverify stack deploy -c docker-compose.yml demo",
+			"--config /tmp/config stack deploy -c docker-compose.yml demo",
+			"-H unix:///var/run/docker.sock stack deploy -c docker-compose.yml demo",
+			"--context remote -D --tlsverify stack deploy -c docker-compose.yml demo",
+		]) {
+			await expect(
+				writeDeploy(
+					compose({
+						composeType: "docker-compose",
+						command,
+						composeFile: models,
+					}),
+				),
+			).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		}
+	});
+
+	it("rejects quoted stack deploy custom commands when models are present", async () => {
+		const models = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		await expect(
+			writeDeploy(
+				compose({
+					composeType: "docker-compose",
+					command: "'stack' 'deploy' -c docker-compose.yml demo",
+					composeFile: models,
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		await expect(
+			writeDeploy(
+				compose({
+					composeType: "docker-compose",
+					command:
+						'--config "/tmp/docker config" stack deploy -c docker-compose.yml demo',
+					composeFile: models,
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("rejects later && docker stack deploy at sanitize time", () => {
+		expect(() =>
+			createCommand(
+				compose({
+					command: "compose up -d && docker stack deploy -c file.yml demo",
+				}) as never,
+			),
+		).toThrow(/Chained commands must strictly start with 'docker compose '/);
+		expect(() =>
+			createCommand(
+				compose({
+					command:
+						"compose up -d && docker --context remote stack deploy -c file.yml demo",
+				}) as never,
+			),
+		).toThrow(/Chained commands must strictly start with 'docker compose '/);
+	});
+
+	it("allows compose commands that only resemble stack deploy after globals", async () => {
+		const models = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		for (const command of [
+			"--context remote compose up -d",
+			"-D compose up -d",
+			"compose run app stack deploy",
+			"compose exec app stack deploy",
+			"--context stack compose up -d",
+		]) {
+			await expect(
+				writeDeploy(
+					compose({
+						composeType: "docker-compose",
+						command,
+						composeFile: models,
+					}),
+				),
+			).resolves.toContain("base64 -d");
+		}
+	});
 });
 
 describe("compose-file patch order", () => {
@@ -410,5 +614,158 @@ describe("getBuildComposeCommand stack models", () => {
 				}),
 			),
 		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("does not emit stack deploy when global options precede stack deploy and models are present", async () => {
+		await expect(
+			getBuildComposeCommand(
+				buildArgs({
+					composeType: "docker-compose",
+					command: "--context remote stack deploy -c docker-compose.yml demo",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+});
+
+const fakeDockerArgv = (command: string, pathPrefix: string) => {
+	const result = spawnSync("sh", ["-c", `docker ${command}`], {
+		encoding: "utf8",
+		env: { ...process.env, PATH: `${pathPrefix}:${process.env.PATH ?? ""}` },
+	});
+	if (result.status !== 0) {
+		throw new Error(result.stderr || `fake docker failed: ${result.status}`);
+	}
+	return JSON.parse(result.stdout) as string[];
+};
+
+const argvLooksLikeStackDeploy = (argv: string[]) => {
+	let i = 0;
+	while (i < argv.length) {
+		const token = argv[i];
+		if (!token || token === "-" || !token.startsWith("-")) break;
+		if (token === "--") {
+			i += 1;
+			break;
+		}
+		if (
+			token === "-D" ||
+			token === "-v" ||
+			token === "-h" ||
+			token.startsWith("--debug") ||
+			token.startsWith("--tls") ||
+			token.startsWith("--help") ||
+			token.startsWith("--version")
+		) {
+			i += 1;
+			continue;
+		}
+		if (
+			token.startsWith("--context") ||
+			token.startsWith("--config") ||
+			token.startsWith("--host") ||
+			token.startsWith("--log-level") ||
+			token.startsWith("--tlscacert") ||
+			token.startsWith("--tlscert") ||
+			token.startsWith("--tlskey") ||
+			token === "-c" ||
+			token.startsWith("-c") ||
+			token === "-H" ||
+			token.startsWith("-H") ||
+			token === "-l" ||
+			token.startsWith("-l")
+		) {
+			if (token.includes("=") || (token.startsWith("-c") && token.length > 2)) {
+				i += 1;
+				continue;
+			}
+			i += 2;
+			continue;
+		}
+		break;
+	}
+	return argv[i] === "stack" && argv[i + 1] === "deploy";
+};
+
+describe("fake-docker shell argv differential", () => {
+	let fakePath = "";
+
+	beforeAll(() => {
+		fakePath = mkdtempSync(join(tmpdir(), "dokploy-fake-docker-"));
+		const bin = join(fakePath, "docker");
+		writeFileSync(
+			bin,
+			`#!/usr/bin/env node
+process.stdout.write(JSON.stringify(process.argv.slice(2)));
+`,
+		);
+		chmodSync(bin, 0o755);
+	});
+
+	afterAll(() => {
+		if (fakePath) rmSync(fakePath, { recursive: true, force: true });
+	});
+
+	const corpus = [
+		"stack deploy -c docker-compose.yml demo",
+		"'stack' 'deploy' -c docker-compose.yml demo",
+		"st\"ack\" de'ploy' -c docker-compose.yml demo",
+		'--config "/tmp/docker config" stack deploy -c file.yml demo',
+		"--config '/tmp/docker config' stack deploy -c file.yml demo",
+		'--context "remote" stack deploy -c file.yml demo',
+		"-c 'remote' stack deploy -c file.yml demo",
+		"-D stack deploy -c file.yml demo",
+		"--debug=false stack deploy -c file.yml demo",
+		"--context=remote stack deploy -c file.yml demo",
+		"-c remote stack deploy -c file.yml demo",
+		"-H unix:///var/run/docker.sock stack deploy -c file.yml demo",
+		"'compose' up",
+		"compose run app 'stack' 'deploy'",
+		"--context remote compose up",
+		"-D compose up",
+		"--debug false stack deploy --help",
+		"-H stack deploy --help",
+		"compose -f my-stack deploy-file.yml up",
+		"stack\tdeploy -c file.yml demo",
+		"  stack   deploy  -c file.yml demo",
+	];
+
+	it("agrees with /bin/sh argv for the supported custom-command corpus", () => {
+		for (const command of corpus) {
+			const argv = fakeDockerArgv(command, fakePath);
+			expect(isStackDeployCommand(command), command).toBe(
+				argvLooksLikeStackDeploy(argv),
+			);
+		}
+	});
+
+	it("classifies default createCommand stack deploy as stack deploy in generated-shell argv", () => {
+		const command = createCommand(compose({ command: "" }) as never);
+		expect(command.startsWith("stack deploy")).toBe(true);
+		expect(isStackDeployCommand(command)).toBe(true);
+		const argv = fakeDockerArgv(command, fakePath);
+		expect(argv[0]).toBe("stack");
+		expect(argv[1]).toBe("deploy");
+	});
+
+	it("expands quoted stack deploy to stack/deploy argv", () => {
+		expect(
+			fakeDockerArgv("'stack' 'deploy' -c file.yml demo", fakePath),
+		).toEqual(["stack", "deploy", "-c", "file.yml", "demo"]);
+		expect(
+			fakeDockerArgv(
+				'--config "/tmp/docker config" stack deploy -c file.yml demo',
+				fakePath,
+			),
+		).toEqual([
+			"--config",
+			"/tmp/docker config",
+			"stack",
+			"deploy",
+			"-c",
+			"file.yml",
+			"demo",
+		]);
 	});
 });

--- a/apps/dokploy/__test__/compose/stack-compose-models.test.ts
+++ b/apps/dokploy/__test__/compose/stack-compose-models.test.ts
@@ -15,6 +15,7 @@ import {
 	writeDomainsToCompose,
 } from "@dokploy/server/utils/docker/domain";
 import type { ComposeSpecification } from "@dokploy/server/utils/docker/types";
+import * as processUtils from "@dokploy/server/utils/process/execAsync";
 import {
 	afterAll,
 	afterEach,
@@ -28,6 +29,7 @@ import { parse, stringify } from "yaml";
 
 const disk = vi.hoisted(() => ({
 	yaml: "services:\n  app:\n    image: nginx:alpine\n",
+	reads: [] as string[],
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -36,6 +38,7 @@ vi.mock("node:fs", async (importOriginal) => {
 		...actual,
 		existsSync: (p: Parameters<typeof actual.existsSync>[0]) => {
 			const path = String(p);
+			disk.reads.push(path);
 			if (path.includes("/code/") && path.endsWith("docker-compose.yml")) {
 				return true;
 			}
@@ -46,6 +49,7 @@ vi.mock("node:fs", async (importOriginal) => {
 			enc?: BufferEncoding,
 		) => {
 			const path = String(p);
+			disk.reads.push(path);
 			if (path.includes("/code/") && path.endsWith("docker-compose.yml")) {
 				return disk.yaml;
 			}
@@ -88,6 +92,129 @@ const compose = (
 
 const writeDeploy = (c: ReturnType<typeof compose>) =>
 	writeDomainsToCompose(c, [], createCommand(c as never));
+
+describe("managed Stack command regressions", () => {
+	afterEach(() => vi.restoreAllMocks());
+	it.each([
+		"-D=false stack deploy",
+		"-D=true stack deploy",
+		"-D stack deploy",
+		"--debug=false stack up",
+		"-Dlerror stack deploy",
+		"-l=error stack deploy",
+		"-- stack deploy",
+		"stack --orchestrator swarm --orchestrator=swarm deploy",
+		"stack --orchestrator deploy --orchestrator up deploy",
+		"-c --something stack --orchestrator=--something deploy",
+	])("recognizes and blocks models for %s", async (prefix) => {
+		const command = `${prefix} -c docker-compose.yml demo`;
+		expect(isStackDeployCommand(command)).toBe(true);
+		await expect(
+			writeDeploy(
+				compose({ command, composeFile: yaml(spec({ models: {} })) }),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it.each([
+		"-c models.yml",
+		"-c plain.yml",
+		"-c docker-compose.yml -c models.yml",
+		"-c docker-compose.yml --compose-file docker-compose.yml",
+		"--compose-file=docker-compose.yml,models.yml",
+		"-c -",
+		"-c ../outside.yml",
+		"-c /etc/compose.yml",
+		"-c subdir/../docker-compose.yml",
+		"-c linked-compose.yml",
+		"-c '../outside file.yml'",
+		"",
+	])("rejects unmanaged input without reading files: %s", async (files) => {
+		disk.reads.length = 0;
+		await expect(
+			writeDeploy(
+				compose({
+					sourceType: "github",
+					command: `stack deploy ${files} demo`,
+				}),
+			),
+		).rejects.toThrow(/exactly one.*managed Compose file/);
+		expect(disk.reads).toEqual([]);
+	});
+
+	it("reports selected-file policy before configured models", async () => {
+		await expect(
+			writeDeploy(
+				compose({
+					command: "stack deploy -c plain.yml demo",
+					composeFile: yaml(spec({ models: {} })),
+				}),
+			),
+		).rejects.toThrow(/exactly one.*managed Compose file/);
+	});
+
+	it("accepts the managed Git path with quoted spaces", async () => {
+		vi.spyOn(db.query.patch, "findMany").mockResolvedValue([]);
+		await expect(
+			writeDeploy(
+				compose({
+					sourceType: "github",
+					composePath: "dir with spaces/docker-compose.yml",
+					command: 'stack deploy -c "dir with spaces/docker-compose.yml" demo',
+				}),
+			),
+		).resolves.toContain("base64 -d");
+	});
+
+	it("rejects remote alternative input before opening an SSH read", async () => {
+		const remote = vi
+			.spyOn(processUtils, "execAsyncRemote")
+			.mockRejectedValue(new Error("unexpected SSH read"));
+		await expect(
+			writeDeploy(
+				compose({
+					sourceType: "github",
+					serverId: "fixture",
+					command: "stack deploy -c models.yml demo",
+				}),
+			),
+		).rejects.toThrow(/exactly one.*managed Compose file/);
+		expect(remote).not.toHaveBeenCalled();
+	});
+
+	it("keeps the managed remote document and ordinary transforms", async () => {
+		vi.spyOn(db.query.patch, "findMany").mockResolvedValue([]);
+		const remote = vi
+			.spyOn(processUtils, "execAsyncRemote")
+			.mockResolvedValue({ stdout: yaml(spec()), stderr: "" });
+		await expect(
+			writeDeploy(compose({ sourceType: "github", serverId: "fixture" })),
+		).resolves.toContain("base64 -d");
+		expect(remote).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		"stack deploy -cdocker-compose.yml demo",
+		"stack deploy -c=docker-compose.yml demo",
+		"stack deploy -qdc./docker-compose.yml demo",
+		"stack deploy demo --compose-file=./docker-compose.yml",
+		"stack deploy --resolve-image -c -c docker-compose.yml demo",
+		"stack deploy --orchestrator swarm -c docker-compose.yml demo",
+		"stack deploy -c docker-compose.yml -- demo",
+	])("accepts one managed input: %s", async (command) => {
+		await expect(writeDeploy(compose({ command }))).resolves.toContain(
+			"base64 -d",
+		);
+	});
+
+	it("does not treat operands after -- as selected inputs", async () => {
+		await expect(
+			writeDeploy(
+				compose({ command: "stack deploy -- demo -c docker-compose.yml" }),
+			),
+		).rejects.toThrow(/exactly one.*managed Compose file/);
+	});
+});
 
 describe("composeSpecificationUsesModels", () => {
 	it("detects top-level and service-level models structurally", () => {
@@ -760,55 +887,7 @@ const fakeDockerArgv = (command: string, pathPrefix: string) => {
 	return JSON.parse(result.stdout) as string[];
 };
 
-const argvLooksLikeStackDeploy = (argv: string[]) => {
-	let i = 0;
-	while (i < argv.length) {
-		const token = argv[i];
-		if (!token || token === "-" || !token.startsWith("-")) break;
-		if (token === "--") {
-			i += 1;
-			break;
-		}
-		if (
-			token === "-D" ||
-			token === "-v" ||
-			token === "-h" ||
-			token.startsWith("--debug") ||
-			token.startsWith("--tls") ||
-			token.startsWith("--help") ||
-			token.startsWith("--version")
-		) {
-			i += 1;
-			continue;
-		}
-		if (
-			token.startsWith("--context") ||
-			token.startsWith("--config") ||
-			token.startsWith("--host") ||
-			token.startsWith("--log-level") ||
-			token.startsWith("--tlscacert") ||
-			token.startsWith("--tlscert") ||
-			token.startsWith("--tlskey") ||
-			token === "-c" ||
-			token.startsWith("-c") ||
-			token === "-H" ||
-			token.startsWith("-H") ||
-			token === "-l" ||
-			token.startsWith("-l")
-		) {
-			if (token.includes("=") || (token.startsWith("-c") && token.length > 2)) {
-				i += 1;
-				continue;
-			}
-			i += 2;
-			continue;
-		}
-		break;
-	}
-	return argv[i] === "stack" && argv[i + 1] === "deploy";
-};
-
-describe("fake-docker shell argv differential", () => {
+describe("captured Docker shell argv", () => {
 	let fakePath = "";
 
 	beforeAll(() => {
@@ -825,39 +904,6 @@ process.stdout.write(JSON.stringify(process.argv.slice(2)));
 
 	afterAll(() => {
 		if (fakePath) rmSync(fakePath, { recursive: true, force: true });
-	});
-
-	const corpus = [
-		"stack deploy -c docker-compose.yml demo",
-		"'stack' 'deploy' -c docker-compose.yml demo",
-		"st\"ack\" de'ploy' -c docker-compose.yml demo",
-		'--config "/tmp/docker config" stack deploy -c file.yml demo',
-		"--config '/tmp/docker config' stack deploy -c file.yml demo",
-		'--context "remote" stack deploy -c file.yml demo',
-		"-c 'remote' stack deploy -c file.yml demo",
-		"-D stack deploy -c file.yml demo",
-		"--debug=false stack deploy -c file.yml demo",
-		"--context=remote stack deploy -c file.yml demo",
-		"-c remote stack deploy -c file.yml demo",
-		"-H unix:///var/run/docker.sock stack deploy -c file.yml demo",
-		"'compose' up",
-		"compose run app 'stack' 'deploy'",
-		"--context remote compose up",
-		"-D compose up",
-		"--debug false stack deploy --help",
-		"-H stack deploy --help",
-		"compose -f my-stack deploy-file.yml up",
-		"stack\tdeploy -c file.yml demo",
-		"  stack   deploy  -c file.yml demo",
-	];
-
-	it("agrees with /bin/sh argv for the supported custom-command corpus", () => {
-		for (const command of corpus) {
-			const argv = fakeDockerArgv(command, fakePath);
-			expect(isStackDeployCommand(command), command).toBe(
-				argvLooksLikeStackDeploy(argv),
-			);
-		}
 	});
 
 	it("classifies default createCommand stack deploy as stack deploy in generated-shell argv", () => {

--- a/apps/dokploy/__test__/compose/stack-compose-models.test.ts
+++ b/apps/dokploy/__test__/compose/stack-compose-models.test.ts
@@ -1,0 +1,414 @@
+import { db } from "@dokploy/server/db";
+import {
+	createCommand,
+	getBuildComposeCommand,
+} from "@dokploy/server/utils/builders/compose";
+import {
+	addDomainToCompose,
+	composeSpecificationUsesModels,
+	isStackDeployCommand,
+	STACK_COMPOSE_MODELS_ERROR,
+	writeDomainsToCompose,
+} from "@dokploy/server/utils/docker/domain";
+import type { ComposeSpecification } from "@dokploy/server/utils/docker/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse, stringify } from "yaml";
+
+const disk = vi.hoisted(() => ({
+	yaml: "services:\n  app:\n    image: nginx:alpine\n",
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		existsSync: (p: Parameters<typeof actual.existsSync>[0]) => {
+			const path = String(p);
+			if (path.includes("/code/") && path.endsWith("docker-compose.yml")) {
+				return true;
+			}
+			return actual.existsSync(p);
+		},
+		readFileSync: (
+			p: Parameters<typeof actual.readFileSync>[0],
+			enc?: BufferEncoding,
+		) => {
+			const path = String(p);
+			if (path.includes("/code/") && path.endsWith("docker-compose.yml")) {
+				return disk.yaml;
+			}
+			return actual.readFileSync(p, enc as never);
+		},
+	};
+});
+
+const yaml = (spec: unknown) => stringify(spec, { lineWidth: 1000 });
+
+const spec = (extra: Record<string, unknown> = {}): ComposeSpecification => ({
+	services: {
+		app: { image: "nginx:alpine" },
+	},
+	...extra,
+});
+
+const compose = (
+	overrides: Record<string, unknown> = {},
+): Parameters<typeof writeDomainsToCompose>[0] =>
+	({
+		appName: "demo",
+		composeFile: yaml(spec()),
+		composePath: "docker-compose.yml",
+		composeType: "stack",
+		command: "",
+		isolatedDeployment: false,
+		isolatedDeploymentsVolume: false,
+		randomize: false,
+		serverId: null,
+		sourceType: "raw",
+		suffix: "",
+		env: "",
+		createEnvFile: false,
+		mounts: [],
+		domains: [],
+		environment: { project: { env: "" }, env: "" },
+		...overrides,
+	}) as unknown as Parameters<typeof writeDomainsToCompose>[0];
+
+const writeDeploy = (c: ReturnType<typeof compose>) =>
+	writeDomainsToCompose(c, [], createCommand(c as never));
+
+describe("composeSpecificationUsesModels", () => {
+	it("detects top-level and service-level models structurally", () => {
+		expect(composeSpecificationUsesModels(spec())).toBe(false);
+		expect(
+			composeSpecificationUsesModels(
+				spec({ models: { llm: { model: "ai/smollm2" } } }),
+			),
+		).toBe(true);
+		expect(
+			composeSpecificationUsesModels({
+				services: { app: { image: "nginx:alpine", models: ["llm"] } },
+			}),
+		).toBe(true);
+		expect(composeSpecificationUsesModels(spec({ models: {} }))).toBe(true);
+		expect(composeSpecificationUsesModels(spec({ models: null }))).toBe(true);
+		expect(composeSpecificationUsesModels(spec({ models: [] }))).toBe(true);
+		expect(composeSpecificationUsesModels(spec({ models: "foo" }))).toBe(true);
+		expect(composeSpecificationUsesModels(spec({ models: 123 }))).toBe(true);
+		expect(
+			composeSpecificationUsesModels({
+				services: { app: { image: "nginx:alpine", models: [] } },
+			}),
+		).toBe(true);
+		expect(
+			composeSpecificationUsesModels({
+				services: { app: { image: "nginx:alpine", models: null } },
+			} as unknown as ComposeSpecification),
+		).toBe(true);
+	});
+
+	it("does not treat x-models or the word models in strings as models", () => {
+		expect(
+			composeSpecificationUsesModels(
+				spec({ "x-models": { llm: { model: "ai/smollm2" } } }),
+			),
+		).toBe(false);
+		const fromStrings = parse(`
+services:
+  app:
+    image: nginx:alpine
+    # models: fake
+    environment:
+      NOTE: "models: in env"
+    labels:
+      info: "models: in label"
+    command: ["echo", "models: in command"]
+`) as ComposeSpecification;
+		expect(composeSpecificationUsesModels(fromStrings)).toBe(false);
+	});
+
+	it("detects stack deploy from the first two command tokens", () => {
+		expect(
+			isStackDeployCommand("stack deploy -c docker-compose.yml demo"),
+		).toBe(true);
+		expect(
+			isStackDeployCommand("  stack   deploy  -c docker-compose.yml demo"),
+		).toBe(true);
+		expect(
+			isStackDeployCommand("compose -p demo -f docker-compose.yml up -d"),
+		).toBe(false);
+		expect(
+			isStackDeployCommand("compose -f my-stack deploy-file.yml up -d"),
+		).toBe(false);
+	});
+
+	it("does not crash on malformed specs", () => {
+		expect(composeSpecificationUsesModels(null)).toBe(false);
+		expect(composeSpecificationUsesModels(undefined)).toBe(false);
+		expect(composeSpecificationUsesModels("nope" as never)).toBe(false);
+		expect(
+			composeSpecificationUsesModels({
+				services: null,
+			} as unknown as ComposeSpecification),
+		).toBe(false);
+		expect(
+			composeSpecificationUsesModels({
+				services: { app: "bad" },
+			} as unknown as ComposeSpecification),
+		).toBe(false);
+	});
+});
+
+describe("stack deploy compatibility", () => {
+	it("allows docker compose with models and stack without models", async () => {
+		const withModels = compose({
+			composeType: "docker-compose",
+			composeFile: yaml(
+				spec({
+					models: { llm: { model: "ai/smollm2" } },
+					services: { app: { image: "nginx:alpine", models: ["llm"] } },
+				}),
+			),
+		});
+		await expect(writeDeploy(withModels)).resolves.toContain("base64 -d");
+		await expect(writeDeploy(compose())).resolves.toContain("base64 -d");
+	});
+
+	it("rejects default stack deploy when the final spec has models", async () => {
+		const top = compose({
+			composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+		});
+		const svc = compose({
+			composeFile: yaml({
+				services: { app: { image: "nginx:alpine", models: ["llm"] } },
+			}),
+		});
+		const both = compose({
+			composeFile: yaml({
+				services: { app: { image: "nginx:alpine", models: ["llm"] } },
+				models: { llm: { model: "ai/smollm2" } },
+			}),
+		});
+		await expect(writeDeploy(top)).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		await expect(writeDeploy(svc)).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		await expect(writeDeploy(both)).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("allows x-models and textual 'models:' that are not Compose models keys", async () => {
+		await expect(
+			writeDeploy(
+				compose({
+					composeFile: yaml(
+						spec({ "x-models": { llm: { model: "ai/smollm2" } } }),
+					),
+				}),
+			),
+		).resolves.toContain("base64 -d");
+		await expect(
+			writeDeploy(
+				compose({
+					composeFile: `
+services:
+  app:
+    image: nginx:alpine
+    # models: fake
+    environment:
+      NOTE: "models: in env"
+    labels:
+      info: "models: in label"
+    command: ["echo", "models: in command"]
+`,
+				}),
+			),
+		).resolves.toContain("base64 -d");
+	});
+
+	it("still converts stack compose with models for preview", async () => {
+		const converted = await addDomainToCompose(
+			compose({
+				composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+			}),
+			[],
+		);
+		expect(converted?.models).toEqual({ llm: { model: "ai/smollm2" } });
+	});
+
+	it("inspects the transformed spec so randomization keeps models detectable", async () => {
+		await expect(
+			writeDeploy(
+				compose({
+					randomize: true,
+					suffix: "abc123",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		await expect(
+			writeDeploy(
+				compose({
+					isolatedDeployment: true,
+					suffix: "iso",
+					composeFile: yaml({
+						services: { app: { image: "nginx:alpine", models: ["llm"] } },
+					}),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("allows stack records whose custom command is compose up", async () => {
+		await expect(
+			writeDeploy(
+				compose({
+					command: "compose -p demo -f docker-compose.yml up -d",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).resolves.toContain("base64 -d");
+	});
+
+	it("rejects docker-compose records whose custom command is stack deploy", async () => {
+		const models = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		await expect(
+			writeDeploy(
+				compose({
+					composeType: "docker-compose",
+					command: "stack deploy -c docker-compose.yml demo",
+					composeFile: models,
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+		await expect(
+			writeDeploy(
+				compose({
+					composeType: "docker-compose",
+					command: "  stack   deploy  -c docker-compose.yml demo",
+					composeFile: models,
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("does not treat a compose file token containing 'stack deploy' as stack deploy", async () => {
+		await expect(
+			writeDeploy(
+				compose({
+					composeType: "docker-compose",
+					command: "compose -f my-stack deploy-file.yml up -d",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).resolves.toContain("base64 -d");
+	});
+});
+
+describe("compose-file patch order", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		disk.yaml = yaml(spec());
+	});
+
+	const gitCompose = (overrides: Record<string, unknown> = {}) =>
+		compose({
+			sourceType: "github",
+			composeId: "compose-1",
+			composePath: "docker-compose.yml",
+			...overrides,
+		});
+
+	it("rejects when a patch adds models to a stack deploy", async () => {
+		disk.yaml = yaml(spec());
+		vi.spyOn(db.query.patch, "findMany").mockResolvedValue([
+			{
+				enabled: true,
+				type: "update",
+				filePath: "docker-compose.yml",
+				content: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+			},
+		] as never);
+		await expect(writeDeploy(gitCompose())).rejects.toThrow(
+			STACK_COMPOSE_MODELS_ERROR,
+		);
+	});
+
+	it("allows stack deploy when a patch removes models", async () => {
+		disk.yaml = yaml(spec({ models: { llm: { model: "ai/smollm2" } } }));
+		vi.spyOn(db.query.patch, "findMany").mockResolvedValue([
+			{
+				enabled: true,
+				type: "update",
+				filePath: "docker-compose.yml",
+				content: yaml(spec()),
+			},
+		] as never);
+		await expect(writeDeploy(gitCompose())).resolves.toContain("base64 -d");
+	});
+});
+
+describe("getBuildComposeCommand stack models", () => {
+	const buildArgs = (overrides: Record<string, unknown> = {}) =>
+		({
+			...compose(overrides),
+			type: "compose" as const,
+		}) as unknown as Parameters<typeof getBuildComposeCommand>[0];
+
+	it("does not emit stack deploy for default stack + models", async () => {
+		await expect(
+			getBuildComposeCommand(
+				buildArgs({
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("still emits stack deploy without models and compose up with models", async () => {
+		const stack = await getBuildComposeCommand(buildArgs());
+		expect(stack).toContain("stack deploy");
+		expect(stack).not.toContain("docker network inspect");
+		const up = await getBuildComposeCommand(
+			buildArgs({
+				composeType: "docker-compose",
+				composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+			}),
+		);
+		expect(up).toContain("compose -p demo");
+		expect(up).toContain("up -d");
+		expect(up).not.toContain("stack deploy");
+	});
+
+	it("does not create an isolated overlay network when stack + models is rejected", async () => {
+		await expect(
+			getBuildComposeCommand(
+				buildArgs({
+					isolatedDeployment: true,
+					suffix: "iso",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+
+	it("keeps a custom compose command for stack + models", async () => {
+		const command = await getBuildComposeCommand(
+			buildArgs({
+				command: "compose -p demo -f docker-compose.yml up -d",
+				composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+			}),
+		);
+		expect(command).toContain("compose -p demo");
+		expect(command).not.toContain("stack deploy");
+	});
+
+	it("does not emit stack deploy for a docker-compose record with a custom stack command and models", async () => {
+		await expect(
+			getBuildComposeCommand(
+				buildArgs({
+					composeType: "docker-compose",
+					command: "stack deploy -c docker-compose.yml demo",
+					composeFile: yaml(spec({ models: { llm: { model: "ai/smollm2" } } })),
+				}),
+			),
+		).rejects.toThrow(STACK_COMPOSE_MODELS_ERROR);
+	});
+});

--- a/packages/server/src/utils/builders/compose.ts
+++ b/packages/server/src/utils/builders/compose.ts
@@ -31,7 +31,7 @@ export const getBuildComposeCommand = async (rawCompose: ComposeNested) => {
 		: "";
 	const exportEnvCommand = getExportEnvCommand(compose);
 
-	const newCompose = await writeDomainsToCompose(compose, domains);
+	const newCompose = await writeDomainsToCompose(compose, domains, command);
 	const logContent = `
 App Name: ${appName}
 Build Compose 🐳

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -6,7 +6,7 @@ import { network, patch } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
 import { eq, inArray } from "drizzle-orm";
-import { quote } from "shell-quote";
+import { parse as parseShell, quote } from "shell-quote";
 import { parse, stringify } from "yaml";
 import { execAsyncRemote } from "../process/execAsync";
 import { cloneBitbucketRepository } from "../providers/bitbucket";
@@ -132,9 +132,107 @@ export const composeSpecificationUsesModels = (
 	return false;
 };
 
+const DOCKER_VALUE_LONG = new Set([
+	"config",
+	"context",
+	"host",
+	"log-level",
+	"tlscacert",
+	"tlscert",
+	"tlskey",
+]);
+const DOCKER_VALUE_SHORT = new Set(["c", "H", "l"]);
+const DOCKER_BOOL_LONG = new Set([
+	"debug",
+	"help",
+	"tls",
+	"tlsverify",
+	"version",
+]);
+const DOCKER_BOOL_SHORT = new Set(["D", "h", "v"]);
+
+const tokenizeDockerCommand = (command: string) => {
+	const tokens: string[] = [];
+	for (const entry of parseShell(command, {})) {
+		if (typeof entry === "string") {
+			tokens.push(entry);
+			continue;
+		}
+		if ("comment" in entry) continue;
+		if ("op" in entry) {
+			if (entry.op === "glob") {
+				tokens.push(entry.pattern);
+				continue;
+			}
+			if (entry.op === "&&") break;
+			return [];
+		}
+	}
+	return tokens;
+};
+
+const skipDockerGlobalOptions = (tokens: string[]) => {
+	let i = 0;
+	while (i < tokens.length) {
+		const token = tokens[i];
+		if (!token || token === "-") break;
+		if (token === "--") return i + 1;
+		if (!token.startsWith("-")) break;
+
+		if (token.startsWith("--")) {
+			const eq = token.indexOf("=");
+			const name = eq === -1 ? token.slice(2) : token.slice(2, eq);
+			if (DOCKER_BOOL_LONG.has(name)) {
+				i += 1;
+				continue;
+			}
+			if (DOCKER_VALUE_LONG.has(name)) {
+				if (eq !== -1) {
+					i += 1;
+					continue;
+				}
+				if (i + 1 >= tokens.length) return -1;
+				i += 2;
+				continue;
+			}
+			return -1;
+		}
+
+		let k = 1;
+		let consumeNextValue = false;
+		while (k < token.length) {
+			const flag = token[k];
+			if (!flag) break;
+			if (DOCKER_BOOL_SHORT.has(flag)) {
+				k += 1;
+				continue;
+			}
+			if (DOCKER_VALUE_SHORT.has(flag)) {
+				if (k + 1 < token.length) {
+					consumeNextValue = false;
+					k = token.length;
+					break;
+				}
+				consumeNextValue = true;
+				break;
+			}
+			return -1;
+		}
+		if (consumeNextValue) {
+			if (i + 1 >= tokens.length) return -1;
+			i += 2;
+			continue;
+		}
+		i += 1;
+	}
+	return i;
+};
+
 export const isStackDeployCommand = (command: string) => {
-	const [first, second] = command.trim().split(/\s+/);
-	return first === "stack" && second === "deploy";
+	const tokens = tokenizeDockerCommand(command);
+	const i = skipDockerGlobalOptions(tokens);
+	if (i < 0) return false;
+	return tokens[i] === "stack" && tokens[i + 1] === "deploy";
 };
 
 export const writeDomainsToCompose = async (

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -110,24 +110,41 @@ export const readComposeFile = async (compose: Compose) => {
 	return null;
 };
 
+export const STACK_COMPOSE_MODELS_ERROR =
+	"Compose models are not supported with Docker Swarm stack deployments. Use Docker Compose deployment type or remove the models configuration.";
+
+export const composeSpecificationUsesModels = (
+	spec: ComposeSpecification | null | undefined,
+): boolean => {
+	if (!spec || typeof spec !== "object") return false;
+	if (Object.hasOwn(spec, "models")) return true;
+	const services = spec.services;
+	if (!services || typeof services !== "object") return false;
+	for (const service of Object.values(services)) {
+		if (
+			service &&
+			typeof service === "object" &&
+			Object.hasOwn(service, "models")
+		) {
+			return true;
+		}
+	}
+	return false;
+};
+
+export const isStackDeployCommand = (command: string) => {
+	const [first, second] = command.trim().split(/\s+/);
+	return first === "stack" && second === "deploy";
+};
+
 export const writeDomainsToCompose = async (
 	compose: Compose,
 	domains: Domain[],
+	dockerCommand = "",
 ) => {
+	let composeConverted: ComposeSpecification | null;
 	try {
-		const composeConverted = await addDomainToCompose(compose, domains);
-		const path = getComposePath(compose);
-
-		if (!composeConverted) {
-			return `
-echo "❌ Error: Compose file not found";
-exit 1;
-			`;
-		}
-
-		const composeString = stringify(composeConverted, { lineWidth: 1000 });
-		const encodedContent = encodeBase64(composeString);
-		return `echo "${encodedContent}" | base64 -d > "${path}";`;
+		composeConverted = await addDomainToCompose(compose, domains);
 	} catch (error) {
 		const message =
 			error instanceof Error ? error.message : String(error ?? "");
@@ -137,6 +154,26 @@ exit 1;
 exit 1;
 		`;
 	}
+
+	const path = getComposePath(compose);
+
+	if (!composeConverted) {
+		return `
+echo "❌ Error: Compose file not found";
+exit 1;
+			`;
+	}
+
+	if (
+		isStackDeployCommand(dockerCommand) &&
+		composeSpecificationUsesModels(composeConverted)
+	) {
+		throw new Error(STACK_COMPOSE_MODELS_ERROR);
+	}
+
+	const composeString = stringify(composeConverted, { lineWidth: 1000 });
+	const encodedContent = encodeBase64(composeString);
+	return `echo "${encodedContent}" | base64 -d > "${path}";`;
 };
 export const applyComposeFilePatch = async (
 	compose: Compose,

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -228,11 +228,28 @@ const skipDockerGlobalOptions = (tokens: string[]) => {
 	return i;
 };
 
+const skipStackOrchestratorOption = (tokens: string[], i: number) => {
+	const token = tokens[i];
+	if (!token) return i;
+	if (token === "--orchestrator") {
+		if (i + 1 >= tokens.length) return -1;
+		return i + 2;
+	}
+	if (token.startsWith("--orchestrator=")) return i + 1;
+	return i;
+};
+
+// Docker documents `stack up` as an alias of `stack deploy` (CLI 28.5+ / 29.x).
+// Deprecated `--orchestrator` is a stack-level string flag that may sit between
+// `stack` and `deploy`/`up`; `stack --orchestrator deploy` consumes `deploy` as
+// the flag value and is not a deployment.
 export const isStackDeployCommand = (command: string) => {
 	const tokens = tokenizeDockerCommand(command);
 	const i = skipDockerGlobalOptions(tokens);
-	if (i < 0) return false;
-	return tokens[i] === "stack" && tokens[i + 1] === "deploy";
+	if (i < 0 || tokens[i] !== "stack") return false;
+	const j = skipStackOrchestratorOption(tokens, i + 1);
+	if (j < 0) return false;
+	return tokens[j] === "deploy" || tokens[j] === "up";
 };
 
 export const writeDomainsToCompose = async (

--- a/packages/server/src/utils/docker/domain.ts
+++ b/packages/server/src/utils/docker/domain.ts
@@ -6,7 +6,7 @@ import { network, patch } from "@dokploy/server/db/schema";
 import type { Compose } from "@dokploy/server/services/compose";
 import type { Domain } from "@dokploy/server/services/domain";
 import { eq, inArray } from "drizzle-orm";
-import { parse as parseShell, quote } from "shell-quote";
+import { quote } from "shell-quote";
 import { parse, stringify } from "yaml";
 import { execAsyncRemote } from "../process/execAsync";
 import { cloneBitbucketRepository } from "../providers/bitbucket";
@@ -17,12 +17,18 @@ import { cloneGitlabRepository } from "../providers/gitlab";
 import { getCreateComposeFileCommand } from "../providers/raw";
 import { randomizeDeployableSpecificationFile } from "./collision";
 import { randomizeSpecificationFile } from "./compose";
+import {
+	isStackDeployCommand,
+	validateStackComposeInput,
+} from "./stack-command";
 import type {
 	ComposeSpecification,
 	DefinitionsService,
 	PropertiesNetworks,
 } from "./types";
 import { encodeBase64 } from "./utils";
+
+export { isStackDeployCommand } from "./stack-command";
 
 export const cloneCompose = async (compose: Compose) => {
 	let command = "set -e;";
@@ -132,131 +138,15 @@ export const composeSpecificationUsesModels = (
 	return false;
 };
 
-const DOCKER_VALUE_LONG = new Set([
-	"config",
-	"context",
-	"host",
-	"log-level",
-	"tlscacert",
-	"tlscert",
-	"tlskey",
-]);
-const DOCKER_VALUE_SHORT = new Set(["c", "H", "l"]);
-const DOCKER_BOOL_LONG = new Set([
-	"debug",
-	"help",
-	"tls",
-	"tlsverify",
-	"version",
-]);
-const DOCKER_BOOL_SHORT = new Set(["D", "h", "v"]);
-
-const tokenizeDockerCommand = (command: string) => {
-	const tokens: string[] = [];
-	for (const entry of parseShell(command, {})) {
-		if (typeof entry === "string") {
-			tokens.push(entry);
-			continue;
-		}
-		if ("comment" in entry) continue;
-		if ("op" in entry) {
-			if (entry.op === "glob") {
-				tokens.push(entry.pattern);
-				continue;
-			}
-			if (entry.op === "&&") break;
-			return [];
-		}
-	}
-	return tokens;
-};
-
-const skipDockerGlobalOptions = (tokens: string[]) => {
-	let i = 0;
-	while (i < tokens.length) {
-		const token = tokens[i];
-		if (!token || token === "-") break;
-		if (token === "--") return i + 1;
-		if (!token.startsWith("-")) break;
-
-		if (token.startsWith("--")) {
-			const eq = token.indexOf("=");
-			const name = eq === -1 ? token.slice(2) : token.slice(2, eq);
-			if (DOCKER_BOOL_LONG.has(name)) {
-				i += 1;
-				continue;
-			}
-			if (DOCKER_VALUE_LONG.has(name)) {
-				if (eq !== -1) {
-					i += 1;
-					continue;
-				}
-				if (i + 1 >= tokens.length) return -1;
-				i += 2;
-				continue;
-			}
-			return -1;
-		}
-
-		let k = 1;
-		let consumeNextValue = false;
-		while (k < token.length) {
-			const flag = token[k];
-			if (!flag) break;
-			if (DOCKER_BOOL_SHORT.has(flag)) {
-				k += 1;
-				continue;
-			}
-			if (DOCKER_VALUE_SHORT.has(flag)) {
-				if (k + 1 < token.length) {
-					consumeNextValue = false;
-					k = token.length;
-					break;
-				}
-				consumeNextValue = true;
-				break;
-			}
-			return -1;
-		}
-		if (consumeNextValue) {
-			if (i + 1 >= tokens.length) return -1;
-			i += 2;
-			continue;
-		}
-		i += 1;
-	}
-	return i;
-};
-
-const skipStackOrchestratorOption = (tokens: string[], i: number) => {
-	const token = tokens[i];
-	if (!token) return i;
-	if (token === "--orchestrator") {
-		if (i + 1 >= tokens.length) return -1;
-		return i + 2;
-	}
-	if (token.startsWith("--orchestrator=")) return i + 1;
-	return i;
-};
-
-// Docker documents `stack up` as an alias of `stack deploy` (CLI 28.5+ / 29.x).
-// Deprecated `--orchestrator` is a stack-level string flag that may sit between
-// `stack` and `deploy`/`up`; `stack --orchestrator deploy` consumes `deploy` as
-// the flag value and is not a deployment.
-export const isStackDeployCommand = (command: string) => {
-	const tokens = tokenizeDockerCommand(command);
-	const i = skipDockerGlobalOptions(tokens);
-	if (i < 0 || tokens[i] !== "stack") return false;
-	const j = skipStackOrchestratorOption(tokens, i + 1);
-	if (j < 0) return false;
-	return tokens[j] === "deploy" || tokens[j] === "up";
-};
-
 export const writeDomainsToCompose = async (
 	compose: Compose,
 	domains: Domain[],
 	dockerCommand = "",
 ) => {
+	validateStackComposeInput(
+		dockerCommand,
+		compose.sourceType === "raw" ? "docker-compose.yml" : compose.composePath,
+	);
 	let composeConverted: ComposeSpecification | null;
 	try {
 		composeConverted = await addDomainToCompose(compose, domains);

--- a/packages/server/src/utils/docker/stack-command.ts
+++ b/packages/server/src/utils/docker/stack-command.ts
@@ -1,0 +1,165 @@
+import { posix } from "node:path";
+import { parse } from "shell-quote";
+
+type OptionKind = "boolean" | "value" | "file";
+type Options = Readonly<Record<string, OptionKind>>;
+
+const ROOT_OPTIONS: Options = {
+	"--config": "value",
+	"--context": "value",
+	"-c": "value",
+	"--host": "value",
+	"-H": "value",
+	"--log-level": "value",
+	"-l": "value",
+	"--tlscacert": "value",
+	"--tlscert": "value",
+	"--tlskey": "value",
+	"--debug": "boolean",
+	"-D": "boolean",
+	"--help": "boolean",
+	"-h": "boolean",
+	"--tls": "boolean",
+	"--tlsverify": "boolean",
+	"--version": "boolean",
+	"-v": "boolean",
+};
+const STACK_OPTIONS: Options = { "--orchestrator": "value" };
+const DEPLOY_OPTIONS: Options = {
+	...STACK_OPTIONS,
+	"--compose-file": "file",
+	"-c": "file",
+	"--resolve-image": "value",
+	"--detach": "boolean",
+	"-d": "boolean",
+	"--quiet": "boolean",
+	"-q": "boolean",
+	"--prune": "boolean",
+	"--with-registry-auth": "boolean",
+	"--help": "boolean",
+	"-h": "boolean",
+};
+
+const tokenize = (command: string): string[] => {
+	const tokens: string[] = [];
+	for (const entry of parse(command, {})) {
+		if (typeof entry === "string") tokens.push(entry);
+		else if ("op" in entry) {
+			if (entry.op === "glob") tokens.push(entry.pattern);
+			else if (entry.op === "&&") break;
+			else return [];
+		}
+	}
+	return tokens;
+};
+
+// Docker's short boolean flags accept =VALUE; value flags consume the rest
+// of a short cluster or the next token, even when that token starts with '-'.
+const consumeOption = (
+	tokens: readonly string[],
+	index: number,
+	options: Options,
+): { next: number; file?: string } | null => {
+	const token = tokens[index];
+	if (!token?.startsWith("-") || token === "-" || token === "--") return null;
+	const long = token.startsWith("--");
+	let offset = long ? 2 : 1;
+	while (offset < token.length) {
+		const equals = token.indexOf("=", offset);
+		const name = long
+			? token.slice(0, equals < 0 ? undefined : equals)
+			: `-${token[offset]}`;
+		const kind = options[name];
+		if (!kind) return null;
+		const rest = long
+			? equals < 0
+				? ""
+				: token.slice(equals)
+			: token.slice(offset + 1);
+		if (kind === "boolean") {
+			if (long || rest.startsWith("=")) return { next: index + 1 };
+			offset += 1;
+			continue;
+		}
+		const attached = rest.length > 0;
+		const value = attached ? rest.replace(/^=/, "") : tokens[index + 1];
+		if (value === undefined) return null;
+		return {
+			next: index + (attached ? 1 : 2),
+			...(kind === "file" ? { file: value } : {}),
+		};
+	}
+	return { next: index + 1 };
+};
+
+const commandIndex = (
+	tokens: readonly string[],
+	start: number,
+	options: Options,
+	root = false,
+): number => {
+	let index = start;
+	while (tokens[index]?.startsWith("-")) {
+		if (root && tokens[index] === "--") return index + 1;
+		const option = consumeOption(tokens, index, options);
+		if (!option) return -1;
+		index = option.next;
+	}
+	return index;
+};
+
+const deploymentIndex = (tokens: readonly string[]): number => {
+	const stack = commandIndex(tokens, 0, ROOT_OPTIONS, true);
+	if (stack < 0 || tokens[stack] !== "stack") return -1;
+	const deploy = commandIndex(tokens, stack + 1, STACK_OPTIONS);
+	return deploy >= 0 && (tokens[deploy] === "deploy" || tokens[deploy] === "up")
+		? deploy
+		: -1;
+};
+
+export const isStackDeployCommand = (command: string): boolean =>
+	deploymentIndex(tokenize(command)) >= 0;
+
+export const STACK_COMPOSE_INPUT_ERROR =
+	"Custom Stack deployments must select exactly one Dokploy-managed Compose file. Use the configured Compose path with -c; alternate files, multiple files, CSV lists, stdin, absolute paths and parent traversal are not supported.";
+
+const isManagedPath = (selected: string, managed: string): boolean => {
+	if (
+		!selected ||
+		selected === "-" ||
+		/[,"]/.test(selected) ||
+		posix.isAbsolute(selected) ||
+		selected.split("/").includes("..")
+	)
+		return false;
+	return posix.normalize(selected) === posix.normalize(managed);
+};
+
+// Only the configured document receives Dokploy's patches, domains and name
+// transforms. Confining Stack input avoids reading or merging arbitrary files.
+export const validateStackComposeInput = (
+	command: string,
+	managedPath: string,
+): void => {
+	const tokens = tokenize(command);
+	const deploy = deploymentIndex(tokens);
+	if (deploy < 0) return;
+	const files: string[] = [];
+	let index = deploy + 1;
+	while (index < tokens.length) {
+		if (tokens[index] === "--") break;
+		if (!tokens[index]?.startsWith("-")) {
+			index += 1;
+			continue;
+		}
+		const option = consumeOption(tokens, index, DEPLOY_OPTIONS);
+		if (!option) throw new Error(STACK_COMPOSE_INPUT_ERROR);
+		if (option.file !== undefined) files.push(option.file);
+		index = option.next;
+	}
+	if (
+		files.length !== 1 ||
+		!files.every((file) => isManagedPath(file, managedPath))
+	)
+		throw new Error(STACK_COMPOSE_INPUT_ERROR);
+};


### PR DESCRIPTION
## What is this PR about?

Rejects Docker Swarm Stack deployments whose final Compose specification declares top-level or service-level `models`. Docker Compose deployments continue to support models.

The guard recognizes supported `stack deploy` and `stack up` command forms and validates the Compose input selected by custom commands. A custom command can no longer bypass the inspected document by selecting another file with `-c` or `--compose-file`.

## Behavior

- Docker Compose with `models`: allowed.
- Stack deployment with the managed Compose file and no `models`: allowed.
- Stack deployment with top-level or service-level `models`, including empty/malformed declarations: rejected before deployment-side network creation and Docker execution.
- Unreferenced `x-models` extensions, comments, and string values containing `models:`: allowed.
- Preview/converted Compose output retains its existing behavior.

The structural models check examines the final parsed specification after Compose-file patches, randomization/isolation, domain changes, and network injection. The decision uses the effective sanitized Docker command, including custom overrides.

## Custom Stack input policy

**Compatibility change:** custom Stack deployments must select exactly one Dokploy-managed Compose file. Only that document receives Dokploy's patches, domains, and other transforms.

Use one `-c` or `--compose-file` pointing to the configured Compose path, or `docker-compose.yml` for raw Compose. Equivalent relative paths and ordinary quoted spaces are supported. Alternate paths, repeated file flags (even for the same file), CSV lists, stdin, absolute paths, and any parent-traversal segment are rejected. Rejected selected paths are not read or merged by this validation.

For example, with `composePath = docker-compose.yml`:

```sh
# Accepted input selection; models are still checked separately.
docker -D=false stack deploy -c ./docker-compose.yml demo

# Rejected: selects a different document.
docker stack deploy -c other.yml demo

# Rejected: selects multiple inputs.
docker stack deploy -c docker-compose.yml -c override.yml demo
```

This validates the configured path rather than resolving arbitrary filesystem aliases. It does not introduce symlink resolution or a Compose merge implementation.

## Command handling and errors

A shared table-driven scanner uses existing shell tokenization and explicit Docker option arity for detection and input selection. It handles `deploy`/`up`, Docker global options, short clusters, attached values, short boolean assignments such as `-D=false`, repeated `--orchestrator`, and supported `--` placement.

Models rejection:

> Compose models are not supported with Docker Swarm stack deployments. Use Docker Compose deployment type or remove the models configuration.

Unsupported file selection receives a separate error explaining the single managed-file requirement. No Model Runner lifecycle, model execution, hardware, UI, database, or Dockerfile changes are added.

## Validation

Verified locally at `439f68b07`:

- **274 tests passed** across Compose and Git-provider command-injection suites, including Stack models, command parsing, managed-file selection, patches, raw Compose, enabled filtering, and preview behavior.
- Regressions cover `-D=false`, repeated `--orchestrator`, alternate/multiple file inputs, both placements of models across configured/alternate documents, and traversal rejection.
- Real Docker CLI 28.5.2 and 29.1.3 parsing fixtures reproduced the boolean and repeated-orchestrator forms without deploying a stack.
- `pnpm typecheck`, Biome on changed TypeScript files, `pnpm dokploy:build`, and `git diff --check` passed.

A disposable integration with #5424, #5423, and unchanged #5426 passed **484 tests**, typecheck, Biome, production build, and diff checks. These are local results, separate from GitHub CI status. This PR remains independent of the hardware and Model Runner capability PRs.

## Automated review history

The automated review below refers to the earlier commit linked in that section. The implementation and local validation above describe the current head.

## Validation update

Stack-path remediation commit `889acad16` is now on this branch. Configured Compose-path failures receive path-specific errors while the existing Stack models guard remains intact.

The combined PR2-PR5 integration passed 270/270 focused tests on amd64 and arm64 (arm64 under QEMU), including command parsing, managed-file selection, invalid-path rejection, and Stack models behavior. No new PR-related full-suite failures were found.

Dependency clarification: only #5423 depends on #5424. This PR is independent of both capability endpoints and can be reviewed/merged separately.

## Review follow-up (2026-09-19)

No source changes were required in this PR for the Health integration requested on #5424. A local integration of current upstream `canary` (`f397c1a86`), all four PRs, and that correction passed 496 tests (1 skipped), plus a separate cross-endpoint parity test, and workspace typecheck. This includes the current Compose and Stack guard tests. This follow-up did not rerun a multi-architecture image build or a physical NVIDIA test. Earlier validation and automated review text refer to their stated commits.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63308972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The runtime guard appears correct, but the PR should not merge until the new shell differential tests preserve a PATH that can resolve Node.

<h3>Summary</h3>

- Inspects the fully transformed Compose specification before deployment-side network creation.
- Detects stack deploy/up commands after supported Docker global options.
- Adds extensive compatibility, transformation-order, command-parsing, and shell-argv tests.
- The previous global-option bypass has been fixed, but the new shell differential tests use a child PATH that cannot resolve their Node shebang.

<sub>Reviews (2) · Last reviewed commit: ["fix(compose): handle stack up alias in m..."](https://github.com/dokploy/dokploy/commit/69a007a175239ea630b46544fa38b0004a825ef2)</sub>

<!-- /greptile_comment -->

