### PR TITLE
feat(overview): add active deployments indicator to sidebar

### DIFF
--- a/apps/dokploy/__test__/services/overview-active-deployments-by-organization.test.ts
+++ b/apps/dokploy/__test__/services/overview-active-deployments-by-organization.test.ts
@@ -1,0 +1,122 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type Membership = {
+	organizationId: string;
+	role: string;
+	accessedServices: string[];
+};
+
+const memberships: Membership[] = [
+	{ organizationId: "org-a", role: "owner", accessedServices: [] },
+	{ organizationId: "org-b", role: "member", accessedServices: ["svc-b"] },
+	{ organizationId: "org-c", role: "member", accessedServices: ["svc-c"] },
+];
+const readableOrganizations = new Set(["org-a", "org-b"]);
+const membershipWhere: SQL[] = [];
+const countWhere: SQL[] = [];
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		query: {
+			member: {
+				findMany: vi.fn(({ where }: { where: SQL }) => {
+					membershipWhere.push(where);
+					const { params } = new PgDialect().sqlToQuery(where);
+					// The where clause carries [userId] or [userId, organizationId]
+					const scopedTo = params[1] as string | undefined;
+					return Promise.resolve(
+						memberships.filter(
+							(m) => !scopedTo || m.organizationId === scopedTo,
+						),
+					);
+				}),
+			},
+		},
+		select: vi.fn(() => ({
+			from: () => ({
+				innerJoin: () => ({
+					innerJoin: () => ({
+						where: (clause: SQL) => {
+							countWhere.push(clause);
+							return Promise.resolve([{ count: 1 }]);
+						},
+					}),
+				}),
+			}),
+		})),
+	},
+}));
+
+vi.mock("@dokploy/server/services/permission", () => ({
+	hasPermission: vi.fn((ctx: { session: { activeOrganizationId: string } }) =>
+		Promise.resolve(
+			readableOrganizations.has(ctx.session.activeOrganizationId),
+		),
+	),
+}));
+
+const { countActiveDeploymentsByOrganization } = await import(
+	"@dokploy/server/services/overview"
+);
+
+beforeEach(() => {
+	membershipWhere.length = 0;
+	countWhere.length = 0;
+});
+
+describe("countActiveDeploymentsByOrganization", () => {
+	test("session users get a count for every readable organization", async () => {
+		const result = await countActiveDeploymentsByOrganization("user-1", null);
+
+		// 8 service types × 2 readable organizations; org-c lacks service:read and is never counted
+		expect(result).toEqual({ "org-a": 8, "org-b": 8, "org-c": 0 });
+		expect(countWhere).toHaveLength(16);
+		expect(new PgDialect().sqlToQuery(membershipWhere[0]!).params).toEqual([
+			"user-1",
+		]);
+	});
+
+	test("owner/admin memberships are not restricted by accessedServices, members are", async () => {
+		await countActiveDeploymentsByOrganization("user-1", null);
+
+		const paramsPerQuery = countWhere.map(
+			(clause) => new PgDialect().sqlToQuery(clause).params,
+		);
+		expect(paramsPerQuery.filter((p) => p[0] === "org-a")).toEqual(
+			Array(8).fill(["org-a", "running"]),
+		);
+		expect(paramsPerQuery.filter((p) => p[0] === "org-b")).toEqual(
+			Array(8).fill(["org-b", "svc-b", "running"]),
+		);
+	});
+
+	test("an organization-scoped lookup (API key) never touches other memberships", async () => {
+		const result = await countActiveDeploymentsByOrganization(
+			"user-1",
+			"org-b",
+		);
+
+		expect(result).toEqual({ "org-b": 8 });
+		expect(new PgDialect().sqlToQuery(membershipWhere[0]!).params).toEqual([
+			"user-1",
+			"org-b",
+		]);
+		expect(
+			countWhere.every(
+				(clause) => new PgDialect().sqlToQuery(clause).params[0] === "org-b",
+			),
+		).toBe(true);
+	});
+
+	test("an organization-scoped lookup without service:read returns 0 without counting", async () => {
+		const result = await countActiveDeploymentsByOrganization(
+			"user-1",
+			"org-c",
+		);
+
+		expect(result).toEqual({ "org-c": 0 });
+		expect(countWhere).toHaveLength(0);
+	});
+});

--- a/apps/dokploy/__test__/services/overview-service-href.test.ts
+++ b/apps/dokploy/__test__/services/overview-service-href.test.ts
@@ -1,0 +1,58 @@
+import { getOverviewServiceHref } from "@dokploy/server/services/overview-shared";
+import { describe, expect, test } from "vitest";
+
+const service = {
+	id: "svc-1",
+	projectId: "proj-1",
+	environmentId: "env-1",
+} as const;
+const base = "/dashboard/project/proj-1/environment/env-1/services";
+
+describe("getOverviewServiceHref", () => {
+	test("links application/compose to the deployments tab with deployment.read", () => {
+		expect(
+			getOverviewServiceHref(
+				{ ...service, type: "application" },
+				{ canReadDeployments: true },
+			),
+		).toBe(`${base}/application/svc-1?tab=deployments`);
+		expect(
+			getOverviewServiceHref(
+				{ ...service, type: "compose" },
+				{ canReadDeployments: true },
+			),
+		).toBe(`${base}/compose/svc-1?tab=deployments`);
+	});
+
+	test("links application/compose to the service page without deployment.read", () => {
+		expect(
+			getOverviewServiceHref(
+				{ ...service, type: "application" },
+				{ canReadDeployments: false },
+			),
+		).toBe(`${base}/application/svc-1`);
+		expect(
+			getOverviewServiceHref(
+				{ ...service, type: "compose" },
+				{ canReadDeployments: false },
+			),
+		).toBe(`${base}/compose/svc-1`);
+	});
+
+	test("databases always link to their service page", () => {
+		for (const type of [
+			"postgres",
+			"mysql",
+			"mariadb",
+			"mongo",
+			"redis",
+			"libsql",
+		] as const) {
+			for (const canReadDeployments of [true, false]) {
+				expect(
+					getOverviewServiceHref({ ...service, type }, { canReadDeployments }),
+				).toBe(`${base}/${type}/svc-1`);
+			}
+		}
+	});
+});

--- a/apps/dokploy/__test__/services/overview-services-status.test.ts
+++ b/apps/dokploy/__test__/services/overview-services-status.test.ts
@@ -3,37 +3,59 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const whereCalls: SQL[] = [];
+let countPerType = 0;
 
-vi.mock("@dokploy/server/db", () => ({
-	db: {
-		select: vi.fn(() => ({
-			from: () => ({
-				innerJoin: () => ({
-					innerJoin: () => ({
-						leftJoin: () => ({
-							where: (clause: SQL) => {
-								whereCalls.push(clause);
-								return Promise.resolve([]);
-							},
-						}),
-					}),
+// getAllServicesForOrganization joins environments, projects and server; the count path stops at projects.
+const selectChain = () => ({
+	from: () => ({
+		innerJoin: () => ({
+			innerJoin: () => ({
+				where: (clause: SQL) => {
+					whereCalls.push(clause);
+					return Promise.resolve([{ count: countPerType }]);
+				},
+				leftJoin: () => ({
+					where: (clause: SQL) => {
+						whereCalls.push(clause);
+						return Promise.resolve([]);
+					},
 				}),
 			}),
-		})),
-	},
+		}),
+	}),
+});
+
+vi.mock("@dokploy/server/db", () => ({
+	db: { select: vi.fn(selectChain) },
 }));
 
-const { getAllServicesForOrganization } = await import(
-	"@dokploy/server/services/overview"
-);
+vi.mock("@dokploy/server/services/permission", () => ({
+	hasPermission: vi.fn(),
+}));
+
+const { getAllServicesForOrganization, countServicesForOrganization } =
+	await import("@dokploy/server/services/overview");
 
 const toSql = (clause: SQL) => new PgDialect().sqlToQuery(clause);
 
-describe("getAllServicesForOrganization status filter", () => {
-	beforeEach(() => {
-		whereCalls.length = 0;
-	});
+const expectStatusClauseOnEveryType = () => {
+	expect(whereCalls).toHaveLength(8);
+	const statusColumns = whereCalls.map(
+		(clause) =>
+			toSql(clause).sql.match(/"(applicationStatus|composeStatus)"/)?.[1],
+	);
+	expect(statusColumns.filter((c) => c === "composeStatus")).toHaveLength(1);
+	expect(statusColumns.filter((c) => c === "applicationStatus")).toHaveLength(
+		7,
+	);
+};
 
+beforeEach(() => {
+	whereCalls.length = 0;
+	countPerType = 0;
+});
+
+describe("getAllServicesForOrganization status filter", () => {
 	test("returns early without querying when the member has no services", async () => {
 		expect(await getAllServicesForOrganization("org", [])).toEqual([]);
 		expect(whereCalls).toHaveLength(0);
@@ -51,15 +73,7 @@ describe("getAllServicesForOrganization status filter", () => {
 
 	test("adds the status clause to every service type query", async () => {
 		await getAllServicesForOrganization("org", null, "running");
-		expect(whereCalls).toHaveLength(8);
-		const statusColumns = whereCalls.map(
-			(clause) =>
-				toSql(clause).sql.match(/"(applicationStatus|composeStatus)"/)?.[1],
-		);
-		expect(statusColumns.filter((c) => c === "composeStatus")).toHaveLength(1);
-		expect(statusColumns.filter((c) => c === "applicationStatus")).toHaveLength(
-			7,
-		);
+		expectStatusClauseOnEveryType();
 		for (const clause of whereCalls) {
 			expect(toSql(clause).params).toEqual(["org", "running"]);
 		}
@@ -71,6 +85,34 @@ describe("getAllServicesForOrganization status filter", () => {
 			const { sql, params } = toSql(clause);
 			expect(sql).toContain(" in (");
 			expect(params).toEqual(["org", "svc-1", "running"]);
+		}
+	});
+});
+
+describe("countServicesForOrganization", () => {
+	test("returns 0 without querying when the member has no services", async () => {
+		expect(await countServicesForOrganization("org", [], "running")).toBe(0);
+		expect(whereCalls).toHaveLength(0);
+	});
+
+	test("sums the per-type counts using the same status scoping", async () => {
+		countPerType = 2;
+		expect(await countServicesForOrganization("org", null, "running")).toBe(16);
+		expectStatusClauseOnEveryType();
+		for (const clause of whereCalls) {
+			expect(toSql(clause).params).toEqual(["org", "running"]);
+		}
+	});
+
+	test("respects accessedServices for members", async () => {
+		countPerType = 1;
+		expect(
+			await countServicesForOrganization("org", ["svc-1", "svc-2"], "running"),
+		).toBe(8);
+		for (const clause of whereCalls) {
+			const { sql, params } = toSql(clause);
+			expect(sql).toContain(" in (");
+			expect(params).toEqual(["org", "svc-1", "svc-2", "running"]);
 		}
 	});
 });

--- a/apps/dokploy/__test__/services/overview-services-status.test.ts
+++ b/apps/dokploy/__test__/services/overview-services-status.test.ts
@@ -1,0 +1,76 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const whereCalls: SQL[] = [];
+
+vi.mock("@dokploy/server/db", () => ({
+	db: {
+		select: vi.fn(() => ({
+			from: () => ({
+				innerJoin: () => ({
+					innerJoin: () => ({
+						leftJoin: () => ({
+							where: (clause: SQL) => {
+								whereCalls.push(clause);
+								return Promise.resolve([]);
+							},
+						}),
+					}),
+				}),
+			}),
+		})),
+	},
+}));
+
+const { getAllServicesForOrganization } = await import(
+	"@dokploy/server/services/overview"
+);
+
+const toSql = (clause: SQL) => new PgDialect().sqlToQuery(clause);
+
+describe("getAllServicesForOrganization status filter", () => {
+	beforeEach(() => {
+		whereCalls.length = 0;
+	});
+
+	test("returns early without querying when the member has no services", async () => {
+		expect(await getAllServicesForOrganization("org", [])).toEqual([]);
+		expect(whereCalls).toHaveLength(0);
+	});
+
+	test("queries every service type without a status clause by default", async () => {
+		await getAllServicesForOrganization("org", null);
+		expect(whereCalls).toHaveLength(8);
+		for (const clause of whereCalls) {
+			const { sql, params } = toSql(clause);
+			expect(sql).not.toContain("Status");
+			expect(params).toEqual(["org"]);
+		}
+	});
+
+	test("adds the status clause to every service type query", async () => {
+		await getAllServicesForOrganization("org", null, "running");
+		expect(whereCalls).toHaveLength(8);
+		const statusColumns = whereCalls.map(
+			(clause) =>
+				toSql(clause).sql.match(/"(applicationStatus|composeStatus)"/)?.[1],
+		);
+		expect(statusColumns.filter((c) => c === "composeStatus")).toHaveLength(1);
+		expect(statusColumns.filter((c) => c === "applicationStatus")).toHaveLength(
+			7,
+		);
+		for (const clause of whereCalls) {
+			expect(toSql(clause).params).toEqual(["org", "running"]);
+		}
+	});
+
+	test("keeps member service scoping alongside the status clause", async () => {
+		await getAllServicesForOrganization("org", ["svc-1"], "running");
+		for (const clause of whereCalls) {
+			const { sql, params } = toSql(clause);
+			expect(sql).toContain(" in (");
+			expect(params).toEqual(["org", "svc-1", "running"]);
+		}
+	});
+});

--- a/apps/dokploy/components/dashboard/overview/show-overview-services.tsx
+++ b/apps/dokploy/components/dashboard/overview/show-overview-services.tsx
@@ -1,4 +1,5 @@
 import type {
+	OverviewService,
 	OverviewServiceType,
 	OverviewSortBy,
 } from "@dokploy/server/services/overview-shared";
@@ -46,6 +47,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { useSortPreference } from "@/hooks/use-sort-preference";
+import { cn } from "@/lib/utils";
 import { api } from "@/utils/api";
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
@@ -93,6 +95,33 @@ const idKeyByType: Record<string, string> = {
 	mariadb: "mariadbId",
 	redis: "redisId",
 	mongo: "mongoId",
+};
+
+export const OverviewServiceIcon = ({
+	service,
+	className = "h-5 w-5",
+}: {
+	service: Pick<OverviewService, "type" | "icon" | "name">;
+	className?: string;
+}) => {
+	if (service.type in DB_ENGINE_ICONS) {
+		const Icon = DB_ENGINE_ICONS[service.type as keyof typeof DB_ENGINE_ICONS];
+		return <Icon className={className} />;
+	}
+	if (service.icon) {
+		return (
+			<img
+				src={service.icon}
+				alt={service.name}
+				className={cn("object-contain rounded-sm", className)}
+			/>
+		);
+	}
+	return service.type === "compose" ? (
+		<CircuitBoard className={className} />
+	) : (
+		<GlobeIcon className={className} />
+	);
 };
 
 export const ShowOverviewServices = () => {
@@ -246,28 +275,6 @@ export const ShowOverviewServices = () => {
 		currentPageIndex * pageSize + pageSize,
 	);
 
-	const renderIcon = (service: NonNullable<typeof services>[number]) => {
-		if (service.type in DB_ENGINE_ICONS) {
-			const Icon =
-				DB_ENGINE_ICONS[service.type as keyof typeof DB_ENGINE_ICONS];
-			return <Icon className="h-5 w-5" />;
-		}
-		if (service.icon) {
-			return (
-				<img
-					src={service.icon}
-					alt={service.name}
-					className="size-5 object-contain rounded-sm"
-				/>
-			);
-		}
-		return service.type === "compose" ? (
-			<CircuitBoard className="h-5 w-5" />
-		) : (
-			<GlobeIcon className="h-5 w-5" />
-		);
-	};
-
 	return (
 		<Card className="bg-sidebar p-2.5 rounded-xl w-full">
 			<div className="rounded-xl bg-background shadow-md p-6 flex flex-col gap-4">
@@ -406,7 +413,7 @@ export const ShowOverviewServices = () => {
 										<TableRow key={service.id}>
 											<TableCell>
 												<Link href={href} className="flex items-center gap-2">
-													{renderIcon(service)}
+													<OverviewServiceIcon service={service} />
 													<div className="flex flex-col min-w-0">
 														<span className="font-medium truncate">
 															{service.name}

--- a/apps/dokploy/components/layouts/active-deployments.tsx
+++ b/apps/dokploy/components/layouts/active-deployments.tsx
@@ -1,4 +1,4 @@
-import type { OverviewService } from "@dokploy/server/services/overview-shared";
+import { getOverviewServiceHref } from "@dokploy/server/services/overview-shared";
 import { formatDistanceToNow } from "date-fns";
 import { Loader2 } from "lucide-react";
 import Link from "next/link";
@@ -24,14 +24,6 @@ interface Props {
 	isCollapsed: boolean;
 }
 
-// Application/compose keep deployment logs under their deployments tab; databases only have a general page.
-const serviceHref = (service: OverviewService) => {
-	const base = `/dashboard/project/${service.projectId}/environment/${service.environmentId}/services/${service.type}/${service.id}`;
-	return service.type === "application" || service.type === "compose"
-		? `${base}?tab=deployments`
-		: base;
-};
-
 export const ActiveDeployments = ({ isCollapsed }: Props) => {
 	const { data: permissions } = api.user.getPermissions.useQuery();
 	const { data: active } = api.overview.services.useQuery(
@@ -46,6 +38,8 @@ export const ActiveDeployments = ({ isCollapsed }: Props) => {
 	if (!active || active.length === 0) {
 		return null;
 	}
+
+	const canReadDeployments = !!permissions?.deployment.read;
 
 	const label = `${active.length} Active ${active.length === 1 ? "Deployment" : "Deployments"}`;
 	const single = active.length === 1 ? active[0] : null;
@@ -62,7 +56,7 @@ export const ActiveDeployments = ({ isCollapsed }: Props) => {
 			asChild={!!single}
 		>
 			{single ? (
-				<Link href={serviceHref(single)}>
+				<Link href={getOverviewServiceHref(single, { canReadDeployments })}>
 					<ActiveDeploymentsIcon
 						count={active.length}
 						isCollapsed={isCollapsed}
@@ -108,7 +102,7 @@ export const ActiveDeployments = ({ isCollapsed }: Props) => {
 					{active.map((service) => (
 						<DropdownMenuItem key={service.id} asChild>
 							<Link
-								href={serviceHref(service)}
+								href={getOverviewServiceHref(service, { canReadDeployments })}
 								className="flex items-center gap-2 cursor-pointer"
 							>
 								<OverviewServiceIcon

--- a/apps/dokploy/components/layouts/active-deployments.tsx
+++ b/apps/dokploy/components/layouts/active-deployments.tsx
@@ -1,0 +1,163 @@
+import type { OverviewService } from "@dokploy/server/services/overview-shared";
+import { formatDistanceToNow } from "date-fns";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { OverviewServiceIcon } from "@/components/dashboard/overview/show-overview-services";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SidebarMenuItem } from "@/components/ui/sidebar";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { api } from "@/utils/api";
+
+interface Props {
+	isCollapsed: boolean;
+}
+
+// Application/compose keep deployment logs under their deployments tab; databases only have a general page.
+const serviceHref = (service: OverviewService) => {
+	const base = `/dashboard/project/${service.projectId}/environment/${service.environmentId}/services/${service.type}/${service.id}`;
+	return service.type === "application" || service.type === "compose"
+		? `${base}?tab=deployments`
+		: base;
+};
+
+export const ActiveDeployments = ({ isCollapsed }: Props) => {
+	const { data: permissions } = api.user.getPermissions.useQuery();
+	const { data: active } = api.overview.services.useQuery(
+		{ status: "running" },
+		{
+			enabled: !!permissions?.service.read,
+			// Poll faster while something is deploying so the indicator clears promptly
+			refetchInterval: (query) => (query.state.data?.length ? 3000 : 10000),
+		},
+	);
+
+	if (!active || active.length === 0) {
+		return null;
+	}
+
+	const label = `${active.length} Active ${active.length === 1 ? "Deployment" : "Deployments"}`;
+	const single = active.length === 1 ? active[0] : null;
+
+	const button = (
+		<Button
+			variant="ghost"
+			size={isCollapsed ? "icon" : "sm"}
+			className={cn(
+				"relative gap-1.5 px-2",
+				isCollapsed && "h-8 w-8 p-1.5 mx-auto",
+			)}
+			aria-label={label}
+			asChild={!!single}
+		>
+			{single ? (
+				<Link href={serviceHref(single)}>
+					<ActiveDeploymentsIcon
+						count={active.length}
+						isCollapsed={isCollapsed}
+					/>
+				</Link>
+			) : (
+				<ActiveDeploymentsIcon
+					count={active.length}
+					isCollapsed={isCollapsed}
+				/>
+			)}
+		</Button>
+	);
+
+	const tooltip = (
+		<TooltipContent side="right">
+			{single ? `${label}: ${single.name}` : label}
+		</TooltipContent>
+	);
+
+	if (single) {
+		return (
+			<SidebarMenuItem className={cn(isCollapsed && "mt-2")}>
+				<Tooltip>
+					<TooltipTrigger asChild>{button}</TooltipTrigger>
+					{tooltip}
+				</Tooltip>
+			</SidebarMenuItem>
+		);
+	}
+
+	return (
+		<SidebarMenuItem className={cn(isCollapsed && "mt-2")}>
+			<DropdownMenu>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenuTrigger asChild>{button}</DropdownMenuTrigger>
+					</TooltipTrigger>
+					{tooltip}
+				</Tooltip>
+				<DropdownMenuContent align="start" side="right" className="w-80">
+					<DropdownMenuLabel>{label}</DropdownMenuLabel>
+					{active.map((service) => (
+						<DropdownMenuItem key={service.id} asChild>
+							<Link
+								href={serviceHref(service)}
+								className="flex items-center gap-2 cursor-pointer"
+							>
+								<OverviewServiceIcon
+									service={service}
+									className="size-4 shrink-0"
+								/>
+								<div className="flex flex-col min-w-0 flex-1">
+									<span className="text-sm truncate">{service.name}</span>
+									<span className="text-xs text-muted-foreground truncate">
+										{service.projectName} · {service.environmentName}
+									</span>
+								</div>
+								<div className="flex flex-col items-end gap-0.5 shrink-0 text-xs text-muted-foreground">
+									<span className="flex items-center gap-1">
+										<Loader2 className="size-3 animate-spin text-yellow-600 dark:text-yellow-500" />
+										Deploying
+									</span>
+									{service.lastDeployAt && (
+										<span className="text-[10px] whitespace-nowrap">
+											{formatDistanceToNow(new Date(service.lastDeployAt), {
+												addSuffix: true,
+											})}
+										</span>
+									)}
+								</div>
+							</Link>
+						</DropdownMenuItem>
+					))}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</SidebarMenuItem>
+	);
+};
+
+const ActiveDeploymentsIcon = ({
+	count,
+	isCollapsed,
+}: {
+	count: number;
+	isCollapsed: boolean;
+}) => (
+	<>
+		<Loader2 className="size-4 animate-spin text-yellow-600 dark:text-yellow-500" />
+		{isCollapsed ? (
+			<span className="absolute top-0 right-0 flex size-4 items-center justify-center rounded-full bg-yellow-500 text-xs text-black">
+				{count}
+			</span>
+		) : (
+			<span className="text-xs tabular-nums">{count} active</span>
+		)}
+	</>
+);

--- a/apps/dokploy/components/layouts/side.tsx
+++ b/apps/dokploy/components/layouts/side.tsx
@@ -107,6 +107,7 @@ import { DialogAction } from "../shared/dialog-action";
 import { Logo } from "../shared/logo";
 import { Button } from "../ui/button";
 import { TimeBadge } from "../ui/time-badge";
+import { ActiveDeployments } from "./active-deployments";
 import { UpdateServerButton } from "./update-server";
 import { UserNav } from "./user-nav";
 
@@ -597,6 +598,11 @@ function SidebarLogo() {
 	>(null);
 	const [organizationSelectorOpen, setOrganizationSelectorOpen] =
 		useState(false);
+	const { data: activeDeploymentsByOrg } =
+		api.overview.activeDeploymentsByOrganization.useQuery(undefined, {
+			enabled: organizationSelectorOpen,
+			refetchInterval: 5000,
+		});
 
 	useEffect(() => {
 		if (activeOrganization) {
@@ -717,6 +723,16 @@ function SidebarLogo() {
 																/>
 															</div>
 															<span className="truncate">{org.name}</span>
+															{!!activeDeploymentsByOrg?.[org.id] && (
+																<Badge
+																	variant="yellow"
+																	className="shrink-0 gap-1"
+																	title={`${activeDeploymentsByOrg[org.id]} active ${activeDeploymentsByOrg[org.id] === 1 ? "deployment" : "deployments"}`}
+																>
+																	<Loader2 className="animate-spin" />
+																	{activeDeploymentsByOrg[org.id]}
+																</Badge>
+															)}
 														</div>
 
 														<div
@@ -827,6 +843,8 @@ function SidebarLogo() {
 							</PopoverContent>
 						</Popover>
 					</SidebarMenuItem>
+
+					<ActiveDeployments isCollapsed={isCollapsed} />
 
 					{/* Notification Bell */}
 					<SidebarMenuItem className={cn(isCollapsed && "mt-2")}>

--- a/apps/dokploy/server/api/routers/overview.ts
+++ b/apps/dokploy/server/api/routers/overview.ts
@@ -3,21 +3,67 @@ import {
 	getAllDomainsForOrganization,
 	getAllServicesForOrganization,
 } from "@dokploy/server";
+import { db } from "@dokploy/server/db";
 import {
 	findMemberByUserId,
 	hasPermission,
 } from "@dokploy/server/services/permission";
 import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { applicationStatus, member } from "@/server/db/schema";
 import { createTRPCRouter, protectedProcedure, withPermission } from "../trpc";
 
 export const overviewRouter = createTRPCRouter({
-	services: withPermission("service", "read").query(async ({ ctx }) => {
-		const orgId = ctx.session.activeOrganizationId;
-		const accessedServices =
-			ctx.user.role !== "owner" && ctx.user.role !== "admin"
-				? (await findMemberByUserId(ctx.user.id, orgId)).accessedServices
-				: null;
-		return getAllServicesForOrganization(orgId, accessedServices);
+	services: withPermission("service", "read")
+		.input(
+			z
+				.object({ status: z.enum(applicationStatus.enumValues).optional() })
+				.optional(),
+		)
+		.query(async ({ input, ctx }) => {
+			const orgId = ctx.session.activeOrganizationId;
+			const accessedServices =
+				ctx.user.role !== "owner" && ctx.user.role !== "admin"
+					? (await findMemberByUserId(ctx.user.id, orgId)).accessedServices
+					: null;
+			return getAllServicesForOrganization(
+				orgId,
+				accessedServices,
+				input?.status,
+			);
+		}),
+
+	// Counts deploying services in every organization the user belongs to, applying that org's own membership rules.
+	activeDeploymentsByOrganization: protectedProcedure.query(async ({ ctx }) => {
+		const memberships = await db.query.member.findMany({
+			where: eq(member.userId, ctx.user.id),
+			columns: { organizationId: true, role: true, accessedServices: true },
+		});
+
+		const entries = await Promise.all(
+			memberships.map(async (membership) => {
+				const orgCtx = {
+					user: ctx.user,
+					session: { activeOrganizationId: membership.organizationId },
+				};
+				if (!(await hasPermission(orgCtx, { service: ["read"] }))) {
+					return [membership.organizationId, 0] as const;
+				}
+				const accessedServices =
+					membership.role !== "owner" && membership.role !== "admin"
+						? membership.accessedServices
+						: null;
+				const running = await getAllServicesForOrganization(
+					membership.organizationId,
+					accessedServices,
+					"running",
+				);
+				return [membership.organizationId, running.length] as const;
+			}),
+		);
+
+		return Object.fromEntries(entries) as Record<string, number>;
 	}),
 
 	// Reads backup and/or volumeBackup run history depending on which the user can see.

--- a/apps/dokploy/server/api/routers/overview.ts
+++ b/apps/dokploy/server/api/routers/overview.ts
@@ -1,17 +1,16 @@
 import {
+	countActiveDeploymentsByOrganization,
 	getAllBackupsForOrganization,
 	getAllDomainsForOrganization,
 	getAllServicesForOrganization,
 } from "@dokploy/server";
-import { db } from "@dokploy/server/db";
 import {
 	findMemberByUserId,
 	hasPermission,
 } from "@dokploy/server/services/permission";
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { applicationStatus, member } from "@/server/db/schema";
+import { applicationStatus } from "@/server/db/schema";
 import { createTRPCRouter, protectedProcedure, withPermission } from "../trpc";
 
 export const overviewRouter = createTRPCRouter({
@@ -34,36 +33,13 @@ export const overviewRouter = createTRPCRouter({
 			);
 		}),
 
-	// Counts deploying services in every organization the user belongs to, applying that org's own membership rules.
 	activeDeploymentsByOrganization: protectedProcedure.query(async ({ ctx }) => {
-		const memberships = await db.query.member.findMany({
-			where: eq(member.userId, ctx.user.id),
-			columns: { organizationId: true, role: true, accessedServices: true },
-		});
-
-		const entries = await Promise.all(
-			memberships.map(async (membership) => {
-				const orgCtx = {
-					user: ctx.user,
-					session: { activeOrganizationId: membership.organizationId },
-				};
-				if (!(await hasPermission(orgCtx, { service: ["read"] }))) {
-					return [membership.organizationId, 0] as const;
-				}
-				const accessedServices =
-					membership.role !== "owner" && membership.role !== "admin"
-						? membership.accessedServices
-						: null;
-				const running = await getAllServicesForOrganization(
-					membership.organizationId,
-					accessedServices,
-					"running",
-				);
-				return [membership.organizationId, running.length] as const;
-			}),
+		// An API key is scoped to a single organization (see validateRequest); never let it enumerate the owner's other memberships.
+		const isApiKeyRequest = !!ctx.req.headers["x-api-key"];
+		return countActiveDeploymentsByOrganization(
+			ctx.user.id,
+			isApiKeyRequest ? ctx.session.activeOrganizationId : null,
 		);
-
-		return Object.fromEntries(entries) as Record<string, number>;
 	}),
 
 	// Reads backup and/or volumeBackup run history depending on which the user can see.

--- a/packages/server/src/services/overview-shared.ts
+++ b/packages/server/src/services/overview-shared.ts
@@ -181,3 +181,18 @@ export const getBackupOverviewIcon = (
 	}
 	return { kind: "generic", type: "application" };
 };
+
+/**
+ * Link to a service from the overview. Application/compose keep deployment logs under their
+ * deployments tab, which is only rendered with deployment.read; databases only have a general page.
+ */
+export const getOverviewServiceHref = (
+	service: Pick<OverviewService, "type" | "id" | "projectId" | "environmentId">,
+	options: { canReadDeployments: boolean },
+): string => {
+	const base = `/dashboard/project/${service.projectId}/environment/${service.environmentId}/services/${service.type}/${service.id}`;
+	return options.canReadDeployments &&
+		(service.type === "application" || service.type === "compose")
+		? `${base}?tab=deployments`
+		: base;
+};

--- a/packages/server/src/services/overview.ts
+++ b/packages/server/src/services/overview.ts
@@ -10,6 +10,7 @@ import {
 	environments,
 	libsql,
 	mariadb,
+	member,
 	mongo,
 	mysql,
 	postgres,
@@ -19,7 +20,8 @@ import {
 	server as serverTable,
 	volumeBackups,
 } from "@dokploy/server/db/schema";
-import { and, desc, eq, inArray, isNull, max, or } from "drizzle-orm";
+import { hasPermission } from "@dokploy/server/services/permission";
+import { and, desc, eq, inArray, isNull, max, or, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import type {
 	OverviewBackup,
@@ -51,12 +53,7 @@ type TypeQueryConfig = {
 export type OverviewServiceStatus =
 	(typeof applicationStatus.enumValues)[number];
 
-async function getServicesOfType(
-	config: TypeQueryConfig,
-	orgId: string,
-	accessedServices: string[] | null,
-	status?: OverviewServiceStatus,
-): Promise<OverviewService[]> {
+function serviceTypeColumns(config: TypeQueryConfig) {
 	const table = config.table as typeof applications;
 	const idCol = (table as unknown as Record<string, unknown>)[
 		config.idColumn.name
@@ -64,16 +61,41 @@ async function getServicesOfType(
 	const statusCol = (table as unknown as Record<string, unknown>)[
 		config.statusColumn.name
 	] as typeof applications.applicationStatus;
+	return { table, idCol, statusCol };
+}
+
+function serviceTypeConditions(
+	config: TypeQueryConfig,
+	orgId: string,
+	accessedServices: string[] | null,
+	status?: OverviewServiceStatus,
+) {
+	const { idCol, statusCol } = serviceTypeColumns(config);
+	return [
+		eq(projects.organizationId, orgId),
+		...(accessedServices !== null ? [inArray(idCol, accessedServices)] : []),
+		...(status ? [eq(statusCol, status)] : []),
+	];
+}
+
+async function getServicesOfType(
+	config: TypeQueryConfig,
+	orgId: string,
+	accessedServices: string[] | null,
+	status?: OverviewServiceStatus,
+): Promise<OverviewService[]> {
+	const { table, idCol, statusCol } = serviceTypeColumns(config);
 	const iconCol = config.hasIcon
 		? ((table as unknown as Record<string, unknown>)
 				.icon as typeof applications.icon)
 		: null;
 
-	const conditions = [
-		eq(projects.organizationId, orgId),
-		...(accessedServices !== null ? [inArray(idCol, accessedServices)] : []),
-		...(status ? [eq(statusCol, status)] : []),
-	];
+	const conditions = serviceTypeConditions(
+		config,
+		orgId,
+		accessedServices,
+		status,
+	);
 
 	const baseSelect = {
 		id: idCol,
@@ -248,6 +270,86 @@ export const getAllServicesForOrganization = async (
 	);
 
 	return attachLastDeployAt(results.flat());
+};
+
+/**
+ * Count-only counterpart of getAllServicesForOrganization for the same scoping rules;
+ * skips the display/enrichment joins since callers only need the number.
+ */
+export const countServicesForOrganization = async (
+	orgId: string,
+	accessedServices: string[] | null,
+	status: OverviewServiceStatus,
+): Promise<number> => {
+	if (accessedServices !== null && accessedServices.length === 0) {
+		return 0;
+	}
+
+	const counts = await Promise.all(
+		SERVICE_TYPE_CONFIGS.map(async (config) => {
+			const { table } = serviceTypeColumns(config);
+			const [row] = await db
+				.select({ count: sql<number>`count(*)::int` })
+				.from(table)
+				.innerJoin(
+					environments,
+					eq(table.environmentId, environments.environmentId),
+				)
+				.innerJoin(projects, eq(environments.projectId, projects.projectId))
+				.where(
+					and(
+						...serviceTypeConditions(config, orgId, accessedServices, status),
+					),
+				);
+			return row?.count ?? 0;
+		}),
+	);
+
+	return counts.reduce((total, count) => total + count, 0);
+};
+
+/**
+ * Deploying-service count for every organization the user belongs to, each evaluated with that
+ * membership's own role, permissions and accessedServices. `organizationId` limits the lookup to
+ * one organization — API keys are scoped to a single organization and must not see the others.
+ */
+export const countActiveDeploymentsByOrganization = async (
+	userId: string,
+	organizationId: string | null,
+): Promise<Record<string, number>> => {
+	const memberships = await db.query.member.findMany({
+		where: organizationId
+			? and(
+					eq(member.userId, userId),
+					eq(member.organizationId, organizationId),
+				)
+			: eq(member.userId, userId),
+		columns: { organizationId: true, role: true, accessedServices: true },
+	});
+
+	const entries = await Promise.all(
+		memberships.map(async (membership) => {
+			const orgCtx = {
+				user: { id: userId },
+				session: { activeOrganizationId: membership.organizationId },
+			};
+			if (!(await hasPermission(orgCtx, { service: ["read"] }))) {
+				return [membership.organizationId, 0] as const;
+			}
+			const accessedServices =
+				membership.role !== "owner" && membership.role !== "admin"
+					? membership.accessedServices
+					: null;
+			const count = await countServicesForOrganization(
+				membership.organizationId,
+				accessedServices,
+				"running",
+			);
+			return [membership.organizationId, count] as const;
+		}),
+	);
+
+	return Object.fromEntries(entries);
 };
 
 type Owner = {

--- a/packages/server/src/services/overview.ts
+++ b/packages/server/src/services/overview.ts
@@ -1,5 +1,6 @@
 import { db } from "@dokploy/server/db";
 import {
+	type applicationStatus,
 	applications,
 	backups,
 	compose,
@@ -47,10 +48,14 @@ type TypeQueryConfig = {
 	hasIcon: boolean;
 };
 
+export type OverviewServiceStatus =
+	(typeof applicationStatus.enumValues)[number];
+
 async function getServicesOfType(
 	config: TypeQueryConfig,
 	orgId: string,
 	accessedServices: string[] | null,
+	status?: OverviewServiceStatus,
 ): Promise<OverviewService[]> {
 	const table = config.table as typeof applications;
 	const idCol = (table as unknown as Record<string, unknown>)[
@@ -67,6 +72,7 @@ async function getServicesOfType(
 	const conditions = [
 		eq(projects.organizationId, orgId),
 		...(accessedServices !== null ? [inArray(idCol, accessedServices)] : []),
+		...(status ? [eq(statusCol, status)] : []),
 	];
 
 	const baseSelect = {
@@ -229,6 +235,7 @@ async function attachLastDeployAt(
 export const getAllServicesForOrganization = async (
 	orgId: string,
 	accessedServices: string[] | null,
+	status?: OverviewServiceStatus,
 ): Promise<OverviewService[]> => {
 	if (accessedServices !== null && accessedServices.length === 0) {
 		return [];
@@ -236,7 +243,7 @@ export const getAllServicesForOrganization = async (
 
 	const results = await Promise.all(
 		SERVICE_TYPE_CONFIGS.map((config) =>
-			getServicesOfType(config, orgId, accessedServices),
+			getServicesOfType(config, orgId, accessedServices, status),
 		),
 	);
 


### PR DESCRIPTION
## Summary

Adds an **Active Deployments** indicator to the sidebar so users can see at a glance when something is deploying and jump straight to it, without leaving the page they are on.

- A compact indicator (spinner + count) appears in the sidebar header, next to the notification bell, **only while at least one service is deploying**. It is rendered on every dashboard page, including project pages where the top header is hidden.
- **One** deploying service → the indicator links directly to it (deployments tab for application/compose, service page for databases).
- **Several** → a dropdown lists each service with its icon, project · environment, a "Deploying" status and, when available, when the deployment started. Each row links to the service.
- The organization switcher shows a per-organization badge with the number of deploying services, so users with several organizations can see where activity is happening.
- Collapsed sidebar: icon-only button with a count badge, same pattern as the notification bell.

## Why `applicationStatus` instead of the `deployment` table

Only applications and compose create rows in `deployment`; databases (postgres, mysql, mariadb, mongo, redis, libsql) don't. The `applicationStatus` / `composeStatus` column is the one signal shared by all eight service types and is already what the Overview page uses — it only holds `running` while a deploy is in progress (labelled "Deploying" there). Using it means the indicator covers database deploys too and never double-counts a service.

## Changes

- `packages/server/src/services/overview.ts` — `getAllServicesForOrganization` accepts an optional `status` filter (applied per service type inside `getServicesOfType`).
- `apps/dokploy/server/api/routers/overview.ts`
  - `overview.services` accepts an optional `{ status }` input (backward compatible; existing callers pass nothing).
  - new `overview.activeDeploymentsByOrganization`: for every organization the user belongs to, checks `service:read` **with that organization's membership**, applies `accessedServices` for non-owner/admin members, and returns `{ [organizationId]: count }`.
- `apps/dokploy/components/layouts/active-deployments.tsx` — the indicator (new).
- `apps/dokploy/components/layouts/side.tsx` — mounts the indicator; per-organization badge in the organization switcher.
- `apps/dokploy/components/dashboard/overview/show-overview-services.tsx` — extracts the existing icon logic into `OverviewServiceIcon` so it can be reused (no behaviour change).

No new dependencies, no schema/migration changes.

## Updates

Dokploy has no status subscription channel (websockets are only used for log streaming), so this follows the existing React Query polling pattern:

- Indicator: `overview.services({ status: "running" })`, **3 s while something is deploying, 10 s when idle**. Disabled entirely without `service:read`.
- Organization badges: `overview.activeDeploymentsByOrganization`, fetched **only while the organization popover is open** (5 s), so there is no extra background polling.

## Authorization

- `overview.services` keeps `withPermission("service", "read")` and the member `accessedServices` scoping.
- `activeDeploymentsByOrganization` evaluates permissions per organization via `hasPermission` with that org's `activeOrganizationId`; organizations where the user lacks `service:read` report `0`.

## Tests

- New `__test__/services/overview-services-status.test.ts`: no status clause by default, the status clause is added to all eight service-type queries (7 × `applicationStatus`, 1 × `composeStatus`), and member scoping is preserved alongside it.
- `pnpm -r typecheck` and Biome pass on all touched files; the full `apps/dokploy` suite passes (the `application.real.test.ts` cases require `nixpacks` and a network clone and are unaffected).

## Manual test

1. Deploy any service (an image pull or a git build gives you a few seconds).
2. The sidebar shows `⟳ 1 active`; hovering shows the service name; clicking opens it.
3. Deploy a second one → `2 active` with a dropdown listing both.
4. Open the organization switcher → a `⟳ N` badge next to the organization.
5. When the deploys finish (or fail / are cancelled) the counts drop and the indicator disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63449051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with all previous findings addressed and no new actionable regressions identified.

<h3>Summary</h3>

Adds a sidebar indicator for deploying services across all eight service types, with direct navigation for one service and a dropdown for multiple services.

- Polls every three seconds while deployments are active and every ten seconds when idle, gated by service-read permission.
- Shows per-organization counts while the organization switcher is open, using dedicated count-only queries with membership permissions and accessed-service filtering.
- Restricts API-key count requests to the key’s authenticated organization.
- Opens application and Compose deployment tabs only with deployment-read permission; otherwise links to the general service page.
- Adds regression tests for status filtering, scoped counts, and permission-aware links.
- All three previous findings are addressed; no new actionable issues were identified in the changes since the previous review.

<sub>Reviews (2) · Last reviewed commit: ["fix(overview): scope active deployment c..."](https://github.com/dokploy/dokploy/commit/16dc3e5db12d177ce68f5b4608295d95af256f39)</sub>

<!-- /greptile_comment -->