### PR TITLE
feat(application): add multi-arch docker builds via buildx

### DIFF
--- a/apps/dokploy/__test__/deploy/build-platform.test.ts
+++ b/apps/dokploy/__test__/deploy/build-platform.test.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_MULTIARCH_BUILDER,
 	dockerfileBuilderName,
 	ensureMultiarchBuilderCommand,
+	mergePersistedArchitecture,
 	planArchitecture,
 	planPlatformArgs,
 	usesBuildx,
@@ -131,6 +132,54 @@ describe("assertPersistedArchitecture", () => {
 				buildRegistryId: null,
 			}),
 		).toThrow(/cluster registry or a build registry/);
+	});
+
+	it("rejects a Cluster Settings save that drops the last registry while multi stays set", () => {
+		expect(() =>
+			assertPersistedArchitecture(
+				mergePersistedArchitecture(
+					{
+						buildType: "dockerfile",
+						buildArchitecture: "multi",
+						registryId: "cluster-registry",
+						buildRegistryId: null,
+					},
+					{ registryId: null },
+				),
+			),
+		).toThrow(/cluster registry or a build registry/);
+	});
+
+	it("rejects a pack-builder switch that leaves a pinned architecture in place", () => {
+		expect(() =>
+			assertPersistedArchitecture(
+				mergePersistedArchitecture(
+					{
+						buildType: "dockerfile",
+						buildArchitecture: "amd64",
+						registryId: null,
+						buildRegistryId: null,
+					},
+					{ buildType: "nixpacks" },
+				),
+			),
+		).toThrow(BuildArchitectureError);
+	});
+
+	it("allows a partial update that does not change architecture, build type, or registries", () => {
+		expect(() =>
+			assertPersistedArchitecture(
+				mergePersistedArchitecture(
+					{
+						buildType: "dockerfile",
+						buildArchitecture: "multi",
+						registryId: "cluster-registry",
+						buildRegistryId: null,
+					},
+					{},
+				),
+			),
+		).not.toThrow();
 	});
 });
 

--- a/apps/dokploy/__test__/deploy/build-platform.test.ts
+++ b/apps/dokploy/__test__/deploy/build-platform.test.ts
@@ -150,6 +150,7 @@ describe("dockerfile builder selection", () => {
 		expect(ensureMultiarchBuilderCommand(plan)).toContain(
 			DEFAULT_MULTIARCH_BUILDER,
 		);
+		expect(ensureMultiarchBuilderCommand(plan)).toContain("network=host");
 		expect(usesBuildx(plan)).toBe(true);
 	});
 

--- a/apps/dokploy/__test__/deploy/build-platform.test.ts
+++ b/apps/dokploy/__test__/deploy/build-platform.test.ts
@@ -1,0 +1,132 @@
+import {
+	BuildArchitectureError,
+	DEFAULT_MULTIARCH_BUILDER,
+	dockerfileBuildxBuilder,
+	ensureMultiarchBuilderCommand,
+	planBuildArchitecture,
+	planPlatformArgs,
+	usesBuildx,
+} from "@dokploy/server/utils/builders/build-platform";
+import { describe, expect, it } from "vitest";
+
+const base = {
+	buildType: "dockerfile",
+	sourceType: "git",
+	registry: null,
+	buildRegistry: null,
+	rollbackRegistry: null,
+};
+
+describe("planBuildArchitecture", () => {
+	it("defaults to host with no platform", () => {
+		const plan = planBuildArchitecture(base);
+		expect(plan).toEqual({ kind: "host", builder: null });
+		expect(planPlatformArgs(plan)).toEqual([]);
+		expect(usesBuildx(plan)).toBe(false);
+	});
+
+	it("trims a named builder on host", () => {
+		const plan = planBuildArchitecture({
+			...base,
+			buildArchitecture: "host",
+			buildxBuilder: "  native-arm  ",
+		});
+		expect(plan).toEqual({ kind: "host", builder: "native-arm" });
+		expect(usesBuildx(plan)).toBe(true);
+		expect(dockerfileBuildxBuilder(plan)).toBe("native-arm");
+	});
+
+	it("maps amd64 and arm64 to a single platform", () => {
+		expect(
+			planBuildArchitecture({
+				...base,
+				buildArchitecture: "amd64",
+			}),
+		).toEqual({
+			kind: "single",
+			platform: "linux/amd64",
+			builder: null,
+		});
+		expect(
+			planBuildArchitecture({
+				...base,
+				buildArchitecture: "arm64",
+				buildxBuilder: "box",
+			}),
+		).toEqual({
+			kind: "single",
+			platform: "linux/arm64",
+			builder: "box",
+		});
+	});
+
+	it("plans multi-arch when a registry is present", () => {
+		const plan = planBuildArchitecture({
+			...base,
+			buildArchitecture: "multi",
+			registry: { registryId: "r1" },
+		});
+		expect(plan).toEqual({
+			kind: "multi",
+			platforms: ["linux/amd64", "linux/arm64"],
+			builder: null,
+		});
+		expect(planPlatformArgs(plan)).toEqual([
+			"--platform",
+			"linux/amd64,linux/arm64",
+		]);
+		expect(dockerfileBuildxBuilder(plan)).toBe(DEFAULT_MULTIARCH_BUILDER);
+		expect(ensureMultiarchBuilderCommand(plan)).toContain(
+			DEFAULT_MULTIARCH_BUILDER,
+		);
+	});
+
+	it("does not create the default builder when the user named one", () => {
+		const plan = planBuildArchitecture({
+			...base,
+			buildArchitecture: "multi",
+			buildxBuilder: "farm",
+			buildRegistry: { registryId: "r1" },
+		});
+		expect(dockerfileBuildxBuilder(plan)).toBe("farm");
+		expect(ensureMultiarchBuilderCommand(plan)).toBe("");
+	});
+
+	it("rejects multi-arch without a registry", () => {
+		expect(() =>
+			planBuildArchitecture({
+				...base,
+				buildArchitecture: "multi",
+			}),
+		).toThrow(BuildArchitectureError);
+	});
+
+	it("rejects pack builders when architecture is not host", () => {
+		expect(() =>
+			planBuildArchitecture({
+				...base,
+				buildType: "nixpacks",
+				buildArchitecture: "amd64",
+			}),
+		).toThrow(/Host native/);
+		expect(() =>
+			planBuildArchitecture({
+				...base,
+				buildType: "heroku_buildpacks",
+				buildArchitecture: "multi",
+				registry: { registryId: "r1" },
+			}),
+		).toThrow(/Host native/);
+	});
+
+	it("ignores architecture for docker source images", () => {
+		const plan = planBuildArchitecture({
+			...base,
+			sourceType: "docker",
+			buildArchitecture: "multi",
+			buildxBuilder: "farm",
+			registry: { registryId: "r1" },
+		});
+		expect(plan).toEqual({ kind: "host", builder: null });
+	});
+});

--- a/apps/dokploy/__test__/deploy/build-platform.test.ts
+++ b/apps/dokploy/__test__/deploy/build-platform.test.ts
@@ -1,4 +1,5 @@
 import {
+	assertPersistedArchitecture,
 	BuildArchitectureError,
 	DEFAULT_MULTIARCH_BUILDER,
 	dockerfileBuilderName,
@@ -95,6 +96,41 @@ describe("planArchitecture", () => {
 		});
 		expect(plan.architecture).toBe("host");
 		expect(plan.platforms).toEqual([]);
+	});
+});
+
+describe("assertPersistedArchitecture", () => {
+	it("allows host with any builder and no registry", () => {
+		expect(() =>
+			assertPersistedArchitecture({
+				buildType: "nixpacks",
+				buildArchitecture: "host",
+				registryId: null,
+				buildRegistryId: null,
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects pack builders with a pinned architecture", () => {
+		expect(() =>
+			assertPersistedArchitecture({
+				buildType: "nixpacks",
+				buildArchitecture: "amd64",
+				registryId: "r1",
+				buildRegistryId: null,
+			}),
+		).toThrow(BuildArchitectureError);
+	});
+
+	it("rejects multi-arch after both run registries are cleared", () => {
+		expect(() =>
+			assertPersistedArchitecture({
+				buildType: "dockerfile",
+				buildArchitecture: "multi",
+				registryId: null,
+				buildRegistryId: null,
+			}),
+		).toThrow(/cluster registry or a build registry/);
 	});
 });
 

--- a/apps/dokploy/__test__/deploy/build-platform.test.ts
+++ b/apps/dokploy/__test__/deploy/build-platform.test.ts
@@ -1,13 +1,9 @@
 import {
 	assertPersistedArchitecture,
 	BuildArchitectureError,
-	DEFAULT_MULTIARCH_BUILDER,
-	dockerfileBuilderName,
-	ensureMultiarchBuilderCommand,
 	mergePersistedArchitecture,
 	planArchitecture,
 	planPlatformArgs,
-	usesBuildx,
 } from "@dokploy/server/utils/builders/build-platform";
 import { describe, expect, it } from "vitest";
 
@@ -180,41 +176,5 @@ describe("assertPersistedArchitecture", () => {
 				),
 			),
 		).not.toThrow();
-	});
-});
-
-describe("dockerfile builder selection", () => {
-	it("creates dokploy-multiarch only when pushing without a named builder", () => {
-		const plan = {
-			platforms: ["linux/amd64", "linux/arm64"] as const,
-			builder: null,
-			createDefaultBuilder: true,
-			output: {
-				mode: "push" as const,
-				tags: ["ghcr.io/acme/app:latest"],
-				logins: "",
-			},
-		};
-		expect(dockerfileBuilderName(plan)).toBe(DEFAULT_MULTIARCH_BUILDER);
-		expect(ensureMultiarchBuilderCommand(plan)).toContain(
-			DEFAULT_MULTIARCH_BUILDER,
-		);
-		expect(ensureMultiarchBuilderCommand(plan)).toContain("network=host");
-		expect(usesBuildx(plan)).toBe(true);
-	});
-
-	it("does not create the default builder when the user named one", () => {
-		const plan = {
-			platforms: ["linux/amd64", "linux/arm64"] as const,
-			builder: "farm",
-			createDefaultBuilder: false,
-			output: {
-				mode: "push" as const,
-				tags: ["ghcr.io/acme/app:latest"],
-				logins: "",
-			},
-		};
-		expect(dockerfileBuilderName(plan)).toBe("farm");
-		expect(ensureMultiarchBuilderCommand(plan)).toBe("");
 	});
 });

--- a/apps/dokploy/__test__/deploy/build-platform.test.ts
+++ b/apps/dokploy/__test__/deploy/build-platform.test.ts
@@ -1,116 +1,82 @@
 import {
 	BuildArchitectureError,
 	DEFAULT_MULTIARCH_BUILDER,
-	dockerfileBuildxBuilder,
+	dockerfileBuilderName,
 	ensureMultiarchBuilderCommand,
-	planBuildArchitecture,
+	planArchitecture,
 	planPlatformArgs,
 	usesBuildx,
 } from "@dokploy/server/utils/builders/build-platform";
 import { describe, expect, it } from "vitest";
 
 const base = {
+	appName: "test-app",
 	buildType: "dockerfile",
 	sourceType: "git",
 	registry: null,
 	buildRegistry: null,
-	rollbackRegistry: null,
 };
 
-describe("planBuildArchitecture", () => {
+describe("planArchitecture", () => {
 	it("defaults to host with no platform", () => {
-		const plan = planBuildArchitecture(base);
-		expect(plan).toEqual({ kind: "host", builder: null });
+		const plan = planArchitecture(base);
+		expect(plan.architecture).toBe("host");
+		expect(plan.platforms).toEqual([]);
+		expect(plan.builder).toBe(null);
 		expect(planPlatformArgs(plan)).toEqual([]);
-		expect(usesBuildx(plan)).toBe(false);
 	});
 
-	it("trims a named builder on host", () => {
-		const plan = planBuildArchitecture({
+	it("trims a named builder", () => {
+		const plan = planArchitecture({
 			...base,
 			buildArchitecture: "host",
 			buildxBuilder: "  native-arm  ",
 		});
-		expect(plan).toEqual({ kind: "host", builder: "native-arm" });
-		expect(usesBuildx(plan)).toBe(true);
-		expect(dockerfileBuildxBuilder(plan)).toBe("native-arm");
+		expect(plan.builder).toBe("native-arm");
 	});
 
 	it("maps amd64 and arm64 to a single platform", () => {
 		expect(
-			planBuildArchitecture({
+			planArchitecture({
 				...base,
 				buildArchitecture: "amd64",
-			}),
-		).toEqual({
-			kind: "single",
-			platform: "linux/amd64",
-			builder: null,
-		});
+			}).platforms,
+		).toEqual(["linux/amd64"]);
 		expect(
-			planBuildArchitecture({
+			planArchitecture({
 				...base,
 				buildArchitecture: "arm64",
 				buildxBuilder: "box",
 			}),
-		).toEqual({
-			kind: "single",
-			platform: "linux/arm64",
+		).toMatchObject({
+			platforms: ["linux/arm64"],
 			builder: "box",
 		});
 	});
 
-	it("plans multi-arch when a registry is present", () => {
-		const plan = planBuildArchitecture({
+	it("maps multi-arch to both platforms", () => {
+		const plan = planArchitecture({
 			...base,
 			buildArchitecture: "multi",
 			registry: { registryId: "r1" },
 		});
-		expect(plan).toEqual({
-			kind: "multi",
-			platforms: ["linux/amd64", "linux/arm64"],
-			builder: null,
-		});
+		expect(plan.platforms).toEqual(["linux/amd64", "linux/arm64"]);
 		expect(planPlatformArgs(plan)).toEqual([
 			"--platform",
 			"linux/amd64,linux/arm64",
 		]);
-		expect(dockerfileBuildxBuilder(plan)).toBe(DEFAULT_MULTIARCH_BUILDER);
-		expect(ensureMultiarchBuilderCommand(plan)).toContain(
-			DEFAULT_MULTIARCH_BUILDER,
-		);
-	});
-
-	it("does not create the default builder when the user named one", () => {
-		const plan = planBuildArchitecture({
-			...base,
-			buildArchitecture: "multi",
-			buildxBuilder: "farm",
-			buildRegistry: { registryId: "r1" },
-		});
-		expect(dockerfileBuildxBuilder(plan)).toBe("farm");
-		expect(ensureMultiarchBuilderCommand(plan)).toBe("");
-	});
-
-	it("rejects multi-arch without a registry", () => {
-		expect(() =>
-			planBuildArchitecture({
-				...base,
-				buildArchitecture: "multi",
-			}),
-		).toThrow(BuildArchitectureError);
 	});
 
 	it("rejects pack builders when architecture is not host", () => {
 		expect(() =>
-			planBuildArchitecture({
+			planArchitecture({
 				...base,
 				buildType: "nixpacks",
 				buildArchitecture: "amd64",
 			}),
-		).toThrow(/Host native/);
+		).toThrow(BuildArchitectureError);
 		expect(() =>
-			planBuildArchitecture({
+			planArchitecture({
 				...base,
 				buildType: "heroku_buildpacks",
 				buildArchitecture: "multi",
@@ -120,13 +86,49 @@ describe("planBuildArchitecture", () => {
 	});
 
 	it("ignores architecture for docker source images", () => {
-		const plan = planBuildArchitecture({
+		const plan = planArchitecture({
 			...base,
 			sourceType: "docker",
 			buildArchitecture: "multi",
 			buildxBuilder: "farm",
 			registry: { registryId: "r1" },
 		});
-		expect(plan).toEqual({ kind: "host", builder: null });
+		expect(plan.architecture).toBe("host");
+		expect(plan.platforms).toEqual([]);
+	});
+});
+
+describe("dockerfile builder selection", () => {
+	it("creates dokploy-multiarch only when pushing without a named builder", () => {
+		const plan = {
+			platforms: ["linux/amd64", "linux/arm64"] as const,
+			builder: null,
+			createDefaultBuilder: true,
+			output: {
+				mode: "push" as const,
+				tags: ["ghcr.io/acme/app:latest"],
+				logins: "",
+			},
+		};
+		expect(dockerfileBuilderName(plan)).toBe(DEFAULT_MULTIARCH_BUILDER);
+		expect(ensureMultiarchBuilderCommand(plan)).toContain(
+			DEFAULT_MULTIARCH_BUILDER,
+		);
+		expect(usesBuildx(plan)).toBe(true);
+	});
+
+	it("does not create the default builder when the user named one", () => {
+		const plan = {
+			platforms: ["linux/amd64", "linux/arm64"] as const,
+			builder: "farm",
+			createDefaultBuilder: false,
+			output: {
+				mode: "push" as const,
+				tags: ["ghcr.io/acme/app:latest"],
+				logins: "",
+			},
+		};
+		expect(dockerfileBuilderName(plan)).toBe("farm");
+		expect(ensureMultiarchBuilderCommand(plan)).toBe("");
 	});
 });

--- a/apps/dokploy/__test__/deploy/docker-file.command.test.ts
+++ b/apps/dokploy/__test__/deploy/docker-file.command.test.ts
@@ -1,0 +1,139 @@
+import type { ApplicationNested } from "@dokploy/server/utils/builders";
+import { getDockerCommand } from "@dokploy/server/utils/builders/docker-file";
+import { describe, expect, it } from "vitest";
+
+const createApplication = (
+	overrides: Partial<ApplicationNested> = {},
+): ApplicationNested =>
+	({
+		appName: "test-app",
+		buildType: "dockerfile",
+		sourceType: "git",
+		customGitBuildPath: "/",
+		dockerfile: "Dockerfile",
+		env: null,
+		buildArgs: null,
+		buildSecrets: null,
+		publishDirectory: null,
+		dockerBuildStage: null,
+		dockerContextPath: null,
+		cleanCache: false,
+		createEnvFile: false,
+		environment: {
+			project: {
+				env: "",
+			},
+			env: "",
+		},
+		...overrides,
+	}) as unknown as ApplicationNested;
+
+describe("getDockerCommand", () => {
+	it("builds with classic docker build and no platform flag by default", () => {
+		const command = getDockerCommand(createApplication());
+
+		expect(command).toContain("docker build -t test-app -f");
+		expect(command).not.toContain("buildx");
+		expect(command).not.toContain("--platform");
+		expect(command).not.toContain("--push");
+	});
+
+	it("adds --target when dockerBuildStage is set", () => {
+		const command = getDockerCommand(
+			createApplication({
+				dockerBuildStage: "builder",
+			}),
+		);
+
+		expect(command).toContain("--target builder");
+	});
+
+	it("adds --no-cache when cleanCache is enabled", () => {
+		const command = getDockerCommand(
+			createApplication({
+				cleanCache: true,
+			}),
+		);
+
+		expect(command).toContain("--no-cache");
+	});
+
+	it("does not write an env file when createEnvFile is false", () => {
+		const command = getDockerCommand(
+			createApplication({
+				createEnvFile: false,
+			}),
+		);
+
+		expect(command).not.toContain("base64 -d");
+	});
+
+	it("writes an env file when createEnvFile is true", () => {
+		const command = getDockerCommand(
+			createApplication({
+				createEnvFile: true,
+			}),
+		);
+
+		expect(command).toContain("base64 -d");
+	});
+
+	it("adds --platform on classic docker build for a single architecture", () => {
+		const command = getDockerCommand(
+			createApplication({
+				buildArchitecture: "amd64",
+			}),
+		);
+
+		expect(command).toContain("docker build ");
+		expect(command).toContain("--platform linux/amd64");
+		expect(command).not.toContain("buildx");
+		expect(command).not.toContain("--push");
+	});
+
+	it("uses buildx --load when a named builder is set for a single architecture", () => {
+		const command = getDockerCommand(
+			createApplication({
+				buildArchitecture: "arm64",
+				buildxBuilder: "native-arm",
+			}),
+		);
+
+		expect(command).toContain("docker buildx build");
+		expect(command).toContain("--builder");
+		expect(command).toContain("native-arm");
+		expect(command).toContain("--platform linux/arm64");
+		expect(command).not.toContain("--push");
+	});
+
+	it("pushes a multi-arch manifest and does not tag a local image", () => {
+		const command = getDockerCommand(
+			createApplication({
+				buildArchitecture: "multi",
+				registry: { registryId: "r1" } as ApplicationNested["registry"],
+			}),
+			{ pushTags: ["ghcr.io/acme/test-app:latest"] },
+		);
+
+		expect(command).toContain("docker buildx create");
+		expect(command).toContain("dokploy-multiarch");
+		expect(command).toContain("docker buildx build");
+		expect(command).toContain("--platform linux/amd64,linux/arm64");
+		expect(command).toContain("--push");
+		expect(command).toContain("-t");
+		expect(command).toContain("ghcr.io/acme/test-app");
+		expect(command).not.toContain("docker build -t test-app");
+	});
+
+	it("quotes a user-supplied builder name so it cannot break out of the command", () => {
+		const command = getDockerCommand(
+			createApplication({
+				buildArchitecture: "amd64",
+				buildxBuilder: "x; touch /tmp/pwned",
+			}),
+		);
+
+		expect(command).toContain("buildx");
+		expect(command).not.toMatch(/buildx build --builder x; touch/);
+	});
+});

--- a/apps/dokploy/__test__/deploy/docker-file.command.test.ts
+++ b/apps/dokploy/__test__/deploy/docker-file.command.test.ts
@@ -1,4 +1,5 @@
 import type { ApplicationNested } from "@dokploy/server/utils/builders";
+import type { BuildPlan } from "@dokploy/server/utils/builders/build-platform";
 import { getDockerCommand } from "@dokploy/server/utils/builders/docker-file";
 import { describe, expect, it } from "vitest";
 
@@ -28,14 +29,23 @@ const createApplication = (
 		...overrides,
 	}) as unknown as ApplicationNested;
 
+const localPlan = (overrides: Partial<BuildPlan> = {}): BuildPlan => ({
+	platforms: [],
+	builder: null,
+	createDefaultBuilder: false,
+	output: { mode: "local", image: "test-app" },
+	...overrides,
+});
+
 describe("getDockerCommand", () => {
 	it("builds with classic docker build and no platform flag by default", () => {
-		const command = getDockerCommand(createApplication());
+		const command = getDockerCommand(createApplication(), localPlan());
 
 		expect(command).toContain("docker build -t test-app -f");
 		expect(command).not.toContain("buildx");
 		expect(command).not.toContain("--platform");
 		expect(command).not.toContain("--push");
+		expect(command).not.toContain("--load");
 	});
 
 	it("adds --target when dockerBuildStage is set", () => {
@@ -43,6 +53,7 @@ describe("getDockerCommand", () => {
 			createApplication({
 				dockerBuildStage: "builder",
 			}),
+			localPlan(),
 		);
 
 		expect(command).toContain("--target builder");
@@ -53,6 +64,7 @@ describe("getDockerCommand", () => {
 			createApplication({
 				cleanCache: true,
 			}),
+			localPlan(),
 		);
 
 		expect(command).toContain("--no-cache");
@@ -63,6 +75,7 @@ describe("getDockerCommand", () => {
 			createApplication({
 				createEnvFile: false,
 			}),
+			localPlan(),
 		);
 
 		expect(command).not.toContain("base64 -d");
@@ -73,6 +86,7 @@ describe("getDockerCommand", () => {
 			createApplication({
 				createEnvFile: true,
 			}),
+			localPlan(),
 		);
 
 		expect(command).toContain("base64 -d");
@@ -80,9 +94,8 @@ describe("getDockerCommand", () => {
 
 	it("adds --platform on classic docker build for a single architecture", () => {
 		const command = getDockerCommand(
-			createApplication({
-				buildArchitecture: "amd64",
-			}),
+			createApplication(),
+			localPlan({ platforms: ["linux/amd64"] }),
 		);
 
 		expect(command).toContain("docker build ");
@@ -91,11 +104,12 @@ describe("getDockerCommand", () => {
 		expect(command).not.toContain("--push");
 	});
 
-	it("uses buildx --load when a named builder is set for a single architecture", () => {
+	it("uses buildx --load when a named builder is set for a local image", () => {
 		const command = getDockerCommand(
-			createApplication({
-				buildArchitecture: "arm64",
-				buildxBuilder: "native-arm",
+			createApplication(),
+			localPlan({
+				platforms: ["linux/arm64"],
+				builder: "native-arm",
 			}),
 		);
 
@@ -103,17 +117,21 @@ describe("getDockerCommand", () => {
 		expect(command).toContain("--builder");
 		expect(command).toContain("native-arm");
 		expect(command).toContain("--platform linux/arm64");
+		expect(command).toContain("--load");
 		expect(command).not.toContain("--push");
 	});
 
 	it("pushes a multi-arch manifest and does not tag a local image", () => {
-		const command = getDockerCommand(
-			createApplication({
-				buildArchitecture: "multi",
-				registry: { registryId: "r1" } as ApplicationNested["registry"],
-			}),
-			{ pushTags: ["ghcr.io/acme/test-app:latest"] },
-		);
+		const command = getDockerCommand(createApplication(), {
+			platforms: ["linux/amd64", "linux/arm64"],
+			builder: null,
+			createDefaultBuilder: true,
+			output: {
+				mode: "push",
+				tags: ["ghcr.io/acme/test-app:latest"],
+				logins: "",
+			},
+		});
 
 		expect(command).toContain("docker buildx create");
 		expect(command).toContain("dokploy-multiarch");
@@ -123,13 +141,15 @@ describe("getDockerCommand", () => {
 		expect(command).toContain("-t");
 		expect(command).toContain("ghcr.io/acme/test-app");
 		expect(command).not.toContain("docker build -t test-app");
+		expect(command).not.toContain("--load");
 	});
 
 	it("quotes a user-supplied builder name so it cannot break out of the command", () => {
 		const command = getDockerCommand(
-			createApplication({
-				buildArchitecture: "amd64",
-				buildxBuilder: "x; touch /tmp/pwned",
+			createApplication(),
+			localPlan({
+				platforms: ["linux/amd64"],
+				builder: "x; touch /tmp/pwned",
 			}),
 		);
 

--- a/apps/dokploy/__test__/deploy/docker-file.command.test.ts
+++ b/apps/dokploy/__test__/deploy/docker-file.command.test.ts
@@ -133,8 +133,9 @@ describe("getDockerCommand", () => {
 			},
 		});
 
-		expect(command).toContain("docker buildx create");
+		expect(command).toContain("docker buildx inspect");
 		expect(command).toContain("dokploy-multiarch");
+		expect(command).toContain("network=host");
 		expect(command).toContain("docker buildx build");
 		expect(command).toContain("--platform linux/amd64,linux/arm64");
 		expect(command).toContain("--push");

--- a/apps/dokploy/__test__/deploy/docker-file.command.test.ts
+++ b/apps/dokploy/__test__/deploy/docker-file.command.test.ts
@@ -32,7 +32,6 @@ const createApplication = (
 const localPlan = (overrides: Partial<BuildPlan> = {}): BuildPlan => ({
 	platforms: [],
 	builder: null,
-	createDefaultBuilder: false,
 	output: { mode: "local", image: "test-app" },
 	...overrides,
 });
@@ -125,7 +124,6 @@ describe("getDockerCommand", () => {
 		const command = getDockerCommand(createApplication(), {
 			platforms: ["linux/amd64", "linux/arm64"],
 			builder: null,
-			createDefaultBuilder: true,
 			output: {
 				mode: "push",
 				tags: ["ghcr.io/acme/test-app:latest"],
@@ -143,6 +141,22 @@ describe("getDockerCommand", () => {
 		expect(command).toContain("ghcr.io/acme/test-app");
 		expect(command).not.toContain("docker build -t test-app");
 		expect(command).not.toContain("--load");
+	});
+
+	it("uses a named builder for multi-arch and does not create dokploy-multiarch", () => {
+		const command = getDockerCommand(createApplication(), {
+			platforms: ["linux/amd64", "linux/arm64"],
+			builder: "farm",
+			output: {
+				mode: "push",
+				tags: ["ghcr.io/acme/test-app:latest"],
+				logins: "",
+			},
+		});
+
+		expect(command).toContain("--builder farm");
+		expect(command).not.toContain("dokploy-multiarch");
+		expect(command).toContain("--push");
 	});
 
 	it("quotes a user-supplied builder name so it cannot break out of the command", () => {

--- a/apps/dokploy/__test__/deploy/get-build-command.test.ts
+++ b/apps/dokploy/__test__/deploy/get-build-command.test.ts
@@ -1,0 +1,128 @@
+import type { ApplicationNested } from "@dokploy/server/utils/builders";
+import { getBuildCommand } from "@dokploy/server/utils/builders";
+import {
+	BuildArchitectureError,
+	resolveBuildPlan,
+} from "@dokploy/server/utils/builders/build-platform";
+import * as upload from "@dokploy/server/utils/cluster/upload";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@dokploy/server/utils/vault", () => ({
+	withResolvedVaultRefs: async (application: unknown) => application,
+}));
+
+vi.mock("@dokploy/server/utils/cluster/upload", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("@dokploy/server/utils/cluster/upload")
+		>();
+	return {
+		...actual,
+		collectRegistryPushTargets: vi.fn(),
+		uploadImageRemoteCommand: vi.fn(),
+		registryLoginCommands: vi.fn(() => "docker login ghcr.io"),
+	};
+});
+
+const createApplication = (
+	overrides: Partial<ApplicationNested> = {},
+): ApplicationNested =>
+	({
+		appName: "test-app",
+		buildType: "dockerfile",
+		sourceType: "git",
+		customGitBuildPath: "/",
+		dockerfile: "Dockerfile",
+		env: null,
+		buildArgs: null,
+		buildSecrets: null,
+		publishDirectory: null,
+		dockerBuildStage: null,
+		dockerContextPath: null,
+		cleanCache: false,
+		createEnvFile: false,
+		registry: null,
+		buildRegistry: null,
+		rollbackRegistry: null,
+		environment: {
+			project: {
+				env: "",
+			},
+			env: "",
+		},
+		...overrides,
+	}) as unknown as ApplicationNested;
+
+const clusterTarget = {
+	kind: "cluster" as const,
+	registry: {
+		registryId: "r1",
+		registryUrl: "ghcr.io",
+		username: "acme",
+		password: "secret",
+	} as upload.RegistryPushTarget["registry"],
+	imageName: "test-app:latest",
+	tag: "ghcr.io/acme/test-app:latest",
+};
+
+describe("resolveBuildPlan and getBuildCommand", () => {
+	beforeEach(() => {
+		vi.mocked(upload.collectRegistryPushTargets).mockReset();
+		vi.mocked(upload.uploadImageRemoteCommand).mockReset();
+		vi.mocked(upload.registryLoginCommands).mockReset();
+		vi.mocked(upload.registryLoginCommands).mockReturnValue(
+			"docker login ghcr.io",
+		);
+		vi.mocked(upload.uploadImageRemoteCommand).mockResolvedValue(
+			"\ndocker tag test-app:latest ghcr.io/acme/test-app:latest\ndocker push ghcr.io/acme/test-app:latest\n",
+		);
+	});
+
+	it("keeps host builds on the local tag-and-push path", async () => {
+		const application = createApplication({
+			registry: { registryId: "r1" } as ApplicationNested["registry"],
+		});
+		const command = await getBuildCommand(application);
+
+		expect(command).toContain("docker build -t test-app -f");
+		expect(command).not.toContain("--push");
+		expect(upload.uploadImageRemoteCommand).toHaveBeenCalled();
+		expect(upload.collectRegistryPushTargets).not.toHaveBeenCalled();
+	});
+
+	it("pushes multi-arch with buildx and does not tag a local image afterward", async () => {
+		vi.mocked(upload.collectRegistryPushTargets).mockResolvedValue([
+			clusterTarget,
+		]);
+		const application = createApplication({
+			buildArchitecture: "multi",
+			registry: { registryId: "r1" } as ApplicationNested["registry"],
+		});
+
+		const plan = await resolveBuildPlan(application);
+		expect(plan.output.mode).toBe("push");
+
+		const command = await getBuildCommand(application);
+		expect(command).toContain("docker login ghcr.io");
+		expect(command).toContain("docker buildx build");
+		expect(command).toContain("--push");
+		expect(command).toContain("ghcr.io/acme/test-app");
+		expect(command).not.toContain("docker tag ");
+		expect(command).not.toContain("docker push ");
+		expect(upload.uploadImageRemoteCommand).not.toHaveBeenCalled();
+	});
+
+	it("rejects multi-arch without a cluster or build registry", async () => {
+		await expect(
+			resolveBuildPlan(
+				createApplication({
+					buildArchitecture: "multi",
+					rollbackRegistry: {
+						registryId: "rb",
+					} as ApplicationNested["rollbackRegistry"],
+				}),
+			),
+		).rejects.toThrow(BuildArchitectureError);
+		expect(upload.collectRegistryPushTargets).not.toHaveBeenCalled();
+	});
+});

--- a/apps/dokploy/__test__/deploy/railpack.command.test.ts
+++ b/apps/dokploy/__test__/deploy/railpack.command.test.ts
@@ -45,6 +45,7 @@ describe("getRailpackCommand", () => {
 		const command = getRailpackCommand(createApplication(), localPlan());
 
 		expect(command).toContain("--build-arg secrets-hash=");
+		expect(command).toContain("network=host");
 		expect(command).not.toContain("cache-key=");
 	});
 
@@ -113,6 +114,7 @@ describe("getRailpackCommand", () => {
 
 		expect(command).toContain("--platform linux/amd64,linux/arm64");
 		expect(command).toContain("--push");
+		expect(command).toContain("network=host");
 		expect(command).not.toContain("--output type=docker");
 	});
 

--- a/apps/dokploy/__test__/deploy/railpack.command.test.ts
+++ b/apps/dokploy/__test__/deploy/railpack.command.test.ts
@@ -1,6 +1,15 @@
 import type { ApplicationNested } from "@dokploy/server/utils/builders";
+import type { BuildPlan } from "@dokploy/server/utils/builders/build-platform";
 import { getRailpackCommand } from "@dokploy/server/utils/builders/railpack";
 import { describe, expect, it } from "vitest";
+
+const localPlan = (overrides: Partial<BuildPlan> = {}): BuildPlan => ({
+	platforms: [],
+	builder: null,
+	createDefaultBuilder: false,
+	output: { mode: "local", image: "test-app" },
+	...overrides,
+});
 
 const createApplication = (
 	overrides: Partial<ApplicationNested> = {},
@@ -33,7 +42,7 @@ const getSecretsHash = (command: string) => {
 
 describe("getRailpackCommand", () => {
 	it("includes secrets-hash without clean cache", () => {
-		const command = getRailpackCommand(createApplication());
+		const command = getRailpackCommand(createApplication(), localPlan());
 
 		expect(command).toContain("--build-arg secrets-hash=");
 		expect(command).not.toContain("cache-key=");
@@ -44,6 +53,7 @@ describe("getRailpackCommand", () => {
 			createApplication({
 				cleanCache: true,
 			}),
+			localPlan(),
 		);
 
 		expect(command).toContain("--build-arg secrets-hash=");
@@ -51,7 +61,7 @@ describe("getRailpackCommand", () => {
 	});
 
 	it("installs Railpack through sudo for non-root users", () => {
-		const command = getRailpackCommand(createApplication());
+		const command = getRailpackCommand(createApplication(), localPlan());
 
 		expect(command).toContain(
 			'$SUDO_CMD bash -c "$(curl -fsSL https://railpack.com/install.sh)"',
@@ -64,11 +74,13 @@ describe("getRailpackCommand", () => {
 			createApplication({
 				env: "TEST_VAR=one",
 			}),
+			localPlan(),
 		);
 		const secondCommand = getRailpackCommand(
 			createApplication({
 				env: "TEST_VAR=two",
 			}),
+			localPlan(),
 		);
 
 		expect(getSecretsHash(firstCommand)).not.toEqual(
@@ -78,9 +90,8 @@ describe("getRailpackCommand", () => {
 
 	it("adds --platform for a single architecture and keeps a local docker output", () => {
 		const command = getRailpackCommand(
-			createApplication({
-				buildArchitecture: "amd64",
-			}),
+			createApplication(),
+			localPlan({ platforms: ["linux/amd64"] }),
 		);
 
 		expect(command).toContain("--platform linux/amd64");
@@ -89,13 +100,16 @@ describe("getRailpackCommand", () => {
 	});
 
 	it("pushes a multi-arch image instead of loading into docker", () => {
-		const command = getRailpackCommand(
-			createApplication({
-				buildArchitecture: "multi",
-				registry: { registryId: "r1" },
-			} as Partial<ApplicationNested>),
-			{ pushTags: ["ghcr.io/acme/test-app:latest"] },
-		);
+		const command = getRailpackCommand(createApplication(), {
+			platforms: ["linux/amd64", "linux/arm64"],
+			builder: null,
+			createDefaultBuilder: false,
+			output: {
+				mode: "push",
+				tags: ["ghcr.io/acme/test-app:latest"],
+				logins: "",
+			},
+		});
 
 		expect(command).toContain("--platform linux/amd64,linux/arm64");
 		expect(command).toContain("--push");
@@ -116,6 +130,7 @@ describe("getRailpackCommand", () => {
 					env: "SHARED_VALUE=alpha",
 				},
 			} as Partial<ApplicationNested>),
+			localPlan(),
 		);
 		const secondCommand = getRailpackCommand(
 			createApplication({
@@ -130,6 +145,7 @@ describe("getRailpackCommand", () => {
 					env: "SHARED_VALUE=beta",
 				},
 			} as Partial<ApplicationNested>),
+			localPlan(),
 		);
 
 		expect(getSecretsHash(firstCommand)).not.toEqual(

--- a/apps/dokploy/__test__/deploy/railpack.command.test.ts
+++ b/apps/dokploy/__test__/deploy/railpack.command.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from "vitest";
 const localPlan = (overrides: Partial<BuildPlan> = {}): BuildPlan => ({
 	platforms: [],
 	builder: null,
-	createDefaultBuilder: false,
 	output: { mode: "local", image: "test-app" },
 	...overrides,
 });
@@ -104,7 +103,6 @@ describe("getRailpackCommand", () => {
 		const command = getRailpackCommand(createApplication(), {
 			platforms: ["linux/amd64", "linux/arm64"],
 			builder: null,
-			createDefaultBuilder: false,
 			output: {
 				mode: "push",
 				tags: ["ghcr.io/acme/test-app:latest"],

--- a/apps/dokploy/__test__/deploy/railpack.command.test.ts
+++ b/apps/dokploy/__test__/deploy/railpack.command.test.ts
@@ -76,6 +76,32 @@ describe("getRailpackCommand", () => {
 		);
 	});
 
+	it("adds --platform for a single architecture and keeps a local docker output", () => {
+		const command = getRailpackCommand(
+			createApplication({
+				buildArchitecture: "amd64",
+			}),
+		);
+
+		expect(command).toContain("--platform linux/amd64");
+		expect(command).toContain("--output type=docker,name=test-app");
+		expect(command).not.toContain("--push");
+	});
+
+	it("pushes a multi-arch image instead of loading into docker", () => {
+		const command = getRailpackCommand(
+			createApplication({
+				buildArchitecture: "multi",
+				registry: { registryId: "r1" },
+			} as Partial<ApplicationNested>),
+			{ pushTags: ["ghcr.io/acme/test-app:latest"] },
+		);
+
+		expect(command).toContain("--platform linux/amd64,linux/arm64");
+		expect(command).toContain("--push");
+		expect(command).not.toContain("--output type=docker");
+	});
+
 	it("changes secrets-hash when referenced project or environment values change", () => {
 		const firstCommand = getRailpackCommand(
 			createApplication({

--- a/apps/dokploy/__test__/drop/drop.test.ts
+++ b/apps/dokploy/__test__/drop/drop.test.ts
@@ -95,6 +95,8 @@ const baseApp: ApplicationNested = {
 	buildPath: "/",
 	gitlabPathNamespace: "",
 	buildType: "nixpacks",
+	buildArchitecture: "host",
+	buildxBuilder: null,
 	bitbucketBranch: "",
 	bitbucketBuildPath: "",
 	bitbucketId: "",

--- a/apps/dokploy/__test__/traefik/traefik.test.ts
+++ b/apps/dokploy/__test__/traefik/traefik.test.ts
@@ -71,6 +71,8 @@ const baseApp: ApplicationNested = {
 	buildPath: "/",
 	gitlabPathNamespace: "",
 	buildType: "nixpacks",
+	buildArchitecture: "host",
+	buildxBuilder: null,
 	bitbucketBranch: "",
 	bitbucketBuildPath: "",
 	bitbucketId: "",

--- a/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
@@ -1,0 +1,200 @@
+import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
+import { Cpu } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { AlertBlock } from "@/components/shared/alert-block";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Form,
+	FormControl,
+	FormDescription,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/utils/api";
+
+interface Props {
+	applicationId: string;
+}
+
+const BUILD_ARCHITECTURES = ["host", "amd64", "arm64", "multi"] as const;
+
+const architectureLabels: Record<(typeof BUILD_ARCHITECTURES)[number], string> =
+	{
+		host: "Host native (default)",
+		amd64: "linux/amd64",
+		arm64: "linux/arm64",
+		multi: "linux/amd64 and linux/arm64 (multi-arch)",
+	};
+
+const formSchema = z.object({
+	buildArchitecture: z.enum(BUILD_ARCHITECTURES),
+	buildxBuilder: z.string().optional(),
+});
+
+type Schema = z.infer<typeof formSchema>;
+
+export const ShowBuildArchitecture = ({ applicationId }: Props) => {
+	const { data, refetch } = api.application.one.useQuery(
+		{ applicationId },
+		{ enabled: !!applicationId },
+	);
+	const { mutateAsync, isPending } = api.application.update.useMutation();
+
+	const hasRegistry = Boolean(
+		data?.registryId || data?.buildRegistryId || data?.rollbackRegistryId,
+	);
+
+	const form = useForm<Schema>({
+		defaultValues: {
+			buildArchitecture: "host",
+			buildxBuilder: "",
+		},
+		resolver: zodResolver(formSchema),
+	});
+
+	useEffect(() => {
+		if (data) {
+			form.reset({
+				buildArchitecture: data.buildArchitecture || "host",
+				buildxBuilder: data.buildxBuilder || "",
+			});
+		}
+	}, [form, data]);
+
+	const architecture = form.watch("buildArchitecture");
+
+	const onSubmit = async (formData: Schema) => {
+		if (formData.buildArchitecture === "multi" && !hasRegistry) {
+			form.setError("buildArchitecture", {
+				message:
+					"Multi-arch builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
+			});
+			return;
+		}
+		await mutateAsync({
+			applicationId,
+			buildArchitecture: formData.buildArchitecture,
+			buildxBuilder: formData.buildxBuilder?.trim()
+				? formData.buildxBuilder.trim()
+				: null,
+		})
+			.then(async () => {
+				toast.success("Build architecture updated");
+				await refetch();
+			})
+			.catch(() => {
+				toast.error("Error updating build architecture");
+			});
+	};
+
+	return (
+		<Card className="bg-background">
+			<CardHeader>
+				<div className="flex flex-row items-center gap-2">
+					<Cpu className="size-6 text-muted-foreground" />
+					<div>
+						<CardTitle className="text-xl">Build Architecture</CardTitle>
+						<CardDescription>
+							Choose which CPU architectures Docker should build for.
+						</CardDescription>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="flex flex-col gap-4">
+				<AlertBlock type="info">
+					Host native builds for the CPU of the build server. Pinning amd64 or
+					arm64 adds --platform to the build. Multi-arch uses Buildx and pushes
+					a manifest list to a registry so each deploy server pulls the matching
+					image.
+				</AlertBlock>
+				{architecture === "multi" && !hasRegistry ? (
+					<AlertBlock type="warning">
+						Select a registry in Cluster Settings or Build Server before saving
+						multi-arch. Buildx cannot load a multi-arch image into the local
+						Docker daemon.
+					</AlertBlock>
+				) : null}
+				<Form {...form}>
+					<form
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="grid w-full gap-4"
+					>
+						<FormField
+							control={form.control}
+							name="buildArchitecture"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Architecture</FormLabel>
+									<Select onValueChange={field.onChange} value={field.value}>
+										<FormControl>
+											<SelectTrigger>
+												<SelectValue placeholder="Select architecture" />
+											</SelectTrigger>
+										</FormControl>
+										<SelectContent>
+											{BUILD_ARCHITECTURES.map((value) => (
+												<SelectItem key={value} value={value}>
+													{architectureLabels[value]}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+									<FormDescription>
+										Cross-compilation uses QEMU unless you point at a native
+										buildx builder below.
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="buildxBuilder"
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Buildx builder name</FormLabel>
+									<FormControl>
+										<Input
+											placeholder="Leave empty for the default builder"
+											{...field}
+										/>
+									</FormControl>
+									<FormDescription>
+										Optional named builder already created on the build host,
+										for example a builder with native ARM and AMD64 nodes.
+									</FormDescription>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+						<div className="flex w-full justify-end">
+							<Button isLoading={isPending} type="submit">
+								Save
+							</Button>
+						</div>
+					</form>
+				</Form>
+			</CardContent>
+		</Card>
+	);
+};

--- a/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
@@ -1,7 +1,5 @@
-import { isPackBuildType } from "@dokploy/server/utils/builders/build-platform";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { Cpu } from "lucide-react";
-import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -62,24 +60,18 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 	const { mutateAsync, isPending } = api.application.update.useMutation();
 
 	const hasRegistry = Boolean(data?.registryId || data?.buildRegistryId);
-	const packBuilder = isPackBuildType(data?.buildType ?? "");
+	const packBuilder =
+		data?.buildType === "nixpacks" ||
+		data?.buildType === "heroku_buildpacks" ||
+		data?.buildType === "paketo_buildpacks";
 
 	const form = useForm<Schema>({
-		defaultValues: {
-			buildArchitecture: "host",
-			buildxBuilder: "",
+		values: {
+			buildArchitecture: data?.buildArchitecture || "host",
+			buildxBuilder: data?.buildxBuilder || "",
 		},
 		resolver: zodResolver(formSchema),
 	});
-
-	useEffect(() => {
-		if (data) {
-			form.reset({
-				buildArchitecture: data.buildArchitecture || "host",
-				buildxBuilder: data.buildxBuilder || "",
-			});
-		}
-	}, [form, data]);
 
 	const architecture = form.watch("buildArchitecture");
 
@@ -160,11 +152,9 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 								<FormItem>
 									<FormLabel>Architecture</FormLabel>
 									<Select onValueChange={field.onChange} value={field.value}>
-										<FormControl>
-											<SelectTrigger>
-												<SelectValue placeholder="Select architecture" />
-											</SelectTrigger>
-										</FormControl>
+										<SelectTrigger>
+											<SelectValue placeholder="Select architecture" />
+										</SelectTrigger>
 										<SelectContent>
 											{BUILD_ARCHITECTURES.map((value) => (
 												<SelectItem

--- a/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
@@ -76,13 +76,6 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 	const architecture = form.watch("buildArchitecture");
 
 	const onSubmit = async (formData: Schema) => {
-		if (packBuilder && formData.buildArchitecture !== "host") {
-			form.setError("buildArchitecture", {
-				message:
-					"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
-			});
-			return;
-		}
 		if (formData.buildArchitecture === "multi" && !hasRegistry) {
 			form.setError("buildArchitecture", {
 				message:

--- a/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
+++ b/apps/dokploy/components/dashboard/application/advanced/show-build-architecture.tsx
@@ -1,3 +1,4 @@
+import { isPackBuildType } from "@dokploy/server/utils/builders/build-platform";
 import { standardSchemaResolver as zodResolver } from "@hookform/resolvers/standard-schema";
 import { Cpu } from "lucide-react";
 import { useEffect } from "react";
@@ -60,9 +61,8 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 	);
 	const { mutateAsync, isPending } = api.application.update.useMutation();
 
-	const hasRegistry = Boolean(
-		data?.registryId || data?.buildRegistryId || data?.rollbackRegistryId,
-	);
+	const hasRegistry = Boolean(data?.registryId || data?.buildRegistryId);
+	const packBuilder = isPackBuildType(data?.buildType ?? "");
 
 	const form = useForm<Schema>({
 		defaultValues: {
@@ -84,6 +84,13 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 	const architecture = form.watch("buildArchitecture");
 
 	const onSubmit = async (formData: Schema) => {
+		if (packBuilder && formData.buildArchitecture !== "host") {
+			form.setError("buildArchitecture", {
+				message:
+					"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
+			});
+			return;
+		}
 		if (formData.buildArchitecture === "multi" && !hasRegistry) {
 			form.setError("buildArchitecture", {
 				message:
@@ -127,6 +134,13 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 					a manifest list to a registry so each deploy server pulls the matching
 					image.
 				</AlertBlock>
+				{packBuilder ? (
+					<AlertBlock type="info">
+						Nixpacks, Heroku Buildpacks, and Paketo only support host native
+						builds. Switch the build type to Dockerfile, Railpack, or Static to
+						pin an architecture.
+					</AlertBlock>
+				) : null}
 				{architecture === "multi" && !hasRegistry ? (
 					<AlertBlock type="warning">
 						Select a registry in Cluster Settings or Build Server before saving
@@ -153,7 +167,11 @@ export const ShowBuildArchitecture = ({ applicationId }: Props) => {
 										</FormControl>
 										<SelectContent>
 											{BUILD_ARCHITECTURES.map((value) => (
-												<SelectItem key={value} value={value}>
+												<SelectItem
+													key={value}
+													value={value}
+													disabled={packBuilder && value !== "host"}
+												>
 													{architectureLabels[value]}
 												</SelectItem>
 											))}

--- a/apps/dokploy/drizzle/0197_old_retro_girl.sql
+++ b/apps/dokploy/drizzle/0197_old_retro_girl.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "public"."buildArchitecture" AS ENUM('host', 'amd64', 'arm64', 'multi');--> statement-breakpoint
+ALTER TABLE "application" ADD COLUMN "buildArchitecture" "buildArchitecture" DEFAULT 'host' NOT NULL;--> statement-breakpoint
+ALTER TABLE "application" ADD COLUMN "buildxBuilder" text;

--- a/apps/dokploy/drizzle/meta/0197_snapshot.json
+++ b/apps/dokploy/drizzle/meta/0197_snapshot.json
@@ -1,0 +1,9194 @@
+{
+  "id": "258e4b59-5350-48dd-a153-ef71026f0f45",
+  "prevId": "c9ad226a-7a8f-4c3b-8f04-fef6bccf9bfb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is2FAEnabled": {
+          "name": "is2FAEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resetPasswordToken": {
+          "name": "resetPasswordToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resetPasswordExpiresAt": {
+          "name": "resetPasswordExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmationToken": {
+          "name": "confirmationToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmationExpiresAt": {
+          "name": "confirmationExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apikey": {
+      "name": "apikey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apikey_reference_id_user_id_fk": {
+          "name": "apikey_reference_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canCreateProjects": {
+          "name": "canCreateProjects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canAccessToSSHKeys": {
+          "name": "canAccessToSSHKeys",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canCreateServices": {
+          "name": "canCreateServices",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDeleteProjects": {
+          "name": "canDeleteProjects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDeleteServices": {
+          "name": "canDeleteServices",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canAccessToDocker": {
+          "name": "canAccessToDocker",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canAccessToAPI": {
+          "name": "canAccessToAPI",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canAccessToGitProviders": {
+          "name": "canAccessToGitProviders",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canAccessToTraefikFiles": {
+          "name": "canAccessToTraefikFiles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDeleteEnvironments": {
+          "name": "canDeleteEnvironments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canCreateEnvironments": {
+          "name": "canCreateEnvironments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accesedProjects": {
+          "name": "accesedProjects",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "accessedEnvironments": {
+          "name": "accessedEnvironments",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "accesedServices": {
+          "name": "accesedServices",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "accessedGitProviders": {
+          "name": "accessedGitProviders",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "accessedServers": {
+          "name": "accessedServers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_role": {
+          "name": "default_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_owner_id_user_id_fk": {
+          "name": "organization_owner_id_user_id_fk",
+          "tableFrom": "organization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_role": {
+      "name": "organization_role",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organizationRole_organizationId_idx": {
+          "name": "organizationRole_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organizationRole_role_idx": {
+          "name": "organizationRole_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_role_organization_id_organization_id_fk": {
+          "name": "organization_role_organization_id_organization_id_fk",
+          "tableFrom": "organization_role",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai": {
+      "name": "ai",
+      "schema": "",
+      "columns": {
+        "aiId": {
+          "name": "aiId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiUrl": {
+          "name": "apiUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_organizationId_organization_id_fk": {
+          "name": "ai_organizationId_organization_id_fk",
+          "tableFrom": "ai",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application": {
+      "name": "application",
+      "schema": "",
+      "columns": {
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewEnv": {
+          "name": "previewEnv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchPaths": {
+          "name": "watchPaths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewBuildArgs": {
+          "name": "previewBuildArgs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewBuildSecrets": {
+          "name": "previewBuildSecrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewLabels": {
+          "name": "previewLabels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewWildcard": {
+          "name": "previewWildcard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewPort": {
+          "name": "previewPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3000
+        },
+        "previewHttps": {
+          "name": "previewHttps",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "previewPath": {
+          "name": "previewPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "certificateType": {
+          "name": "certificateType",
+          "type": "certificateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "previewCustomCertResolver": {
+          "name": "previewCustomCertResolver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewLimit": {
+          "name": "previewLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "isPreviewDeploymentsActive": {
+          "name": "isPreviewDeploymentsActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "previewRequireCollaboratorPermissions": {
+          "name": "previewRequireCollaboratorPermissions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "rollbackActive": {
+          "name": "rollbackActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "buildArgs": {
+          "name": "buildArgs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildSecrets": {
+          "name": "buildSecrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "sourceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "cleanCache": {
+          "name": "cleanCache",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildPath": {
+          "name": "buildPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "triggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'push'"
+        },
+        "autoDeploy": {
+          "name": "autoDeploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabProjectId": {
+          "name": "gitlabProjectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabRepository": {
+          "name": "gitlabRepository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabOwner": {
+          "name": "gitlabOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabBranch": {
+          "name": "gitlabBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabBuildPath": {
+          "name": "gitlabBuildPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "gitlabPathNamespace": {
+          "name": "gitlabPathNamespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaRepository": {
+          "name": "giteaRepository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaOwner": {
+          "name": "giteaOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaBranch": {
+          "name": "giteaBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaBuildPath": {
+          "name": "giteaBuildPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "bitbucketRepository": {
+          "name": "bitbucketRepository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketRepositorySlug": {
+          "name": "bitbucketRepositorySlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketOwner": {
+          "name": "bitbucketOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketBranch": {
+          "name": "bitbucketBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketBuildPath": {
+          "name": "bitbucketBuildPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registryUrl": {
+          "name": "registryUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitUrl": {
+          "name": "customGitUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitBranch": {
+          "name": "customGitBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitBuildPath": {
+          "name": "customGitBuildPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitSSHKeyId": {
+          "name": "customGitSSHKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableSubmodules": {
+          "name": "enableSubmodules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dockerfile": {
+          "name": "dockerfile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Dockerfile'"
+        },
+        "dockerContextPath": {
+          "name": "dockerContextPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dockerBuildStage": {
+          "name": "dockerBuildStage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropBuildPath": {
+          "name": "dropBuildPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ulimitsSwarm": {
+          "name": "ulimitsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "buildType": {
+          "name": "buildType",
+          "type": "buildType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'nixpacks'"
+        },
+        "buildArchitecture": {
+          "name": "buildArchitecture",
+          "type": "buildArchitecture",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'host'"
+        },
+        "buildxBuilder": {
+          "name": "buildxBuilder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "railpackVersion": {
+          "name": "railpackVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.15.4'"
+        },
+        "herokuVersion": {
+          "name": "herokuVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'24'"
+        },
+        "publishDirectory": {
+          "name": "publishDirectory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isStaticSpa": {
+          "name": "isStaticSpa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createEnvFile": {
+          "name": "createEnvFile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registryId": {
+          "name": "registryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackRegistryId": {
+          "name": "rollbackRegistryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabId": {
+          "name": "gitlabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaId": {
+          "name": "giteaId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketId": {
+          "name": "bitbucketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildServerId": {
+          "name": "buildServerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildRegistryId": {
+          "name": "buildRegistryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_customGitSSHKeyId_ssh-key_sshKeyId_fk": {
+          "name": "application_customGitSSHKeyId_ssh-key_sshKeyId_fk",
+          "tableFrom": "application",
+          "tableTo": "ssh-key",
+          "columnsFrom": [
+            "customGitSSHKeyId"
+          ],
+          "columnsTo": [
+            "sshKeyId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_registryId_registry_registryId_fk": {
+          "name": "application_registryId_registry_registryId_fk",
+          "tableFrom": "application",
+          "tableTo": "registry",
+          "columnsFrom": [
+            "registryId"
+          ],
+          "columnsTo": [
+            "registryId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_rollbackRegistryId_registry_registryId_fk": {
+          "name": "application_rollbackRegistryId_registry_registryId_fk",
+          "tableFrom": "application",
+          "tableTo": "registry",
+          "columnsFrom": [
+            "rollbackRegistryId"
+          ],
+          "columnsTo": [
+            "registryId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_environmentId_environment_environmentId_fk": {
+          "name": "application_environmentId_environment_environmentId_fk",
+          "tableFrom": "application",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_githubId_github_githubId_fk": {
+          "name": "application_githubId_github_githubId_fk",
+          "tableFrom": "application",
+          "tableTo": "github",
+          "columnsFrom": [
+            "githubId"
+          ],
+          "columnsTo": [
+            "githubId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_gitlabId_gitlab_gitlabId_fk": {
+          "name": "application_gitlabId_gitlab_gitlabId_fk",
+          "tableFrom": "application",
+          "tableTo": "gitlab",
+          "columnsFrom": [
+            "gitlabId"
+          ],
+          "columnsTo": [
+            "gitlabId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_giteaId_gitea_giteaId_fk": {
+          "name": "application_giteaId_gitea_giteaId_fk",
+          "tableFrom": "application",
+          "tableTo": "gitea",
+          "columnsFrom": [
+            "giteaId"
+          ],
+          "columnsTo": [
+            "giteaId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_bitbucketId_bitbucket_bitbucketId_fk": {
+          "name": "application_bitbucketId_bitbucket_bitbucketId_fk",
+          "tableFrom": "application",
+          "tableTo": "bitbucket",
+          "columnsFrom": [
+            "bitbucketId"
+          ],
+          "columnsTo": [
+            "bitbucketId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_serverId_server_serverId_fk": {
+          "name": "application_serverId_server_serverId_fk",
+          "tableFrom": "application",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_buildServerId_server_serverId_fk": {
+          "name": "application_buildServerId_server_serverId_fk",
+          "tableFrom": "application",
+          "tableTo": "server",
+          "columnsFrom": [
+            "buildServerId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_buildRegistryId_registry_registryId_fk": {
+          "name": "application_buildRegistryId_registry_registryId_fk",
+          "tableFrom": "application",
+          "tableTo": "registry",
+          "columnsFrom": [
+            "buildRegistryId"
+          ],
+          "columnsTo": [
+            "registryId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_appName_unique": {
+          "name": "application_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_role": {
+          "name": "user_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auditLog_organizationId_idx": {
+          "name": "auditLog_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auditLog_userId_idx": {
+          "name": "auditLog_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auditLog_createdAt_idx": {
+          "name": "auditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_organization_id_organization_id_fk": {
+          "name": "audit_log_organization_id_organization_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_user_id_fk": {
+          "name": "audit_log_user_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup": {
+      "name": "backup",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "database": {
+          "name": "database",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serviceName": {
+          "name": "serviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destinationId": {
+          "name": "destinationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keepLatestCount": {
+          "name": "keepLatestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeEncryptionKey": {
+          "name": "includeEncryptionKey",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "backupType": {
+          "name": "backupType",
+          "type": "backupType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'database'"
+        },
+        "databaseType": {
+          "name": "databaseType",
+          "type": "databaseType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postgresId": {
+          "name": "postgresId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mariadbId": {
+          "name": "mariadbId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mysqlId": {
+          "name": "mysqlId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mongoId": {
+          "name": "mongoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "libsqlId": {
+          "name": "libsqlId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backup_destinationId_destination_destinationId_fk": {
+          "name": "backup_destinationId_destination_destinationId_fk",
+          "tableFrom": "backup",
+          "tableTo": "destination",
+          "columnsFrom": [
+            "destinationId"
+          ],
+          "columnsTo": [
+            "destinationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_composeId_compose_composeId_fk": {
+          "name": "backup_composeId_compose_composeId_fk",
+          "tableFrom": "backup",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_postgresId_postgres_postgresId_fk": {
+          "name": "backup_postgresId_postgres_postgresId_fk",
+          "tableFrom": "backup",
+          "tableTo": "postgres",
+          "columnsFrom": [
+            "postgresId"
+          ],
+          "columnsTo": [
+            "postgresId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_mariadbId_mariadb_mariadbId_fk": {
+          "name": "backup_mariadbId_mariadb_mariadbId_fk",
+          "tableFrom": "backup",
+          "tableTo": "mariadb",
+          "columnsFrom": [
+            "mariadbId"
+          ],
+          "columnsTo": [
+            "mariadbId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_mysqlId_mysql_mysqlId_fk": {
+          "name": "backup_mysqlId_mysql_mysqlId_fk",
+          "tableFrom": "backup",
+          "tableTo": "mysql",
+          "columnsFrom": [
+            "mysqlId"
+          ],
+          "columnsTo": [
+            "mysqlId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_mongoId_mongo_mongoId_fk": {
+          "name": "backup_mongoId_mongo_mongoId_fk",
+          "tableFrom": "backup",
+          "tableTo": "mongo",
+          "columnsFrom": [
+            "mongoId"
+          ],
+          "columnsTo": [
+            "mongoId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_libsqlId_libsql_libsqlId_fk": {
+          "name": "backup_libsqlId_libsql_libsqlId_fk",
+          "tableFrom": "backup",
+          "tableTo": "libsql",
+          "columnsFrom": [
+            "libsqlId"
+          ],
+          "columnsTo": [
+            "libsqlId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "backup_userId_user_id_fk": {
+          "name": "backup_userId_user_id_fk",
+          "tableFrom": "backup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "backup_appName_unique": {
+          "name": "backup_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bitbucket": {
+      "name": "bitbucket",
+      "schema": "",
+      "columns": {
+        "bitbucketId": {
+          "name": "bitbucketId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bitbucketUsername": {
+          "name": "bitbucketUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketEmail": {
+          "name": "bitbucketEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appPassword": {
+          "name": "appPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apiToken": {
+          "name": "apiToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketWorkspaceName": {
+          "name": "bitbucketWorkspaceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitProviderId": {
+          "name": "gitProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bitbucket_gitProviderId_git_provider_gitProviderId_fk": {
+          "name": "bitbucket_gitProviderId_git_provider_gitProviderId_fk",
+          "tableFrom": "bitbucket",
+          "tableTo": "git_provider",
+          "columnsFrom": [
+            "gitProviderId"
+          ],
+          "columnsTo": [
+            "gitProviderId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate": {
+      "name": "certificate",
+      "schema": "",
+      "columns": {
+        "certificateId": {
+          "name": "certificateId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificateData": {
+          "name": "certificateData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificatePath": {
+          "name": "certificatePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autoRenew": {
+          "name": "autoRenew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certificate_organizationId_organization_id_fk": {
+          "name": "certificate_organizationId_organization_id_fk",
+          "tableFrom": "certificate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificate_serverId_server_serverId_fk": {
+          "name": "certificate_serverId_server_serverId_fk",
+          "tableFrom": "certificate",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificate_certificatePath_unique": {
+          "name": "certificate_certificatePath_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "certificatePath"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose": {
+      "name": "compose",
+      "schema": "",
+      "columns": {
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composeFile": {
+          "name": "composeFile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "sourceTypeCompose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "composeType": {
+          "name": "composeType",
+          "type": "composeType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'docker-compose'"
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autoDeploy": {
+          "name": "autoDeploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabProjectId": {
+          "name": "gitlabProjectId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabRepository": {
+          "name": "gitlabRepository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabOwner": {
+          "name": "gitlabOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabBranch": {
+          "name": "gitlabBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabPathNamespace": {
+          "name": "gitlabPathNamespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketRepository": {
+          "name": "bitbucketRepository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketRepositorySlug": {
+          "name": "bitbucketRepositorySlug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketOwner": {
+          "name": "bitbucketOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketBranch": {
+          "name": "bitbucketBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaRepository": {
+          "name": "giteaRepository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaOwner": {
+          "name": "giteaOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaBranch": {
+          "name": "giteaBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitUrl": {
+          "name": "customGitUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitBranch": {
+          "name": "customGitBranch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customGitSSHKeyId": {
+          "name": "customGitSSHKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createEnvFile": {
+          "name": "createEnvFile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enableSubmodules": {
+          "name": "enableSubmodules",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "composePath": {
+          "name": "composePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'./docker-compose.yml'"
+        },
+        "suffix": {
+          "name": "suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "randomize": {
+          "name": "randomize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isolatedDeployment": {
+          "name": "isolatedDeployment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isolatedDeploymentsVolume": {
+          "name": "isolatedDeploymentsVolume",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pullImages": {
+          "name": "pullImages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "triggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'push'"
+        },
+        "composeStatus": {
+          "name": "composeStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "watchPaths": {
+          "name": "watchPaths",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubId": {
+          "name": "githubId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitlabId": {
+          "name": "gitlabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitbucketId": {
+          "name": "bitbucketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "giteaId": {
+          "name": "giteaId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviceNetworks": {
+          "name": "serviceNetworks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "compose_customGitSSHKeyId_ssh-key_sshKeyId_fk": {
+          "name": "compose_customGitSSHKeyId_ssh-key_sshKeyId_fk",
+          "tableFrom": "compose",
+          "tableTo": "ssh-key",
+          "columnsFrom": [
+            "customGitSSHKeyId"
+          ],
+          "columnsTo": [
+            "sshKeyId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compose_environmentId_environment_environmentId_fk": {
+          "name": "compose_environmentId_environment_environmentId_fk",
+          "tableFrom": "compose",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "compose_githubId_github_githubId_fk": {
+          "name": "compose_githubId_github_githubId_fk",
+          "tableFrom": "compose",
+          "tableTo": "github",
+          "columnsFrom": [
+            "githubId"
+          ],
+          "columnsTo": [
+            "githubId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compose_gitlabId_gitlab_gitlabId_fk": {
+          "name": "compose_gitlabId_gitlab_gitlabId_fk",
+          "tableFrom": "compose",
+          "tableTo": "gitlab",
+          "columnsFrom": [
+            "gitlabId"
+          ],
+          "columnsTo": [
+            "gitlabId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compose_bitbucketId_bitbucket_bitbucketId_fk": {
+          "name": "compose_bitbucketId_bitbucket_bitbucketId_fk",
+          "tableFrom": "compose",
+          "tableTo": "bitbucket",
+          "columnsFrom": [
+            "bitbucketId"
+          ],
+          "columnsTo": [
+            "bitbucketId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compose_giteaId_gitea_giteaId_fk": {
+          "name": "compose_giteaId_gitea_giteaId_fk",
+          "tableFrom": "compose",
+          "tableTo": "gitea",
+          "columnsFrom": [
+            "giteaId"
+          ],
+          "columnsTo": [
+            "giteaId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "compose_serverId_server_serverId_fk": {
+          "name": "compose_serverId_server_serverId_fk",
+          "tableFrom": "compose",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment": {
+      "name": "deployment",
+      "schema": "",
+      "columns": {
+        "deploymentId": {
+          "name": "deploymentId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "deploymentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'running'"
+        },
+        "logPath": {
+          "name": "logPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pid": {
+          "name": "pid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPreviewDeployment": {
+          "name": "isPreviewDeployment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "previewDeploymentId": {
+          "name": "previewDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduleId": {
+          "name": "scheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackId": {
+          "name": "rollbackId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volumeBackupId": {
+          "name": "volumeBackupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildServerId": {
+          "name": "buildServerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_applicationId_application_applicationId_fk": {
+          "name": "deployment_applicationId_application_applicationId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_composeId_compose_composeId_fk": {
+          "name": "deployment_composeId_compose_composeId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_serverId_server_serverId_fk": {
+          "name": "deployment_serverId_server_serverId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_previewDeploymentId_preview_deployments_previewDeploymentId_fk": {
+          "name": "deployment_previewDeploymentId_preview_deployments_previewDeploymentId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "preview_deployments",
+          "columnsFrom": [
+            "previewDeploymentId"
+          ],
+          "columnsTo": [
+            "previewDeploymentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_scheduleId_schedule_scheduleId_fk": {
+          "name": "deployment_scheduleId_schedule_scheduleId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "schedule",
+          "columnsFrom": [
+            "scheduleId"
+          ],
+          "columnsTo": [
+            "scheduleId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_backupId_backup_backupId_fk": {
+          "name": "deployment_backupId_backup_backupId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "backup",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "backupId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_rollbackId_rollback_rollbackId_fk": {
+          "name": "deployment_rollbackId_rollback_rollbackId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "rollback",
+          "columnsFrom": [
+            "rollbackId"
+          ],
+          "columnsTo": [
+            "rollbackId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_volumeBackupId_volume_backup_volumeBackupId_fk": {
+          "name": "deployment_volumeBackupId_volume_backup_volumeBackupId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "volume_backup",
+          "columnsFrom": [
+            "volumeBackupId"
+          ],
+          "columnsTo": [
+            "volumeBackupId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_buildServerId_server_serverId_fk": {
+          "name": "deployment_buildServerId_server_serverId_fk",
+          "tableFrom": "deployment",
+          "tableTo": "server",
+          "columnsFrom": [
+            "buildServerId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.destination": {
+      "name": "destination",
+      "schema": "",
+      "columns": {
+        "destinationId": {
+          "name": "destinationId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessKey": {
+          "name": "accessKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secretAccessKey": {
+          "name": "secretAccessKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additionalFlags": {
+          "name": "additionalFlags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "destination_organizationId_organization_id_fk": {
+          "name": "destination_organizationId_organization_id_fk",
+          "tableFrom": "destination",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dns_provider": {
+      "name": "dns_provider",
+      "schema": "",
+      "columns": {
+        "dnsProviderId": {
+          "name": "dnsProviderId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "DnsProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dns_provider_org_name_idx": {
+          "name": "dns_provider_org_name_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dns_provider_organizationId_organization_id_fk": {
+          "name": "dns_provider_organizationId_organization_id_fk",
+          "tableFrom": "dns_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain": {
+      "name": "domain",
+      "schema": "",
+      "columns": {
+        "domainId": {
+          "name": "domainId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "https": {
+          "name": "https",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3000
+        },
+        "customEntrypoint": {
+          "name": "customEntrypoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "serviceName": {
+          "name": "serviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domainType": {
+          "name": "domainType",
+          "type": "domainType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'application'"
+        },
+        "uniqueConfigKey": {
+          "name": "uniqueConfigKey",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customCertResolver": {
+          "name": "customCertResolver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewDeploymentId": {
+          "name": "previewDeploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificateType": {
+          "name": "certificateType",
+          "type": "certificateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "internalPath": {
+          "name": "internalPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/'"
+        },
+        "stripPath": {
+          "name": "stripPath",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "middlewares": {
+          "name": "middlewares",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "ARRAY[]::text[]"
+        },
+        "forwardAuthEnabled": {
+          "name": "forwardAuthEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "domain_composeId_compose_composeId_fk": {
+          "name": "domain_composeId_compose_composeId_fk",
+          "tableFrom": "domain",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_applicationId_application_applicationId_fk": {
+          "name": "domain_applicationId_application_applicationId_fk",
+          "tableFrom": "domain",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "domain_previewDeploymentId_preview_deployments_previewDeploymentId_fk": {
+          "name": "domain_previewDeploymentId_preview_deployments_previewDeploymentId_fk",
+          "tableFrom": "domain",
+          "tableTo": "preview_deployments",
+          "columnsFrom": [
+            "previewDeploymentId"
+          ],
+          "columnsTo": [
+            "previewDeploymentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment": {
+      "name": "environment",
+      "schema": "",
+      "columns": {
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "environment_projectId_project_projectId_fk": {
+          "name": "environment_projectId_project_projectId_fk",
+          "tableFrom": "environment",
+          "tableTo": "project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "projectId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forward_auth_settings": {
+      "name": "forward_auth_settings",
+      "schema": "",
+      "columns": {
+        "forwardAuthSettingsId": {
+          "name": "forwardAuthSettingsId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "authDomain": {
+          "name": "authDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseDomain": {
+          "name": "baseDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "https": {
+          "name": "https",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "certificateType": {
+          "name": "certificateType",
+          "type": "certificateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'letsencrypt'"
+        },
+        "customCertResolver": {
+          "name": "customCertResolver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forward_auth_settings_providerId_sso_provider_provider_id_fk": {
+          "name": "forward_auth_settings_providerId_sso_provider_provider_id_fk",
+          "tableFrom": "forward_auth_settings",
+          "tableTo": "sso_provider",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "provider_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "forward_auth_settings_serverId_server_serverId_fk": {
+          "name": "forward_auth_settings_serverId_server_serverId_fk",
+          "tableFrom": "forward_auth_settings",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "forward_auth_settings_serverId_unique": {
+          "name": "forward_auth_settings_serverId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serverId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_provider": {
+      "name": "git_provider",
+      "schema": "",
+      "columns": {
+        "gitProviderId": {
+          "name": "gitProviderId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "gitProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedWithOrganization": {
+          "name": "sharedWithOrganization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "git_provider_organizationId_organization_id_fk": {
+          "name": "git_provider_organizationId_organization_id_fk",
+          "tableFrom": "git_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_provider_userId_user_id_fk": {
+          "name": "git_provider_userId_user_id_fk",
+          "tableFrom": "git_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitea": {
+      "name": "gitea",
+      "schema": "",
+      "columns": {
+        "giteaId": {
+          "name": "giteaId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "giteaUrl": {
+          "name": "giteaUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://gitea.com'"
+        },
+        "giteaInternalUrl": {
+          "name": "giteaInternalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitProviderId": {
+          "name": "gitProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'repo,repo:status,read:user,read:org'"
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gitea_gitProviderId_git_provider_gitProviderId_fk": {
+          "name": "gitea_gitProviderId_git_provider_gitProviderId_fk",
+          "tableFrom": "gitea",
+          "tableTo": "git_provider",
+          "columnsFrom": [
+            "gitProviderId"
+          ],
+          "columnsTo": [
+            "gitProviderId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github": {
+      "name": "github",
+      "schema": "",
+      "columns": {
+        "githubId": {
+          "name": "githubId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "githubAppName": {
+          "name": "githubAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubAppId": {
+          "name": "githubAppId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubClientId": {
+          "name": "githubClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubClientSecret": {
+          "name": "githubClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubInstallationId": {
+          "name": "githubInstallationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubPrivateKey": {
+          "name": "githubPrivateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubWebhookSecret": {
+          "name": "githubWebhookSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUrl": {
+          "name": "githubUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://github.com'"
+        },
+        "gitProviderId": {
+          "name": "gitProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_gitProviderId_git_provider_gitProviderId_fk": {
+          "name": "github_gitProviderId_git_provider_gitProviderId_fk",
+          "tableFrom": "github",
+          "tableTo": "git_provider",
+          "columnsFrom": [
+            "gitProviderId"
+          ],
+          "columnsTo": [
+            "gitProviderId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab": {
+      "name": "gitlab",
+      "schema": "",
+      "columns": {
+        "gitlabId": {
+          "name": "gitlabId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gitlabUrl": {
+          "name": "gitlabUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://gitlab.com'"
+        },
+        "gitlabInternalUrl": {
+          "name": "gitlabInternalUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gitProviderId": {
+          "name": "gitProviderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gitlab_gitProviderId_git_provider_gitProviderId_fk": {
+          "name": "gitlab_gitProviderId_git_provider_gitProviderId_fk",
+          "tableFrom": "gitlab",
+          "tableTo": "git_provider",
+          "columnsFrom": [
+            "gitProviderId"
+          ],
+          "columnsTo": [
+            "gitProviderId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.libsql": {
+      "name": "libsql",
+      "schema": "",
+      "columns": {
+        "libsqlId": {
+          "name": "libsqlId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databaseUser": {
+          "name": "databaseUser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databasePassword": {
+          "name": "databasePassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sqldNode": {
+          "name": "sqldNode",
+          "type": "sqldNode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'primary'"
+        },
+        "sqldPrimaryUrl": {
+          "name": "sqldPrimaryUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableNamespaces": {
+          "name": "enableNamespaces",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalPort": {
+          "name": "externalPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalGRPCPort": {
+          "name": "externalGRPCPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalAdminPort": {
+          "name": "externalAdminPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "libsql_environmentId_environment_environmentId_fk": {
+          "name": "libsql_environmentId_environment_environmentId_fk",
+          "tableFrom": "libsql",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "libsql_serverId_server_serverId_fk": {
+          "name": "libsql_serverId_server_serverId_fk",
+          "tableFrom": "libsql",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "libsql_appName_unique": {
+          "name": "libsql_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mariadb": {
+      "name": "mariadb",
+      "schema": "",
+      "columns": {
+        "mariadbId": {
+          "name": "mariadbId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databaseName": {
+          "name": "databaseName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databaseUser": {
+          "name": "databaseUser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databasePassword": {
+          "name": "databasePassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootPassword": {
+          "name": "rootPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalPort": {
+          "name": "externalPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ulimitsSwarm": {
+          "name": "ulimitsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mariadb_environmentId_environment_environmentId_fk": {
+          "name": "mariadb_environmentId_environment_environmentId_fk",
+          "tableFrom": "mariadb",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mariadb_serverId_server_serverId_fk": {
+          "name": "mariadb_serverId_server_serverId_fk",
+          "tableFrom": "mariadb",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mariadb_appName_unique": {
+          "name": "mariadb_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mongo": {
+      "name": "mongo",
+      "schema": "",
+      "columns": {
+        "mongoId": {
+          "name": "mongoId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databaseUser": {
+          "name": "databaseUser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databasePassword": {
+          "name": "databasePassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mongo:8'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalPort": {
+          "name": "externalPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ulimitsSwarm": {
+          "name": "ulimitsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicaSets": {
+          "name": "replicaSets",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mongo_environmentId_environment_environmentId_fk": {
+          "name": "mongo_environmentId_environment_environmentId_fk",
+          "tableFrom": "mongo",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mongo_serverId_server_serverId_fk": {
+          "name": "mongo_serverId_server_serverId_fk",
+          "tableFrom": "mongo",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mongo_appName_unique": {
+          "name": "mongo_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mount": {
+      "name": "mount",
+      "schema": "",
+      "columns": {
+        "mountId": {
+          "name": "mountId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "mountType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostPath": {
+          "name": "hostPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volumeName": {
+          "name": "volumeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serviceType": {
+          "name": "serviceType",
+          "type": "serviceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'application'"
+        },
+        "mountPath": {
+          "name": "mountPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "libsqlId": {
+          "name": "libsqlId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mariadbId": {
+          "name": "mariadbId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mongoId": {
+          "name": "mongoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mysqlId": {
+          "name": "mysqlId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postgresId": {
+          "name": "postgresId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redisId": {
+          "name": "redisId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mount_applicationId_application_applicationId_fk": {
+          "name": "mount_applicationId_application_applicationId_fk",
+          "tableFrom": "mount",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_composeId_compose_composeId_fk": {
+          "name": "mount_composeId_compose_composeId_fk",
+          "tableFrom": "mount",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_libsqlId_libsql_libsqlId_fk": {
+          "name": "mount_libsqlId_libsql_libsqlId_fk",
+          "tableFrom": "mount",
+          "tableTo": "libsql",
+          "columnsFrom": [
+            "libsqlId"
+          ],
+          "columnsTo": [
+            "libsqlId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_mariadbId_mariadb_mariadbId_fk": {
+          "name": "mount_mariadbId_mariadb_mariadbId_fk",
+          "tableFrom": "mount",
+          "tableTo": "mariadb",
+          "columnsFrom": [
+            "mariadbId"
+          ],
+          "columnsTo": [
+            "mariadbId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_mongoId_mongo_mongoId_fk": {
+          "name": "mount_mongoId_mongo_mongoId_fk",
+          "tableFrom": "mount",
+          "tableTo": "mongo",
+          "columnsFrom": [
+            "mongoId"
+          ],
+          "columnsTo": [
+            "mongoId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_mysqlId_mysql_mysqlId_fk": {
+          "name": "mount_mysqlId_mysql_mysqlId_fk",
+          "tableFrom": "mount",
+          "tableTo": "mysql",
+          "columnsFrom": [
+            "mysqlId"
+          ],
+          "columnsTo": [
+            "mysqlId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_postgresId_postgres_postgresId_fk": {
+          "name": "mount_postgresId_postgres_postgresId_fk",
+          "tableFrom": "mount",
+          "tableTo": "postgres",
+          "columnsFrom": [
+            "postgresId"
+          ],
+          "columnsTo": [
+            "postgresId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mount_redisId_redis_redisId_fk": {
+          "name": "mount_redisId_redis_redisId_fk",
+          "tableFrom": "mount",
+          "tableTo": "redis",
+          "columnsFrom": [
+            "redisId"
+          ],
+          "columnsTo": [
+            "redisId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mysql": {
+      "name": "mysql",
+      "schema": "",
+      "columns": {
+        "mysqlId": {
+          "name": "mysqlId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databaseName": {
+          "name": "databaseName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databaseUser": {
+          "name": "databaseUser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databasePassword": {
+          "name": "databasePassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootPassword": {
+          "name": "rootPassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalPort": {
+          "name": "externalPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ulimitsSwarm": {
+          "name": "ulimitsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mysql_environmentId_environment_environmentId_fk": {
+          "name": "mysql_environmentId_environment_environmentId_fk",
+          "tableFrom": "mysql",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mysql_serverId_server_serverId_fk": {
+          "name": "mysql_serverId_server_serverId_fk",
+          "tableFrom": "mysql",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mysql_appName_unique": {
+          "name": "mysql_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.network": {
+      "name": "network",
+      "schema": "",
+      "columns": {
+        "networkId": {
+          "name": "networkId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dockerId": {
+          "name": "dockerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driver": {
+          "name": "driver",
+          "type": "networkDriver",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bridge'"
+        },
+        "internal": {
+          "name": "internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attachable": {
+          "name": "attachable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableIPv4": {
+          "name": "enableIPv4",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enableIPv6": {
+          "name": "enableIPv6",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mtu": {
+          "name": "mtu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipam": {
+          "name": "ipam",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "network_organizationId_organization_id_fk": {
+          "name": "network_organizationId_organization_id_fk",
+          "tableFrom": "network",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "network_serverId_server_serverId_fk": {
+          "name": "network_serverId_server_serverId_fk",
+          "tableFrom": "network",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom": {
+      "name": "custom",
+      "schema": "",
+      "columns": {
+        "customId": {
+          "name": "customId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord": {
+      "name": "discord",
+      "schema": "",
+      "columns": {
+        "discordId": {
+          "name": "discordId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookUrl": {
+          "name": "webhookUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decoration": {
+          "name": "decoration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email": {
+      "name": "email",
+      "schema": "",
+      "columns": {
+        "emailId": {
+          "name": "emailId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "smtpServer": {
+          "name": "smtpServer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "smtpPort": {
+          "name": "smtpPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromAddress": {
+          "name": "fromAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toAddress": {
+          "name": "toAddress",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gotify": {
+      "name": "gotify",
+      "schema": "",
+      "columns": {
+        "gotifyId": {
+          "name": "gotifyId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appToken": {
+          "name": "appToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "decoration": {
+          "name": "decoration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lark": {
+      "name": "lark",
+      "schema": "",
+      "columns": {
+        "larkId": {
+          "name": "larkId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookUrl": {
+          "name": "webhookUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mattermost": {
+      "name": "mattermost",
+      "schema": "",
+      "columns": {
+        "mattermostId": {
+          "name": "mattermostId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookUrl": {
+          "name": "webhookUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appDeploy": {
+          "name": "appDeploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appBuildError": {
+          "name": "appBuildError",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "databaseBackup": {
+          "name": "databaseBackup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "volumeBackup": {
+          "name": "volumeBackup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dokployRestart": {
+          "name": "dokployRestart",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dokployBackup": {
+          "name": "dokployBackup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dockerCleanup": {
+          "name": "dockerCleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "serverThreshold": {
+          "name": "serverThreshold",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "notificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slackId": {
+          "name": "slackId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegramId": {
+          "name": "telegramId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordId": {
+          "name": "discordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailId": {
+          "name": "emailId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resendId": {
+          "name": "resendId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gotifyId": {
+          "name": "gotifyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ntfyId": {
+          "name": "ntfyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mattermostId": {
+          "name": "mattermostId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customId": {
+          "name": "customId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "larkId": {
+          "name": "larkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pushoverId": {
+          "name": "pushoverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teamsId": {
+          "name": "teamsId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_slackId_slack_slackId_fk": {
+          "name": "notification_slackId_slack_slackId_fk",
+          "tableFrom": "notification",
+          "tableTo": "slack",
+          "columnsFrom": [
+            "slackId"
+          ],
+          "columnsTo": [
+            "slackId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_telegramId_telegram_telegramId_fk": {
+          "name": "notification_telegramId_telegram_telegramId_fk",
+          "tableFrom": "notification",
+          "tableTo": "telegram",
+          "columnsFrom": [
+            "telegramId"
+          ],
+          "columnsTo": [
+            "telegramId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_discordId_discord_discordId_fk": {
+          "name": "notification_discordId_discord_discordId_fk",
+          "tableFrom": "notification",
+          "tableTo": "discord",
+          "columnsFrom": [
+            "discordId"
+          ],
+          "columnsTo": [
+            "discordId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_emailId_email_emailId_fk": {
+          "name": "notification_emailId_email_emailId_fk",
+          "tableFrom": "notification",
+          "tableTo": "email",
+          "columnsFrom": [
+            "emailId"
+          ],
+          "columnsTo": [
+            "emailId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_resendId_resend_resendId_fk": {
+          "name": "notification_resendId_resend_resendId_fk",
+          "tableFrom": "notification",
+          "tableTo": "resend",
+          "columnsFrom": [
+            "resendId"
+          ],
+          "columnsTo": [
+            "resendId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_gotifyId_gotify_gotifyId_fk": {
+          "name": "notification_gotifyId_gotify_gotifyId_fk",
+          "tableFrom": "notification",
+          "tableTo": "gotify",
+          "columnsFrom": [
+            "gotifyId"
+          ],
+          "columnsTo": [
+            "gotifyId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_ntfyId_ntfy_ntfyId_fk": {
+          "name": "notification_ntfyId_ntfy_ntfyId_fk",
+          "tableFrom": "notification",
+          "tableTo": "ntfy",
+          "columnsFrom": [
+            "ntfyId"
+          ],
+          "columnsTo": [
+            "ntfyId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_mattermostId_mattermost_mattermostId_fk": {
+          "name": "notification_mattermostId_mattermost_mattermostId_fk",
+          "tableFrom": "notification",
+          "tableTo": "mattermost",
+          "columnsFrom": [
+            "mattermostId"
+          ],
+          "columnsTo": [
+            "mattermostId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_customId_custom_customId_fk": {
+          "name": "notification_customId_custom_customId_fk",
+          "tableFrom": "notification",
+          "tableTo": "custom",
+          "columnsFrom": [
+            "customId"
+          ],
+          "columnsTo": [
+            "customId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_larkId_lark_larkId_fk": {
+          "name": "notification_larkId_lark_larkId_fk",
+          "tableFrom": "notification",
+          "tableTo": "lark",
+          "columnsFrom": [
+            "larkId"
+          ],
+          "columnsTo": [
+            "larkId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_pushoverId_pushover_pushoverId_fk": {
+          "name": "notification_pushoverId_pushover_pushoverId_fk",
+          "tableFrom": "notification",
+          "tableTo": "pushover",
+          "columnsFrom": [
+            "pushoverId"
+          ],
+          "columnsTo": [
+            "pushoverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_teamsId_teams_teamsId_fk": {
+          "name": "notification_teamsId_teams_teamsId_fk",
+          "tableFrom": "notification",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "teamsId"
+          ],
+          "columnsTo": [
+            "teamsId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_organizationId_organization_id_fk": {
+          "name": "notification_organizationId_organization_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ntfy": {
+      "name": "ntfy",
+      "schema": "",
+      "columns": {
+        "ntfyId": {
+          "name": "ntfyId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pushover": {
+      "name": "pushover",
+      "schema": "",
+      "columns": {
+        "pushoverId": {
+          "name": "pushoverId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userKey": {
+          "name": "userKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiToken": {
+          "name": "apiToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry": {
+          "name": "retry",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expire": {
+          "name": "expire",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resend": {
+      "name": "resend",
+      "schema": "",
+      "columns": {
+        "resendId": {
+          "name": "resendId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "apiKey": {
+          "name": "apiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromAddress": {
+          "name": "fromAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toAddress": {
+          "name": "toAddress",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack": {
+      "name": "slack",
+      "schema": "",
+      "columns": {
+        "slackId": {
+          "name": "slackId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookUrl": {
+          "name": "webhookUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "teamsId": {
+          "name": "teamsId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookUrl": {
+          "name": "webhookUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram": {
+      "name": "telegram",
+      "schema": "",
+      "columns": {
+        "telegramId": {
+          "name": "telegramId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "botToken": {
+          "name": "botToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageThreadId": {
+          "name": "messageThreadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patch": {
+      "name": "patch",
+      "schema": "",
+      "columns": {
+        "patchId": {
+          "name": "patchId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "patchType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "patch_applicationId_application_applicationId_fk": {
+          "name": "patch_applicationId_application_applicationId_fk",
+          "tableFrom": "patch",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "patch_composeId_compose_composeId_fk": {
+          "name": "patch_composeId_compose_composeId_fk",
+          "tableFrom": "patch",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "patch_filepath_application_unique": {
+          "name": "patch_filepath_application_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filePath",
+            "applicationId"
+          ]
+        },
+        "patch_filepath_compose_unique": {
+          "name": "patch_filepath_compose_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filePath",
+            "composeId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.port": {
+      "name": "port",
+      "schema": "",
+      "columns": {
+        "portId": {
+          "name": "portId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedPort": {
+          "name": "publishedPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publishMode": {
+          "name": "publishMode",
+          "type": "publishModeType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'host'"
+        },
+        "targetPort": {
+          "name": "targetPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "protocolType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "port_applicationId_application_applicationId_fk": {
+          "name": "port_applicationId_application_applicationId_fk",
+          "tableFrom": "port",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.postgres": {
+      "name": "postgres",
+      "schema": "",
+      "columns": {
+        "postgresId": {
+          "name": "postgresId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databaseName": {
+          "name": "databaseName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databaseUser": {
+          "name": "databaseUser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "databasePassword": {
+          "name": "databasePassword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalPort": {
+          "name": "externalPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ulimitsSwarm": {
+          "name": "ulimitsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "postgres_environmentId_environment_environmentId_fk": {
+          "name": "postgres_environmentId_environment_environmentId_fk",
+          "tableFrom": "postgres",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "postgres_serverId_server_serverId_fk": {
+          "name": "postgres_serverId_server_serverId_fk",
+          "tableFrom": "postgres",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "postgres_appName_unique": {
+          "name": "postgres_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preview_deployments": {
+      "name": "preview_deployments",
+      "schema": "",
+      "columns": {
+        "previewDeploymentId": {
+          "name": "previewDeploymentId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pullRequestId": {
+          "name": "pullRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pullRequestNumber": {
+          "name": "pullRequestNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pullRequestURL": {
+          "name": "pullRequestURL",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pullRequestTitle": {
+          "name": "pullRequestTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pullRequestCommentId": {
+          "name": "pullRequestCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previewStatus": {
+          "name": "previewStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domainId": {
+          "name": "domainId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "preview_deployments_applicationId_application_applicationId_fk": {
+          "name": "preview_deployments_applicationId_application_applicationId_fk",
+          "tableFrom": "preview_deployments",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "preview_deployments_domainId_domain_domainId_fk": {
+          "name": "preview_deployments_domainId_domain_domainId_fk",
+          "tableFrom": "preview_deployments",
+          "tableTo": "domain",
+          "columnsFrom": [
+            "domainId"
+          ],
+          "columnsTo": [
+            "domainId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preview_deployments_appName_unique": {
+          "name": "preview_deployments_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_organizationId_organization_id_fk": {
+          "name": "project_organizationId_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.redirect": {
+      "name": "redirect",
+      "schema": "",
+      "columns": {
+        "redirectId": {
+          "name": "redirectId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "regex": {
+          "name": "regex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permanent": {
+          "name": "permanent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uniqueConfigKey": {
+          "name": "uniqueConfigKey",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "redirect_applicationId_application_applicationId_fk": {
+          "name": "redirect_applicationId_application_applicationId_fk",
+          "tableFrom": "redirect",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.redis": {
+      "name": "redis",
+      "schema": "",
+      "columns": {
+        "redisId": {
+          "name": "redisId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dockerImage": {
+          "name": "dockerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryReservation": {
+          "name": "memoryReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryLimit": {
+          "name": "memoryLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuReservation": {
+          "name": "cpuReservation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpuLimit": {
+          "name": "cpuLimit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalPort": {
+          "name": "externalPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicationStatus": {
+          "name": "applicationStatus",
+          "type": "applicationStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "healthCheckSwarm": {
+          "name": "healthCheckSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restartPolicySwarm": {
+          "name": "restartPolicySwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placementSwarm": {
+          "name": "placementSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updateConfigSwarm": {
+          "name": "updateConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackConfigSwarm": {
+          "name": "rollbackConfigSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modeSwarm": {
+          "name": "modeSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labelsSwarm": {
+          "name": "labelsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkSwarm": {
+          "name": "networkSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopGracePeriodSwarm": {
+          "name": "stopGracePeriodSwarm",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpointSpecSwarm": {
+          "name": "endpointSpecSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ulimitsSwarm": {
+          "name": "ulimitsSwarm",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "environmentId": {
+          "name": "environmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "networkIds": {
+          "name": "networkIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "detachDokployNetwork": {
+          "name": "detachDokployNetwork",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "redis_environmentId_environment_environmentId_fk": {
+          "name": "redis_environmentId_environment_environmentId_fk",
+          "tableFrom": "redis",
+          "tableTo": "environment",
+          "columnsFrom": [
+            "environmentId"
+          ],
+          "columnsTo": [
+            "environmentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "redis_serverId_server_serverId_fk": {
+          "name": "redis_serverId_server_serverId_fk",
+          "tableFrom": "redis",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "redis_appName_unique": {
+          "name": "redis_appName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appName"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registry": {
+      "name": "registry",
+      "schema": "",
+      "columns": {
+        "registryId": {
+          "name": "registryId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "registryName": {
+          "name": "registryName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imagePrefix": {
+          "name": "imagePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registryUrl": {
+          "name": "registryUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selfHosted": {
+          "name": "selfHosted",
+          "type": "RegistryType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cloud'"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "registry_organizationId_organization_id_fk": {
+          "name": "registry_organizationId_organization_id_fk",
+          "tableFrom": "registry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollback": {
+      "name": "rollback",
+      "schema": "",
+      "columns": {
+        "rollbackId": {
+          "name": "rollbackId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deploymentId": {
+          "name": "deploymentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fullContext": {
+          "name": "fullContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rollback_deploymentId_deployment_deploymentId_fk": {
+          "name": "rollback_deploymentId_deployment_deploymentId_fk",
+          "tableFrom": "rollback",
+          "tableTo": "deployment",
+          "columnsFrom": [
+            "deploymentId"
+          ],
+          "columnsTo": [
+            "deploymentId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule": {
+      "name": "schedule",
+      "schema": "",
+      "columns": {
+        "scheduleId": {
+          "name": "scheduleId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serviceName": {
+          "name": "serviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shellType": {
+          "name": "shellType",
+          "type": "shellType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bash'"
+        },
+        "scheduleType": {
+          "name": "scheduleType",
+          "type": "scheduleType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'application'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_applicationId_application_applicationId_fk": {
+          "name": "schedule_applicationId_application_applicationId_fk",
+          "tableFrom": "schedule",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_composeId_compose_composeId_fk": {
+          "name": "schedule_composeId_compose_composeId_fk",
+          "tableFrom": "schedule",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_serverId_server_serverId_fk": {
+          "name": "schedule_serverId_server_serverId_fk",
+          "tableFrom": "schedule",
+          "tableTo": "server",
+          "columnsFrom": [
+            "serverId"
+          ],
+          "columnsTo": [
+            "serverId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_organizationId_organization_id_fk": {
+          "name": "schedule_organizationId_organization_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scim_provider": {
+      "name": "scim_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scim_token": {
+          "name": "scim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scim_provider_organization_id_organization_id_fk": {
+          "name": "scim_provider_organization_id_organization_id_fk",
+          "tableFrom": "scim_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scim_provider_provider_id_unique": {
+          "name": "scim_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        },
+        "scim_provider_scim_token_unique": {
+          "name": "scim_provider_scim_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scim_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security": {
+      "name": "security",
+      "schema": "",
+      "columns": {
+        "securityId": {
+          "name": "securityId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "security_applicationId_application_applicationId_fk": {
+          "name": "security_applicationId_application_applicationId_fk",
+          "tableFrom": "security",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "security_username_applicationId_unique": {
+          "name": "security_username_applicationId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username",
+            "applicationId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server": {
+      "name": "server",
+      "schema": "",
+      "columns": {
+        "serverId": {
+          "name": "serverId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'root'"
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enableDockerCleanup": {
+          "name": "enableDockerCleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "buildsConcurrency": {
+          "name": "buildsConcurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverStatus": {
+          "name": "serverStatus",
+          "type": "serverStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "serverType": {
+          "name": "serverType",
+          "type": "serverType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deploy'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sshKeyId": {
+          "name": "sshKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metricsConfig": {
+          "name": "metricsConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"server\":{\"type\":\"Remote\",\"refreshRate\":60,\"port\":4500,\"token\":\"\",\"urlCallback\":\"\",\"cronJob\":\"\",\"retentionDays\":2,\"thresholds\":{\"cpu\":0,\"memory\":0}},\"containers\":{\"refreshRate\":60,\"services\":{\"include\":[],\"exclude\":[]}}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "server_organizationId_organization_id_fk": {
+          "name": "server_organizationId_organization_id_fk",
+          "tableFrom": "server",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "server_sshKeyId_ssh-key_sshKeyId_fk": {
+          "name": "server_sshKeyId_ssh-key_sshKeyId_fk",
+          "tableFrom": "server",
+          "tableTo": "ssh-key",
+          "columnsFrom": [
+            "sshKeyId"
+          ],
+          "columnsTo": [
+            "sshKeyId"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh-key": {
+      "name": "ssh-key",
+      "schema": "",
+      "columns": {
+        "sshKeyId": {
+          "name": "sshKeyId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ssh-key_organizationId_organization_id_fk": {
+          "name": "ssh-key_organizationId_organization_id_fk",
+          "tableFrom": "ssh-key",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_tag": {
+      "name": "project_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_tag_projectId_project_projectId_fk": {
+          "name": "project_tag_projectId_project_projectId_fk",
+          "tableFrom": "project_tag",
+          "tableTo": "project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "projectId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_tag_tagId_tag_tagId_fk": {
+          "name": "project_tag_tagId_tag_tagId_fk",
+          "tableFrom": "project_tag",
+          "tableTo": "tag",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "tagId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_project_tag": {
+          "name": "unique_project_tag",
+          "nullsNotDistinct": false,
+          "columns": [
+            "projectId",
+            "tagId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tag_organizationId_organization_id_fk": {
+          "name": "tag_organizationId_organization_id_fk",
+          "tableFrom": "tag",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_org_tag_name": {
+          "name": "unique_org_tag_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organizationId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firstName": {
+          "name": "firstName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "lastName": {
+          "name": "lastName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "isRegistered": {
+          "name": "isRegistered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expirationDate": {
+          "name": "expirationDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "enablePaidFeatures": {
+          "name": "enablePaidFeatures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allowImpersonation": {
+          "name": "allowImpersonation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enableEnterpriseFeatures": {
+          "name": "enableEnterpriseFeatures",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "licenseKey": {
+          "name": "licenseKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isValidEnterpriseLicense": {
+          "name": "isValidEnterpriseLicense",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serversQuantity": {
+          "name": "serversQuantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sendInvoiceNotifications": {
+          "name": "sendInvoiceNotifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isEnterpriseCloud": {
+          "name": "isEnterpriseCloud",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trustedOrigins": {
+          "name": "trustedOrigins",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmarkedTemplates": {
+          "name": "bookmarkedTemplates",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "ARRAY[]::text[]"
+        },
+        "onboardingCompletedAt": {
+          "name": "onboardingCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vault_provider": {
+      "name": "vault_provider",
+      "schema": "",
+      "columns": {
+        "vaultProviderId": {
+          "name": "vaultProviderId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerType": {
+          "name": "providerType",
+          "type": "VaultProviderType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "vault_provider_org_name_idx": {
+          "name": "vault_provider_org_name_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vault_provider_organizationId_organization_id_fk": {
+          "name": "vault_provider_organizationId_organization_id_fk",
+          "tableFrom": "vault_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volume_backup": {
+      "name": "volume_backup",
+      "schema": "",
+      "columns": {
+        "volumeBackupId": {
+          "name": "volumeBackupId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volumeName": {
+          "name": "volumeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serviceType": {
+          "name": "serviceType",
+          "type": "serviceType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'application'"
+        },
+        "appName": {
+          "name": "appName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serviceName": {
+          "name": "serviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnOff": {
+          "name": "turnOff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keepLatestCount": {
+          "name": "keepLatestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicationId": {
+          "name": "applicationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postgresId": {
+          "name": "postgresId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mariadbId": {
+          "name": "mariadbId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mongoId": {
+          "name": "mongoId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mysqlId": {
+          "name": "mysqlId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redisId": {
+          "name": "redisId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "libsqlId": {
+          "name": "libsqlId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "composeId": {
+          "name": "composeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destinationId": {
+          "name": "destinationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "volume_backup_applicationId_application_applicationId_fk": {
+          "name": "volume_backup_applicationId_application_applicationId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "application",
+          "columnsFrom": [
+            "applicationId"
+          ],
+          "columnsTo": [
+            "applicationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_postgresId_postgres_postgresId_fk": {
+          "name": "volume_backup_postgresId_postgres_postgresId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "postgres",
+          "columnsFrom": [
+            "postgresId"
+          ],
+          "columnsTo": [
+            "postgresId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_mariadbId_mariadb_mariadbId_fk": {
+          "name": "volume_backup_mariadbId_mariadb_mariadbId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "mariadb",
+          "columnsFrom": [
+            "mariadbId"
+          ],
+          "columnsTo": [
+            "mariadbId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_mongoId_mongo_mongoId_fk": {
+          "name": "volume_backup_mongoId_mongo_mongoId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "mongo",
+          "columnsFrom": [
+            "mongoId"
+          ],
+          "columnsTo": [
+            "mongoId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_mysqlId_mysql_mysqlId_fk": {
+          "name": "volume_backup_mysqlId_mysql_mysqlId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "mysql",
+          "columnsFrom": [
+            "mysqlId"
+          ],
+          "columnsTo": [
+            "mysqlId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_redisId_redis_redisId_fk": {
+          "name": "volume_backup_redisId_redis_redisId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "redis",
+          "columnsFrom": [
+            "redisId"
+          ],
+          "columnsTo": [
+            "redisId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_libsqlId_libsql_libsqlId_fk": {
+          "name": "volume_backup_libsqlId_libsql_libsqlId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "libsql",
+          "columnsFrom": [
+            "libsqlId"
+          ],
+          "columnsTo": [
+            "libsqlId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_composeId_compose_composeId_fk": {
+          "name": "volume_backup_composeId_compose_composeId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "compose",
+          "columnsFrom": [
+            "composeId"
+          ],
+          "columnsTo": [
+            "composeId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "volume_backup_destinationId_destination_destinationId_fk": {
+          "name": "volume_backup_destinationId_destination_destinationId_fk",
+          "tableFrom": "volume_backup",
+          "tableTo": "destination",
+          "columnsFrom": [
+            "destinationId"
+          ],
+          "columnsTo": [
+            "destinationId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webServerSettings": {
+      "name": "webServerSettings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serverIp": {
+          "name": "serverIp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificateType": {
+          "name": "certificateType",
+          "type": "certificateType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "https": {
+          "name": "https",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "letsEncryptEmail": {
+          "name": "letsEncryptEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sshPrivateKey": {
+          "name": "sshPrivateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enableDockerCleanup": {
+          "name": "enableDockerCleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "logCleanupCron": {
+          "name": "logCleanupCron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 0 * * *'"
+        },
+        "metricsConfig": {
+          "name": "metricsConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"server\":{\"type\":\"Dokploy\",\"refreshRate\":60,\"port\":4500,\"token\":\"\",\"retentionDays\":2,\"cronJob\":\"\",\"urlCallback\":\"\",\"thresholds\":{\"cpu\":0,\"memory\":0}},\"containers\":{\"refreshRate\":60,\"services\":{\"include\":[],\"exclude\":[]}}}'::jsonb"
+        },
+        "whitelabelingConfig": {
+          "name": "whitelabelingConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"appName\":null,\"appDescription\":null,\"logoUrl\":null,\"faviconUrl\":null,\"customCss\":null,\"loginLogoUrl\":null,\"supportUrl\":null,\"docsUrl\":null,\"errorPageTitle\":null,\"errorPageDescription\":null,\"footerText\":null,\"ogImageUrl\":null}'::jsonb"
+        },
+        "remoteServersOnly": {
+          "name": "remoteServersOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "buildsConcurrency": {
+          "name": "buildsConcurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "enforceSSO": {
+          "name": "enforceSSO",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cleanupCacheApplications": {
+          "name": "cleanupCacheApplications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cleanupCacheOnPreviews": {
+          "name": "cleanupCacheOnPreviews",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cleanupCacheOnCompose": {
+          "name": "cleanupCacheOnCompose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.buildArchitecture": {
+      "name": "buildArchitecture",
+      "schema": "public",
+      "values": [
+        "host",
+        "amd64",
+        "arm64",
+        "multi"
+      ]
+    },
+    "public.buildType": {
+      "name": "buildType",
+      "schema": "public",
+      "values": [
+        "dockerfile",
+        "heroku_buildpacks",
+        "paketo_buildpacks",
+        "nixpacks",
+        "static",
+        "railpack"
+      ]
+    },
+    "public.sourceType": {
+      "name": "sourceType",
+      "schema": "public",
+      "values": [
+        "docker",
+        "git",
+        "github",
+        "gitlab",
+        "bitbucket",
+        "gitea",
+        "drop"
+      ]
+    },
+    "public.backupType": {
+      "name": "backupType",
+      "schema": "public",
+      "values": [
+        "database",
+        "compose"
+      ]
+    },
+    "public.databaseType": {
+      "name": "databaseType",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "mariadb",
+        "mysql",
+        "mongo",
+        "web-server",
+        "libsql"
+      ]
+    },
+    "public.composeType": {
+      "name": "composeType",
+      "schema": "public",
+      "values": [
+        "docker-compose",
+        "stack"
+      ]
+    },
+    "public.sourceTypeCompose": {
+      "name": "sourceTypeCompose",
+      "schema": "public",
+      "values": [
+        "git",
+        "github",
+        "gitlab",
+        "bitbucket",
+        "gitea",
+        "raw"
+      ]
+    },
+    "public.deploymentStatus": {
+      "name": "deploymentStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "done",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.DnsProviderType": {
+      "name": "DnsProviderType",
+      "schema": "public",
+      "values": [
+        "cloudflare",
+        "route53",
+        "porkbun",
+        "infomaniak",
+        "ovh"
+      ]
+    },
+    "public.domainType": {
+      "name": "domainType",
+      "schema": "public",
+      "values": [
+        "compose",
+        "application",
+        "preview"
+      ]
+    },
+    "public.gitProviderType": {
+      "name": "gitProviderType",
+      "schema": "public",
+      "values": [
+        "github",
+        "gitlab",
+        "bitbucket",
+        "gitea"
+      ]
+    },
+    "public.mountType": {
+      "name": "mountType",
+      "schema": "public",
+      "values": [
+        "bind",
+        "volume",
+        "file"
+      ]
+    },
+    "public.serviceType": {
+      "name": "serviceType",
+      "schema": "public",
+      "values": [
+        "application",
+        "postgres",
+        "mysql",
+        "mariadb",
+        "mongo",
+        "redis",
+        "compose",
+        "libsql"
+      ]
+    },
+    "public.networkDriver": {
+      "name": "networkDriver",
+      "schema": "public",
+      "values": [
+        "bridge",
+        "overlay"
+      ]
+    },
+    "public.notificationType": {
+      "name": "notificationType",
+      "schema": "public",
+      "values": [
+        "slack",
+        "telegram",
+        "discord",
+        "email",
+        "resend",
+        "gotify",
+        "ntfy",
+        "mattermost",
+        "pushover",
+        "custom",
+        "lark",
+        "teams"
+      ]
+    },
+    "public.patchType": {
+      "name": "patchType",
+      "schema": "public",
+      "values": [
+        "create",
+        "update",
+        "delete"
+      ]
+    },
+    "public.protocolType": {
+      "name": "protocolType",
+      "schema": "public",
+      "values": [
+        "tcp",
+        "udp"
+      ]
+    },
+    "public.publishModeType": {
+      "name": "publishModeType",
+      "schema": "public",
+      "values": [
+        "ingress",
+        "host"
+      ]
+    },
+    "public.RegistryType": {
+      "name": "RegistryType",
+      "schema": "public",
+      "values": [
+        "selfHosted",
+        "cloud"
+      ]
+    },
+    "public.scheduleType": {
+      "name": "scheduleType",
+      "schema": "public",
+      "values": [
+        "application",
+        "compose",
+        "server",
+        "dokploy-server"
+      ]
+    },
+    "public.shellType": {
+      "name": "shellType",
+      "schema": "public",
+      "values": [
+        "bash",
+        "sh"
+      ]
+    },
+    "public.serverStatus": {
+      "name": "serverStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.serverType": {
+      "name": "serverType",
+      "schema": "public",
+      "values": [
+        "deploy",
+        "build"
+      ]
+    },
+    "public.applicationStatus": {
+      "name": "applicationStatus",
+      "schema": "public",
+      "values": [
+        "idle",
+        "running",
+        "done",
+        "error"
+      ]
+    },
+    "public.certificateType": {
+      "name": "certificateType",
+      "schema": "public",
+      "values": [
+        "letsencrypt",
+        "none",
+        "custom"
+      ]
+    },
+    "public.sqldNode": {
+      "name": "sqldNode",
+      "schema": "public",
+      "values": [
+        "primary",
+        "replica"
+      ]
+    },
+    "public.triggerType": {
+      "name": "triggerType",
+      "schema": "public",
+      "values": [
+        "push",
+        "tag"
+      ]
+    },
+    "public.VaultProviderType": {
+      "name": "VaultProviderType",
+      "schema": "public",
+      "values": [
+        "hashicorp",
+        "infisical",
+        "aws",
+        "aws-parameter-store",
+        "doppler",
+        "azure",
+        "scaleway",
+        "phase"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/dokploy/drizzle/meta/_journal.json
+++ b/apps/dokploy/drizzle/meta/_journal.json
@@ -1380,6 +1380,13 @@
       "when": 1788995453103,
       "tag": "0196_worthless_ravenous",
       "breakpoints": true
+    },
+    {
+      "idx": 197,
+      "version": "7",
+      "when": 1789229973517,
+      "tag": "0197_old_retro_girl",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
+++ b/apps/dokploy/pages/dashboard/project/[projectId]/environment/[environmentId]/services/application/[applicationId].tsx
@@ -17,6 +17,7 @@ import { AddCommand } from "@/components/dashboard/application/advanced/general/
 import { ShowPorts } from "@/components/dashboard/application/advanced/ports/show-port";
 import { ShowRedirects } from "@/components/dashboard/application/advanced/redirects/show-redirects";
 import { ShowSecurity } from "@/components/dashboard/application/advanced/security/show-security";
+import { ShowBuildArchitecture } from "@/components/dashboard/application/advanced/show-build-architecture";
 import { ShowBuildServer } from "@/components/dashboard/application/advanced/show-build-server";
 import { ShowResources } from "@/components/dashboard/application/advanced/show-resources";
 import { ShowTraefikConfig } from "@/components/dashboard/application/advanced/traefik/show-traefik-config";
@@ -425,6 +426,7 @@ const Service = (
 													id={applicationId}
 													type="application"
 												/>
+												<ShowBuildArchitecture applicationId={applicationId} />
 												<ShowBuildServer applicationId={applicationId} />
 												<ShowResources id={applicationId} type="application" />
 												<ShowVolumes id={applicationId} type="application" />

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -41,7 +41,11 @@ import {
 	checkServicePermissionAndAccess,
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
-import { isPackBuildType } from "@dokploy/server/utils/builders/build-platform";
+import {
+	assertPersistedArchitecture,
+	BuildArchitectureError,
+	isPackBuildType,
+} from "@dokploy/server/utils/builders/build-platform";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -524,6 +528,9 @@ export const applicationRouter = createTRPCRouter({
 				herokuVersion: input.herokuVersion,
 				isStaticSpa: input.isStaticSpa,
 				railpackVersion: input.railpackVersion,
+				...(isPackBuildType(input.buildType)
+					? { buildArchitecture: "host" as const, buildxBuilder: null }
+					: {}),
 			});
 			const application = await findApplicationById(input.applicationId);
 			await audit(ctx, {
@@ -775,33 +782,29 @@ export const applicationRouter = createTRPCRouter({
 				}
 			}
 
-			if (input.buildArchitecture && input.buildArchitecture !== "host") {
-				const current = await findApplicationById(input.applicationId);
-				const buildType = input.buildType ?? current.buildType;
-				if (isPackBuildType(buildType)) {
-					throw new TRPCError({
-						code: "BAD_REQUEST",
-						message:
-							"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
-					});
-				}
-				if (input.buildArchitecture === "multi") {
-					const registryId =
+			const current = await findApplicationById(input.applicationId);
+			try {
+				assertPersistedArchitecture({
+					buildType: input.buildType ?? current.buildType,
+					buildArchitecture:
+						input.buildArchitecture ?? current.buildArchitecture,
+					registryId:
 						input.registryId === undefined
 							? current.registryId
-							: input.registryId;
-					const buildRegistryId =
+							: input.registryId,
+					buildRegistryId:
 						input.buildRegistryId === undefined
 							? current.buildRegistryId
-							: input.buildRegistryId;
-					if (!registryId && !buildRegistryId) {
-						throw new TRPCError({
-							code: "BAD_REQUEST",
-							message:
-								"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
-						});
-					}
+							: input.buildRegistryId,
+				});
+			} catch (error) {
+				if (error instanceof BuildArchitectureError) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message: error.message,
+					});
 				}
+				throw error;
 			}
 
 			const { applicationId, ...rest } = input;

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -41,6 +41,7 @@ import {
 	checkServicePermissionAndAccess,
 	findMemberByUserId,
 } from "@dokploy/server/services/permission";
+import { isPackBuildType } from "@dokploy/server/utils/builders/build-platform";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -771,6 +772,35 @@ export const applicationRouter = createTRPCRouter({
 						code: "UNAUTHORIZED",
 						message: "You are not authorized to access this build server",
 					});
+				}
+			}
+
+			if (input.buildArchitecture && input.buildArchitecture !== "host") {
+				const current = await findApplicationById(input.applicationId);
+				const buildType = input.buildType ?? current.buildType;
+				if (isPackBuildType(buildType)) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
+					});
+				}
+				if (input.buildArchitecture === "multi") {
+					const registryId =
+						input.registryId === undefined
+							? current.registryId
+							: input.registryId;
+					const buildRegistryId =
+						input.buildRegistryId === undefined
+							? current.buildRegistryId
+							: input.buildRegistryId;
+					if (!registryId && !buildRegistryId) {
+						throw new TRPCError({
+							code: "BAD_REQUEST",
+							message:
+								"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
+						});
+					}
 				}
 			}
 

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -45,6 +45,7 @@ import {
 	assertPersistedArchitecture,
 	BuildArchitectureError,
 	isPackBuildType,
+	mergePersistedArchitecture,
 } from "@dokploy/server/utils/builders/build-platform";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
@@ -784,19 +785,14 @@ export const applicationRouter = createTRPCRouter({
 
 			const current = await findApplicationById(input.applicationId);
 			try {
-				assertPersistedArchitecture({
-					buildType: input.buildType ?? current.buildType,
-					buildArchitecture:
-						input.buildArchitecture ?? current.buildArchitecture,
-					registryId:
-						input.registryId === undefined
-							? current.registryId
-							: input.registryId,
-					buildRegistryId:
-						input.buildRegistryId === undefined
-							? current.buildRegistryId
-							: input.buildRegistryId,
-				});
+				assertPersistedArchitecture(
+					mergePersistedArchitecture(current, {
+						buildType: input.buildType,
+						buildArchitecture: input.buildArchitecture,
+						registryId: input.registryId,
+						buildRegistryId: input.buildRegistryId,
+					}),
+				);
 			} catch (error) {
 				if (error instanceof BuildArchitectureError) {
 					throw new TRPCError({

--- a/packages/server/src/db/schema/application.ts
+++ b/packages/server/src/db/schema/application.ts
@@ -76,6 +76,13 @@ export const buildType = pgEnum("buildType", [
 	"railpack",
 ]);
 
+export const BUILD_ARCHITECTURES = ["host", "amd64", "arm64", "multi"] as const;
+export type BuildArchitecture = (typeof BUILD_ARCHITECTURES)[number];
+export const buildArchitecture = pgEnum(
+	"buildArchitecture",
+	BUILD_ARCHITECTURES,
+);
+
 export const applications = pgTable("application", {
 	applicationId: text("applicationId")
 		.notNull()
@@ -189,6 +196,10 @@ export const applications = pgTable("application", {
 		.notNull()
 		.default("idle"),
 	buildType: buildType("buildType").notNull().default("nixpacks"),
+	buildArchitecture: buildArchitecture("buildArchitecture")
+		.notNull()
+		.default("host"),
+	buildxBuilder: text("buildxBuilder"),
 	railpackVersion: text("railpackVersion").default("0.15.4"),
 	herokuVersion: text("herokuVersion").default("24"),
 	publishDirectory: text("publishDirectory"),
@@ -352,6 +363,8 @@ const createSchema = createInsertSchema(applications, {
 		"static",
 		"railpack",
 	]),
+	buildArchitecture: z.enum(BUILD_ARCHITECTURES).optional(),
+	buildxBuilder: z.string().nullable().optional(),
 	railpackVersion: z.string().optional(),
 	herokuVersion: z.string().optional(),
 	publishDirectory: z.string().optional(),

--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -432,6 +432,8 @@ export const deployPreviewApplication = async ({
 		application.buildRegistry = null;
 		application.rollbackRegistry = null;
 		application.registry = null;
+		application.buildArchitecture = "host";
+		application.buildxBuilder = null;
 
 		let command = "set -e;";
 		if (application.sourceType === "github") {
@@ -551,6 +553,8 @@ export const rebuildPreviewApplication = async ({
 		application.buildRegistry = null;
 		application.rollbackRegistry = null;
 		application.registry = null;
+		application.buildArchitecture = "host";
+		application.buildxBuilder = null;
 
 		const serverId = application.serverId;
 		let command = "set -e;";

--- a/packages/server/src/services/application.ts
+++ b/packages/server/src/services/application.ts
@@ -160,6 +160,22 @@ export const updateApplication = async (
 	return application[0];
 };
 
+const stripPreviewBuildOverrides = (application: {
+	rollbackActive: boolean | null;
+	buildRegistry: unknown;
+	rollbackRegistry: unknown;
+	registry: unknown;
+	buildArchitecture: Application["buildArchitecture"];
+	buildxBuilder: string | null;
+}) => {
+	application.rollbackActive = false;
+	application.buildRegistry = null;
+	application.rollbackRegistry = null;
+	application.registry = null;
+	application.buildArchitecture = "host";
+	application.buildxBuilder = null;
+};
+
 export const updateApplicationStatus = async (
 	applicationId: string,
 	applicationStatus: Application["applicationStatus"],
@@ -267,7 +283,7 @@ export const deployApplication = async ({
 			projectName: application.environment.project.name,
 			applicationName: application.name,
 			applicationType: "application",
-			// @ts-ignore
+			// @ts-expect-error
 			errorMessage: error?.message || "Error building",
 			buildLink,
 			organizationId: application.environment.project.organizationId,
@@ -428,12 +444,7 @@ export const deployPreviewApplication = async ({
 		application.env = `${application.previewEnv}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 		application.buildArgs = `${application.previewBuildArgs}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 		application.buildSecrets = `${application.previewBuildSecrets}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
-		application.rollbackActive = false;
-		application.buildRegistry = null;
-		application.rollbackRegistry = null;
-		application.registry = null;
-		application.buildArchitecture = "host";
-		application.buildxBuilder = null;
+		stripPreviewBuildOverrides(application);
 
 		let command = "set -e;";
 		if (application.sourceType === "github") {
@@ -549,12 +560,7 @@ export const rebuildPreviewApplication = async ({
 		application.env = `${application.previewEnv}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 		application.buildArgs = `${application.previewBuildArgs}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
 		application.buildSecrets = `${application.previewBuildSecrets}\nDOKPLOY_DEPLOY_URL=${previewDeployment?.domain?.host}`;
-		application.rollbackActive = false;
-		application.buildRegistry = null;
-		application.rollbackRegistry = null;
-		application.registry = null;
-		application.buildArchitecture = "host";
-		application.buildxBuilder = null;
+		stripPreviewBuildOverrides(application);
 
 		const serverId = application.serverId;
 		let command = "set -e;";

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -32,6 +32,31 @@ export const isPackBuildType = (
 	return (PACK_BUILD_TYPES as readonly string[]).includes(buildType);
 };
 
+export const assertPersistedArchitecture = (input: {
+	buildType: string;
+	buildArchitecture: BuildArchitecture;
+	registryId: string | null | undefined;
+	buildRegistryId: string | null | undefined;
+}): void => {
+	if (input.buildArchitecture === "host") {
+		return;
+	}
+	if (isPackBuildType(input.buildType)) {
+		throw new BuildArchitectureError(
+			"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
+		);
+	}
+	if (
+		input.buildArchitecture === "multi" &&
+		!input.registryId &&
+		!input.buildRegistryId
+	) {
+		throw new BuildArchitectureError(
+			"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
+		);
+	}
+};
+
 export type BuildOutput =
 	| { mode: "local"; image: string }
 	| { mode: "push"; tags: string[]; logins: string };

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -199,5 +199,5 @@ export const ensureMultiarchBuilderCommand = (plan: BuildPlan): string => {
 	if (!plan.createDefaultBuilder) {
 		return "";
 	}
-	return `docker buildx create --name ${quote([DEFAULT_MULTIARCH_BUILDER])} --driver docker-container || true\n`;
+	return `docker buildx inspect ${quote([DEFAULT_MULTIARCH_BUILDER])} >/dev/null 2>&1 || docker buildx create --name ${quote([DEFAULT_MULTIARCH_BUILDER])} --driver docker-container --driver-opt network=host\n`;
 };

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -32,12 +32,30 @@ export const isPackBuildType = (
 	return (PACK_BUILD_TYPES as readonly string[]).includes(buildType);
 };
 
-export const assertPersistedArchitecture = (input: {
+export type PersistedArchitecture = {
 	buildType: string;
 	buildArchitecture: BuildArchitecture;
 	registryId: string | null | undefined;
 	buildRegistryId: string | null | undefined;
-}): void => {
+};
+
+export const mergePersistedArchitecture = (
+	current: PersistedArchitecture,
+	patch: Partial<PersistedArchitecture>,
+): PersistedArchitecture => ({
+	buildType: patch.buildType ?? current.buildType,
+	buildArchitecture: patch.buildArchitecture ?? current.buildArchitecture,
+	registryId:
+		patch.registryId === undefined ? current.registryId : patch.registryId,
+	buildRegistryId:
+		patch.buildRegistryId === undefined
+			? current.buildRegistryId
+			: patch.buildRegistryId,
+});
+
+export const assertPersistedArchitecture = (
+	input: PersistedArchitecture,
+): void => {
 	if (input.buildArchitecture === "host") {
 		return;
 	}

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -2,7 +2,6 @@ import {
 	BUILD_ARCHITECTURES,
 	type BuildArchitecture,
 } from "@dokploy/server/db/schema";
-import { quote } from "shell-quote";
 import {
 	collectRegistryPushTargets,
 	registryLoginCommands,
@@ -82,7 +81,6 @@ export type BuildOutput =
 export type BuildPlan = {
 	platforms: readonly string[];
 	builder: string | null;
-	createDefaultBuilder: boolean;
 	output: BuildOutput;
 };
 
@@ -157,7 +155,6 @@ export const resolveBuildPlan = async (
 		return {
 			platforms,
 			builder,
-			createDefaultBuilder: false,
 			output: { mode: "local", image: localImage },
 		};
 	}
@@ -181,7 +178,6 @@ export const resolveBuildPlan = async (
 	return {
 		platforms,
 		builder,
-		createDefaultBuilder: builder === null,
 		output: {
 			mode: "push",
 			tags: targets.map((target) => target.tag),
@@ -197,25 +193,4 @@ export const planPlatformArgs = (
 		return [];
 	}
 	return ["--platform", plan.platforms.join(",")];
-};
-
-export const dockerfileBuilderName = (plan: BuildPlan): string | null => {
-	if (plan.builder) {
-		return plan.builder;
-	}
-	if (plan.createDefaultBuilder) {
-		return DEFAULT_MULTIARCH_BUILDER;
-	}
-	return null;
-};
-
-export const usesBuildx = (plan: BuildPlan): boolean => {
-	return plan.output.mode === "push" || plan.builder !== null;
-};
-
-export const ensureMultiarchBuilderCommand = (plan: BuildPlan): string => {
-	if (!plan.createDefaultBuilder) {
-		return "";
-	}
-	return `docker buildx inspect ${quote([DEFAULT_MULTIARCH_BUILDER])} >/dev/null 2>&1 || docker buildx create --name ${quote([DEFAULT_MULTIARCH_BUILDER])} --driver docker-container --driver-opt network=host\n`;
 };

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -1,14 +1,9 @@
-import {
-	BUILD_ARCHITECTURES,
-	type BuildArchitecture,
-} from "@dokploy/server/db/schema";
+import type { BuildArchitecture } from "@dokploy/server/db/schema";
 import {
 	collectRegistryPushTargets,
 	registryLoginCommands,
 } from "../cluster/upload";
 import type { ApplicationNested } from ".";
-
-export { BUILD_ARCHITECTURES, type BuildArchitecture };
 
 export const BUILD_ARCHITECTURE_PLATFORMS = {
 	host: [] as const,
@@ -30,6 +25,11 @@ export const isPackBuildType = (
 ): buildType is (typeof PACK_BUILD_TYPES)[number] => {
 	return (PACK_BUILD_TYPES as readonly string[]).includes(buildType);
 };
+
+const PACK_NEEDS_HOST =
+	"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.";
+const MULTI_ARCH_NEEDS_REGISTRY =
+	"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.";
 
 export type PersistedArchitecture = {
 	buildType: string;
@@ -59,18 +59,14 @@ export const assertPersistedArchitecture = (
 		return;
 	}
 	if (isPackBuildType(input.buildType)) {
-		throw new BuildArchitectureError(
-			"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
-		);
+		throw new BuildArchitectureError(PACK_NEEDS_HOST);
 	}
 	if (
 		input.buildArchitecture === "multi" &&
 		!input.registryId &&
 		!input.buildRegistryId
 	) {
-		throw new BuildArchitectureError(
-			"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
-		);
+		throw new BuildArchitectureError(MULTI_ARCH_NEEDS_REGISTRY);
 	}
 };
 
@@ -92,17 +88,10 @@ export class BuildArchitectureError extends Error {
 }
 
 export type PlanBuildArchitectureInput = {
-	appName?: string;
-	buildArchitecture?: BuildArchitecture | null;
-	buildxBuilder?: string | null;
 	buildType: string;
 	sourceType: string;
-	registry: unknown;
-	buildRegistry: unknown;
-	rollbackRegistry?: unknown;
-	applicationId?: string;
-	rollbackActive?: boolean | null;
-	dockerImage?: string | null;
+	buildArchitecture?: BuildArchitecture | null;
+	buildxBuilder?: string | null;
 };
 
 export const parseBuildxBuilder = (
@@ -115,27 +104,19 @@ export const parseBuildxBuilder = (
 	return trimmed.length > 0 ? trimmed : null;
 };
 
-export const architectureForApplication = (
-	application: PlanBuildArchitectureInput,
-): BuildArchitecture => {
-	if (application.sourceType === "docker") {
-		return "host";
-	}
-	return application.buildArchitecture ?? "host";
-};
-
 export const planArchitecture = (
 	application: PlanBuildArchitectureInput,
 ): Pick<BuildPlan, "platforms" | "builder"> & {
 	architecture: BuildArchitecture;
 } => {
-	const architecture = architectureForApplication(application);
+	const architecture =
+		application.sourceType === "docker"
+			? "host"
+			: (application.buildArchitecture ?? "host");
 	const builder = parseBuildxBuilder(application.buildxBuilder);
 
 	if (architecture !== "host" && isPackBuildType(application.buildType)) {
-		throw new BuildArchitectureError(
-			"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
-		);
+		throw new BuildArchitectureError(PACK_NEEDS_HOST);
 	}
 
 	return {
@@ -160,9 +141,7 @@ export const resolveBuildPlan = async (
 	}
 
 	if (!application.registry && !application.buildRegistry) {
-		throw new BuildArchitectureError(
-			"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
-		);
+		throw new BuildArchitectureError(MULTI_ARCH_NEEDS_REGISTRY);
 	}
 
 	const targets = await collectRegistryPushTargets(application);
@@ -170,9 +149,7 @@ export const resolveBuildPlan = async (
 		(target) => target.kind === "cluster" || target.kind === "build",
 	);
 	if (runTargets.length === 0) {
-		throw new BuildArchitectureError(
-			"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
-		);
+		throw new BuildArchitectureError(MULTI_ARCH_NEEDS_REGISTRY);
 	}
 
 	return {

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -1,0 +1,154 @@
+import {
+	BUILD_ARCHITECTURES,
+	type BuildArchitecture,
+} from "@dokploy/server/db/schema";
+import { quote } from "shell-quote";
+
+export { BUILD_ARCHITECTURES, type BuildArchitecture };
+
+export const BUILD_ARCHITECTURE_PLATFORMS = {
+	host: [] as const,
+	amd64: ["linux/amd64"] as const,
+	arm64: ["linux/arm64"] as const,
+	multi: ["linux/amd64", "linux/arm64"] as const,
+} satisfies Record<BuildArchitecture, readonly string[]>;
+
+export const DEFAULT_MULTIARCH_BUILDER = "dokploy-multiarch";
+
+const PACK_BUILD_TYPES = [
+	"nixpacks",
+	"heroku_buildpacks",
+	"paketo_buildpacks",
+] as const;
+
+export type BuildArchitecturePlan =
+	| { kind: "host"; builder: string | null }
+	| {
+			kind: "single";
+			platform: "linux/amd64" | "linux/arm64";
+			builder: string | null;
+	  }
+	| {
+			kind: "multi";
+			platforms: ["linux/amd64", "linux/arm64"];
+			builder: string | null;
+	  };
+
+export class BuildArchitectureError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "BuildArchitectureError";
+	}
+}
+
+export type PlanBuildArchitectureInput = {
+	buildArchitecture?: BuildArchitecture | null;
+	buildxBuilder?: string | null;
+	buildType: string;
+	sourceType: string;
+	registry: unknown;
+	buildRegistry: unknown;
+	rollbackRegistry: unknown;
+};
+
+export const parseBuildxBuilder = (
+	raw: string | null | undefined,
+): string | null => {
+	if (raw == null) {
+		return null;
+	}
+	const trimmed = raw.trim();
+	return trimmed.length > 0 ? trimmed : null;
+};
+
+export const planBuildArchitecture = (
+	application: PlanBuildArchitectureInput,
+): BuildArchitecturePlan => {
+	if (application.sourceType === "docker") {
+		return { kind: "host", builder: null };
+	}
+
+	const architecture = application.buildArchitecture ?? "host";
+	const builder = parseBuildxBuilder(application.buildxBuilder);
+
+	if (
+		architecture !== "host" &&
+		PACK_BUILD_TYPES.includes(
+			application.buildType as (typeof PACK_BUILD_TYPES)[number],
+		)
+	) {
+		throw new BuildArchitectureError(
+			"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
+		);
+	}
+
+	if (architecture === "multi") {
+		if (
+			!application.registry &&
+			!application.buildRegistry &&
+			!application.rollbackRegistry
+		) {
+			throw new BuildArchitectureError(
+				"Multi-architecture builds require a registry. Docker cannot load a multi-arch image into the local daemon.",
+			);
+		}
+		return {
+			kind: "multi",
+			platforms: [...BUILD_ARCHITECTURE_PLATFORMS.multi],
+			builder,
+		};
+	}
+
+	if (architecture === "amd64") {
+		return {
+			kind: "single",
+			platform: BUILD_ARCHITECTURE_PLATFORMS.amd64[0],
+			builder,
+		};
+	}
+
+	if (architecture === "arm64") {
+		return {
+			kind: "single",
+			platform: BUILD_ARCHITECTURE_PLATFORMS.arm64[0],
+			builder,
+		};
+	}
+
+	return { kind: "host", builder };
+};
+
+export const planPlatformArgs = (plan: BuildArchitecturePlan): string[] => {
+	if (plan.kind === "single") {
+		return ["--platform", plan.platform];
+	}
+	if (plan.kind === "multi") {
+		return ["--platform", plan.platforms.join(",")];
+	}
+	return [];
+};
+
+export const dockerfileBuildxBuilder = (
+	plan: BuildArchitecturePlan,
+): string | null => {
+	if (plan.builder) {
+		return plan.builder;
+	}
+	if (plan.kind === "multi") {
+		return DEFAULT_MULTIARCH_BUILDER;
+	}
+	return null;
+};
+
+export const usesBuildx = (plan: BuildArchitecturePlan): boolean => {
+	return plan.kind === "multi" || plan.builder !== null;
+};
+
+export const ensureMultiarchBuilderCommand = (
+	plan: BuildArchitecturePlan,
+): string => {
+	if (plan.kind !== "multi" || plan.builder) {
+		return "";
+	}
+	return `docker buildx create --name ${quote([DEFAULT_MULTIARCH_BUILDER])} --driver docker-container || true\n`;
+};

--- a/packages/server/src/utils/builders/build-platform.ts
+++ b/packages/server/src/utils/builders/build-platform.ts
@@ -3,6 +3,11 @@ import {
 	type BuildArchitecture,
 } from "@dokploy/server/db/schema";
 import { quote } from "shell-quote";
+import {
+	collectRegistryPushTargets,
+	registryLoginCommands,
+} from "../cluster/upload";
+import type { ApplicationNested } from ".";
 
 export { BUILD_ARCHITECTURES, type BuildArchitecture };
 
@@ -21,18 +26,22 @@ const PACK_BUILD_TYPES = [
 	"paketo_buildpacks",
 ] as const;
 
-export type BuildArchitecturePlan =
-	| { kind: "host"; builder: string | null }
-	| {
-			kind: "single";
-			platform: "linux/amd64" | "linux/arm64";
-			builder: string | null;
-	  }
-	| {
-			kind: "multi";
-			platforms: ["linux/amd64", "linux/arm64"];
-			builder: string | null;
-	  };
+export const isPackBuildType = (
+	buildType: string,
+): buildType is (typeof PACK_BUILD_TYPES)[number] => {
+	return (PACK_BUILD_TYPES as readonly string[]).includes(buildType);
+};
+
+export type BuildOutput =
+	| { mode: "local"; image: string }
+	| { mode: "push"; tags: string[]; logins: string };
+
+export type BuildPlan = {
+	platforms: readonly string[];
+	builder: string | null;
+	createDefaultBuilder: boolean;
+	output: BuildOutput;
+};
 
 export class BuildArchitectureError extends Error {
 	constructor(message: string) {
@@ -42,13 +51,17 @@ export class BuildArchitectureError extends Error {
 }
 
 export type PlanBuildArchitectureInput = {
+	appName?: string;
 	buildArchitecture?: BuildArchitecture | null;
 	buildxBuilder?: string | null;
 	buildType: string;
 	sourceType: string;
 	registry: unknown;
 	buildRegistry: unknown;
-	rollbackRegistry: unknown;
+	rollbackRegistry?: unknown;
+	applicationId?: string;
+	rollbackActive?: boolean | null;
+	dockerImage?: string | null;
 };
 
 export const parseBuildxBuilder = (
@@ -61,93 +74,104 @@ export const parseBuildxBuilder = (
 	return trimmed.length > 0 ? trimmed : null;
 };
 
-export const planBuildArchitecture = (
+export const architectureForApplication = (
 	application: PlanBuildArchitectureInput,
-): BuildArchitecturePlan => {
+): BuildArchitecture => {
 	if (application.sourceType === "docker") {
-		return { kind: "host", builder: null };
+		return "host";
 	}
+	return application.buildArchitecture ?? "host";
+};
 
-	const architecture = application.buildArchitecture ?? "host";
+export const planArchitecture = (
+	application: PlanBuildArchitectureInput,
+): Pick<BuildPlan, "platforms" | "builder"> & {
+	architecture: BuildArchitecture;
+} => {
+	const architecture = architectureForApplication(application);
 	const builder = parseBuildxBuilder(application.buildxBuilder);
 
-	if (
-		architecture !== "host" &&
-		PACK_BUILD_TYPES.includes(
-			application.buildType as (typeof PACK_BUILD_TYPES)[number],
-		)
-	) {
+	if (architecture !== "host" && isPackBuildType(application.buildType)) {
 		throw new BuildArchitectureError(
 			"Nixpacks, Heroku Buildpacks, and Paketo Buildpacks only support Host native architecture.",
 		);
 	}
 
-	if (architecture === "multi") {
-		if (
-			!application.registry &&
-			!application.buildRegistry &&
-			!application.rollbackRegistry
-		) {
-			throw new BuildArchitectureError(
-				"Multi-architecture builds require a registry. Docker cannot load a multi-arch image into the local daemon.",
-			);
-		}
-		return {
-			kind: "multi",
-			platforms: [...BUILD_ARCHITECTURE_PLATFORMS.multi],
-			builder,
-		};
-	}
-
-	if (architecture === "amd64") {
-		return {
-			kind: "single",
-			platform: BUILD_ARCHITECTURE_PLATFORMS.amd64[0],
-			builder,
-		};
-	}
-
-	if (architecture === "arm64") {
-		return {
-			kind: "single",
-			platform: BUILD_ARCHITECTURE_PLATFORMS.arm64[0],
-			builder,
-		};
-	}
-
-	return { kind: "host", builder };
+	return {
+		architecture,
+		platforms: BUILD_ARCHITECTURE_PLATFORMS[architecture],
+		builder,
+	};
 };
 
-export const planPlatformArgs = (plan: BuildArchitecturePlan): string[] => {
-	if (plan.kind === "single") {
-		return ["--platform", plan.platform];
+export const resolveBuildPlan = async (
+	application: ApplicationNested,
+): Promise<BuildPlan> => {
+	const { architecture, platforms, builder } = planArchitecture(application);
+	const localImage = application.appName;
+
+	if (architecture !== "multi") {
+		return {
+			platforms,
+			builder,
+			createDefaultBuilder: false,
+			output: { mode: "local", image: localImage },
+		};
 	}
-	if (plan.kind === "multi") {
-		return ["--platform", plan.platforms.join(",")];
+
+	if (!application.registry && !application.buildRegistry) {
+		throw new BuildArchitectureError(
+			"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
+		);
 	}
-	return [];
+
+	const targets = await collectRegistryPushTargets(application);
+	const runTargets = targets.filter(
+		(target) => target.kind === "cluster" || target.kind === "build",
+	);
+	if (runTargets.length === 0) {
+		throw new BuildArchitectureError(
+			"Multi-architecture builds require a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.",
+		);
+	}
+
+	return {
+		platforms,
+		builder,
+		createDefaultBuilder: builder === null,
+		output: {
+			mode: "push",
+			tags: targets.map((target) => target.tag),
+			logins: registryLoginCommands(targets),
+		},
+	};
 };
 
-export const dockerfileBuildxBuilder = (
-	plan: BuildArchitecturePlan,
-): string | null => {
+export const planPlatformArgs = (
+	plan: Pick<BuildPlan, "platforms">,
+): string[] => {
+	if (plan.platforms.length === 0) {
+		return [];
+	}
+	return ["--platform", plan.platforms.join(",")];
+};
+
+export const dockerfileBuilderName = (plan: BuildPlan): string | null => {
 	if (plan.builder) {
 		return plan.builder;
 	}
-	if (plan.kind === "multi") {
+	if (plan.createDefaultBuilder) {
 		return DEFAULT_MULTIARCH_BUILDER;
 	}
 	return null;
 };
 
-export const usesBuildx = (plan: BuildArchitecturePlan): boolean => {
-	return plan.kind === "multi" || plan.builder !== null;
+export const usesBuildx = (plan: BuildPlan): boolean => {
+	return plan.output.mode === "push" || plan.builder !== null;
 };
 
-export const ensureMultiarchBuilderCommand = (
-	plan: BuildArchitecturePlan,
-): string => {
-	if (plan.kind !== "multi" || plan.builder) {
+export const ensureMultiarchBuilderCommand = (plan: BuildPlan): string => {
+	if (!plan.createDefaultBuilder) {
 		return "";
 	}
 	return `docker buildx create --name ${quote([DEFAULT_MULTIARCH_BUILDER])} --driver docker-container || true\n`;

--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -9,21 +9,17 @@ import {
 } from "../filesystem/directory";
 import type { ApplicationNested } from ".";
 import {
-	dockerfileBuildxBuilder,
+	type BuildPlan,
+	dockerfileBuilderName,
 	ensureMultiarchBuilderCommand,
-	planBuildArchitecture,
 	planPlatformArgs,
 	usesBuildx,
 } from "./build-platform";
 import { createEnvFileCommand } from "./utils";
 
-export type DockerBuildOptions = {
-	pushTags?: string[];
-};
-
 export const getDockerCommand = (
 	application: ApplicationNested,
-	options: DockerBuildOptions = {},
+	plan: BuildPlan,
 ) => {
 	const {
 		appName,
@@ -36,40 +32,31 @@ export const getDockerCommand = (
 		createEnvFile,
 	} = application;
 	const dockerFilePath = getBuildAppDirectory(application);
-	const plan = planBuildArchitecture(application);
 
 	try {
-		const image = `${appName}`;
-
 		const defaultContextPath =
 			dockerFilePath.substring(0, dockerFilePath.lastIndexOf("/") + 1) || ".";
 
 		const dockerContextPath =
 			getDockerContextPath(application) || defaultContextPath;
 
-		if (
-			plan.kind === "multi" &&
-			(!options.pushTags || options.pushTags.length === 0)
-		) {
-			throw new Error(
-				"Multi-architecture builds require registry tags to push.",
-			);
-		}
-
 		const commandArgs = usesBuildx(plan) ? ["buildx", "build"] : ["build"];
-		const builder = dockerfileBuildxBuilder(plan);
+		const builder = dockerfileBuilderName(plan);
 		if (builder) {
 			commandArgs.push("--builder", quote([builder]));
 		}
 		commandArgs.push(...planPlatformArgs(plan));
 
-		if (plan.kind === "multi") {
-			for (const tag of options.pushTags ?? []) {
+		if (plan.output.mode === "push") {
+			for (const tag of plan.output.tags) {
 				commandArgs.push("-t", quote([tag]));
 			}
 			commandArgs.push("--push");
 		} else {
-			commandArgs.push("-t", image);
+			commandArgs.push("-t", plan.output.image);
+			if (usesBuildx(plan)) {
+				commandArgs.push("--load");
+			}
 		}
 
 		commandArgs.push("-f", dockerFilePath, dockerContextPath);

--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -10,10 +10,8 @@ import {
 import type { ApplicationNested } from ".";
 import {
 	type BuildPlan,
-	dockerfileBuilderName,
-	ensureMultiarchBuilderCommand,
+	DEFAULT_MULTIARCH_BUILDER,
 	planPlatformArgs,
-	usesBuildx,
 } from "./build-platform";
 import { createEnvFileCommand } from "./utils";
 
@@ -40,8 +38,11 @@ export const getDockerCommand = (
 		const dockerContextPath =
 			getDockerContextPath(application) || defaultContextPath;
 
-		const commandArgs = usesBuildx(plan) ? ["buildx", "build"] : ["build"];
-		const builder = dockerfileBuilderName(plan);
+		const useBuildx = plan.output.mode === "push" || plan.builder !== null;
+		const builder =
+			plan.builder ??
+			(plan.output.mode === "push" ? DEFAULT_MULTIARCH_BUILDER : null);
+		const commandArgs = useBuildx ? ["buildx", "build"] : ["build"];
 		if (builder) {
 			commandArgs.push("--builder", quote([builder]));
 		}
@@ -54,7 +55,7 @@ export const getDockerCommand = (
 			commandArgs.push("--push");
 		} else {
 			commandArgs.push("-t", plan.output.image);
-			if (usesBuildx(plan)) {
+			if (useBuildx) {
 				commandArgs.push("--load");
 			}
 		}
@@ -111,13 +112,18 @@ export const getDockerCommand = (
 			commandArgs.push("--secret", `type=env,id=${key}`);
 		}
 
+		const createDefaultBuilder =
+			plan.output.mode === "push" && !plan.builder
+				? `docker buildx inspect ${quote([DEFAULT_MULTIARCH_BUILDER])} >/dev/null 2>&1 || docker buildx create --name ${quote([DEFAULT_MULTIARCH_BUILDER])} --driver docker-container --driver-opt network=host\n`
+				: "";
+
 		command += `
 echo ${quote([`Building ${appName}`])} ;
 cd ${quote([dockerContextPath])} || {
   echo ${quote([`❌ The path ${dockerContextPath} does not exist`])} ;
   exit 1;
 }
-${ensureMultiarchBuilderCommand(plan)}
+${createDefaultBuilder}
 ${joinedSecrets} docker ${commandArgs.join(" ")} || {
   echo "❌ Docker build failed" ;
   exit 1;

--- a/packages/server/src/utils/builders/docker-file.ts
+++ b/packages/server/src/utils/builders/docker-file.ts
@@ -8,9 +8,23 @@ import {
 	getDockerContextPath,
 } from "../filesystem/directory";
 import type { ApplicationNested } from ".";
+import {
+	dockerfileBuildxBuilder,
+	ensureMultiarchBuilderCommand,
+	planBuildArchitecture,
+	planPlatformArgs,
+	usesBuildx,
+} from "./build-platform";
 import { createEnvFileCommand } from "./utils";
 
-export const getDockerCommand = (application: ApplicationNested) => {
+export type DockerBuildOptions = {
+	pushTags?: string[];
+};
+
+export const getDockerCommand = (
+	application: ApplicationNested,
+	options: DockerBuildOptions = {},
+) => {
 	const {
 		appName,
 		env,
@@ -22,6 +36,7 @@ export const getDockerCommand = (application: ApplicationNested) => {
 		createEnvFile,
 	} = application;
 	const dockerFilePath = getBuildAppDirectory(application);
+	const plan = planBuildArchitecture(application);
 
 	try {
 		const image = `${appName}`;
@@ -32,14 +47,32 @@ export const getDockerCommand = (application: ApplicationNested) => {
 		const dockerContextPath =
 			getDockerContextPath(application) || defaultContextPath;
 
-		const commandArgs = [
-			"build",
-			"-t",
-			image,
-			"-f",
-			dockerFilePath,
-			dockerContextPath,
-		];
+		if (
+			plan.kind === "multi" &&
+			(!options.pushTags || options.pushTags.length === 0)
+		) {
+			throw new Error(
+				"Multi-architecture builds require registry tags to push.",
+			);
+		}
+
+		const commandArgs = usesBuildx(plan) ? ["buildx", "build"] : ["build"];
+		const builder = dockerfileBuildxBuilder(plan);
+		if (builder) {
+			commandArgs.push("--builder", quote([builder]));
+		}
+		commandArgs.push(...planPlatformArgs(plan));
+
+		if (plan.kind === "multi") {
+			for (const tag of options.pushTags ?? []) {
+				commandArgs.push("-t", quote([tag]));
+			}
+			commandArgs.push("--push");
+		} else {
+			commandArgs.push("-t", image);
+		}
+
+		commandArgs.push("-f", dockerFilePath, dockerContextPath);
 
 		if (dockerBuildStage) {
 			commandArgs.push("--target", dockerBuildStage);
@@ -97,7 +130,7 @@ cd ${quote([dockerContextPath])} || {
   echo ${quote([`❌ The path ${dockerContextPath} does not exist`])} ;
   exit 1;
 }
-
+${ensureMultiarchBuilderCommand(plan)}
 ${joinedSecrets} docker ${commandArgs.join(" ")} || {
   echo "❌ Docker build failed" ;
   exit 1;

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -2,7 +2,12 @@ import { resolveServiceNetworks } from "@dokploy/server/services/network";
 import { findRegistryByIdWithCredentials } from "@dokploy/server/services/registry";
 import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
-import { getRegistryTag, uploadImageRemoteCommand } from "../cluster/upload";
+import {
+	collectRegistryPushTargets,
+	getRegistryTag,
+	registryLoginCommands,
+	uploadImageRemoteCommand,
+} from "../cluster/upload";
 import {
 	calculateResources,
 	generateBindMounts,
@@ -13,7 +18,8 @@ import {
 } from "../docker/utils";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
-import { getDockerCommand } from "./docker-file";
+import { planBuildArchitecture } from "./build-platform";
+import { type DockerBuildOptions, getDockerCommand } from "./docker-file";
 import { getHerokuCommand } from "./heroku";
 import { getNixpacksCommand } from "./nixpacks";
 import { getPaketoCommand } from "./paketo";
@@ -41,36 +47,53 @@ export type ApplicationNested = InferResultType<
 
 export const getBuildCommand = async (rawApplication: ApplicationNested) => {
 	const application = await withResolvedVaultRefs(rawApplication);
+	const plan = planBuildArchitecture(application);
 	let command = "";
+	const buildOptions: DockerBuildOptions = {};
+
+	if (plan.kind === "multi") {
+		const targets = await collectRegistryPushTargets(application);
+		if (targets.length === 0) {
+			throw new Error(
+				"Multi-architecture builds require a registry. Docker cannot load a multi-arch image into the local daemon.",
+			);
+		}
+		buildOptions.pushTags = targets.map((target) => target.tag);
+		const logins = registryLoginCommands(targets);
+		if (logins) {
+			command += `${logins}\n`;
+		}
+	}
 
 	if (application.sourceType !== "docker") {
 		const { buildType } = application;
 		switch (buildType) {
 			case "nixpacks":
-				command = getNixpacksCommand(application);
+				command += getNixpacksCommand(application);
 				break;
 			case "heroku_buildpacks":
-				command = getHerokuCommand(application);
+				command += getHerokuCommand(application);
 				break;
 			case "paketo_buildpacks":
-				command = getPaketoCommand(application);
+				command += getPaketoCommand(application);
 				break;
 			case "static":
-				command = getStaticCommand(application);
+				command += getStaticCommand(application, buildOptions);
 				break;
 			case "dockerfile":
-				command = getDockerCommand(application);
+				command += getDockerCommand(application, buildOptions);
 				break;
 			case "railpack":
-				command = getRailpackCommand(application);
+				command += getRailpackCommand(application, buildOptions);
 				break;
 		}
 	}
 
 	if (
-		application.registry ||
-		application.buildRegistry ||
-		application.rollbackRegistry
+		plan.kind !== "multi" &&
+		(application.registry ||
+			application.buildRegistry ||
+			application.rollbackRegistry)
 	) {
 		command += await uploadImageRemoteCommand(application);
 	}

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -2,12 +2,7 @@ import { resolveServiceNetworks } from "@dokploy/server/services/network";
 import { findRegistryByIdWithCredentials } from "@dokploy/server/services/registry";
 import type { InferResultType } from "@dokploy/server/types/with";
 import type { CreateServiceOptions } from "dockerode";
-import {
-	collectRegistryPushTargets,
-	getRegistryTag,
-	registryLoginCommands,
-	uploadImageRemoteCommand,
-} from "../cluster/upload";
+import { getRegistryTag, uploadImageRemoteCommand } from "../cluster/upload";
 import {
 	calculateResources,
 	generateBindMounts,
@@ -18,8 +13,8 @@ import {
 } from "../docker/utils";
 import { getRemoteDocker } from "../servers/remote-docker";
 import { withResolvedVaultRefs } from "../vault";
-import { planBuildArchitecture } from "./build-platform";
-import { type DockerBuildOptions, getDockerCommand } from "./docker-file";
+import { resolveBuildPlan } from "./build-platform";
+import { getDockerCommand } from "./docker-file";
 import { getHerokuCommand } from "./heroku";
 import { getNixpacksCommand } from "./nixpacks";
 import { getPaketoCommand } from "./paketo";
@@ -47,22 +42,11 @@ export type ApplicationNested = InferResultType<
 
 export const getBuildCommand = async (rawApplication: ApplicationNested) => {
 	const application = await withResolvedVaultRefs(rawApplication);
-	const plan = planBuildArchitecture(application);
+	const plan = await resolveBuildPlan(application);
 	let command = "";
-	const buildOptions: DockerBuildOptions = {};
 
-	if (plan.kind === "multi") {
-		const targets = await collectRegistryPushTargets(application);
-		if (targets.length === 0) {
-			throw new Error(
-				"Multi-architecture builds require a registry. Docker cannot load a multi-arch image into the local daemon.",
-			);
-		}
-		buildOptions.pushTags = targets.map((target) => target.tag);
-		const logins = registryLoginCommands(targets);
-		if (logins) {
-			command += `${logins}\n`;
-		}
+	if (plan.output.mode === "push" && plan.output.logins) {
+		command += `${plan.output.logins}\n`;
 	}
 
 	if (application.sourceType !== "docker") {
@@ -78,19 +62,19 @@ export const getBuildCommand = async (rawApplication: ApplicationNested) => {
 				command += getPaketoCommand(application);
 				break;
 			case "static":
-				command += getStaticCommand(application, buildOptions);
+				command += getStaticCommand(application, plan);
 				break;
 			case "dockerfile":
-				command += getDockerCommand(application, buildOptions);
+				command += getDockerCommand(application, plan);
 				break;
 			case "railpack":
-				command += getRailpackCommand(application, buildOptions);
+				command += getRailpackCommand(application, plan);
 				break;
 		}
 	}
 
 	if (
-		plan.kind !== "multi" &&
+		plan.output.mode === "local" &&
 		(application.registry ||
 			application.buildRegistry ||
 			application.rollbackRegistry)

--- a/packages/server/src/utils/builders/nixpacks.ts
+++ b/packages/server/src/utils/builders/nixpacks.ts
@@ -60,7 +60,12 @@ export const getNixpacksCommand = (application: ApplicationNested) => {
 		exit 1;
 	}
 	docker rm ${buildContainerId}
-	${getStaticCommand(application)}
+	${getStaticCommand(application, {
+		platforms: [],
+		builder: null,
+		createDefaultBuilder: false,
+		output: { mode: "local", image: application.appName },
+	})}
 				`;
 	}
 

--- a/packages/server/src/utils/builders/nixpacks.ts
+++ b/packages/server/src/utils/builders/nixpacks.ts
@@ -63,7 +63,6 @@ export const getNixpacksCommand = (application: ApplicationNested) => {
 	${getStaticCommand(application, {
 		platforms: [],
 		builder: null,
-		createDefaultBuilder: false,
 		output: { mode: "local", image: application.appName },
 	})}
 				`;

--- a/packages/server/src/utils/builders/railpack.ts
+++ b/packages/server/src/utils/builders/railpack.ts
@@ -8,8 +8,7 @@ import {
 } from "../docker/utils";
 import { getBuildAppDirectory } from "../filesystem/directory";
 import type { ApplicationNested } from ".";
-import { planBuildArchitecture, planPlatformArgs } from "./build-platform";
-import type { DockerBuildOptions } from "./docker-file";
+import { type BuildPlan, planPlatformArgs } from "./build-platform";
 
 const calculateSecretsHash = (envVariables: string[]): string => {
 	const hash = createHash("sha256");
@@ -21,10 +20,9 @@ const calculateSecretsHash = (envVariables: string[]): string => {
 
 export const getRailpackCommand = (
 	application: ApplicationNested,
-	options: DockerBuildOptions = {},
+	plan: BuildPlan,
 ) => {
 	const { env, appName, cleanCache } = application;
-	const plan = planBuildArchitecture(application);
 	const buildAppDirectory = getBuildAppDirectory(application);
 	const envVariables = prepareEnvironmentVariablesForShell(
 		env,
@@ -50,17 +48,16 @@ export const getRailpackCommand = (
 	const secretsHash = calculateSecretsHash(envVariables);
 
 	const cacheKey = cleanCache ? nanoid(10) : undefined;
-	const pushTags = options.pushTags ?? [];
-	if (plan.kind === "multi" && pushTags.length === 0) {
-		throw new Error("Multi-architecture builds require registry tags to push.");
-	}
 	// Use a unique builder name per build so concurrent deployments don't race
 	// on a shared "builder-containerd" instance (create/use/rm collisions).
 	const ephemeralBuilder = `railpack-${appName}-${nanoid(6)}`;
 	const builderName = plan.builder ?? ephemeralBuilder;
 	const ownsEphemeralBuilder = plan.builder === null;
 	const quotedBuilder = quote([builderName]);
-	const multiArchArgs = pushTags.flatMap((tag) => ["-t", quote([tag])]);
+	const pushArgs =
+		plan.output.mode === "push"
+			? [...plan.output.tags.flatMap((tag) => ["-t", quote([tag])]), "--push"]
+			: ["--output", `type=docker,name=${plan.output.image}`];
 	const buildArgs = [
 		"buildx",
 		"build",
@@ -74,9 +71,7 @@ export const getRailpackCommand = (
 		`BUILDKIT_SYNTAX=ghcr.io/railwayapp/railpack-frontend:v${application.railpackVersion}`,
 		"-f",
 		`${buildAppDirectory}/railpack-plan.json`,
-		...(plan.kind === "multi"
-			? [...multiArchArgs, "--push"]
-			: ["--output", `type=docker,name=${appName}`]),
+		...pushArgs,
 	];
 
 	// Add secrets properly formatted

--- a/packages/server/src/utils/builders/railpack.ts
+++ b/packages/server/src/utils/builders/railpack.ts
@@ -8,6 +8,8 @@ import {
 } from "../docker/utils";
 import { getBuildAppDirectory } from "../filesystem/directory";
 import type { ApplicationNested } from ".";
+import { planBuildArchitecture, planPlatformArgs } from "./build-platform";
+import type { DockerBuildOptions } from "./docker-file";
 
 const calculateSecretsHash = (envVariables: string[]): string => {
 	const hash = createHash("sha256");
@@ -17,8 +19,12 @@ const calculateSecretsHash = (envVariables: string[]): string => {
 	return hash.digest("hex");
 };
 
-export const getRailpackCommand = (application: ApplicationNested) => {
+export const getRailpackCommand = (
+	application: ApplicationNested,
+	options: DockerBuildOptions = {},
+) => {
 	const { env, appName, cleanCache } = application;
+	const plan = planBuildArchitecture(application);
 	const buildAppDirectory = getBuildAppDirectory(application);
 	const envVariables = prepareEnvironmentVariablesForShell(
 		env,
@@ -44,15 +50,23 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 	const secretsHash = calculateSecretsHash(envVariables);
 
 	const cacheKey = cleanCache ? nanoid(10) : undefined;
-	// Build command.
+	const pushTags = options.pushTags ?? [];
+	if (plan.kind === "multi" && pushTags.length === 0) {
+		throw new Error("Multi-architecture builds require registry tags to push.");
+	}
 	// Use a unique builder name per build so concurrent deployments don't race
 	// on a shared "builder-containerd" instance (create/use/rm collisions).
-	const builderName = `railpack-${appName}-${nanoid(6)}`;
+	const ephemeralBuilder = `railpack-${appName}-${nanoid(6)}`;
+	const builderName = plan.builder ?? ephemeralBuilder;
+	const ownsEphemeralBuilder = plan.builder === null;
+	const quotedBuilder = quote([builderName]);
+	const multiArchArgs = pushTags.flatMap((tag) => ["-t", quote([tag])]);
 	const buildArgs = [
 		"buildx",
 		"build",
 		"--builder",
-		builderName,
+		quotedBuilder,
+		...planPlatformArgs(plan),
 		"--build-arg",
 		`secrets-hash=${secretsHash}`,
 		...(cacheKey ? ["--build-arg", `cache-key=${cacheKey}`] : []),
@@ -60,8 +74,9 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 		`BUILDKIT_SYNTAX=ghcr.io/railwayapp/railpack-frontend:v${application.railpackVersion}`,
 		"-f",
 		`${buildAppDirectory}/railpack-plan.json`,
-		"--output",
-		`type=docker,name=${appName}`,
+		...(plan.kind === "multi"
+			? [...multiArchArgs, "--push"]
+			: ["--output", `type=docker,name=${appName}`]),
 	];
 
 	// Add secrets properly formatted
@@ -82,6 +97,13 @@ export const getRailpackCommand = (application: ApplicationNested) => {
 
 	buildArgs.push(buildAppDirectory);
 
+	const createBuilder = ownsEphemeralBuilder
+		? `docker buildx create --name ${quotedBuilder} --driver docker-container || true`
+		: "";
+	const removeBuilder = ownsEphemeralBuilder
+		? `docker buildx rm ${quotedBuilder} || true`
+		: "";
+
 	const bashCommand = `
 
 # Ensure we have a builder with containerd (isolated per build)
@@ -96,12 +118,12 @@ else
 	SUDO_CMD=""
 fi
 $SUDO_CMD bash -c "$(curl -fsSL https://railpack.com/install.sh)"
-docker buildx create --name ${builderName} --driver docker-container || true
+${createBuilder}
 
 echo "Preparing Railpack build plan..." ;
 railpack ${prepareArgs.join(" ")} || {
 	echo "❌ Railpack prepare failed" ;
-	docker buildx rm ${builderName} || true
+	${removeBuilder}
 	exit 1;
 }
 echo "✅ Railpack prepare completed." ;
@@ -111,11 +133,11 @@ echo "Building with Railpack frontend..." ;
 ${exportEnvs.join("\n")}
 docker ${buildArgs.join(" ")} || {
 	echo "❌ Railpack build failed" ;
-	docker buildx rm ${builderName} || true
+	${removeBuilder}
 	exit 1;
 }
 echo "✅ Railpack build completed." ;
-docker buildx rm ${builderName} || true
+${removeBuilder}
 `;
 
 	return bashCommand;

--- a/packages/server/src/utils/builders/railpack.ts
+++ b/packages/server/src/utils/builders/railpack.ts
@@ -93,7 +93,7 @@ export const getRailpackCommand = (
 	buildArgs.push(buildAppDirectory);
 
 	const createBuilder = ownsEphemeralBuilder
-		? `docker buildx create --name ${quotedBuilder} --driver docker-container || true`
+		? `docker buildx create --name ${quotedBuilder} --driver docker-container --driver-opt network=host || true`
 		: "";
 	const removeBuilder = ownsEphemeralBuilder
 		? `docker buildx rm ${quotedBuilder} || true`

--- a/packages/server/src/utils/builders/static.ts
+++ b/packages/server/src/utils/builders/static.ts
@@ -1,10 +1,8 @@
-import {
-	type DockerBuildOptions,
-	getDockerCommand,
-} from "@dokploy/server/utils/builders/docker-file";
+import { getDockerCommand } from "@dokploy/server/utils/builders/docker-file";
 import { getCreateFileCommand } from "../docker/utils";
 import { getBuildAppDirectory } from "../filesystem/directory";
 import type { ApplicationNested } from ".";
+import type { BuildPlan } from "./build-platform";
 
 const nginxSpaConfig = `
 worker_processes 1;
@@ -33,7 +31,7 @@ http {
 
 export const getStaticCommand = (
 	application: ApplicationNested,
-	options: DockerBuildOptions = {},
+	plan: BuildPlan,
 ) => {
 	const { publishDirectory, isStaticSpa } = application;
 	const buildAppDirectory = getBuildAppDirectory(application);
@@ -70,7 +68,7 @@ export const getStaticCommand = (
 			buildType: "dockerfile",
 			dockerfile: "Dockerfile",
 		},
-		options,
+		plan,
 	);
 	return command;
 };

--- a/packages/server/src/utils/builders/static.ts
+++ b/packages/server/src/utils/builders/static.ts
@@ -1,4 +1,7 @@
-import { getDockerCommand } from "@dokploy/server/utils/builders/docker-file";
+import {
+	type DockerBuildOptions,
+	getDockerCommand,
+} from "@dokploy/server/utils/builders/docker-file";
 import { getCreateFileCommand } from "../docker/utils";
 import { getBuildAppDirectory } from "../filesystem/directory";
 import type { ApplicationNested } from ".";
@@ -28,7 +31,10 @@ http {
 }
 `;
 
-export const getStaticCommand = (application: ApplicationNested) => {
+export const getStaticCommand = (
+	application: ApplicationNested,
+	options: DockerBuildOptions = {},
+) => {
 	const { publishDirectory, isStaticSpa } = application;
 	const buildAppDirectory = getBuildAppDirectory(application);
 	let command = "";
@@ -58,10 +64,13 @@ export const getStaticCommand = (application: ApplicationNested) => {
 		].join("\n"),
 	);
 
-	command += getDockerCommand({
-		...application,
-		buildType: "dockerfile",
-		dockerfile: "Dockerfile",
-	});
+	command += getDockerCommand(
+		{
+			...application,
+			buildType: "dockerfile",
+			dockerfile: "Dockerfile",
+		},
+		options,
+	);
 	return command;
 };

--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -95,29 +95,31 @@ export const uploadImageRemoteCommand = async (
 	const targets = await collectRegistryPushTargets(application);
 	const commands: string[] = [];
 	for (const target of targets) {
-		if (target.kind === "cluster") {
-			commands.push(`echo "📦 [Enabled Registry Swarm]"`);
-			commands.push(
-				getRegistryCommands(target.registry, target.imageName, target.tag),
-			);
-		}
-		if (target.kind === "build") {
-			commands.push(`echo "🔑 [Enabled Build Registry]"`);
-			commands.push(
-				getRegistryCommands(target.registry, target.imageName, target.tag),
-			);
-			commands.push(
-				`echo "⚠️ INFO: After the build is finished, you need to wait a few seconds for the server to download the image and run the container."`,
-			);
-			commands.push(
-				`echo "📊 Check the Logs tab to see when the container starts running."`,
-			);
-		}
-		if (target.kind === "rollback") {
-			commands.push(`echo "🔄 [Enabled Rollback Registry]"`);
-			commands.push(
-				getRegistryCommands(target.registry, target.imageName, target.tag),
-			);
+		switch (target.kind) {
+			case "cluster":
+				commands.push(`echo "📦 [Enabled Registry Swarm]"`);
+				commands.push(
+					getRegistryCommands(target.registry, target.imageName, target.tag),
+				);
+				break;
+			case "build":
+				commands.push(`echo "🔑 [Enabled Build Registry]"`);
+				commands.push(
+					getRegistryCommands(target.registry, target.imageName, target.tag),
+				);
+				commands.push(
+					`echo "⚠️ INFO: After the build is finished, you need to wait a few seconds for the server to download the image and run the container."`,
+				);
+				commands.push(
+					`echo "📊 Check the Logs tab to see when the container starts running."`,
+				);
+				break;
+			case "rollback":
+				commands.push(`echo "🔄 [Enabled Rollback Registry]"`);
+				commands.push(
+					getRegistryCommands(target.registry, target.imageName, target.tag),
+				);
+				break;
 		}
 	}
 	try {

--- a/packages/server/src/utils/cluster/upload.ts
+++ b/packages/server/src/utils/cluster/upload.ts
@@ -8,6 +8,79 @@ import { createRollback } from "@dokploy/server/services/rollbacks";
 import { quote } from "shell-quote";
 import type { ApplicationNested } from "../builders";
 
+export type RegistryPushTarget = {
+	kind: "cluster" | "build" | "rollback";
+	registry: Registry;
+	imageName: string;
+	tag: string;
+};
+
+export const collectRegistryPushTargets = async (
+	application: ApplicationNested,
+): Promise<RegistryPushTarget[]> => {
+	const registry = application.registry;
+	const buildRegistry = application.buildRegistry;
+	const rollbackRegistry = application.rollbackRegistry;
+	const { appName } = application;
+	const imageName =
+		application.sourceType === "docker"
+			? application.dockerImage || ""
+			: `${appName}:latest`;
+
+	const targets: RegistryPushTarget[] = [];
+
+	if (registry) {
+		const r = await findRegistryByIdWithCredentials(registry.registryId);
+		const tag = getRegistryTag(r, imageName);
+		if (tag) {
+			targets.push({ kind: "cluster", registry: r, imageName, tag });
+		}
+	}
+	if (buildRegistry) {
+		const r = await findRegistryByIdWithCredentials(buildRegistry.registryId);
+		const tag = getRegistryTag(r, imageName);
+		if (tag) {
+			targets.push({ kind: "build", registry: r, imageName, tag });
+		}
+	}
+	if (rollbackRegistry && application.rollbackActive) {
+		const deployment = await findAllDeploymentsByApplicationId(
+			application.applicationId,
+		);
+		if (!deployment || !deployment[0]) {
+			throw new Error("Deployment not found");
+		}
+		const rollback = await createRollback({
+			appName: appName,
+			deploymentId: deployment[0].deploymentId,
+		});
+		const r = await findRegistryByIdWithCredentials(
+			rollbackRegistry.registryId,
+		);
+		const tag = getRegistryTag(r, rollback?.image || "");
+		if (tag) {
+			targets.push({ kind: "rollback", registry: r, imageName, tag });
+		}
+	}
+
+	return targets;
+};
+
+export const registryLoginCommands = (
+	targets: RegistryPushTarget[],
+): string => {
+	return targets
+		.map((target) => {
+			const loginCmd = safeDockerLoginCommand(
+				target.registry.registryUrl,
+				target.registry.username,
+				target.registry.password,
+			);
+			return `${loginCmd} || { echo "❌ DockerHub Failed" ; exit 1; }`;
+		})
+		.join("\n");
+};
+
 export const uploadImageRemoteCommand = async (
 	application: ApplicationNested,
 ) => {
@@ -19,27 +92,20 @@ export const uploadImageRemoteCommand = async (
 		throw new Error("No registry found");
 	}
 
-	const { appName } = application;
-	const imageName =
-		application.sourceType === "docker"
-			? application.dockerImage || ""
-			: `${appName}:latest`;
-
+	const targets = await collectRegistryPushTargets(application);
 	const commands: string[] = [];
-	if (registry) {
-		const r = await findRegistryByIdWithCredentials(registry.registryId);
-		const registryTag = getRegistryTag(r, imageName);
-		if (registryTag) {
+	for (const target of targets) {
+		if (target.kind === "cluster") {
 			commands.push(`echo "📦 [Enabled Registry Swarm]"`);
-			commands.push(getRegistryCommands(r, imageName, registryTag));
+			commands.push(
+				getRegistryCommands(target.registry, target.imageName, target.tag),
+			);
 		}
-	}
-	if (buildRegistry) {
-		const r = await findRegistryByIdWithCredentials(buildRegistry.registryId);
-		const buildRegistryTag = getRegistryTag(r, imageName);
-		if (buildRegistryTag) {
+		if (target.kind === "build") {
 			commands.push(`echo "🔑 [Enabled Build Registry]"`);
-			commands.push(getRegistryCommands(r, imageName, buildRegistryTag));
+			commands.push(
+				getRegistryCommands(target.registry, target.imageName, target.tag),
+			);
 			commands.push(
 				`echo "⚠️ INFO: After the build is finished, you need to wait a few seconds for the server to download the image and run the container."`,
 			);
@@ -47,28 +113,11 @@ export const uploadImageRemoteCommand = async (
 				`echo "📊 Check the Logs tab to see when the container starts running."`,
 			);
 		}
-	}
-
-	if (rollbackRegistry && application.rollbackActive) {
-		const deployment = await findAllDeploymentsByApplicationId(
-			application.applicationId,
-		);
-		if (!deployment || !deployment[0]) {
-			throw new Error("Deployment not found");
-		}
-		const deploymentId = deployment[0].deploymentId;
-		const rollback = await createRollback({
-			appName: appName,
-			deploymentId: deploymentId,
-		});
-
-		const r = await findRegistryByIdWithCredentials(
-			rollbackRegistry.registryId,
-		);
-		const rollbackRegistryTag = getRegistryTag(r, rollback?.image || "");
-		if (rollbackRegistryTag) {
+		if (target.kind === "rollback") {
 			commands.push(`echo "🔄 [Enabled Rollback Registry]"`);
-			commands.push(getRegistryCommands(r, imageName, rollbackRegistryTag));
+			commands.push(
+				getRegistryCommands(target.registry, target.imageName, target.tag),
+			);
 		}
 	}
 	try {


### PR DESCRIPTION
> Disclaimer: This is an AI generated code & PR with Grok 4.7 on Extra High.
> I did actually test the feature and run builds with multi-arch for my own usage.

## What is this PR about?

Applications can pick a build architecture: host native (default), linux/amd64, linux/arm64, or both.

The default path stays `docker build` with no `--platform`, so existing apps do not change. Pinning one arch adds `--platform`. Multi-arch uses `docker buildx build --push` and writes a registry manifest list. Swarm then pulls the variant that matches the deploy node.

This matches https://github.com/Dokploy/dokploy/issues/4628 for Dockerfile, Railpack, and Static builds. An optional named buildx builder covers native ARM or AMD64 hardware without QEMU.

## Checklist

- [x] You created a dedicated branch based on the `canary` branch.
- [x] You have read the suggestions in the CONTRIBUTING.md file https://github.com/Dokploy/dokploy/blob/canary/CONTRIBUTING.md#pull-request
- [x] You have tested this PR in your local instance. If you have not tested it yet, please do so before submitting. This helps avoid wasting maintainers' time reviewing code that has not been verified by you.

Fully tested on a local Dokploy instance: Postgres 16 in Docker, `pnpm run dokploy:dev`, a Dockerfile application with cluster registry `localhost:5000`, QEMU binfmt for amd64 on an ARM host, and a `docker-container` buildx builder.

## Issues related (if applicable)

Closes #4628

## Why

An ARM build server currently produces ARM images. An amd64 production node then fails with `exec format error`. Multi-arch images let each server pull the right variant from the registry.

## Scope

- `application.buildArchitecture` enum: `host` (default), `amd64`, `arm64`, `multi`
- `application.buildxBuilder` optional named builder
- Migration `apps/dokploy/drizzle/0197_old_retro_girl.sql`
- `resolveBuildPlan` in `packages/server/src/utils/builders/build-platform.ts` owns platforms, builder, and local-vs-push output
- Dockerfile, Static, and Railpack render that plan. Nixpacks, Heroku, and Paketo stay host-only
- Advanced tab card `ShowBuildArchitecture`
- Preview deploys force host native after they drop registries
- Default `dokploy-multiarch` builder is created with `--driver-opt network=host` so `--push` can reach a registry bound on the build host (the builder container's `localhost` is not the host)

Out of this PR: Compose, QEMU autodetection, extra cache-from/cache-to, docs in Dokploy/website.

## Tradeoffs

- Multi-arch requires a cluster registry or a build registry. Docker cannot load a multi-arch image into the local daemon.
- Cross-compiling a foreign arch without a native builder uses QEMU if the host has it, otherwise the build fails with Docker's error.
- Rollback-only registry is not enough for multi-arch. Swarm would still try to run a local `appName:latest` that was never loaded.
- The default builder uses host networking. That is required for host-local registries; a named builder can still be supplied for a remote farm.

## Blast Radius

- Existing applications keep `host` and the same `docker build` command.
- `getBuildCommand` now resolves a plan before it calls a builder. Host + registry still uses today's login, tag, and push.
- Multi-arch skips that tag-and-push path so it cannot flatten the manifest list.
- Pack builders reject non-host architecture at plan time and on `application.update`.
- `saveBuildType` and cluster-registry clears reset illegal architecture back to `host`.

## Verification

Unit tests:

```
pnpm --filter=dokploy exec vitest run --config __test__/vitest.config.ts \
  __test__/deploy/build-platform.test.ts \
  __test__/deploy/docker-file.command.test.ts \
  __test__/deploy/railpack.command.test.ts \
  __test__/deploy/get-build-command.test.ts
```

30 passed.

End-to-end on this branch:

- Postgres 16 container `dokploy-postgres` on `:5432`; migration added `application.buildArchitecture`
- Local registry `registry:2` on `:5000`
- `dokploy:dev` on `:3000`; signed in; created project/app `arch-probe` as Dockerfile + cluster registry `local-e2e`
- Advanced → Build Architecture shows `linux/amd64 and linux/arm64 (multi-arch)` with registry `local-e2e`
- Pack-builder save path resets `nixpacks` + `multi` to `host` in the database
- Generated command includes `docker buildx inspect dokploy-multiarch || docker buildx create ... --driver-opt network=host` and `docker buildx build --platform linux/amd64,linux/arm64 --push`
- Ran that command against `FROM alpine:3.20`. Push succeeded:

```
localhost:5000/dokploy/arch-probe-e2e-a9qydw:latest
Digest: sha256:b98d7b518313f97a7cd522190fd6e3f389d8625a918a95763725c10793c79a0d
Platforms: linux/amd64, linux/arm64
```

The getBuildCommand test is the product invariant: multi-arch contains `buildx build` and `--push`, and does not emit a later `docker tag` / `docker push`.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63448267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge until partial application updates consistently enforce the architecture, build-type, and registry invariants.

<h3>Summary</h3>

- Adds persisted architecture and optional Buildx builder settings.
- Introduces centralized build-plan resolution and direct registry pushes for multi-arch manifests.
- Adds the Advanced-tab configuration UI and command-generation tests.
- Forces preview deployments to retain host-native local builds.
- The application update validation does not preserve the new cross-field invariants across partial updates.

<sub>Reviews (1) · Last reviewed commit: ["fix(application): reject pack and rollba..."](https://github.com/dokploy/dokploy/commit/9d4ba70cf597464b276a1c87e0b1f3a70918c183)</sub>

<!-- /greptile_comment -->
